### PR TITLE
chore(flake/nur): `083aa39d` -> `61dfeddf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -745,11 +745,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715299664,
-        "narHash": "sha256-Wg0O5PoLx8IoU1B9eKabueyDpaNWsEnVxPk/0eZwUwI=",
+        "lastModified": 1715313390,
+        "narHash": "sha256-5JUlwlbCfPI/wacfpdqUokAwU8Vi3UCWvMpXZBOZaV4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "083aa39d120538b395d7612ce040fda391ca99b1",
+        "rev": "61dfeddfbb90c0398a4c356d0dc6ba2fe3b45b9d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`61dfeddf`](https://github.com/nix-community/NUR/commit/61dfeddfbb90c0398a4c356d0dc6ba2fe3b45b9d) | `` automatic update `` |
| [`31cf5d0c`](https://github.com/nix-community/NUR/commit/31cf5d0ce41ec26b3db60b21332e6d2c6c5e2a1f) | `` automatic update `` |
| [`660f154c`](https://github.com/nix-community/NUR/commit/660f154c1f4d04d0720a63cbf5ff479c314bf672) | `` automatic update `` |