### PR TITLE
chore(flake/nur): `961f66d2` -> `eb478701`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,11 +742,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715857838,
-        "narHash": "sha256-ilDbhN9fiZVPZhOkUdFmEMV+M6SbxIX6rKpIGb3s8E4=",
+        "lastModified": 1715863924,
+        "narHash": "sha256-Eav+iR8uuBE991jeOBlr3ApgWADEzMTY86qokKrIDMM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "961f66d233d2b9eee9c2f31416f089dcb2655c95",
+        "rev": "eb478701e9a0bf62e19aa466073b0a3577c706e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`eb478701`](https://github.com/nix-community/NUR/commit/eb478701e9a0bf62e19aa466073b0a3577c706e2) | `` automatic update `` |
| [`9c2a38f5`](https://github.com/nix-community/NUR/commit/9c2a38f537ec09b72cf3389af2191275b9823172) | `` automatic update `` |
| [`518d6b90`](https://github.com/nix-community/NUR/commit/518d6b90c3dd9acf98d78f520d141a2d656d7b10) | `` automatic update `` |