### PR TITLE
chore(flake/nur): `a8dcf122` -> `5d9d198c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716276947,
-        "narHash": "sha256-/WrEPe+GAw3MlNzWsIt4wIntHTjh5Q+PEghzRWCGLao=",
+        "lastModified": 1716284797,
+        "narHash": "sha256-yiji8P3j6niWV9GqXlVLI9O7KjtG5jlEQryBRVWKYLw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a8dcf122b0f37f4d816742d287394499dc85272e",
+        "rev": "5d9d198c62e6c690ecff0db80a53d562e14b6bd7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5d9d198c`](https://github.com/nix-community/NUR/commit/5d9d198c62e6c690ecff0db80a53d562e14b6bd7) | `` automatic update `` |