### PR TITLE
chore(flake/srvos): `65d83b87` -> `c1448c70`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -874,11 +874,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715216666,
-        "narHash": "sha256-0aTe4zSO5t6Wn+gaW5Bwr+84INd7htOdn3sdmE6/uC0=",
+        "lastModified": 1715579044,
+        "narHash": "sha256-5nquTfUmom5otO4llOeSZWi7v2ij304Fia43vvJqc5g=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "65d83b87b55c9618cf02aa9b9c08ec8adaa08c9d",
+        "rev": "c1448c70f0106dc664de7a3c6e899a5014a98911",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`c1448c70`](https://github.com/nix-community/srvos/commit/c1448c70f0106dc664de7a3c6e899a5014a98911) | `` dev/private/flake.lock: Update `` |
| [`0c11b42a`](https://github.com/nix-community/srvos/commit/0c11b42a764b01237b604a1094bd09f2e7183ed9) | `` flake.lock: Update ``             |