### PR TITLE
chore(flake/nur): `f78fe612` -> `7b535abc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715668671,
-        "narHash": "sha256-yG1rdxL/ePCHvW8vHi7tpSHfTlCjXmGWI5FWZ+vDScQ=",
+        "lastModified": 1715679499,
+        "narHash": "sha256-rwP31RS7a9bkX5FpuFwgnYrEwKU6tkLk9M/6sU6bKMs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f78fe612baca61fac58a0050f791d8178452ffe4",
+        "rev": "7b535abc38e24b4302961d66ed365312c5000aeb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7b535abc`](https://github.com/nix-community/NUR/commit/7b535abc38e24b4302961d66ed365312c5000aeb) | `` automatic update `` |
| [`7a63bb97`](https://github.com/nix-community/NUR/commit/7a63bb97da0243dd2db8b84c0e7199a9756f987b) | `` automatic update `` |