### PR TITLE
chore(flake/nur): `abc7fbfd` -> `f1c319a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715888814,
-        "narHash": "sha256-skpOwox7ueKzsuZi5pwkNNEdgXPPLridcZNH1txx4Q0=",
+        "lastModified": 1715899068,
+        "narHash": "sha256-dQn+Hv13ln+2d8rbIvGgYMLVGtcZLkghByu0yyRSoVc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "abc7fbfd3d19fec91acf5c4a8689c3cf1fec2c01",
+        "rev": "f1c319a9df9a7d5b0282c3dbc2a0d3fce30270c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f1c319a9`](https://github.com/nix-community/NUR/commit/f1c319a9df9a7d5b0282c3dbc2a0d3fce30270c8) | `` automatic update `` |
| [`397c6240`](https://github.com/nix-community/NUR/commit/397c6240c20b445890bb11ff1011fabc0b8cfde5) | `` automatic update `` |