### PR TITLE
chore(flake/catppuccin): `e5322f7b` -> `deff55c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1715210854,
-        "narHash": "sha256-88jxvd+LIP/XwlvJ3+QPbGCFMChmBfIbUNp1mEP9DJY=",
+        "lastModified": 1715623473,
+        "narHash": "sha256-dqaIFhltvSFWJIeStyF5UPwnc+qayeARWy4qLqNgn8w=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "e5322f7b4001aa8aab38ca5a0f42cafc590f42b6",
+        "rev": "deff55c9027a98eee6af07a630f4a7764598fa4a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                               |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`deff55c9`](https://github.com/catppuccin/nix/commit/deff55c9027a98eee6af07a630f4a7764598fa4a) | `` docs: update for 5e0f749 ``                                        |
| [`5e0f749a`](https://github.com/catppuccin/nix/commit/5e0f749a08bd6b4af2165976c1e3e0c8db5fc74e) | `` feat(home-manager): add `gnomeShellTheme` option for gtk (#161) `` |
| [`a2b462f9`](https://github.com/catppuccin/nix/commit/a2b462f913c50b3a9895c7c7cb68950898e16237) | `` docs: update for 2429fdc ``                                        |
| [`2429fdcd`](https://github.com/catppuccin/nix/commit/2429fdcd672c0958514a85bf024d45af7cb93b92) | `` feat(home-manager): add `extraConfig` option for tmux (#137) ``    |
| [`29aa551d`](https://github.com/catppuccin/nix/commit/29aa551d4a718259d2e928cb92dac2635146b23e) | `` chore: update lockfiles (#160) ``                                  |