### PR TITLE
chore(flake/nur): `bc1596c3` -> `f744c100`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715564597,
-        "narHash": "sha256-XGjYuShnhJw2JIrjuUVP+ZBfcU8vo2qh8zUcYfeKcRk=",
+        "lastModified": 1715572617,
+        "narHash": "sha256-21iQLSENV6BtYr50wdiVbj2UoPUew9xOsVixWX6ESG0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bc1596c32300d0c17c34aef62ee2d68c25ee7f87",
+        "rev": "f744c1003578e97c3db2a364768564d54d60db45",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f744c100`](https://github.com/nix-community/NUR/commit/f744c1003578e97c3db2a364768564d54d60db45) | `` automatic update `` |
| [`702d0cde`](https://github.com/nix-community/NUR/commit/702d0cde0e6abc982602c1670a525d06e8e92a5e) | `` automatic update `` |
| [`cb52304f`](https://github.com/nix-community/NUR/commit/cb52304fca9c444af3815da20d7651a8256b7cb7) | `` automatic update `` |