### PR TITLE
chore(flake/nur): `02c76e24` -> `4f5ecc78`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715781101,
-        "narHash": "sha256-i4uiHrQJg0ljXzuyaWJBmbbsAusMEk4ltA0SIxDvDkM=",
+        "lastModified": 1715783832,
+        "narHash": "sha256-KZt4qjyWdkbRKa7hNJlxvPbmug4FTkPSlKFGXE1J4cA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "02c76e24fe41a2428d01e3200bd7cb852d23b940",
+        "rev": "4f5ecc7815af983257e513c5f9fb643ac5203919",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4f5ecc78`](https://github.com/nix-community/NUR/commit/4f5ecc7815af983257e513c5f9fb643ac5203919) | `` automatic update `` |
| [`9aa5be27`](https://github.com/nix-community/NUR/commit/9aa5be2761de429effdf42b17b00245190cf3fc1) | `` automatic update `` |
| [`c181616e`](https://github.com/nix-community/NUR/commit/c181616eb753118f5dd9893fe1bf5207f7c8efa1) | `` automatic update `` |