### PR TITLE
chore(flake/emacs-overlay): `dab95160` -> `62004f5e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715360806,
-        "narHash": "sha256-5aViJqFMUOFc9NvA7wh5gF71HPrr4NakI3SAEeJg9ts=",
+        "lastModified": 1715392031,
+        "narHash": "sha256-3uhiVHNP/lfki1w4eKUgpBGyoPbbgYCgwWWgn+LUoIA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "dab951609a54ec6e0dfee52950c49d7edac5cd90",
+        "rev": "62004f5ead76e154c4f19e27a94cd24fb4db59aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`62004f5e`](https://github.com/nix-community/emacs-overlay/commit/62004f5ead76e154c4f19e27a94cd24fb4db59aa) | `` Updated emacs ``  |
| [`e522fe44`](https://github.com/nix-community/emacs-overlay/commit/e522fe44165986ea385c1e3bd3c54499deb774b5) | `` Updated melpa ``  |
| [`4a814b7d`](https://github.com/nix-community/emacs-overlay/commit/4a814b7d5ab563fc6a6513f5df7aaa01b490f50f) | `` Updated elpa ``   |
| [`601b0ebf`](https://github.com/nix-community/emacs-overlay/commit/601b0ebf30284fe8c39a4334ec9f20d334aa82e7) | `` Updated nongnu `` |