### PR TITLE
chore(flake/emacs-overlay): `b54ed655` -> `66d6cd21`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1716051926,
-        "narHash": "sha256-Jl1akEkm0SbDksx3geSxGpqMahJAHTWfV4Brp0Yf6GI=",
+        "lastModified": 1716083612,
+        "narHash": "sha256-/ZputM2bBZ1ADB1BJCGpemEmpeey3KYHLLd+MzhvGLo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b54ed655e16db6d9b43b147f8e3b23cb704f1733",
+        "rev": "66d6cd2197e49ce0fd42a4b896bd35c500fd1d15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`66d6cd21`](https://github.com/nix-community/emacs-overlay/commit/66d6cd2197e49ce0fd42a4b896bd35c500fd1d15) | `` Updated emacs ``        |
| [`aa7850d6`](https://github.com/nix-community/emacs-overlay/commit/aa7850d6fbbaf64a26c0c6be6931ac9b8c98b881) | `` Updated melpa ``        |
| [`bde229e6`](https://github.com/nix-community/emacs-overlay/commit/bde229e68fadd64f09386be9e21a7b748ad37d32) | `` Updated elpa ``         |
| [`b89d09e9`](https://github.com/nix-community/emacs-overlay/commit/b89d09e904b449fb6140c2f3e3dfc7af03749b3b) | `` Updated flake inputs `` |