### PR TITLE
chore(flake/emacs-overlay): `07d8fe47` -> `238eefc3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715907706,
-        "narHash": "sha256-fdxRgUxUpWZ7GXRYCRPOc2Omdpy7S44zwMGRV8VdddY=",
+        "lastModified": 1715910562,
+        "narHash": "sha256-5H1xZ7LgJGEGjVgLMSJYftyrIt0zmmJGX9XMxdT1q3k=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "07d8fe47e57552af55a256ca3edff1e87718903b",
+        "rev": "238eefc3f18c7079b2ec3fa4c1b9b11e1c7dcc7c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`238eefc3`](https://github.com/nix-community/emacs-overlay/commit/238eefc3f18c7079b2ec3fa4c1b9b11e1c7dcc7c) | `` Updated emacs `` |