### PR TITLE
chore(flake/emacs-overlay): `eac55caf` -> `1f711204`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715446345,
-        "narHash": "sha256-LC1z+elZ6ysjkg8so8Wc33DhQsAIQ3FjwUGzwRaVoG0=",
+        "lastModified": 1715447076,
+        "narHash": "sha256-uEvbf9BrovJdJsJ31a1nPEN8thj3JIy65fWerNna29A=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "eac55caf45920552d8f4af95e8418aefec9d74fa",
+        "rev": "1f7112047b60e5a5719721b357477178675f8c5e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`1f711204`](https://github.com/nix-community/emacs-overlay/commit/1f7112047b60e5a5719721b357477178675f8c5e) | `` Updated emacs `` |