### PR TITLE
chore(flake/nur): `3b2a891a` -> `3e3d54d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -563,11 +563,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715268567,
-        "narHash": "sha256-+F6v9zTDE6GOByK7cJ1jBr9zTQbg0rloUh15izmKeeM=",
+        "lastModified": 1715272890,
+        "narHash": "sha256-Dpm+2/Kdv1PsYAiLEE1fbft0+bQ3Ou7wwYZg+ZaUNes=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3b2a891ac6ccb5d68069e06ebf0ba01a1bdcc68b",
+        "rev": "3e3d54d319c9384f2ad1d4b85f8851b14f4edcc9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3e3d54d3`](https://github.com/nix-community/NUR/commit/3e3d54d319c9384f2ad1d4b85f8851b14f4edcc9) | `` automatic update `` |
| [`8f43d584`](https://github.com/nix-community/NUR/commit/8f43d5843b5576be21ba2c81d90c230335373f23) | `` automatic update `` |