### PR TITLE
chore(flake/emacs-overlay): `2971e734` -> `dab95160`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715331976,
-        "narHash": "sha256-+FXweWpZboFomJk4b80WD0s2S+s6YF8sFdoAPpDt/0c=",
+        "lastModified": 1715360806,
+        "narHash": "sha256-5aViJqFMUOFc9NvA7wh5gF71HPrr4NakI3SAEeJg9ts=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2971e734eab0a7692800174c27e96c23dbca263f",
+        "rev": "dab951609a54ec6e0dfee52950c49d7edac5cd90",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`dab95160`](https://github.com/nix-community/emacs-overlay/commit/dab951609a54ec6e0dfee52950c49d7edac5cd90) | `` Updated emacs ``  |
| [`169c56cc`](https://github.com/nix-community/emacs-overlay/commit/169c56cc67e22e8796ab877b4a6af385fc2e10af) | `` Updated melpa ``  |
| [`a2eb5a3b`](https://github.com/nix-community/emacs-overlay/commit/a2eb5a3bbcde61ed12e7474b22b35119e6b9f5d5) | `` Updated elpa ``   |
| [`1e108b1c`](https://github.com/nix-community/emacs-overlay/commit/1e108b1c8ed684c55f4e72901d4523fa53182310) | `` Updated nongnu `` |