### PR TITLE
chore(flake/nur): `06b28e80` -> `0d127bc7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715758989,
-        "narHash": "sha256-0iZ6fmdHNRz26CuskdShXwtr9yTKtNds5YyABjtDUKo=",
+        "lastModified": 1715763397,
+        "narHash": "sha256-ddCsvmPylwjzJjbe4NTMqZ864HRLYA9iA0zoHGL42rE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "06b28e8020880620936e765d833672ac201053f0",
+        "rev": "0d127bc7b3b780ea0a081ec3b5c72ce62908a160",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0d127bc7`](https://github.com/nix-community/NUR/commit/0d127bc7b3b780ea0a081ec3b5c72ce62908a160) | `` automatic update `` |
| [`4ad1bb48`](https://github.com/nix-community/NUR/commit/4ad1bb4890b7a3967e49061012eaeb5c9a43af2e) | `` automatic update `` |