### PR TITLE
chore(flake/nur): `7407c98e` -> `0c730b37`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716266758,
-        "narHash": "sha256-708pV80xNVjWSY/jTfEWFJn27c9oWaYQJijwghSCIyw=",
+        "lastModified": 1716272836,
+        "narHash": "sha256-zcSBq9Zunyo4yVoHhUaU74uu8pNO0NDdctVH7XHKFsg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7407c98e38d876ae74b78e0e353b017a81703c1f",
+        "rev": "0c730b3799d45fe7966a830157a274a9792f9708",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0c730b37`](https://github.com/nix-community/NUR/commit/0c730b3799d45fe7966a830157a274a9792f9708) | `` automatic update `` |
| [`32c47df0`](https://github.com/nix-community/NUR/commit/32c47df0637319f1e976828bfdd3dd7d67064104) | `` automatic update `` |
| [`af87873f`](https://github.com/nix-community/NUR/commit/af87873f99392f127f45f7f1aa50220ceecb3491) | `` automatic update `` |