### PR TITLE
chore(flake/nur): `668c153c` -> `8af28f3d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716189812,
-        "narHash": "sha256-o0LPBacQxIsOemRQ99UnZ8oURyhRGS5q4Ykyy5pxWcw=",
+        "lastModified": 1716192985,
+        "narHash": "sha256-UHUsp79I9VMXvv5HIJxyoi3OBBAE6i/N+LdaOrwcF6s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "668c153c004feda29e5af5875de0c7f2a1e4c8b6",
+        "rev": "8af28f3dbe63e2fd0df3dec6dc4d30dff12b06b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8af28f3d`](https://github.com/nix-community/NUR/commit/8af28f3dbe63e2fd0df3dec6dc4d30dff12b06b8) | `` automatic update `` |