### PR TITLE
chore(flake/nur): `b31fdb7e` -> `2d6fba7c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715771758,
-        "narHash": "sha256-Y7LzqMlyF7yccVzT6vL0T4UQYEkFyNkRatECG8m2hSg=",
+        "lastModified": 1715777889,
+        "narHash": "sha256-Ano+4M2xb91QjQ8Ymx4aAIZ1XjhPULSpwd/S2yEvDds=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b31fdb7ea530ed59c09de8d49737beea9c3e8a73",
+        "rev": "2d6fba7ccd75b46ef12b797fd888f4d9ad80cbc6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2d6fba7c`](https://github.com/nix-community/NUR/commit/2d6fba7ccd75b46ef12b797fd888f4d9ad80cbc6) | `` automatic update `` |