### PR TITLE
chore(flake/nur): `4cbb2911` -> `aa16a673`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716082022,
-        "narHash": "sha256-yOrsm9D9TQq/1sJDvDxvwzZOnqDFlXYolmbFPwQzUt0=",
+        "lastModified": 1716097141,
+        "narHash": "sha256-9fO9WRbWBxZGLJrJey0J9cGFDCfrYDN07KjVyNCPVzk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4cbb29112a2ff1f914c826b74cea9c16c78f4024",
+        "rev": "aa16a6737b38c1a6eb9da2743152c10cee3011f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`aa16a673`](https://github.com/nix-community/NUR/commit/aa16a6737b38c1a6eb9da2743152c10cee3011f4) | `` automatic update `` |
| [`d85fa4a6`](https://github.com/nix-community/NUR/commit/d85fa4a6d52b9d40c5a90d91deb3f75cd1f2144a) | `` automatic update `` |
| [`8f7a0e5b`](https://github.com/nix-community/NUR/commit/8f7a0e5b12d637ae4d780fa8f46822f967a5c7ad) | `` automatic update `` |
| [`91a048fa`](https://github.com/nix-community/NUR/commit/91a048faf1d132f883fb396ae07884cc12905084) | `` automatic update `` |
| [`1b4f5402`](https://github.com/nix-community/NUR/commit/1b4f5402e713ce5367376d2d6cc60a0b7ebff867) | `` automatic update `` |
| [`0e2bec3c`](https://github.com/nix-community/NUR/commit/0e2bec3c3442b1c668cc6e27f5ae6d226443182e) | `` automatic update `` |