### PR TITLE
chore(flake/nur): `a42f0e5a` -> `323f4977`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715608391,
-        "narHash": "sha256-FMrt7buRO3BwR/9slNN+0F6aI5DhygJFaIdG/USSRhA=",
+        "lastModified": 1715611234,
+        "narHash": "sha256-i7zIWbB8ohyStvfWsyLTEL4MYOVL9ZUHEdlAiapo6P4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a42f0e5a176713278508c0135c6224ea6ad26a80",
+        "rev": "323f4977a915d531bcf6ca0fd86d6e18c53070e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`323f4977`](https://github.com/nix-community/NUR/commit/323f4977a915d531bcf6ca0fd86d6e18c53070e4) | `` automatic update `` |
| [`6c87ebc0`](https://github.com/nix-community/NUR/commit/6c87ebc0526b8cf99db7be0f1690eb4931080032) | `` automatic update `` |