### PR TITLE
chore(flake/nur): `da7a9159` -> `d9237e80`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715528711,
-        "narHash": "sha256-SJTfRdnUs+3KGfeVVvXhEvvd7s3KdcAD7py44iGwNg8=",
+        "lastModified": 1715535938,
+        "narHash": "sha256-sYP6V74woHxg7vzTnuX+FsvBYfEozcbWomTCd4LcvW4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "da7a91593e4135f735aac923fc6290f37b722733",
+        "rev": "d9237e80c3f325c17a0c5a90adde36fd03362b19",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d9237e80`](https://github.com/nix-community/NUR/commit/d9237e80c3f325c17a0c5a90adde36fd03362b19) | `` automatic update `` |
| [`fb67bbce`](https://github.com/nix-community/NUR/commit/fb67bbce53412fe1f1af6aad3a33c2bed4de0806) | `` automatic update `` |
| [`0059839d`](https://github.com/nix-community/NUR/commit/0059839ddadbea61b50c430c32ea5f7c46b1e595) | `` automatic update `` |