### PR TITLE
chore(flake/home-manager): `6e277d95` -> `22374331`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715077503,
-        "narHash": "sha256-AfHQshzLQfUqk/efMtdebHaQHqVntCMjhymQzVFLes0=",
+        "lastModified": 1715348159,
+        "narHash": "sha256-nP0PJZ3dR0ols1V+w+sYBki7JlSRFvFJ8J8B00Oa7BM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6e277d9566de9976f47228dd8c580b97488734d4",
+        "rev": "223743313bab8b0b44a57eaf9573de9f69082b4d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`22374331`](https://github.com/nix-community/home-manager/commit/223743313bab8b0b44a57eaf9573de9f69082b4d) | `` hyprpaper: add module ``                                 |
| [`c6ddd80f`](https://github.com/nix-community/home-manager/commit/c6ddd80fb1e5a286b3a5cb32ef94a2e4e346a9d3) | `` hyprlock: add module ``                                  |
| [`4855bfb6`](https://github.com/nix-community/home-manager/commit/4855bfb6ce20225a1b0e2aae2379da909ab38350) | `` kanshi: update configuration to better match upstream `` |
| [`f61917cb`](https://github.com/nix-community/home-manager/commit/f61917cbaa6dba317e757aefd0bbb56403aff2f8) | `` fastfetch: add module ``                                 |