### PR TITLE
chore(flake/nur): `a4573c89` -> `3c998241`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716248758,
-        "narHash": "sha256-AMs40Hpz8jByUdDOtAOOWFGpMssxy9vaRKedzN64izg=",
+        "lastModified": 1716254260,
+        "narHash": "sha256-xirSAEHjy2pgVtItAhYhNpIFCn6v+bW3ANiIdWFx+pQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a4573c892e0675a7177187d2a393938f5b5dc094",
+        "rev": "3c9982418c784acc563b1a0d233552247a5418a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3c998241`](https://github.com/nix-community/NUR/commit/3c9982418c784acc563b1a0d233552247a5418a7) | `` automatic update `` |
| [`ae906b69`](https://github.com/nix-community/NUR/commit/ae906b69098f2c8962ba1025fa7a00d654ded9c2) | `` automatic update `` |
| [`64d2881d`](https://github.com/nix-community/NUR/commit/64d2881db0f0dcf1c3ec08dae1e3c47879ec0dc9) | `` automatic update `` |