### PR TITLE
chore(flake/nur): `ee04798f` -> `22c8addb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715690819,
-        "narHash": "sha256-ynud1EKVRwK4hijUmNA2OQQ4C7nTmubq8lyy6PGWHRU=",
+        "lastModified": 1715692144,
+        "narHash": "sha256-H4EQ78QCy86Sb7Q0wj7tQN7F64Ze6aq1HwW23YSM1xc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ee04798f8be3cf3bbc92a15b3ce398362066edac",
+        "rev": "22c8addb8f2d310ce3c20d0ab02c41f0c9d11e67",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`22c8addb`](https://github.com/nix-community/NUR/commit/22c8addb8f2d310ce3c20d0ab02c41f0c9d11e67) | `` automatic update `` |