### PR TITLE
chore(flake/nixos-hardware): `b55712de` -> `f0cf5687`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -548,11 +548,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1716034089,
-        "narHash": "sha256-QBfab6V4TeQ6Y4NiXVrEATdQuhCNFNaXt/L1K/Zw+zc=",
+        "lastModified": 1716141623,
+        "narHash": "sha256-4NEvf7sULDyYoXIgeXHWGe7mXlr7+UL7TvgDkMqpbPY=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "b55712de78725c8fcde422ee0a0fe682046e73c3",
+        "rev": "f0cf56878046c42ec2096a2ade89203e7348917b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`f0cf5687`](https://github.com/NixOS/nixos-hardware/commit/f0cf56878046c42ec2096a2ade89203e7348917b) | `` common/gpu/intel: add extraPackages32 ``                 |
| [`e85c7a78`](https://github.com/NixOS/nixos-hardware/commit/e85c7a78d2657f852a931db3e782c4fab8196fb7) | `` lenovo/thinkpad/t14/amd/gen3: enable amd_pstate ``       |
| [`81f14570`](https://github.com/NixOS/nixos-hardware/commit/81f14570232388b80e62874b2a8153ee53362891) | `` lenovo/thinkpad/t14/amd/gen2: enable amd_pstate ``       |
| [`55f8e366`](https://github.com/NixOS/nixos-hardware/commit/55f8e366f032d46693014fb3c5813065a6262b8a) | `` lenovo/thinkpad/p14s/amd/gen2: enable amd_pstate ``      |
| [`2659a52d`](https://github.com/NixOS/nixos-hardware/commit/2659a52d7a87ff244de51ea9367ee28211a1cc64) | `` lenovo/thinkpad/t14/amd/gen4: init ``                    |
| [`0d3eafc0`](https://github.com/NixOS/nixos-hardware/commit/0d3eafc0142cf51f99c3aea671163d9b737d3f95) | `` lenovo/thinkpad/p14s/amd/gen4: init ``                   |
| [`79cb5c5d`](https://github.com/NixOS/nixos-hardware/commit/79cb5c5df64becdf420d02f6a34f8e405723382a) | `` lenovo/thinkpad/p14s/amd/gen3: init ``                   |
| [`d526edb7`](https://github.com/NixOS/nixos-hardware/commit/d526edb79b6581ce65ea36783c9552f53251ed0d) | `` lenovo/thinkpad/p14s/amd/gen1: init ``                   |
| [`050f52eb`](https://github.com/NixOS/nixos-hardware/commit/050f52eb558f041ec6cf0623a377d6036eb1dc4b) | `` lenovo/thinkpad/p14s: align with Thinkpad T14 configs `` |
| [`2a964239`](https://github.com/NixOS/nixos-hardware/commit/2a964239f6b6473a6ff28892109ebf39a6151b1c) | `` omen/14-fb0798ng: init ``                                |
| [`0a944f8c`](https://github.com/NixOS/nixos-hardware/commit/0a944f8c6840f63a7c289580d427e0c1cd3ec3af) | `` dell/precision/7520: init ``                             |
| [`6e7667c7`](https://github.com/NixOS/nixos-hardware/commit/6e7667c75d01801f1206f5338c4d5b978f92c027) | `` Add hardware config for lenovo t5 26amr5 (#938) ``       |
| [`557645a9`](https://github.com/NixOS/nixos-hardware/commit/557645a9dacee8524ec5e43b7f381b5299818495) | `` fixup! zenpower flake ``                                 |
| [`9fe6b53c`](https://github.com/NixOS/nixos-hardware/commit/9fe6b53cf0bb777cc22b922a10035311d0e1a23b) | `` cpu/amd/zenpower: new ``                                 |