### PR TITLE
chore(flake/nur): `5ce37949` -> `a34e7453`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715925692,
-        "narHash": "sha256-lanH0Wx228cyTWoO9073u28TQizHHrBL1P/1l52JMuU=",
+        "lastModified": 1715928322,
+        "narHash": "sha256-gPCABWfR60tul3w0J/4JISWtCEdyqyoFfjyZ17iDFDU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5ce3794909ae99e54f1d2d8046679bf26d1245dd",
+        "rev": "a34e74536c8374f70ff79ec370e89b2e413a5b3f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a34e7453`](https://github.com/nix-community/NUR/commit/a34e74536c8374f70ff79ec370e89b2e413a5b3f) | `` automatic update `` |
| [`dc55412b`](https://github.com/nix-community/NUR/commit/dc55412bd2029d1b42b1bbf080a042434f9d1431) | `` automatic update `` |