### PR TITLE
chore(flake/nur): `8af28f3d` -> `6ecb7914`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716192985,
-        "narHash": "sha256-UHUsp79I9VMXvv5HIJxyoi3OBBAE6i/N+LdaOrwcF6s=",
+        "lastModified": 1716210038,
+        "narHash": "sha256-tqsTAqDyoRpDQSH6yt1T1iPO6IAOAKqhV3nZt+9BQvw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8af28f3dbe63e2fd0df3dec6dc4d30dff12b06b8",
+        "rev": "6ecb79140ec75fea1a8303b615f848afcddc3d21",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6ecb7914`](https://github.com/nix-community/NUR/commit/6ecb79140ec75fea1a8303b615f848afcddc3d21) | `` automatic update `` |
| [`80015725`](https://github.com/nix-community/NUR/commit/80015725a42bd85970d56003b9ba2bf2aea52145) | `` automatic update `` |
| [`0b04f7a3`](https://github.com/nix-community/NUR/commit/0b04f7a324ed8e6a864f4b801c5715eed2b89d41) | `` automatic update `` |
| [`6fe01ee4`](https://github.com/nix-community/NUR/commit/6fe01ee4961c6597c10e5ed963ee6bf287d57db1) | `` automatic update `` |
| [`884451b8`](https://github.com/nix-community/NUR/commit/884451b869f9b0c64bb4e39a6a600d1fc32ae78b) | `` automatic update `` |
| [`6b292ec2`](https://github.com/nix-community/NUR/commit/6b292ec2872015f38b1db008e11c7c760f5b94ed) | `` automatic update `` |