### PR TITLE
chore(flake/emacs-overlay): `62004f5e` -> `60218560`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715392031,
-        "narHash": "sha256-3uhiVHNP/lfki1w4eKUgpBGyoPbbgYCgwWWgn+LUoIA=",
+        "lastModified": 1715417564,
+        "narHash": "sha256-gGl10eCx4IuPVtXKQbMW7fPIwzw3UXy/ecGgXshHD9Q=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "62004f5ead76e154c4f19e27a94cd24fb4db59aa",
+        "rev": "60218560e0c7ccfd27af007a5e861fc93a075f20",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`60218560`](https://github.com/nix-community/emacs-overlay/commit/60218560e0c7ccfd27af007a5e861fc93a075f20) | `` Updated melpa `` |