### PR TITLE
chore(flake/nur): `8dbdf666` -> `69781c45`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -745,11 +745,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715278358,
-        "narHash": "sha256-uywL09cVlVhOXrKk9CnXw97kq44b2iCz00NOt5/VTec=",
+        "lastModified": 1715283921,
+        "narHash": "sha256-QrSRlqvGibusEgrTjxKO+1gA1UZtJ81zq1srqQkB+Us=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8dbdf666a8197711f56fc3782d38fb8e021be27b",
+        "rev": "69781c45be9db020bec046adb4279bff946c1014",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`69781c45`](https://github.com/nix-community/NUR/commit/69781c45be9db020bec046adb4279bff946c1014) | `` automatic update `` |