### PR TITLE
chore(flake/nur): `2117505a` -> `f2af7309`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716156347,
-        "narHash": "sha256-odtsBkVYnhb8KbFP+zpUaZnWzlQKoIRFQp4BffstqS0=",
+        "lastModified": 1716177927,
+        "narHash": "sha256-E4RcAhpz7BLe+U4xf98n9mqWN3/Ipzn/4gw08eUiSpY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2117505a79a460df4568790e26ea1a0a4ba352f4",
+        "rev": "f2af73098c2630ce26f3ab97e95e295ea69ee0c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f2af7309`](https://github.com/nix-community/NUR/commit/f2af73098c2630ce26f3ab97e95e295ea69ee0c5) | `` automatic update `` |
| [`961f5b10`](https://github.com/nix-community/NUR/commit/961f5b10dbbd5b149d2958b6eca6549fc90989e1) | `` automatic update `` |
| [`ef752955`](https://github.com/nix-community/NUR/commit/ef75295563fe1719df7e8902d80fb57dbdd0507a) | `` automatic update `` |
| [`e47b087d`](https://github.com/nix-community/NUR/commit/e47b087de336c6d486ec36014c430be541675cdf) | `` automatic update `` |
| [`2ef3e2f0`](https://github.com/nix-community/NUR/commit/2ef3e2f06d4c260015dbd2d34fc2ae048110b684) | `` automatic update `` |
| [`4d86a205`](https://github.com/nix-community/NUR/commit/4d86a205b129ddf1ff0fd0dd77cda60abfa8d4d4) | `` automatic update `` |