### PR TITLE
chore(flake/nur): `10afeaf3` -> `3b7597fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716068845,
-        "narHash": "sha256-L/72E+aG3+sfR63iptvDvIYQ46c7jgr/pr3q0zkOdfg=",
+        "lastModified": 1716072372,
+        "narHash": "sha256-Kvi+y8tDwjhhp+0rgF1jCAVKXYSJsWyFHsLMt6+DYiw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "10afeaf3d6fc7aa3e5cc241f59742961bf9db9c8",
+        "rev": "3b7597fbe7af84fe7c6051f64795249e7c17f775",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3b7597fb`](https://github.com/nix-community/NUR/commit/3b7597fbe7af84fe7c6051f64795249e7c17f775) | `` automatic update `` |