### PR TITLE
chore(flake/nur): `2d6fba7c` -> `02c76e24`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715777889,
-        "narHash": "sha256-Ano+4M2xb91QjQ8Ymx4aAIZ1XjhPULSpwd/S2yEvDds=",
+        "lastModified": 1715781101,
+        "narHash": "sha256-i4uiHrQJg0ljXzuyaWJBmbbsAusMEk4ltA0SIxDvDkM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2d6fba7ccd75b46ef12b797fd888f4d9ad80cbc6",
+        "rev": "02c76e24fe41a2428d01e3200bd7cb852d23b940",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`02c76e24`](https://github.com/nix-community/NUR/commit/02c76e24fe41a2428d01e3200bd7cb852d23b940) | `` automatic update `` |