### PR TITLE
chore(flake/nur): `a5ff5dd1` -> `9e4be1ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715355859,
-        "narHash": "sha256-eFHxwiNe4HRhw3CQmqCuAcT6IlB1VqjM+gxFZhMSKmk=",
+        "lastModified": 1715387965,
+        "narHash": "sha256-UjY1U4mlvBlz7IV/vwfZXlmIXTPdzAU+6HvL0lMiD2U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a5ff5dd14ef859f447f8304cd93bee52c5515280",
+        "rev": "9e4be1ab3e4540ef1c679ea4e525150b0e265c34",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9e4be1ab`](https://github.com/nix-community/NUR/commit/9e4be1ab3e4540ef1c679ea4e525150b0e265c34) | `` automatic update `` |
| [`19ab3d9a`](https://github.com/nix-community/NUR/commit/19ab3d9af5cb32efa1135cac729b76545c8c0822) | `` automatic update `` |
| [`65995cff`](https://github.com/nix-community/NUR/commit/65995cfffcbd9dff156f4807002201a7c913b9ef) | `` automatic update `` |
| [`59f34907`](https://github.com/nix-community/NUR/commit/59f34907c2d162ada13a42a68bc01769c8eab990) | `` automatic update `` |
| [`adeafdbf`](https://github.com/nix-community/NUR/commit/adeafdbf6a10f0e892a4f60a97e5395a05e547a0) | `` automatic update `` |
| [`43fb9424`](https://github.com/nix-community/NUR/commit/43fb94249512ef0546a2eb101bad5c469aee7b25) | `` automatic update `` |
| [`b726f926`](https://github.com/nix-community/NUR/commit/b726f9263bd1ff38314ef4e64fbc229487914eb2) | `` automatic update `` |
| [`f34e3751`](https://github.com/nix-community/NUR/commit/f34e3751da550eb46f49ce20d47c31585e137238) | `` automatic update `` |
| [`bc4fa4a1`](https://github.com/nix-community/NUR/commit/bc4fa4a1d276fa3bad680ba69a160e65660c57f3) | `` automatic update `` |
| [`505089b1`](https://github.com/nix-community/NUR/commit/505089b1410ead7d83d0cb5175063dd705795c90) | `` automatic update `` |