### PR TITLE
chore(flake/emacs-overlay): `1f711204` -> `cacd688b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715447076,
-        "narHash": "sha256-uEvbf9BrovJdJsJ31a1nPEN8thj3JIy65fWerNna29A=",
+        "lastModified": 1715478778,
+        "narHash": "sha256-XxQyMAwq+4qPn/Ol1NXG+JtdzmqOEdJVYs1OZmED8c8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1f7112047b60e5a5719721b357477178675f8c5e",
+        "rev": "cacd688b09b4ef4ddff5ff12ede2f24ca25119ad",
         "type": "github"
       },
       "original": {
@@ -624,11 +624,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1715218190,
-        "narHash": "sha256-R98WOBHkk8wIi103JUVQF3ei3oui4HvoZcz9tYOAwlk=",
+        "lastModified": 1715395895,
+        "narHash": "sha256-DreMqi6+qa21ffLQqhMQL2XRUkAGt3N7iVB5FhJKie4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9a9960b98418f8c385f52de3b09a63f9c561427a",
+        "rev": "71bae31b7dbc335528ca7e96f479ec93462323ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`cacd688b`](https://github.com/nix-community/emacs-overlay/commit/cacd688b09b4ef4ddff5ff12ede2f24ca25119ad) | `` Updated emacs ``        |
| [`1efe49d8`](https://github.com/nix-community/emacs-overlay/commit/1efe49d8a72bdbbe4c2a55c95f50900066befb5d) | `` Updated melpa ``        |
| [`1628a0f7`](https://github.com/nix-community/emacs-overlay/commit/1628a0f7cc9558e57c5d6d3a48665f5ee15e220e) | `` Updated elpa ``         |
| [`c43b24f8`](https://github.com/nix-community/emacs-overlay/commit/c43b24f81989a040ae98d3e4ffae71c7e0463057) | `` Updated flake inputs `` |