### PR TITLE
chore(flake/emacs-overlay): `6ca9fed2` -> `cf4f7778`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715564992,
-        "narHash": "sha256-va6ZPJhZ3Sltk8tpa7sDZu4mijwBmwrnHn6AWeOjdno=",
+        "lastModified": 1715591232,
+        "narHash": "sha256-+5W4dnRnx6XhZMz7e6JTiPyTLMJVj05VmR3n0N/23ic=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6ca9fed2e0e1584d6394456aed3a9b2ed3571ac6",
+        "rev": "cf4f77786a4805f0f815d5859913b03da6009270",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`cf4f7778`](https://github.com/nix-community/emacs-overlay/commit/cf4f77786a4805f0f815d5859913b03da6009270) | `` Updated emacs `` |
| [`d704255d`](https://github.com/nix-community/emacs-overlay/commit/d704255dce2f76bc791111f12e5824bf633daec1) | `` Updated melpa `` |