### PR TITLE
chore(flake/emacs-overlay): `cc961816` -> `00193d83`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1716221841,
-        "narHash": "sha256-GNuANwhv2dPYpyjau88x1zkI3/m9Sg2k4/no1O3NETI=",
+        "lastModified": 1716256173,
+        "narHash": "sha256-aJo8V/pEvCiF0Cu+PLPnK0FU63yNAELwSiClnaj3swc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cc961816f69f9d3b4a0a62e8f56dd6bfd6f6c69b",
+        "rev": "00193d839cb752bccc8f6508e54afd2dab60c7c9",
         "type": "github"
       },
       "original": {
@@ -621,11 +621,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1716061101,
-        "narHash": "sha256-H0eCta7ahEgloGIwE/ihkyGstOGu+kQwAiHvwVoXaA0=",
+        "lastModified": 1716218643,
+        "narHash": "sha256-i/E7gzQybvcGAYDRGDl39WL6yVk30Je/NXypBz6/nmM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e7cc61784ddf51c81487637b3031a6dd2d6673a2",
+        "rev": "a8695cbd09a7ecf3376bd62c798b9864d20f86ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`00193d83`](https://github.com/nix-community/emacs-overlay/commit/00193d839cb752bccc8f6508e54afd2dab60c7c9) | `` Updated emacs ``        |
| [`a47befd9`](https://github.com/nix-community/emacs-overlay/commit/a47befd90c6409d2286c9d5d06d6b482814fceaa) | `` Updated melpa ``        |
| [`929636d0`](https://github.com/nix-community/emacs-overlay/commit/929636d0a71c563603786ef642d1efd1c0e6bf83) | `` Updated elpa ``         |
| [`aecc8d6e`](https://github.com/nix-community/emacs-overlay/commit/aecc8d6e8be6afc6c8a47ae43652705d89c49390) | `` Updated flake inputs `` |