### PR TITLE
chore(flake/nur): `4e9b630d` -> `a75e9a17`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716302211,
-        "narHash": "sha256-n4E22rDCv73/4mV2X2YdYnVkPujHCKk2ycBZLaQYFbA=",
+        "lastModified": 1716310310,
+        "narHash": "sha256-xhjPzg3krcJ/XCYfwflEN9irvSUj0aj9joi2gvICh+Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4e9b630d2e016099a359688e826b14eb002fae8f",
+        "rev": "a75e9a17b0aec717b1a8e033b6825fc6f1152bb5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a75e9a17`](https://github.com/nix-community/NUR/commit/a75e9a17b0aec717b1a8e033b6825fc6f1152bb5) | `` automatic update `` |
| [`40523168`](https://github.com/nix-community/NUR/commit/40523168c2b12693a0d80d70fc96551e58cc0c2d) | `` automatic update `` |