### PR TITLE
chore(flake/nur): `dca4eee2` -> `1af479b0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715837929,
-        "narHash": "sha256-WHtOJymdUd5n4lW/Z60CQVn7mRNE2IfaLkBi6Z9Slrw=",
+        "lastModified": 1715845070,
+        "narHash": "sha256-9Z0dcn3p1r/v+buzURfvKXYHceonVhN8k7Es5G5rtrk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dca4eee2fd9fe8877c579c443ae24196fa0a801d",
+        "rev": "1af479b00c62b6dc202dad86d98289b1129c133e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1af479b0`](https://github.com/nix-community/NUR/commit/1af479b00c62b6dc202dad86d98289b1129c133e) | `` automatic update `` |
| [`fdadc702`](https://github.com/nix-community/NUR/commit/fdadc702139f5a3fddc7e36271e0caad164dc842) | `` automatic update `` |