### PR TITLE
chore(flake/nur): `a0994b37` -> `4d807208`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716043533,
-        "narHash": "sha256-nVnv+Fr+TwehRDbbKLZRuls6zcCdhbumuh2TEYeCC/U=",
+        "lastModified": 1716054324,
+        "narHash": "sha256-FGt2XYspJv0CE8V27LqfvExrdOSGKczgZnBQGKkxwbc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a0994b379a309930565f13cafef0f7daa31420d5",
+        "rev": "4d8072080991b96b6d36e21c596bf0d7affa7ff0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4d807208`](https://github.com/nix-community/NUR/commit/4d8072080991b96b6d36e21c596bf0d7affa7ff0) | `` automatic update `` |
| [`f4e21887`](https://github.com/nix-community/NUR/commit/f4e21887115370c490d24e27dfeccd9ec20ecdf8) | `` automatic update `` |
| [`fec22cee`](https://github.com/nix-community/NUR/commit/fec22cee49eb69327158cd6ce405f4b297457e9a) | `` automatic update `` |
| [`0634e610`](https://github.com/nix-community/NUR/commit/0634e610f75821dcdaf2308c44cc750f0dae1818) | `` automatic update `` |
| [`b3b144f7`](https://github.com/nix-community/NUR/commit/b3b144f7c1da0e52c33a4d63a532fc3758f03cc5) | `` automatic update `` |
| [`ffc8397e`](https://github.com/nix-community/NUR/commit/ffc8397ea175881ec5e4e33762bf503cc68e1e0e) | `` automatic update `` |
| [`1086d52b`](https://github.com/nix-community/NUR/commit/1086d52b940cbe561ea0cb48ef4907a3d39216b2) | `` automatic update `` |
| [`125d3286`](https://github.com/nix-community/NUR/commit/125d3286304295e251ba52d66b88884c5ec10185) | `` automatic update `` |