### PR TITLE
chore(flake/nur): `e736aab4` -> `adc79b33`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716119149,
-        "narHash": "sha256-9PaMoyc7eyEnLSs6wkwqnKGBLfby3AILlvLOAG7oqgg=",
+        "lastModified": 1716122862,
+        "narHash": "sha256-k1vKHFTLN+p/s7htb4RqZAiLs95H9catCT99a+VQYTQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e736aab4ffc8abebd5b2b1b3ba44d1e1576595ad",
+        "rev": "adc79b3367910db1052f69f6cf989e08e34e148c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`adc79b33`](https://github.com/nix-community/NUR/commit/adc79b3367910db1052f69f6cf989e08e34e148c) | `` automatic update `` |
| [`9291c551`](https://github.com/nix-community/NUR/commit/9291c551d7c9818ef3ef68694e79f7bffab7a0d9) | `` automatic update `` |