### PR TITLE
chore(flake/home-manager): `22374331` -> `d7682620`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715348159,
-        "narHash": "sha256-nP0PJZ3dR0ols1V+w+sYBki7JlSRFvFJ8J8B00Oa7BM=",
+        "lastModified": 1715380449,
+        "narHash": "sha256-716+f9Rj3wjSyD1xitCv2FcYbgPz1WIVDj+ZBclH99Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "223743313bab8b0b44a57eaf9573de9f69082b4d",
+        "rev": "d7682620185f213df384c363288093b486b2883f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`d7682620`](https://github.com/nix-community/home-manager/commit/d7682620185f213df384c363288093b486b2883f) | `` jujutsu: switch to XDG config home ``                    |
| [`d939ce58`](https://github.com/nix-community/home-manager/commit/d939ce585c611c00ca44145a74acab04c20619ad) | `` mopidy: make scan service depend on `mopidy-local` ``    |
| [`15d7ec30`](https://github.com/nix-community/home-manager/commit/15d7ec30511199349c6cf8b6cbdc5e205a6a15e8) | `` darwin: misc defaults (dock, menu clock, finder) ``      |
| [`5514ed32`](https://github.com/nix-community/home-manager/commit/5514ed321087f0b5af42564352d135acad4ff055) | `` yambar: add module ``                                    |
| [`f2c5ba5e`](https://github.com/nix-community/home-manager/commit/f2c5ba5e720fd584d83f2f97399dac0d26ae60b9) | `` fontconfig: add defaultFonts.* options ``                |
| [`e6a31590`](https://github.com/nix-community/home-manager/commit/e6a315900db775da3bb3138bab8caa70dafdaf9e) | `` flake.lock: Update ``                                    |
| [`f55718ae`](https://github.com/nix-community/home-manager/commit/f55718aec361f6a5101f07e3203106f85d6cad20) | `` hyprland: add support for XDG autostart using systemd `` |