### PR TITLE
chore(flake/nur): `7d021b60` -> `9a3e0177`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715492953,
-        "narHash": "sha256-hEn/tkAbs42Gmm7WK3IhnzQG6X7ICMxhwBqAF9GvoM4=",
+        "lastModified": 1715496290,
+        "narHash": "sha256-izSudPo3jCHfwPflUGfNWSiTx53GC8d/Z2+fe7I5lSY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7d021b60cd4dd8af0e0d8b4ee1f8cdca91f4514c",
+        "rev": "9a3e01771cedc908d3628956560956cf1c86555b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9a3e0177`](https://github.com/nix-community/NUR/commit/9a3e01771cedc908d3628956560956cf1c86555b) | `` automatic update `` |
| [`17729b9b`](https://github.com/nix-community/NUR/commit/17729b9b2d61b2f4ccaca0c28d0ced43e08b3579) | `` automatic update `` |