### PR TITLE
chore(flake/nur): `aa16a673` -> `31704a62`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716097141,
-        "narHash": "sha256-9fO9WRbWBxZGLJrJey0J9cGFDCfrYDN07KjVyNCPVzk=",
+        "lastModified": 1716101626,
+        "narHash": "sha256-NBX9cvZ7WVUcJvein+XMGK92QHEU+fM4Q3yF33QI118=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aa16a6737b38c1a6eb9da2743152c10cee3011f4",
+        "rev": "31704a62583daf17988c1c2167c2e08bcae2793d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`31704a62`](https://github.com/nix-community/NUR/commit/31704a62583daf17988c1c2167c2e08bcae2793d) | `` automatic update `` |