### PR TITLE
chore(flake/emacs-overlay): `0a98303e` -> `c93fb504`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715706530,
-        "narHash": "sha256-1FFQAEYGqksUVxSp7J2rcZgj1m8qUMj5KCcVo3GKqSs=",
+        "lastModified": 1715734900,
+        "narHash": "sha256-CdbBmvyfIPGbxyZfZz1sriM/2O2DDjBY/2YIb9b5gG4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0a98303e2db66b6106623829ef681706d772b9cd",
+        "rev": "c93fb504806f8df5e4ddbd2eea813fe0cc2baef9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`c93fb504`](https://github.com/nix-community/emacs-overlay/commit/c93fb504806f8df5e4ddbd2eea813fe0cc2baef9) | `` Updated elpa ``   |
| [`f36a1da9`](https://github.com/nix-community/emacs-overlay/commit/f36a1da91bed335d50a00a29147d70a4f30f9472) | `` Updated nongnu `` |