### PR TITLE
chore(flake/nur): `bd5ba782` -> `e17ffe54`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -745,11 +745,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715326764,
-        "narHash": "sha256-l6ipwgpTLBhsSJeipd1Cpd+pk4cRpmMW5UM1p4lhMxY=",
+        "lastModified": 1715329545,
+        "narHash": "sha256-OoTnMKSf8d8JXFM1MR2oX497G8ZWMWZ3YNgmYttVK4I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bd5ba782f88f24539b9ec9ac14aca96b7bbf6c80",
+        "rev": "e17ffe545f3e7009fc8338dc4ad087eadd090390",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e17ffe54`](https://github.com/nix-community/NUR/commit/e17ffe545f3e7009fc8338dc4ad087eadd090390) | `` automatic update `` |