### PR TITLE
chore(flake/nur): `e17ffe54` -> `3374d1f3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -745,11 +745,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715329545,
-        "narHash": "sha256-OoTnMKSf8d8JXFM1MR2oX497G8ZWMWZ3YNgmYttVK4I=",
+        "lastModified": 1715334179,
+        "narHash": "sha256-Dc1LjjSlPbG9NfHQtNHt+t74k6SVlvaCjhk2beVqF9c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e17ffe545f3e7009fc8338dc4ad087eadd090390",
+        "rev": "3374d1f3c590e2f7a5ba0f9e949a676da056b79a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3374d1f3`](https://github.com/nix-community/NUR/commit/3374d1f3c590e2f7a5ba0f9e949a676da056b79a) | `` automatic update `` |
| [`63dcaf55`](https://github.com/nix-community/NUR/commit/63dcaf55bb04c1e54270171d52002d3f553510d8) | `` automatic update `` |