### PR TITLE
chore(flake/nur): `15a90dae` -> `5f986886`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -745,11 +745,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715314820,
-        "narHash": "sha256-il4Du63T3VunuMxzJKVjcKKcRXtYpouGsTHGZCO1QtY=",
+        "lastModified": 1715323546,
+        "narHash": "sha256-7G9LRD/HfVf7LkzcmdUf5HqifFbb3jRRiw2Wm009A+c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "15a90dae5c4ea422e794c2e0b241c773c38cae53",
+        "rev": "5f9868861cf6ccd5ed06b38ea96995777a6578e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5f986886`](https://github.com/nix-community/NUR/commit/5f9868861cf6ccd5ed06b38ea96995777a6578e6) | `` automatic update `` |
| [`93ee48a4`](https://github.com/nix-community/NUR/commit/93ee48a499af63a0449143663a3f3b175c2939c1) | `` automatic update `` |
| [`6426eea7`](https://github.com/nix-community/NUR/commit/6426eea740b5aef1a9f39aa1e3ff4b3bacccadbd) | `` automatic update `` |