### PR TITLE
chore(flake/nur): `867a30ff` -> `6834b2d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715517682,
-        "narHash": "sha256-x0fLELr1ddZvO38WoJqInuj5R4yA+tC6jfmwtQIjWAg=",
+        "lastModified": 1715520493,
+        "narHash": "sha256-zKqEBARDjxIZPh3Maj78g+JDZ61YvVe3LsjYuQPtUlc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "867a30ff2dae6b726a34ee2871e9334bf1941edf",
+        "rev": "6834b2d8727d0cbca09b0b823fcd0c471e3fb70d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6834b2d8`](https://github.com/nix-community/NUR/commit/6834b2d8727d0cbca09b0b823fcd0c471e3fb70d) | `` automatic update `` |