### PR TITLE
chore(flake/emacs-overlay): `d9480cbd` -> `aa8ac9a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1716166919,
-        "narHash": "sha256-l/6O5b5MEOKgV67fwHqg+rPFccplL1MZ1H7m30Sh1wI=",
+        "lastModified": 1716169020,
+        "narHash": "sha256-hkeDsZJS+WkAqWJFzmOaNzK0qoa2afozX5HGD+uuxos=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d9480cbdf6bd8313a09fb498779f8062a0739548",
+        "rev": "aa8ac9a29c08356bd9285f66b18dd49631cc2227",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`aa8ac9a2`](https://github.com/nix-community/emacs-overlay/commit/aa8ac9a29c08356bd9285f66b18dd49631cc2227) | `` Updated melpa `` |