### PR TITLE
chore(flake/nur): `6999ce1f` -> `484daf84`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716288499,
-        "narHash": "sha256-tM7PAmC3kvyeDmglI0bHXSqyVbtnjzVPc4NmwP/GaK8=",
+        "lastModified": 1716292849,
+        "narHash": "sha256-Q4aw+tAvQAtLn6sKRStX00t4xcX/gbkG3SE42H4qllY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6999ce1f23a503fd6aaefd875db6b7c0ab7d3637",
+        "rev": "484daf8404400c71c48f3e0745e520a097be7ff6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`484daf84`](https://github.com/nix-community/NUR/commit/484daf8404400c71c48f3e0745e520a097be7ff6) | `` automatic update `` |
| [`32b785cd`](https://github.com/nix-community/NUR/commit/32b785cd6216bcb3c2dc6ecb093eaeafc08a694f) | `` automatic update `` |