### PR TITLE
chore(flake/emacs-overlay): `e41288bc` -> `eac55caf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715418343,
-        "narHash": "sha256-DieMydUZ8oZkH2jdjPv02FXTujJoJ8u0cLXQIYApX5o=",
+        "lastModified": 1715446345,
+        "narHash": "sha256-LC1z+elZ6ysjkg8so8Wc33DhQsAIQ3FjwUGzwRaVoG0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e41288bc8adbd180681d12eb4b9274a7bae7f974",
+        "rev": "eac55caf45920552d8f4af95e8418aefec9d74fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`eac55caf`](https://github.com/nix-community/emacs-overlay/commit/eac55caf45920552d8f4af95e8418aefec9d74fa) | `` Updated melpa ``  |
| [`de2b6b5f`](https://github.com/nix-community/emacs-overlay/commit/de2b6b5f2f87ecd993eaf8368f48d487f023f953) | `` Updated elpa ``   |
| [`4a9ff1b5`](https://github.com/nix-community/emacs-overlay/commit/4a9ff1b53fde5dc90c1464b03676f4d9af9ad8bf) | `` Updated nongnu `` |