### PR TITLE
chore(flake/nur): `11e918ab` -> `15722f61`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715741665,
-        "narHash": "sha256-4rjuW/X5Sri1O9ziRJlCR4Lu59OUlVPGEYjwA2V56xc=",
+        "lastModified": 1715747238,
+        "narHash": "sha256-2SDntG1J87XvN0SARgWbEPwkZa4K75/wsIej9z3R1BA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "11e918ab343eafac7fffff3a047a80da1103eda8",
+        "rev": "15722f6171e918844b5bc4d55509b47db5e25ffa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`15722f61`](https://github.com/nix-community/NUR/commit/15722f6171e918844b5bc4d55509b47db5e25ffa) | `` automatic update `` |
| [`68096183`](https://github.com/nix-community/NUR/commit/6809618376cf6b08a9f00abd3587c0104a92b66e) | `` automatic update `` |
| [`81af55b7`](https://github.com/nix-community/NUR/commit/81af55b71a8d01d6148a5b84ffe9d46f307cc9e0) | `` automatic update `` |