### PR TITLE
chore(flake/nur): `39593093` -> `11e918ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715737563,
-        "narHash": "sha256-w9F9oOfEMXxqx7AOSM65ZNhc1yGLwQL8AcqUIITgAeA=",
+        "lastModified": 1715741665,
+        "narHash": "sha256-4rjuW/X5Sri1O9ziRJlCR4Lu59OUlVPGEYjwA2V56xc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "39593093fd61ec424b3eb73ea0662711aea2dbb7",
+        "rev": "11e918ab343eafac7fffff3a047a80da1103eda8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`11e918ab`](https://github.com/nix-community/NUR/commit/11e918ab343eafac7fffff3a047a80da1103eda8) | `` automatic update `` |