### PR TITLE
chore(flake/nur): `adc79b33` -> `1a4c14eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716122862,
-        "narHash": "sha256-k1vKHFTLN+p/s7htb4RqZAiLs95H9catCT99a+VQYTQ=",
+        "lastModified": 1716129264,
+        "narHash": "sha256-33MoCIDNt3oMVk2FtSVIek3/bQxjzYrGYvs/JXWdbyM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "adc79b3367910db1052f69f6cf989e08e34e148c",
+        "rev": "1a4c14eb3e4c0c025e0fe088e844bc12cfad8559",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1a4c14eb`](https://github.com/nix-community/NUR/commit/1a4c14eb3e4c0c025e0fe088e844bc12cfad8559) | `` automatic update `` |