### PR TITLE
chore(flake/nur): `aa271fda` -> `2117505a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716151529,
-        "narHash": "sha256-Bji4IZ8VAq/aU5eSpxyrGbhRsXXmrQo9SnDZStnqJZU=",
+        "lastModified": 1716156347,
+        "narHash": "sha256-odtsBkVYnhb8KbFP+zpUaZnWzlQKoIRFQp4BffstqS0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aa271fda6285f1bc2108000610cc764140714d27",
+        "rev": "2117505a79a460df4568790e26ea1a0a4ba352f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2117505a`](https://github.com/nix-community/NUR/commit/2117505a79a460df4568790e26ea1a0a4ba352f4) | `` automatic update `` |
| [`434a49f8`](https://github.com/nix-community/NUR/commit/434a49f8736ccc9d108a6d3c34f2650bf15a3fe0) | `` automatic update `` |