### PR TITLE
chore(flake/nur): `49682cc1` -> `118dbdd0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716140745,
-        "narHash": "sha256-ybXfvdAggMnp/X+pj8jT7C5aQ6AtL/pA9sJA/ZzAg7E=",
+        "lastModified": 1716147533,
+        "narHash": "sha256-mlI2D/57S/Vd7zcu0ZAApl53Jk/z5z3mUcRxhp/ANAw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "49682cc18a65cd7a7e0081e9a1464b11655d4d15",
+        "rev": "118dbdd0833cabd588b3c13f5407b5a86458924d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`118dbdd0`](https://github.com/nix-community/NUR/commit/118dbdd0833cabd588b3c13f5407b5a86458924d) | `` automatic update `` |
| [`8e9e4825`](https://github.com/nix-community/NUR/commit/8e9e4825a9af16058c404817de04c34f95779c1f) | `` automatic update `` |
| [`1b148cbf`](https://github.com/nix-community/NUR/commit/1b148cbfd5e748c5ef6a3415a9e51418db24fa0a) | `` automatic update `` |
| [`2f6871f5`](https://github.com/nix-community/NUR/commit/2f6871f58c2be9a7329aae788ecf9897a2988271) | `` automatic update `` |