### PR TITLE
chore(flake/nur): `ad82b187` -> `3adcef54`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715405822,
-        "narHash": "sha256-LypfYqvKHBx43LP3f1vRxN3UIZddmP1Wqwxqpg7c5rQ=",
+        "lastModified": 1715414244,
+        "narHash": "sha256-ZJVNaw4Gv3gBhkklrg6n99bbgCVMqpHXUCzEWUgYQEo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ad82b187ce72b383350973e29d965bb386bbb55e",
+        "rev": "3adcef5479a0b3a6ad1ec9f7abf7cd90e03e41e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3adcef54`](https://github.com/nix-community/NUR/commit/3adcef5479a0b3a6ad1ec9f7abf7cd90e03e41e4) | `` automatic update `` |
| [`f7328852`](https://github.com/nix-community/NUR/commit/f7328852fa5a1939e9cb58e46e9bd44422b4436b) | `` automatic update `` |
| [`0011f830`](https://github.com/nix-community/NUR/commit/0011f8306fc35c7f4af3cac4d58838abdeb6c355) | `` automatic update `` |