### PR TITLE
chore(flake/nur): `9cca173c` -> `ad225f5f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715438000,
-        "narHash": "sha256-a/WjUr6vmjDbqZAp8E741k3eiz1bmSCBmNgupfnPH1s=",
+        "lastModified": 1715449488,
+        "narHash": "sha256-p5MurVM9nCnPsH17FN/A976mUcJDRt+ITUeS/EPxTF0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9cca173c6e452532d367a8dc06ad0fa48d17921b",
+        "rev": "ad225f5ff1c0ce43f744f47dc5607aad92c9554b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ad225f5f`](https://github.com/nix-community/NUR/commit/ad225f5ff1c0ce43f744f47dc5607aad92c9554b) | `` automatic update `` |
| [`558bee4e`](https://github.com/nix-community/NUR/commit/558bee4e8e77063f4c08736b91ed09cf7d97b317) | `` automatic update `` |
| [`5bab5e4b`](https://github.com/nix-community/NUR/commit/5bab5e4bf58ed4aea46476541979db001d6cf1e2) | `` automatic update `` |
| [`b7a8712b`](https://github.com/nix-community/NUR/commit/b7a8712b1fff3a3b3d537aac734ca9d36d0c2542) | `` automatic update `` |