### PR TITLE
chore(flake/nur): `744085e5` -> `8809a29f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716004036,
-        "narHash": "sha256-oTBdN6v4ImHu+BgbDvNy+K/JPtuC2sRnwHAWIjXPYcM=",
+        "lastModified": 1716005514,
+        "narHash": "sha256-9WrBKsbcBVtMMnAD4PC+iwOSGtBCKxYUiuhCiVJZfMg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "744085e561967f41dab4c2a033a5ae555d894dae",
+        "rev": "8809a29f7f4fbfcf8d4c592bf9e321c84b6a8386",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8809a29f`](https://github.com/nix-community/NUR/commit/8809a29f7f4fbfcf8d4c592bf9e321c84b6a8386) | `` automatic update `` |