### PR TITLE
chore(flake/nur): `eb478701` -> `145ffca0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715863924,
-        "narHash": "sha256-Eav+iR8uuBE991jeOBlr3ApgWADEzMTY86qokKrIDMM=",
+        "lastModified": 1715881586,
+        "narHash": "sha256-WiwGioCPfdrkMBQ+XXTPTAsHcTk+tVQZ3g6ADOIvvyM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eb478701e9a0bf62e19aa466073b0a3577c706e2",
+        "rev": "145ffca05f969911946ba86ee1c47ca49e125964",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`145ffca0`](https://github.com/nix-community/NUR/commit/145ffca05f969911946ba86ee1c47ca49e125964) | `` automatic update `` |
| [`87514c71`](https://github.com/nix-community/NUR/commit/87514c71a8eb23e4129e5a4608c0c2ec433b18f3) | `` automatic update `` |
| [`998663f5`](https://github.com/nix-community/NUR/commit/998663f5062ca8ed46364800e1d30161b52d90a2) | `` automatic update `` |
| [`94ceadb3`](https://github.com/nix-community/NUR/commit/94ceadb34322d85bee8ea7c94789cb0d598fa436) | `` automatic update `` |
| [`ba43c550`](https://github.com/nix-community/NUR/commit/ba43c55067d1bfa7018060843a6f2a09b398c0a4) | `` automatic update `` |
| [`ff15e8c0`](https://github.com/nix-community/NUR/commit/ff15e8c091246f611200d40e265f60b381289fc6) | `` automatic update `` |
| [`821d6aa9`](https://github.com/nix-community/NUR/commit/821d6aa90394fdc84550a3be55f3920a71ebb834) | `` automatic update `` |