### PR TITLE
chore(flake/nur): `e01d0714` -> `a0994b37`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716037561,
-        "narHash": "sha256-nAFEi1U9ibHL/C4aRkU9nXjPdlORkvuYpMs5IvNk1+w=",
+        "lastModified": 1716043533,
+        "narHash": "sha256-nVnv+Fr+TwehRDbbKLZRuls6zcCdhbumuh2TEYeCC/U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e01d0714dc39e95a5f8e28b5360c6957fc08ee68",
+        "rev": "a0994b379a309930565f13cafef0f7daa31420d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a0994b37`](https://github.com/nix-community/NUR/commit/a0994b379a309930565f13cafef0f7daa31420d5) | `` automatic update `` |
| [`d7c21409`](https://github.com/nix-community/NUR/commit/d7c21409bd6decb38133290e5963f347c5d374fb) | `` automatic update `` |