### PR TITLE
chore(flake/nur): `3c998241` -> `6e96a655`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716254260,
-        "narHash": "sha256-xirSAEHjy2pgVtItAhYhNpIFCn6v+bW3ANiIdWFx+pQ=",
+        "lastModified": 1716256639,
+        "narHash": "sha256-y3ltagFY05wN4WCvIlthBlmVhEk5Z6sG9tdc6Q2fT9Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3c9982418c784acc563b1a0d233552247a5418a7",
+        "rev": "6e96a6552babd35cd0bdcc180c6e5e82c8844990",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6e96a655`](https://github.com/nix-community/NUR/commit/6e96a6552babd35cd0bdcc180c6e5e82c8844990) | `` automatic update `` |
| [`024f1593`](https://github.com/nix-community/NUR/commit/024f15937b637a36d936a5d6979f9428d39cb7b2) | `` automatic update `` |
| [`1856898e`](https://github.com/nix-community/NUR/commit/1856898edac33d76063dba6f568e6b9d46fca978) | `` automatic update `` |
| [`ca0ada09`](https://github.com/nix-community/NUR/commit/ca0ada0919d65efc5bf5d3a8ac1b4f7affd7e28b) | `` automatic update `` |