### PR TITLE
chore(flake/nur): `4150894d` -> `05ff803d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716013865,
-        "narHash": "sha256-FmkoCFpYrHm+lhrEIFUBNfVE5gQlMSc7j3QNRqr992g=",
+        "lastModified": 1716020069,
+        "narHash": "sha256-+gQcvZNHIEOrlVJ1W7PDisNfAITyZGgm6WMYvYFJ01U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4150894ddd65cb2ce7cb2d5ea279ff1bdfba9bb2",
+        "rev": "05ff803dd01ae3fd87c0b5c3dc3edd31ef0af991",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`05ff803d`](https://github.com/nix-community/NUR/commit/05ff803dd01ae3fd87c0b5c3dc3edd31ef0af991) | `` automatic update `` |