### PR TITLE
chore(flake/nur): `ab2caaea` -> `e01d0714`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716032834,
-        "narHash": "sha256-WmJ+d0QhtewAOiCfj+QQdhz7SrUCtc4diEAEoWxWZ5M=",
+        "lastModified": 1716037561,
+        "narHash": "sha256-nAFEi1U9ibHL/C4aRkU9nXjPdlORkvuYpMs5IvNk1+w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ab2caaeaf540bf1dd551db8adece2a12bc9a7d29",
+        "rev": "e01d0714dc39e95a5f8e28b5360c6957fc08ee68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e01d0714`](https://github.com/nix-community/NUR/commit/e01d0714dc39e95a5f8e28b5360c6957fc08ee68) | `` automatic update `` |
| [`ff7d6e17`](https://github.com/nix-community/NUR/commit/ff7d6e17aa66c9348dbc6f8cf644c582c94ebead) | `` automatic update `` |