### PR TITLE
chore(flake/emacs-overlay): `a5c58d38` -> `6ca9fed2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715562150,
-        "narHash": "sha256-qHTwS8Q5AVrovwAEDbfpCycwe+xl+kvN3b8FGcGtYYE=",
+        "lastModified": 1715564992,
+        "narHash": "sha256-va6ZPJhZ3Sltk8tpa7sDZu4mijwBmwrnHn6AWeOjdno=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a5c58d38a46c3639d8400a6b3e6f937e6c29bf0c",
+        "rev": "6ca9fed2e0e1584d6394456aed3a9b2ed3571ac6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`6ca9fed2`](https://github.com/nix-community/emacs-overlay/commit/6ca9fed2e0e1584d6394456aed3a9b2ed3571ac6) | `` Updated emacs `` |
| [`4fe6cc37`](https://github.com/nix-community/emacs-overlay/commit/4fe6cc37d9fee05e46aed5cc94ed145defb72380) | `` Updated melpa `` |