### PR TITLE
chore(flake/nur): `aef500be` -> `744085e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715996612,
-        "narHash": "sha256-6b1DmWlAdPIHn1hpGucWJUQ2rQE1WTBkPCPK45XnJu0=",
+        "lastModified": 1716004036,
+        "narHash": "sha256-oTBdN6v4ImHu+BgbDvNy+K/JPtuC2sRnwHAWIjXPYcM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aef500beb059946c57dba7c219e41eea723151c6",
+        "rev": "744085e561967f41dab4c2a033a5ae555d894dae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`744085e5`](https://github.com/nix-community/NUR/commit/744085e561967f41dab4c2a033a5ae555d894dae) | `` automatic update `` |
| [`22f497da`](https://github.com/nix-community/NUR/commit/22f497da633b49af8a5e73017a85aa43077d8788) | `` automatic update `` |