### PR TITLE
chore(flake/nur): `ebd54634` -> `668c153c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716183940,
-        "narHash": "sha256-UhNCJCBswfypT4/SBZzTHP3cAMjfliFnDo+wqprHpRA=",
+        "lastModified": 1716189812,
+        "narHash": "sha256-o0LPBacQxIsOemRQ99UnZ8oURyhRGS5q4Ykyy5pxWcw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ebd54634296d6930c1438f2569368111525e466b",
+        "rev": "668c153c004feda29e5af5875de0c7f2a1e4c8b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                            |
| -------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`668c153c`](https://github.com/nix-community/NUR/commit/668c153c004feda29e5af5875de0c7f2a1e4c8b6) | `` Bump cachix/install-nix-action from 26 to 27 `` |
| [`96e33e0c`](https://github.com/nix-community/NUR/commit/96e33e0ced8b33d74458c9728ea5cfe0c52740c8) | `` automatic update ``                             |
| [`5804575c`](https://github.com/nix-community/NUR/commit/5804575c597063deacd8de82cd45dd57c07d2e5c) | `` automatic update ``                             |