### PR TITLE
chore(flake/catppuccin): `deff55c9` -> `0f2d8bba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1715623473,
-        "narHash": "sha256-dqaIFhltvSFWJIeStyF5UPwnc+qayeARWy4qLqNgn8w=",
+        "lastModified": 1715643343,
+        "narHash": "sha256-GtXH1DKaHvcAvu1dC87kDTL1hXGMs8sL3Kv55p6JJ/8=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "deff55c9027a98eee6af07a630f4a7764598fa4a",
+        "rev": "0f2d8bba218dbdd527ba88ed2774c4fd8d83ccea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                     |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`0f2d8bba`](https://github.com/catppuccin/nix/commit/0f2d8bba218dbdd527ba88ed2774c4fd8d83ccea) | `` ci: bump DeterminateSystems/magic-nix-cache-action from 4 to 6 (#169) `` |
| [`29239aef`](https://github.com/catppuccin/nix/commit/29239aefd3532f46ee681e48987b0ce4db98d4a6) | `` docs: update for 28e6d8a ``                                              |
| [`28e6d8a1`](https://github.com/catppuccin/nix/commit/28e6d8a18da22aa5b2cd97904780ecf5cc9a4294) | `` feat(modules): add `catppuccin.sources` option (#129) ``                 |
| [`ef4ffb64`](https://github.com/catppuccin/nix/commit/ef4ffb64b2f1c34e41049d963a524825e437074f) | `` docs: update for 7bf0166 ``                                              |
| [`7bf01664`](https://github.com/catppuccin/nix/commit/7bf0166443903a7626e6aa2411a11e866bb3793e) | `` feat(home-manager): add `apply` option for fcitx5 (#144) ``              |