### PR TITLE
chore(flake/nur): `6834b2d8` -> `ab197585`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715520493,
-        "narHash": "sha256-zKqEBARDjxIZPh3Maj78g+JDZ61YvVe3LsjYuQPtUlc=",
+        "lastModified": 1715524382,
+        "narHash": "sha256-ftczmIyZgWSjiXT3Djbbo+QJMw2ZEYTxscOzW7zKRF0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6834b2d8727d0cbca09b0b823fcd0c471e3fb70d",
+        "rev": "ab1975853e951403f855043226dec29998b989f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ab197585`](https://github.com/nix-community/NUR/commit/ab1975853e951403f855043226dec29998b989f2) | `` automatic update `` |