### PR TITLE
chore(flake/nur): `6c3d26cd` -> `240c9184`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715816750,
-        "narHash": "sha256-o61Xz1fLUGCsjntDI/kUeIU8RSVJWUxZJvd33/NGAus=",
+        "lastModified": 1715827647,
+        "narHash": "sha256-Jjw+tdYlOArYpzG8jr+9g/GJaaW3YG+TLyWDDGd24v4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6c3d26cd2275c8ebc0a21a99192e6e4468513b52",
+        "rev": "240c91847989b30abf65fb8d0bbbddce599cdbda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`240c9184`](https://github.com/nix-community/NUR/commit/240c91847989b30abf65fb8d0bbbddce599cdbda) | `` automatic update `` |
| [`cd63dc42`](https://github.com/nix-community/NUR/commit/cd63dc42b54a59c422abaa9a4b07731537dbdfa9) | `` automatic update `` |
| [`0030eb5f`](https://github.com/nix-community/NUR/commit/0030eb5f347fc0b835803dd41c162ce0e02df519) | `` automatic update `` |
| [`b7ba1ee5`](https://github.com/nix-community/NUR/commit/b7ba1ee59bd180bab9b83e1ef7116242587c7ca5) | `` automatic update `` |