### PR TITLE
chore(flake/nur): `d7896356` -> `c3d5c351`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715802467,
-        "narHash": "sha256-iio9OLZzm4YuahYyH9aSBZVFVyXg5Okm69P5hxCAlMw=",
+        "lastModified": 1715803521,
+        "narHash": "sha256-oz3RCOkLsGN1GbTqYeXxxWQLmBuY24iOR/pJ1d54+T8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d78963567b563ad47bcf7c1a60c46dfee402b7fe",
+        "rev": "c3d5c351a777a79ef95fa64bc7ed2bd10196d33a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c3d5c351`](https://github.com/nix-community/NUR/commit/c3d5c351a777a79ef95fa64bc7ed2bd10196d33a) | `` automatic update `` |