### PR TITLE
chore(flake/nur): `8400f61e` -> `c53f8362`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715471078,
-        "narHash": "sha256-r+Ha1S9eJEvFg2l1Fto4eDmWgrtZvVgP5vli/S6r4Qk=",
+        "lastModified": 1715475764,
+        "narHash": "sha256-23+9wawLAHJS7jUa4jdoMn9JO3PK6pAdYNzOt1WrJYc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8400f61e548792303e73595aeee026701813ca9b",
+        "rev": "c53f8362187c82665c743c80307f3cac4586a69b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c53f8362`](https://github.com/nix-community/NUR/commit/c53f8362187c82665c743c80307f3cac4586a69b) | `` automatic update `` |
| [`bf66dd13`](https://github.com/nix-community/NUR/commit/bf66dd132bcd9f110d505384bd010c1ca7118fad) | `` automatic update `` |