### PR TITLE
chore(flake/home-manager): `44677a1c` -> `e3ad5108`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -352,11 +352,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715486357,
-        "narHash": "sha256-4pRuzsHZOW5W4CsXI9uhKtiJeQSUoe1d2M9mWU98HC4=",
+        "lastModified": 1715930644,
+        "narHash": "sha256-W9pyM3/vePxrffHtzlJI6lDS3seANQ+Nqp+i58O46LI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "44677a1c96810a8e8c4ffaeaad10c842402647c1",
+        "rev": "e3ad5108f54177e6520535768ddbf1e6af54b59d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`e3ad5108`](https://github.com/nix-community/home-manager/commit/e3ad5108f54177e6520535768ddbf1e6af54b59d) | `` espanso: remove `background` process type on Darwin `` |
| [`65b74b20`](https://github.com/nix-community/home-manager/commit/65b74b20450cd54fc6389b43ec7c7e6e58630370) | `` espanso: add n8henrie to maintainers ``                |