### PR TITLE
chore(flake/nur): `145ffca0` -> `abc7fbfd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715881586,
-        "narHash": "sha256-WiwGioCPfdrkMBQ+XXTPTAsHcTk+tVQZ3g6ADOIvvyM=",
+        "lastModified": 1715888814,
+        "narHash": "sha256-skpOwox7ueKzsuZi5pwkNNEdgXPPLridcZNH1txx4Q0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "145ffca05f969911946ba86ee1c47ca49e125964",
+        "rev": "abc7fbfd3d19fec91acf5c4a8689c3cf1fec2c01",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`abc7fbfd`](https://github.com/nix-community/NUR/commit/abc7fbfd3d19fec91acf5c4a8689c3cf1fec2c01) | `` automatic update `` |
| [`8d3f5858`](https://github.com/nix-community/NUR/commit/8d3f585859b43ca44ff73635119e0758412cab94) | `` automatic update `` |
| [`08c1ce32`](https://github.com/nix-community/NUR/commit/08c1ce32f2ebe9a65926611910e08a9dca64b4e1) | `` automatic update `` |