### PR TITLE
chore(flake/nur): `12c94e65` -> `dae966cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715640329,
-        "narHash": "sha256-63UqbFOGu3TuYs2cfFElcmAYIQXZG5mfUNwZ2mRK0xs=",
+        "lastModified": 1715652429,
+        "narHash": "sha256-aGMh7/IWWNFoF/s6YqcEXpWUJAnJZvAJ9Z51YxW7qFY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "12c94e6547b7432466087c3698795dcea329dfdb",
+        "rev": "dae966ccc181af946700dca5fefd215b361022ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dae966cc`](https://github.com/nix-community/NUR/commit/dae966ccc181af946700dca5fefd215b361022ba) | `` automatic update `` |
| [`98e25989`](https://github.com/nix-community/NUR/commit/98e25989829207fdc2d4973a6496beea16d67632) | `` automatic update `` |