### PR TITLE
chore(flake/emacs-overlay): `8ccd52ca` -> `8ec7104a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715504711,
-        "narHash": "sha256-PxIHKQBBqE19jg2vrYToit5tTS9iaF0HlNioXEKDy9g=",
+        "lastModified": 1715532762,
+        "narHash": "sha256-YL53+M9/kQuX2vErHDrFBh6w1hXLJH9TycEGelnbvpc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8ccd52ca342806a99fba8c684bfd43c1d3fe43dd",
+        "rev": "8ec7104a671ea3dce152a5c40b2f7b3395f1291a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`8ec7104a`](https://github.com/nix-community/emacs-overlay/commit/8ec7104a671ea3dce152a5c40b2f7b3395f1291a) | `` Updated melpa ``        |
| [`7adfc898`](https://github.com/nix-community/emacs-overlay/commit/7adfc8989f7bc72302277a41383a8f5a37767315) | `` Updated elpa ``         |
| [`5c04ea98`](https://github.com/nix-community/emacs-overlay/commit/5c04ea9889392eb547bcfce8ea0f9a8eb65451e7) | `` Updated flake inputs `` |