### PR TITLE
chore(flake/nur): `620d3a30` -> `d7896356`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715795201,
-        "narHash": "sha256-o5U97WmESyRflUfqI7c2C90yVKOuAUuBDPxm8FNzLQQ=",
+        "lastModified": 1715802467,
+        "narHash": "sha256-iio9OLZzm4YuahYyH9aSBZVFVyXg5Okm69P5hxCAlMw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "620d3a309d3a81b8fa077df402335c23a925505c",
+        "rev": "d78963567b563ad47bcf7c1a60c46dfee402b7fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d7896356`](https://github.com/nix-community/NUR/commit/d78963567b563ad47bcf7c1a60c46dfee402b7fe) | `` automatic update `` |
| [`77cb9aca`](https://github.com/nix-community/NUR/commit/77cb9acaeb19098bba64a0eb4c74c25fe52c8964) | `` automatic update `` |
| [`dd97d6b2`](https://github.com/nix-community/NUR/commit/dd97d6b20abde87e2275032888795f5338bf9aa6) | `` automatic update `` |
| [`005f2ea2`](https://github.com/nix-community/NUR/commit/005f2ea293b1353465e34a2c29f443df4f9cfc44) | `` automatic update `` |
| [`2023f00e`](https://github.com/nix-community/NUR/commit/2023f00e79013f6b00ca07f2e32dccb100446fb5) | `` automatic update `` |