### PR TITLE
chore(flake/nur): `d70fd42c` -> `d573ea71`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715932485,
-        "narHash": "sha256-U8RVvWGqB9Boa4S/wcZ5q5doAk7kKj11JSG1HPbupe0=",
+        "lastModified": 1715985933,
+        "narHash": "sha256-5l90g+ORNuhuOJrsyeSY4R7RXYGQrWEKR/UsHjlXqyI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d70fd42cf07a72c58a60137cf15f6b5cfd68b71d",
+        "rev": "d573ea71f82e0355ed0074039ce4c1cf75631e5b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d573ea71`](https://github.com/nix-community/NUR/commit/d573ea71f82e0355ed0074039ce4c1cf75631e5b) | `` automatic update `` |
| [`e5fc0ebf`](https://github.com/nix-community/NUR/commit/e5fc0ebfa14ff1936e3c613bbe8bb93b6dacc59d) | `` automatic update `` |
| [`31ea80cf`](https://github.com/nix-community/NUR/commit/31ea80cf3f4da3ed081964a513508741aea3ed7d) | `` automatic update `` |
| [`f4537792`](https://github.com/nix-community/NUR/commit/f453779209035b6ae71ff7928f8e496a1f88af0a) | `` automatic update `` |
| [`7612bdeb`](https://github.com/nix-community/NUR/commit/7612bdeb4817ad336e583519e69977a9aafbf8cb) | `` automatic update `` |
| [`87ad7f7b`](https://github.com/nix-community/NUR/commit/87ad7f7b477e62c458c2d9ae72c6e5721c251d64) | `` automatic update `` |
| [`841a3483`](https://github.com/nix-community/NUR/commit/841a3483fb7f2f6392c9e4081fc29f995b9b3194) | `` automatic update `` |
| [`23708477`](https://github.com/nix-community/NUR/commit/237084770bd92df54e886a702017fbc8e0e5b488) | `` automatic update `` |
| [`6572df0e`](https://github.com/nix-community/NUR/commit/6572df0e6656b9f1f388c7051e070dc962d85993) | `` automatic update `` |
| [`cbe245e7`](https://github.com/nix-community/NUR/commit/cbe245e7ed40f92a6d40bb4a458f9003bbe612d7) | `` automatic update `` |
| [`1fc89eca`](https://github.com/nix-community/NUR/commit/1fc89eca191b0a6240a43a2e2bc46627b1593a30) | `` automatic update `` |