### PR TITLE
chore(flake/srvos): `d368bfdc` -> `c8022a61`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -871,11 +871,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716166358,
-        "narHash": "sha256-SmCc4nKUXgYb8bBGJ3+N+l/2MBROue2x9+CyJ2of24w=",
+        "lastModified": 1716233075,
+        "narHash": "sha256-XG+BujRzINjMEPg8FevP2UnFgT4UyTaOEZq/d2r9LYQ=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "d368bfdc3a409482b92290a105bcacc108a49d24",
+        "rev": "c8022a61950cb41db586ab4ae7079b68cbc18fff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message   |
| ---------------------------------------------------------------------------------------------------- | --------- |
| [`c8022a61`](https://github.com/nix-community/srvos/commit/c8022a61950cb41db586ab4ae7079b68cbc18fff) | `` --- `` |