### PR TITLE
chore(flake/nur): `0cbfc31a` -> `e3ee7597`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716214879,
-        "narHash": "sha256-fDDs/Ulc+j9ZWhROdJ1rHId8437FU83pGIpONGPkBmQ=",
+        "lastModified": 1716220421,
+        "narHash": "sha256-zNQ0jLibJ8lstx22APPw21K+0jrxTOA3GTpb8qGTaCQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0cbfc31af516ec8321cd569e4216cc22771c1119",
+        "rev": "e3ee7597c9291e6eeab293ef25cd8591207f4c1c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e3ee7597`](https://github.com/nix-community/NUR/commit/e3ee7597c9291e6eeab293ef25cd8591207f4c1c) | `` automatic update `` |
| [`0668d103`](https://github.com/nix-community/NUR/commit/0668d10321d6a627a85b7b3db9469a38a24d5461) | `` automatic update `` |
| [`81e6f41a`](https://github.com/nix-community/NUR/commit/81e6f41a5d458d38354fea47c97fbd9a4525b0b7) | `` automatic update `` |