### PR TITLE
chore(flake/emacs-overlay): `4e92dba0` -> `4f3236a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1716135487,
-        "narHash": "sha256-2F2v3xuJJDEPebBaKBhTtVUbb0rBdLZLefXo/pJEsTQ=",
+        "lastModified": 1716138357,
+        "narHash": "sha256-Bi1Y45KxiKoTjJ8/OxGXFrOJqZ6b4qOgnpt3VB0K8+g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4e92dba0291d4ee1804947e1cfeb46617e37df28",
+        "rev": "4f3236a5687ef4608205e15dee1d85b663b2a45e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`4f3236a5`](https://github.com/nix-community/emacs-overlay/commit/4f3236a5687ef4608205e15dee1d85b663b2a45e) | `` Updated emacs `` |