### PR TITLE
chore(flake/emacs-overlay): `999b0485` -> `4e92dba0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1716109578,
-        "narHash": "sha256-6b6PG2h4p5KOGc/bFaet14kvrHaZ5kkI2fZRgdfiJX4=",
+        "lastModified": 1716135487,
+        "narHash": "sha256-2F2v3xuJJDEPebBaKBhTtVUbb0rBdLZLefXo/pJEsTQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "999b048552f496803b01c445834a9ef70410a5cb",
+        "rev": "4e92dba0291d4ee1804947e1cfeb46617e37df28",
         "type": "github"
       },
       "original": {
@@ -621,11 +621,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1715948915,
-        "narHash": "sha256-dxMrggEogQuJQr6f02VAFtsSNtjEPkgxczeiyW7WOQc=",
+        "lastModified": 1716061101,
+        "narHash": "sha256-H0eCta7ahEgloGIwE/ihkyGstOGu+kQwAiHvwVoXaA0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bacb8503d3a51d9e9b52e52a1ba45e2c380ad07d",
+        "rev": "e7cc61784ddf51c81487637b3031a6dd2d6673a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`4e92dba0`](https://github.com/nix-community/emacs-overlay/commit/4e92dba0291d4ee1804947e1cfeb46617e37df28) | `` Updated elpa ``         |
| [`c04b7ca8`](https://github.com/nix-community/emacs-overlay/commit/c04b7ca8b9b5be09acadfcba1bdd3db109ca4b6d) | `` Updated flake inputs `` |