### PR TITLE
chore(flake/nur): `6e96a655` -> `52bf7cee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716256639,
-        "narHash": "sha256-y3ltagFY05wN4WCvIlthBlmVhEk5Z6sG9tdc6Q2fT9Q=",
+        "lastModified": 1716263270,
+        "narHash": "sha256-P3cncuKfyLXMVG9dxZqLKN/GxmoacS4pHNFQeyBJ0Sg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6e96a6552babd35cd0bdcc180c6e5e82c8844990",
+        "rev": "52bf7cee94482ff80e209e5c8ed1c14109890895",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`52bf7cee`](https://github.com/nix-community/NUR/commit/52bf7cee94482ff80e209e5c8ed1c14109890895) | `` automatic update `` |
| [`4f23ae08`](https://github.com/nix-community/NUR/commit/4f23ae08dd7d37eda3693714ff52fb6bfb84114b) | `` automatic update `` |
| [`b993dc4a`](https://github.com/nix-community/NUR/commit/b993dc4a34e782b97722da4607d34a1d6faf2b19) | `` automatic update `` |