### PR TITLE
chore(flake/nur): `6ecb7914` -> `44592939`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716210038,
-        "narHash": "sha256-tqsTAqDyoRpDQSH6yt1T1iPO6IAOAKqhV3nZt+9BQvw=",
+        "lastModified": 1716213549,
+        "narHash": "sha256-giSTYuYUN0Dwy8Hq+X8sgVwYnVytJ0sJ5nm7esiGBYI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6ecb79140ec75fea1a8303b615f848afcddc3d21",
+        "rev": "44592939c02f7586be235019c5e21736446bb7e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`44592939`](https://github.com/nix-community/NUR/commit/44592939c02f7586be235019c5e21736446bb7e7) | `` automatic update `` |
| [`2ca55416`](https://github.com/nix-community/NUR/commit/2ca55416c1049c74b2eddfab5f1ae8ae5f12ab66) | `` automatic update `` |
| [`3934cfd6`](https://github.com/nix-community/NUR/commit/3934cfd60c96003b4f4e45ab51be331f872d8a07) | `` automatic update `` |