### PR TITLE
chore(flake/nur): `2a59491f` -> `daa8b3b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715550322,
-        "narHash": "sha256-Vse7J0PjDFJJIhhJrffKS7Eh12I7c5EGp0l8xxFTuY0=",
+        "lastModified": 1715557495,
+        "narHash": "sha256-ReoRGsaDCuS3OPFIj3Vs8AwVem+su84c7bmk2FahKmo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2a59491fd5daee23e838cda3e80155286af38a63",
+        "rev": "daa8b3b366251d1cad0649cc620778ecfc021315",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`daa8b3b3`](https://github.com/nix-community/NUR/commit/daa8b3b366251d1cad0649cc620778ecfc021315) | `` automatic update `` |
| [`374fced4`](https://github.com/nix-community/NUR/commit/374fced444ed1ade4941f8fc96df11cc62406e79) | `` automatic update `` |