### PR TITLE
chore(flake/nur): `240c9184` -> `faa5398e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715827647,
-        "narHash": "sha256-Jjw+tdYlOArYpzG8jr+9g/GJaaW3YG+TLyWDDGd24v4=",
+        "lastModified": 1715831775,
+        "narHash": "sha256-yb7UwrRNn7QzlNVtgupUONpF7/luza0/YhEnZNcGn0o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "240c91847989b30abf65fb8d0bbbddce599cdbda",
+        "rev": "faa5398e99af1039d1a5a219688cde8fc8bb93b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`faa5398e`](https://github.com/nix-community/NUR/commit/faa5398e99af1039d1a5a219688cde8fc8bb93b9) | `` automatic update `` |
| [`95a4f7f5`](https://github.com/nix-community/NUR/commit/95a4f7f53b9d7db23ecdd704da7df357f6e1abd5) | `` automatic update `` |
| [`8efe4701`](https://github.com/nix-community/NUR/commit/8efe4701059b7bf9fe86db15d14adc603c4314a9) | `` automatic update `` |