### PR TITLE
chore(flake/nur): `1f023392` -> `4150894d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716010987,
-        "narHash": "sha256-DQKLJbOLcLVwQ+5/hgXmdUhXp4pW9aj+lEv3ruOHj9Q=",
+        "lastModified": 1716013865,
+        "narHash": "sha256-FmkoCFpYrHm+lhrEIFUBNfVE5gQlMSc7j3QNRqr992g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1f0233926aeaeb95f84b5570444bbff180e10993",
+        "rev": "4150894ddd65cb2ce7cb2d5ea279ff1bdfba9bb2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4150894d`](https://github.com/nix-community/NUR/commit/4150894ddd65cb2ce7cb2d5ea279ff1bdfba9bb2) | `` automatic update `` |