### PR TITLE
chore(flake/catppuccin): `d6344610` -> `9999d33b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1715659881,
-        "narHash": "sha256-emodPGTXLVqlcOkqbJiOUkf5vo8WWujgzKxms1B+iBs=",
+        "lastModified": 1716250107,
+        "narHash": "sha256-F6ivCjEi0QLodnznKkA0XQ1uiFG/04AJM03FmlZMta4=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "d6344610c04af0f8e315fef45dd3b854014b119e",
+        "rev": "9999d33b51988644c9cdddc58f317689b3974fbe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                       |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`9999d33b`](https://github.com/catppuccin/nix/commit/9999d33b51988644c9cdddc58f317689b3974fbe) | `` ci: bump cachix/install-nix-action from 26 to 27 (#180) `` |
| [`65fdb6ab`](https://github.com/catppuccin/nix/commit/65fdb6ab77a38bd8ca8942b6ed516056158fdd61) | `` chore: update lockfiles (#174) ``                          |