### PR TITLE
chore(flake/srvos): `7a140951` -> `d368bfdc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -871,11 +871,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715820823,
-        "narHash": "sha256-KN9uvEjgzUA0trQdnnpeJEPA/UhpMlwXexJyiyqkH78=",
+        "lastModified": 1716166358,
+        "narHash": "sha256-SmCc4nKUXgYb8bBGJ3+N+l/2MBROue2x9+CyJ2of24w=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "7a140951a5b5db5c05d359ccd53c3f7bd06f317b",
+        "rev": "d368bfdc3a409482b92290a105bcacc108a49d24",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`d368bfdc`](https://github.com/nix-community/srvos/commit/d368bfdc3a409482b92290a105bcacc108a49d24) | `` dev/private/flake.lock: Update `` |
| [`8cbff7b8`](https://github.com/nix-community/srvos/commit/8cbff7b8d83c58bfbc4cffff1c6289f6ce9c55c7) | `` flake.lock: Update ``             |