### PR TITLE
chore(flake/srvos): `c1448c70` -> `7a140951`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -874,11 +874,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715579044,
-        "narHash": "sha256-5nquTfUmom5otO4llOeSZWi7v2ij304Fia43vvJqc5g=",
+        "lastModified": 1715820823,
+        "narHash": "sha256-KN9uvEjgzUA0trQdnnpeJEPA/UhpMlwXexJyiyqkH78=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "c1448c70f0106dc664de7a3c6e899a5014a98911",
+        "rev": "7a140951a5b5db5c05d359ccd53c3f7bd06f317b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`7a140951`](https://github.com/nix-community/srvos/commit/7a140951a5b5db5c05d359ccd53c3f7bd06f317b) | `` dev/private/flake.lock: Update `` |
| [`1e3a789d`](https://github.com/nix-community/srvos/commit/1e3a789d2c149769285d781fd8290b0ad469d89b) | `` flake.lock: Update ``             |