### PR TITLE
chore(flake/nur): `b13a458c` -> `e736aab4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716111915,
-        "narHash": "sha256-3LeFhKU17vEjmOULe/ZC8JHjXfsB4QwH1e42wVyxLTQ=",
+        "lastModified": 1716119149,
+        "narHash": "sha256-9PaMoyc7eyEnLSs6wkwqnKGBLfby3AILlvLOAG7oqgg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b13a458c1a1439c1ba817b6213a422793dddda9e",
+        "rev": "e736aab4ffc8abebd5b2b1b3ba44d1e1576595ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e736aab4`](https://github.com/nix-community/NUR/commit/e736aab4ffc8abebd5b2b1b3ba44d1e1576595ad) | `` automatic update `` |
| [`c8598a09`](https://github.com/nix-community/NUR/commit/c8598a0925ed8adb9fc8f0a7e7f9352dce191f98) | `` automatic update `` |