### PR TITLE
chore(flake/emacs-overlay): `c93fb504` -> `06566ce7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715734900,
-        "narHash": "sha256-CdbBmvyfIPGbxyZfZz1sriM/2O2DDjBY/2YIb9b5gG4=",
+        "lastModified": 1715737790,
+        "narHash": "sha256-exmlRSMsPUkowIqTKmgQboV8ctuk1sD8kJbo0tuwW6s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c93fb504806f8df5e4ddbd2eea813fe0cc2baef9",
+        "rev": "06566ce72388a0f620df7322bceb3d310a0723ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`06566ce7`](https://github.com/nix-community/emacs-overlay/commit/06566ce72388a0f620df7322bceb3d310a0723ec) | `` Updated emacs `` |
| [`e25b6be3`](https://github.com/nix-community/emacs-overlay/commit/e25b6be33695d35ceb5059b37af4da3ba7af8e4d) | `` Updated melpa `` |