### PR TITLE
chore(flake/nur): `9e4be1ab` -> `8dc94cbd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715387965,
-        "narHash": "sha256-UjY1U4mlvBlz7IV/vwfZXlmIXTPdzAU+6HvL0lMiD2U=",
+        "lastModified": 1715391928,
+        "narHash": "sha256-MazTRM2jHtaWkhKD9//Rhs0MWokDTP5dDHx1SGrw6GQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9e4be1ab3e4540ef1c679ea4e525150b0e265c34",
+        "rev": "8dc94cbd90c90dd80aeebe0f778831fc7dc213b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8dc94cbd`](https://github.com/nix-community/NUR/commit/8dc94cbd90c90dd80aeebe0f778831fc7dc213b7) | `` automatic update `` |
| [`ed8944d2`](https://github.com/nix-community/NUR/commit/ed8944d24c8eca1df4ee17eba09244037d2e251e) | `` automatic update `` |