### PR TITLE
chore(flake/nur): `c7fadb94` -> `6577ff02`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -745,11 +745,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715344871,
-        "narHash": "sha256-2LTvsyPSz1//93cjaFVtCqsYEP8+8y95rJny1SLDpCg=",
+        "lastModified": 1715348709,
+        "narHash": "sha256-n7QDouGbn8U/F9f4SpnrKQChdlqRTC1VZ3OBU9veiG0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c7fadb94426d948e9d40d6c9c11fb15e5e9c1516",
+        "rev": "6577ff02941ed22085030aa5ca5a593fe71613c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6577ff02`](https://github.com/nix-community/NUR/commit/6577ff02941ed22085030aa5ca5a593fe71613c6) | `` automatic update `` |