### PR TITLE
chore(flake/nur): `faa5398e` -> `dca4eee2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715831775,
-        "narHash": "sha256-yb7UwrRNn7QzlNVtgupUONpF7/luza0/YhEnZNcGn0o=",
+        "lastModified": 1715837929,
+        "narHash": "sha256-WHtOJymdUd5n4lW/Z60CQVn7mRNE2IfaLkBi6Z9Slrw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "faa5398e99af1039d1a5a219688cde8fc8bb93b9",
+        "rev": "dca4eee2fd9fe8877c579c443ae24196fa0a801d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dca4eee2`](https://github.com/nix-community/NUR/commit/dca4eee2fd9fe8877c579c443ae24196fa0a801d) | `` automatic update `` |
| [`12bad281`](https://github.com/nix-community/NUR/commit/12bad281126c8464bbe59c955632bfacfbc86f7c) | `` automatic update `` |