### PR TITLE
chore(flake/nur): `8165b42d` -> `4f8c4913`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716061511,
-        "narHash": "sha256-N9dunKteUYoAurnSoUdNGvlGwjAATf0/9w4ltuYc5Kw=",
+        "lastModified": 1716065255,
+        "narHash": "sha256-7xd2A1km/KEPUng8+8n+oDfOSm2T20k3WtcdkwpT4uI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8165b42de2bcfacff60797664f2d6d603fa5399e",
+        "rev": "4f8c4913ac36caae92883dcad0e8a0fd6774852c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4f8c4913`](https://github.com/nix-community/NUR/commit/4f8c4913ac36caae92883dcad0e8a0fd6774852c) | `` automatic update `` |