### PR TITLE
chore(flake/emacs-overlay): `9ddac5b5` -> `856376df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1716023158,
-        "narHash": "sha256-2HJyP1FP117po3+dFLvf0BzMatHCmmoQJHc7qD4UlT0=",
+        "lastModified": 1716046407,
+        "narHash": "sha256-Mw+coU/6wllvCfkKCiPyOEPIKH7/U1kYWcYMDQeOLwc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9ddac5b56467772b1962c71191de3e22b4d1fff6",
+        "rev": "856376dfa6837c22eb6100326a02640b7f9f84c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                       |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
| [`0b7067e4`](https://github.com/nix-community/emacs-overlay/commit/0b7067e48e2901ec91b3fa69bb45f7d5a8a7de96) | `` recipes-archive-melpa: fix more incorrect source hashes `` |
| [`95d1baf2`](https://github.com/nix-community/emacs-overlay/commit/95d1baf2d97bd7da291b0316fbe29d8f6671b02b) | `` recipes-archive-melpa: fix incorrect source hashes ``      |