### PR TITLE
chore(flake/emacs-overlay): `79987143` -> `32ffea68`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715850300,
-        "narHash": "sha256-cmwhFzasd7P09YU798FSlLkLCCbHAeu9x2kut7gPDAU=",
+        "lastModified": 1715876289,
+        "narHash": "sha256-81rPPFUOQN1RGEfsnzT5nz/JuSTmFCsDwM2p6xHA6nE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "799871438560ec035b58b44199971a8ac13037d0",
+        "rev": "32ffea682df7a1302c17fef48b3067370b71cfca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`32ffea68`](https://github.com/nix-community/emacs-overlay/commit/32ffea682df7a1302c17fef48b3067370b71cfca) | `` Updated elpa ``   |
| [`dfce4faf`](https://github.com/nix-community/emacs-overlay/commit/dfce4fafbf0b0b9b1d62cb500815929aeeb55353) | `` Updated nongnu `` |