### PR TITLE
chore(flake/emacs-overlay): `60218560` -> `e41288bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715417564,
-        "narHash": "sha256-gGl10eCx4IuPVtXKQbMW7fPIwzw3UXy/ecGgXshHD9Q=",
+        "lastModified": 1715418343,
+        "narHash": "sha256-DieMydUZ8oZkH2jdjPv02FXTujJoJ8u0cLXQIYApX5o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "60218560e0c7ccfd27af007a5e861fc93a075f20",
+        "rev": "e41288bc8adbd180681d12eb4b9274a7bae7f974",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`e41288bc`](https://github.com/nix-community/emacs-overlay/commit/e41288bc8adbd180681d12eb4b9274a7bae7f974) | `` Updated emacs `` |