### PR TITLE
chore(flake/nur): `1a4c14eb` -> `49682cc1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716129264,
-        "narHash": "sha256-33MoCIDNt3oMVk2FtSVIek3/bQxjzYrGYvs/JXWdbyM=",
+        "lastModified": 1716140745,
+        "narHash": "sha256-ybXfvdAggMnp/X+pj8jT7C5aQ6AtL/pA9sJA/ZzAg7E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1a4c14eb3e4c0c025e0fe088e844bc12cfad8559",
+        "rev": "49682cc18a65cd7a7e0081e9a1464b11655d4d15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`49682cc1`](https://github.com/nix-community/NUR/commit/49682cc18a65cd7a7e0081e9a1464b11655d4d15) | `` automatic update `` |