### PR TITLE
chore(flake/nur): `10ba089b` -> `fb6c5bbf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715581759,
-        "narHash": "sha256-o8sOheQ/2ktIhPu4E1Q9KAUNi4DTlyVsm0Rpe5/+byA=",
+        "lastModified": 1715586674,
+        "narHash": "sha256-pHMnb1rrrAQCZrA0ViZZ2vUdDmuPI63Ux1PP1bzGUjY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "10ba089bdded7c7d2dd3b97065af57ebdf2a5d42",
+        "rev": "fb6c5bbf8da07e8cffbe0382208b4a027bf4f749",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fb6c5bbf`](https://github.com/nix-community/NUR/commit/fb6c5bbf8da07e8cffbe0382208b4a027bf4f749) | `` automatic update `` |
| [`5408f55a`](https://github.com/nix-community/NUR/commit/5408f55ae4351b47d4e5cb64416fdff99443c606) | `` automatic update `` |
| [`f4b4b110`](https://github.com/nix-community/NUR/commit/f4b4b1109c341a3355cc444f067a34ba2088767a) | `` automatic update `` |