### PR TITLE
chore(flake/nur): `5c12c09c` -> `867a30ff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715514323,
-        "narHash": "sha256-LBxhNYvhJGujrx0GUxWNyO8zhOIpKJYS7EQV1+kf6I0=",
+        "lastModified": 1715517682,
+        "narHash": "sha256-x0fLELr1ddZvO38WoJqInuj5R4yA+tC6jfmwtQIjWAg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5c12c09c24412352bb9fb9e6607c4a3759dfcb8b",
+        "rev": "867a30ff2dae6b726a34ee2871e9334bf1941edf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`867a30ff`](https://github.com/nix-community/NUR/commit/867a30ff2dae6b726a34ee2871e9334bf1941edf) | `` automatic update `` |
| [`f2596669`](https://github.com/nix-community/NUR/commit/f2596669e80633d83436caafc5cac8fc9fb1c29e) | `` automatic update `` |