### PR TITLE
chore(flake/nur): `cea7ba94` -> `7d021b60`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715479642,
-        "narHash": "sha256-zjkZ6QG74hDW7R2mPFIQq+rVT0G3BZ5oMA6sFJAlehE=",
+        "lastModified": 1715492953,
+        "narHash": "sha256-hEn/tkAbs42Gmm7WK3IhnzQG6X7ICMxhwBqAF9GvoM4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cea7ba9453de3274e2be85d41b231bfd15c4b5d7",
+        "rev": "7d021b60cd4dd8af0e0d8b4ee1f8cdca91f4514c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7d021b60`](https://github.com/nix-community/NUR/commit/7d021b60cd4dd8af0e0d8b4ee1f8cdca91f4514c) | `` automatic update `` |
| [`e136efd7`](https://github.com/nix-community/NUR/commit/e136efd755364fe13a1f1f5bc832c3fff4475141) | `` automatic update `` |
| [`657d627d`](https://github.com/nix-community/NUR/commit/657d627dea38a84d6c7eed2908006a02cd2dff25) | `` automatic update `` |
| [`62333eb1`](https://github.com/nix-community/NUR/commit/62333eb1d959e5cd12d53ae378cc7933261a8069) | `` automatic update `` |
| [`6c99aab9`](https://github.com/nix-community/NUR/commit/6c99aab9abe7c9467ded5dc952f39d3745a38b74) | `` automatic update `` |
| [`debd9bfd`](https://github.com/nix-community/NUR/commit/debd9bfd419b13fc5a17ed6f1f03905516d7e47a) | `` automatic update `` |
| [`8c627de6`](https://github.com/nix-community/NUR/commit/8c627de6d436a7771acf3f43e068dad14d0f9809) | `` automatic update `` |