### PR TITLE
chore(flake/nur): `4f5ecc78` -> `8c0a6008`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715783832,
-        "narHash": "sha256-KZt4qjyWdkbRKa7hNJlxvPbmug4FTkPSlKFGXE1J4cA=",
+        "lastModified": 1715788061,
+        "narHash": "sha256-QBR7fjeUfFECh11LsyQgBtVk+gqW5vtz5XerU7BaD8g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4f5ecc7815af983257e513c5f9fb643ac5203919",
+        "rev": "8c0a6008cfc6f98e1bf96598696c47dc9a3954ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8c0a6008`](https://github.com/nix-community/NUR/commit/8c0a6008cfc6f98e1bf96598696c47dc9a3954ce) | `` automatic update `` |