### PR TITLE
chore(flake/nur): `1af479b0` -> `41026980`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715845070,
-        "narHash": "sha256-9Z0dcn3p1r/v+buzURfvKXYHceonVhN8k7Es5G5rtrk=",
+        "lastModified": 1715849126,
+        "narHash": "sha256-ue+VrKmtSHWCChmvx7uRMQn9P7Iclzzur3yW2ibsY1k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1af479b00c62b6dc202dad86d98289b1129c133e",
+        "rev": "41026980c24715c2227fe7a9d2302062b543f72b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`41026980`](https://github.com/nix-community/NUR/commit/41026980c24715c2227fe7a9d2302062b543f72b) | `` automatic update `` |