### PR TITLE
chore(flake/catppuccin): `9999d33b` -> `57e8376f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1716250107,
-        "narHash": "sha256-F6ivCjEi0QLodnznKkA0XQ1uiFG/04AJM03FmlZMta4=",
+        "lastModified": 1716276506,
+        "narHash": "sha256-OjdP5uPgdRA79vy45V0O2HdK4ztbSZ6aHcvikjjPFKU=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "9999d33b51988644c9cdddc58f317689b3974fbe",
+        "rev": "57e8376fdb3514fb4c4eae432e6dfa4137f1a260",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                    |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`57e8376f`](https://github.com/catppuccin/nix/commit/57e8376fdb3514fb4c4eae432e6dfa4137f1a260) | `` docs: update for 8179a45 ``                                             |
| [`8179a45f`](https://github.com/catppuccin/nix/commit/8179a45f64c7448185eddcacaa81dce080cc45c2) | `` fix(modules): shorten defaultText for `catppuccin.sources` (#185) ``    |
| [`aef56729`](https://github.com/catppuccin/nix/commit/aef567291242b03e141ba68375c2ff75ea8ff676) | `` feat(modules): support nixos & home-manager's stable branches (#182) `` |
| [`45965e11`](https://github.com/catppuccin/nix/commit/45965e113f4dc63d6ff903ef08fc5ec410b963e3) | `` ci: publish to flake registries on tag (#183) ``                        |
| [`6f9cb485`](https://github.com/catppuccin/nix/commit/6f9cb48525c4f198a5d5c6436f567111c9faa9d5) | `` ci: only run on prs that change nix files (#184) ``                     |
| [`63b90f74`](https://github.com/catppuccin/nix/commit/63b90f74b0bac2c582bfc5ca5ca86e03fa858267) | `` docs: update for 1f19ce7 ``                                             |
| [`1f19ce7a`](https://github.com/catppuccin/nix/commit/1f19ce7a912dd22f038ba3103c2c0615c330f577) | `` fix(home-manager): remove xdg.enable assertions (#181) ``               |