### PR TITLE
chore(flake/nur): `f2af7309` -> `ebd54634`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716177927,
-        "narHash": "sha256-E4RcAhpz7BLe+U4xf98n9mqWN3/Ipzn/4gw08eUiSpY=",
+        "lastModified": 1716183940,
+        "narHash": "sha256-UhNCJCBswfypT4/SBZzTHP3cAMjfliFnDo+wqprHpRA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f2af73098c2630ce26f3ab97e95e295ea69ee0c5",
+        "rev": "ebd54634296d6930c1438f2569368111525e466b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ebd54634`](https://github.com/nix-community/NUR/commit/ebd54634296d6930c1438f2569368111525e466b) | `` automatic update `` |
| [`181756fa`](https://github.com/nix-community/NUR/commit/181756fac2a247b7f9e5707e58ed6d7dc86267b5) | `` automatic update `` |