### PR TITLE
chore(flake/nur): `2c670e28` -> `39593093`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715719537,
-        "narHash": "sha256-owPav2+iP7rOiZUzQHsKJ/bwqt7Bz5x7wTHY9ska0Bw=",
+        "lastModified": 1715737563,
+        "narHash": "sha256-w9F9oOfEMXxqx7AOSM65ZNhc1yGLwQL8AcqUIITgAeA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2c670e2861a7c0e6405b3b19843a49082b773222",
+        "rev": "39593093fd61ec424b3eb73ea0662711aea2dbb7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`39593093`](https://github.com/nix-community/NUR/commit/39593093fd61ec424b3eb73ea0662711aea2dbb7) | `` automatic update `` |
| [`f22bd00b`](https://github.com/nix-community/NUR/commit/f22bd00bafa23dcf421eac82a93b75433f8f053a) | `` automatic update `` |
| [`b1f36bd1`](https://github.com/nix-community/NUR/commit/b1f36bd1dc72c16cd41af76a09ff92eea977fd8a) | `` automatic update `` |