### PR TITLE
chore(flake/sops-nix): `0bf1808e` -> `fddd5246`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1716087663,
-        "narHash": "sha256-zuSAGlx8Qk0OILGCC2GUyZ58/SJ5R3GZdeUNQ6IS0fQ=",
+        "lastModified": 1716244104,
+        "narHash": "sha256-XXbqfkyWe0d0O+zqRQWi2oXi6wYDmTzXedFkBRwx1VI=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "0bf1808e70ce80046b0cff821c019df2b19aabf5",
+        "rev": "fddd52460e3332eedd8a0043af5675338a5b3e0b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message   |
| ----------------------------------------------------------------------------------------------- | --------- |
| [`fddd5246`](https://github.com/Mic92/sops-nix/commit/fddd52460e3332eedd8a0043af5675338a5b3e0b) | `` --- `` |