### PR TITLE
chore(flake/emacs-overlay): `bef180cf` -> `b54ed655`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1716049066,
-        "narHash": "sha256-108EZ/fheemHdsnfuaJ2ZJravQhh4DDPRRg6obEtLOs=",
+        "lastModified": 1716051926,
+        "narHash": "sha256-Jl1akEkm0SbDksx3geSxGpqMahJAHTWfV4Brp0Yf6GI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bef180cfb57fd1b1f1cbaea1cea0817dfef9710d",
+        "rev": "b54ed655e16db6d9b43b147f8e3b23cb704f1733",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`b54ed655`](https://github.com/nix-community/emacs-overlay/commit/b54ed655e16db6d9b43b147f8e3b23cb704f1733) | `` Updated emacs `` |