### PR TITLE
chore(flake/emacs-overlay): `753b273b` -> `07d8fe47`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715879166,
-        "narHash": "sha256-w07wvE58CcRfROKkfAt+tM72O04mqnsaktDM5rqcD7Y=",
+        "lastModified": 1715907706,
+        "narHash": "sha256-fdxRgUxUpWZ7GXRYCRPOc2Omdpy7S44zwMGRV8VdddY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "753b273b71af6d181b6182ba530e8eb12e5178e9",
+        "rev": "07d8fe47e57552af55a256ca3edff1e87718903b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message            |
| ------------------------------------------------------------------------------------------------------------ | ------------------ |
| [`07d8fe47`](https://github.com/nix-community/emacs-overlay/commit/07d8fe47e57552af55a256ca3edff1e87718903b) | `` Updated elpa `` |