### PR TITLE
chore(flake/nur): `4ef5e9e6` -> `695ae40e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715708888,
-        "narHash": "sha256-xiuHb9BCQ87IAcK4mSOCDplatwPHFjHZeT6rusgvnvk=",
+        "lastModified": 1715715973,
+        "narHash": "sha256-ofv9RaaFcifuqrapnfuupajgU7TJp4fEfO1FGuCh4p0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ef5e9e689e62b08399cb584eb588c473d31305a",
+        "rev": "695ae40e3e5947d640da59a295b6dc2ef498b4b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`695ae40e`](https://github.com/nix-community/NUR/commit/695ae40e3e5947d640da59a295b6dc2ef498b4b6) | `` automatic update `` |
| [`77e35686`](https://github.com/nix-community/NUR/commit/77e35686c32e59554ac1dbd6fa2bc5fe967f11ff) | `` automatic update `` |
| [`1718304c`](https://github.com/nix-community/NUR/commit/1718304c1b42e97eca088a966d9a93c1508640cc) | `` automatic update `` |