### PR TITLE
chore(flake/nur): `5d9d198c` -> `6999ce1f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716284797,
-        "narHash": "sha256-yiji8P3j6niWV9GqXlVLI9O7KjtG5jlEQryBRVWKYLw=",
+        "lastModified": 1716288499,
+        "narHash": "sha256-tM7PAmC3kvyeDmglI0bHXSqyVbtnjzVPc4NmwP/GaK8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5d9d198c62e6c690ecff0db80a53d562e14b6bd7",
+        "rev": "6999ce1f23a503fd6aaefd875db6b7c0ab7d3637",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6999ce1f`](https://github.com/nix-community/NUR/commit/6999ce1f23a503fd6aaefd875db6b7c0ab7d3637) | `` automatic update `` |