### PR TITLE
chore(flake/nur): `0c730b37` -> `a8dcf122`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716272836,
-        "narHash": "sha256-zcSBq9Zunyo4yVoHhUaU74uu8pNO0NDdctVH7XHKFsg=",
+        "lastModified": 1716276947,
+        "narHash": "sha256-/WrEPe+GAw3MlNzWsIt4wIntHTjh5Q+PEghzRWCGLao=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0c730b3799d45fe7966a830157a274a9792f9708",
+        "rev": "a8dcf122b0f37f4d816742d287394499dc85272e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a8dcf122`](https://github.com/nix-community/NUR/commit/a8dcf122b0f37f4d816742d287394499dc85272e) | `` automatic update `` |
| [`48c9e975`](https://github.com/nix-community/NUR/commit/48c9e975691c029ed2d4102801dba8b7c3458161) | `` automatic update `` |