### PR TITLE
chore(flake/home-manager): `d7682620` -> `44677a1c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -355,11 +355,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715380449,
-        "narHash": "sha256-716+f9Rj3wjSyD1xitCv2FcYbgPz1WIVDj+ZBclH99Y=",
+        "lastModified": 1715486357,
+        "narHash": "sha256-4pRuzsHZOW5W4CsXI9uhKtiJeQSUoe1d2M9mWU98HC4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d7682620185f213df384c363288093b486b2883f",
+        "rev": "44677a1c96810a8e8c4ffaeaad10c842402647c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                  |
| ----------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`44677a1c`](https://github.com/nix-community/home-manager/commit/44677a1c96810a8e8c4ffaeaad10c842402647c1) | `` flake.lock: Update `` |