### PR TITLE
chore(flake/nur): `8809a29f` -> `1f023392`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716005514,
-        "narHash": "sha256-9WrBKsbcBVtMMnAD4PC+iwOSGtBCKxYUiuhCiVJZfMg=",
+        "lastModified": 1716010987,
+        "narHash": "sha256-DQKLJbOLcLVwQ+5/hgXmdUhXp4pW9aj+lEv3ruOHj9Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8809a29f7f4fbfcf8d4c592bf9e321c84b6a8386",
+        "rev": "1f0233926aeaeb95f84b5570444bbff180e10993",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1f023392`](https://github.com/nix-community/NUR/commit/1f0233926aeaeb95f84b5570444bbff180e10993) | `` automatic update `` |