### PR TITLE
chore(flake/deploy-rs): `88b3059b` -> `b3ea6f33`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711973905,
-        "narHash": "sha256-UFKME/N1pbUtn+2Aqnk+agUt8CekbpuqwzljivfIme8=",
+        "lastModified": 1715699772,
+        "narHash": "sha256-sKhqIgucN5sI/7UQgBwsonzR4fONjfMr9OcHK/vPits=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "88b3059b020da69cbe16526b8d639bd5e0b51c8b",
+        "rev": "b3ea6f333f9057b77efd9091119ba67089399ced",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                     |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`b3ea6f33`](https://github.com/serokell/deploy-rs/commit/b3ea6f333f9057b77efd9091119ba67089399ced) | `` Update example to make it work (#247) `` |