### PR TITLE
chore(flake/nur): `3374d1f3` -> `1a91d7aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -745,11 +745,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715334179,
-        "narHash": "sha256-Dc1LjjSlPbG9NfHQtNHt+t74k6SVlvaCjhk2beVqF9c=",
+        "lastModified": 1715340649,
+        "narHash": "sha256-X0YFJCTvjuOYCawH2Nr7t9W+GL1Npx3E1SzXVEBPu60=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3374d1f3c590e2f7a5ba0f9e949a676da056b79a",
+        "rev": "1a91d7aa0def32617cf61c2b215c5763305e8120",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1a91d7aa`](https://github.com/nix-community/NUR/commit/1a91d7aa0def32617cf61c2b215c5763305e8120) | `` automatic update `` |
| [`f6a5823f`](https://github.com/nix-community/NUR/commit/f6a5823ff56706a4e53ffbf57eefcb5b5a336cab) | `` automatic update `` |
| [`b2bf515e`](https://github.com/nix-community/NUR/commit/b2bf515ec0f3ba5aea9f209ce9f0b97c9cdc66f4) | `` automatic update `` |