### PR TITLE
chore(flake/nur): `24e855bc` -> `42642d46`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715918252,
-        "narHash": "sha256-rxVLFIB0tUtGD2H7PoQB5frsUjt2vliRlJtzD7R10B0=",
+        "lastModified": 1715921813,
+        "narHash": "sha256-oAaL3biKuQqelniKOwCKht2O8Y52kTul4Fq70hT2tV8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "24e855bc4c137469780a8de6b32dfdf6949c205f",
+        "rev": "42642d46611153002106192bac3bf6479e8dda1b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`42642d46`](https://github.com/nix-community/NUR/commit/42642d46611153002106192bac3bf6479e8dda1b) | `` automatic update `` |
| [`ec81db4a`](https://github.com/nix-community/NUR/commit/ec81db4a01c1ab17489e82df87d9c6893eb2548d) | `` automatic update `` |
| [`ed9be585`](https://github.com/nix-community/NUR/commit/ed9be585dd3ceaa527badeb0f55d2358b9099cec) | `` automatic update `` |
| [`401e6d7a`](https://github.com/nix-community/NUR/commit/401e6d7ac014503495b1ef2c95ef56a296e1b744) | `` automatic update `` |