### PR TITLE
chore(flake/nur): `695ae40e` -> `2c670e28`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715715973,
-        "narHash": "sha256-ofv9RaaFcifuqrapnfuupajgU7TJp4fEfO1FGuCh4p0=",
+        "lastModified": 1715719537,
+        "narHash": "sha256-owPav2+iP7rOiZUzQHsKJ/bwqt7Bz5x7wTHY9ska0Bw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "695ae40e3e5947d640da59a295b6dc2ef498b4b6",
+        "rev": "2c670e2861a7c0e6405b3b19843a49082b773222",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2c670e28`](https://github.com/nix-community/NUR/commit/2c670e2861a7c0e6405b3b19843a49082b773222) | `` automatic update `` |
| [`d9c75d29`](https://github.com/nix-community/NUR/commit/d9c75d290e54b965427ad0e4b7ec356fc5a14caf) | `` automatic update `` |