### PR TITLE
chore(flake/nur): `74607bbe` -> `88bbe752`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715456758,
-        "narHash": "sha256-ZeH1FQ9O3VCBIKYdsLJlt1LcSP+X+DYLNVpxNLQ/CnQ=",
+        "lastModified": 1715463961,
+        "narHash": "sha256-FWGL+0DVOPdHnM+yWzHZW46bC+z0fpZrwvHiPV4RPe8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "74607bbe69764bc0e15da29d278b64ec47475026",
+        "rev": "88bbe752f191c5b2ae376746c6e85ef951eed594",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`88bbe752`](https://github.com/nix-community/NUR/commit/88bbe752f191c5b2ae376746c6e85ef951eed594) | `` automatic update `` |
| [`cbb014aa`](https://github.com/nix-community/NUR/commit/cbb014aa03b80442afb6c112fbd69fabacc77164) | `` automatic update `` |