### PR TITLE
chore(flake/nur): `b8fd97d6` -> `12c94e65`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715631831,
-        "narHash": "sha256-JnW7GLjsXaSC1SYWmXtOXu6j9rJP4xB+abo97VtiaKs=",
+        "lastModified": 1715640329,
+        "narHash": "sha256-63UqbFOGu3TuYs2cfFElcmAYIQXZG5mfUNwZ2mRK0xs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b8fd97d6755836ca3b40bd25e9e9e75d63ceedf9",
+        "rev": "12c94e6547b7432466087c3698795dcea329dfdb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`12c94e65`](https://github.com/nix-community/NUR/commit/12c94e6547b7432466087c3698795dcea329dfdb) | `` automatic update `` |
| [`32532029`](https://github.com/nix-community/NUR/commit/32532029fd0522f46f8d987c0f3bb6c6c2d3947e) | `` automatic update `` |
| [`8746c747`](https://github.com/nix-community/NUR/commit/8746c747accc7e5897c56105b692bb19d34db53f) | `` automatic update `` |