### PR TITLE
chore(flake/nur): `dae966cc` -> `f78fe612`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715652429,
-        "narHash": "sha256-aGMh7/IWWNFoF/s6YqcEXpWUJAnJZvAJ9Z51YxW7qFY=",
+        "lastModified": 1715668671,
+        "narHash": "sha256-yG1rdxL/ePCHvW8vHi7tpSHfTlCjXmGWI5FWZ+vDScQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dae966ccc181af946700dca5fefd215b361022ba",
+        "rev": "f78fe612baca61fac58a0050f791d8178452ffe4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f78fe612`](https://github.com/nix-community/NUR/commit/f78fe612baca61fac58a0050f791d8178452ffe4) | `` automatic update `` |
| [`82bd8c2c`](https://github.com/nix-community/NUR/commit/82bd8c2c5bd1d0293a10f9e3f35df49baca2e749) | `` automatic update `` |
| [`419f8431`](https://github.com/nix-community/NUR/commit/419f8431c8f7a1951ad050c69dfe339bcae927c3) | `` automatic update `` |
| [`8ef1943f`](https://github.com/nix-community/NUR/commit/8ef1943fafcbfdef91fa8c79250b00f629235a31) | `` automatic update `` |
| [`6e6b53f1`](https://github.com/nix-community/NUR/commit/6e6b53f169b7acd475425591255391e64e8e756b) | `` automatic update `` |
| [`340ddbaa`](https://github.com/nix-community/NUR/commit/340ddbaaf6acfc5829c3fe0848f312d3acd90f1e) | `` automatic update `` |
| [`3f29ba41`](https://github.com/nix-community/NUR/commit/3f29ba41aefc787b7bb28820487d11b777f2d922) | `` automatic update `` |
| [`2f2cb551`](https://github.com/nix-community/NUR/commit/2f2cb551a7f215ac444d8b9949774f25f922781d) | `` automatic update `` |
| [`4df1724f`](https://github.com/nix-community/NUR/commit/4df1724f8a146aa0ecd374c6ae5510b7a93aa62c) | `` automatic update `` |