### PR TITLE
chore(flake/nur): `42642d46` -> `5ce37949`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715921813,
-        "narHash": "sha256-oAaL3biKuQqelniKOwCKht2O8Y52kTul4Fq70hT2tV8=",
+        "lastModified": 1715925692,
+        "narHash": "sha256-lanH0Wx228cyTWoO9073u28TQizHHrBL1P/1l52JMuU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "42642d46611153002106192bac3bf6479e8dda1b",
+        "rev": "5ce3794909ae99e54f1d2d8046679bf26d1245dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5ce37949`](https://github.com/nix-community/NUR/commit/5ce3794909ae99e54f1d2d8046679bf26d1245dd) | `` automatic update `` |
| [`25dece70`](https://github.com/nix-community/NUR/commit/25dece704058934ca53ea31d12889393caf97512) | `` automatic update `` |
| [`e934c241`](https://github.com/nix-community/NUR/commit/e934c241439a21c4e1d23f2b79f45616293ec0fc) | `` automatic update `` |
| [`6b336bee`](https://github.com/nix-community/NUR/commit/6b336bee819008d8cc6696841c40cc166d0615b0) | `` automatic update `` |