### PR TITLE
chore(flake/git-hooks): `2849da03` -> `c182c876`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -314,11 +314,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1714478972,
-        "narHash": "sha256-q//cgb52vv81uOuwz1LaXElp3XAe1TqrABXODAEF6Sk=",
+        "lastModified": 1715609711,
+        "narHash": "sha256-/5u29K0c+4jyQ8x7dUIEUWlz2BoTSZWUP2quPwFCE7M=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "2849da033884f54822af194400f8dff435ada242",
+        "rev": "c182c876690380f8d3b9557c4609472ebfa1b141",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                         |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`a741bc6e`](https://github.com/cachix/git-hooks.nix/commit/a741bc6e926abaf9d4dbd65b28a1f0a82d92078b) | `` flake-parts: add enabledPackages to shell `` |