### PR TITLE
chore(flake/emacs-overlay): `f7262386` -> `79987143`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715824159,
-        "narHash": "sha256-Oe3XNGqhNwEDZjKKJea8Iu1v0UBDQf3ghRKF6DMx66I=",
+        "lastModified": 1715850300,
+        "narHash": "sha256-cmwhFzasd7P09YU798FSlLkLCCbHAeu9x2kut7gPDAU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f72623860d10a4fe8c49ced4fb1e62b8aafba83b",
+        "rev": "799871438560ec035b58b44199971a8ac13037d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`79987143`](https://github.com/nix-community/emacs-overlay/commit/799871438560ec035b58b44199971a8ac13037d0) | `` Updated emacs ``        |
| [`964aa45b`](https://github.com/nix-community/emacs-overlay/commit/964aa45bbf942907446db4a389c6a0086072dee8) | `` Updated flake inputs `` |