### PR TITLE
chore(flake/emacs-overlay): `06566ce7` -> `c20b99a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715737790,
-        "narHash": "sha256-exmlRSMsPUkowIqTKmgQboV8ctuk1sD8kJbo0tuwW6s=",
+        "lastModified": 1715764046,
+        "narHash": "sha256-Xc0QLHMuNnbjmhrGtHz5wLnDJc3SFZq9xoUqE+xsOic=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "06566ce72388a0f620df7322bceb3d310a0723ec",
+        "rev": "c20b99a4ea0750681a9aba949a91cce211c64dc5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`c20b99a4`](https://github.com/nix-community/emacs-overlay/commit/c20b99a4ea0750681a9aba949a91cce211c64dc5) | `` Updated emacs `` |
| [`ce95fab9`](https://github.com/nix-community/emacs-overlay/commit/ce95fab9373f83495aa8966d58dc92b67c2abf25) | `` Updated melpa `` |