### PR TITLE
chore(flake/catppuccin): `76416edb` -> `d6344610`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1715651822,
-        "narHash": "sha256-sfl/nryV1QO/uLMilvsI1RJlsXAsjiIDClLHbIft2z4=",
+        "lastModified": 1715659881,
+        "narHash": "sha256-emodPGTXLVqlcOkqbJiOUkf5vo8WWujgzKxms1B+iBs=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "76416edbf542c3d76786c03155e3a5af44d01847",
+        "rev": "d6344610c04af0f8e315fef45dd3b854014b119e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                             |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`d6344610`](https://github.com/catppuccin/nix/commit/d6344610c04af0f8e315fef45dd3b854014b119e) | `` docs: update for 9ffc6b8 ``                      |
| [`9ffc6b8c`](https://github.com/catppuccin/nix/commit/9ffc6b8c26a7b22899d62d406f9ef90b6de830b5) | `` feat(nixos): add support for plymouth (#166) ``  |
| [`e77424fd`](https://github.com/catppuccin/nix/commit/e77424fd3387e93cfed95e68217ab235fb46f23e) | `` docs: update for 27e71a3 ``                      |
| [`27e71a35`](https://github.com/catppuccin/nix/commit/27e71a35480db654a75696059e169d3e0e029eb4) | `` feat(home-manager): add gtk icon theme (#165) `` |