### PR TITLE
chore(flake/nur): `15722f61` -> `476bb0c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715747238,
-        "narHash": "sha256-2SDntG1J87XvN0SARgWbEPwkZa4K75/wsIej9z3R1BA=",
+        "lastModified": 1715756479,
+        "narHash": "sha256-s4QN29dr1pa5wEnYKT//+Thsq/aBBuDxU+F/ZLBRHcU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "15722f6171e918844b5bc4d55509b47db5e25ffa",
+        "rev": "476bb0c2ca73a63204a32dea303affc08592fcb0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`476bb0c2`](https://github.com/nix-community/NUR/commit/476bb0c2ca73a63204a32dea303affc08592fcb0) | `` automatic update `` |
| [`fa8f9418`](https://github.com/nix-community/NUR/commit/fa8f9418e75549a843af69caf921f2bb7b97f195) | `` automatic update `` |
| [`b1be6054`](https://github.com/nix-community/NUR/commit/b1be605455d01b022aa5b79cdab73f337e5aee45) | `` automatic update `` |