### PR TITLE
chore(flake/emacs-overlay): `00193d83` -> `04c759ff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1716256173,
-        "narHash": "sha256-aJo8V/pEvCiF0Cu+PLPnK0FU63yNAELwSiClnaj3swc=",
+        "lastModified": 1716311169,
+        "narHash": "sha256-hCt9zCXnuvra2X0+fQiejAfpr6nNdR1hSfl63UxmVbM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "00193d839cb752bccc8f6508e54afd2dab60c7c9",
+        "rev": "04c759ffb7af09dbce3c9068c4da7f2f0343da89",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`04c759ff`](https://github.com/nix-community/emacs-overlay/commit/04c759ffb7af09dbce3c9068c4da7f2f0343da89) | `` Updated emacs `` |
| [`856bc088`](https://github.com/nix-community/emacs-overlay/commit/856bc088accbf65128f5c6f9cb09cdfd2e28a13c) | `` Updated melpa `` |
| [`9a5071e5`](https://github.com/nix-community/emacs-overlay/commit/9a5071e5f8a4ab04787c19dc09b895b9b8e8c30d) | `` Updated elpa ``  |