### PR TITLE
chore(flake/nur): `8dc94cbd` -> `1339e5f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715391928,
-        "narHash": "sha256-MazTRM2jHtaWkhKD9//Rhs0MWokDTP5dDHx1SGrw6GQ=",
+        "lastModified": 1715402329,
+        "narHash": "sha256-Y5JKhxXfas1cdNOQG2+hYWw2UtFBM3dhul4q+psbziU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8dc94cbd90c90dd80aeebe0f778831fc7dc213b7",
+        "rev": "1339e5f917aafc19e2479656ddf70f35212071d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1339e5f9`](https://github.com/nix-community/NUR/commit/1339e5f917aafc19e2479656ddf70f35212071d2) | `` automatic update `` |
| [`352325a3`](https://github.com/nix-community/NUR/commit/352325a311ff256010c5362bd75abe643af0d8fc) | `` automatic update `` |
| [`973a33cc`](https://github.com/nix-community/NUR/commit/973a33cc51029e1abc14a765e6681fb9e3cf1021) | `` automatic update `` |
| [`a6fe3429`](https://github.com/nix-community/NUR/commit/a6fe3429a2647cfd15d36fb48bbba76fad0dc657) | `` automatic update `` |
| [`dc1dc695`](https://github.com/nix-community/NUR/commit/dc1dc6950083c8f4ca102683df3306065e2a6edc) | `` automatic update `` |