### PR TITLE
chore(flake/emacs-overlay): `c6e73087` -> `3c648e44`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715274454,
-        "narHash": "sha256-QnQwZXWFE9fj1Y/0DZPRcVQIY/J8ejP6QtWd5QhMpQ8=",
+        "lastModified": 1715302837,
+        "narHash": "sha256-25KeJcDq/z5tzCvS4Lt7B6we0Zk0JUGmRkMAmJ/baC4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c6e7308733e76548d10615d74669919a243e93c8",
+        "rev": "3c648e440c12f85e7521861753ec6bf4e041f595",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`3c648e44`](https://github.com/nix-community/emacs-overlay/commit/3c648e440c12f85e7521861753ec6bf4e041f595) | `` Updated elpa ``   |
| [`5e0523b3`](https://github.com/nix-community/emacs-overlay/commit/5e0523b3b8ec36d713c09ac8cec1d94ce9906c46) | `` Updated nongnu `` |