### PR TITLE
chore(flake/nur): `52bf7cee` -> `7407c98e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716263270,
-        "narHash": "sha256-P3cncuKfyLXMVG9dxZqLKN/GxmoacS4pHNFQeyBJ0Sg=",
+        "lastModified": 1716266758,
+        "narHash": "sha256-708pV80xNVjWSY/jTfEWFJn27c9oWaYQJijwghSCIyw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "52bf7cee94482ff80e209e5c8ed1c14109890895",
+        "rev": "7407c98e38d876ae74b78e0e353b017a81703c1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7407c98e`](https://github.com/nix-community/NUR/commit/7407c98e38d876ae74b78e0e353b017a81703c1f) | `` automatic update `` |
| [`d96b5e96`](https://github.com/nix-community/NUR/commit/d96b5e96adeaa29b17b947872a4dcb787018d5dc) | `` automatic update `` |
| [`12ba9915`](https://github.com/nix-community/NUR/commit/12ba991558837436d53b88d26bffbc1a182eb534) | `` automatic update `` |
| [`414d9486`](https://github.com/nix-community/NUR/commit/414d94861d3d125059a103c0060a4e53567b1a13) | `` automatic update `` |
| [`fc8c0677`](https://github.com/nix-community/NUR/commit/fc8c0677601eb068131c5f8182bbc5d0da187af5) | `` automatic update `` |