### PR TITLE
chore(flake/nur): `fb74d980` -> `24e855bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715914086,
-        "narHash": "sha256-23Js4B3nmyHTffGDIsgNgNpKG5kSMp/MCXoCnZQ19Tw=",
+        "lastModified": 1715918252,
+        "narHash": "sha256-rxVLFIB0tUtGD2H7PoQB5frsUjt2vliRlJtzD7R10B0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fb74d98043e9210b40f3f47ed18f77758a0c48ad",
+        "rev": "24e855bc4c137469780a8de6b32dfdf6949c205f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`24e855bc`](https://github.com/nix-community/NUR/commit/24e855bc4c137469780a8de6b32dfdf6949c205f) | `` automatic update `` |
| [`9e638201`](https://github.com/nix-community/NUR/commit/9e6382016b787c0fb1f040a2b28128867ec29668) | `` automatic update `` |