### PR TITLE
chore(flake/nur): `8d252a32` -> `2a59491f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715547070,
-        "narHash": "sha256-c4igsuyh7VukfPftA73xQVq1ItFKKuqDAma5BnO4Jhc=",
+        "lastModified": 1715550322,
+        "narHash": "sha256-Vse7J0PjDFJJIhhJrffKS7Eh12I7c5EGp0l8xxFTuY0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8d252a325a8e9cbc6d83bd77c2e6e9b92033a739",
+        "rev": "2a59491fd5daee23e838cda3e80155286af38a63",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2a59491f`](https://github.com/nix-community/NUR/commit/2a59491fd5daee23e838cda3e80155286af38a63) | `` automatic update `` |