### PR TITLE
chore(flake/catppuccin): `0f2d8bba` -> `76416edb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1715643343,
-        "narHash": "sha256-GtXH1DKaHvcAvu1dC87kDTL1hXGMs8sL3Kv55p6JJ/8=",
+        "lastModified": 1715651822,
+        "narHash": "sha256-sfl/nryV1QO/uLMilvsI1RJlsXAsjiIDClLHbIft2z4=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "0f2d8bba218dbdd527ba88ed2774c4fd8d83ccea",
+        "rev": "76416edbf542c3d76786c03155e3a5af44d01847",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                        |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`76416edb`](https://github.com/catppuccin/nix/commit/76416edbf542c3d76786c03155e3a5af44d01847) | `` docs: update for d8a6d8a ``                 |
| [`d8a6d8a1`](https://github.com/catppuccin/nix/commit/d8a6d8a146d2fe4a63eaa57fff3cb2fd8b044594) | `` feat(nixos): add support for sddm (#168) `` |