### PR TITLE
chore(flake/nur): `a75e9a17` -> `2e405be3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716310310,
-        "narHash": "sha256-xhjPzg3krcJ/XCYfwflEN9irvSUj0aj9joi2gvICh+Y=",
+        "lastModified": 1716314331,
+        "narHash": "sha256-+8SgZ2Uj6dMmNNNFEfrirJbB0L8yUdcUkN83mIrGmHE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a75e9a17b0aec717b1a8e033b6825fc6f1152bb5",
+        "rev": "2e405be3cc3fb5883a51bd82869986d0e7f1d9cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2e405be3`](https://github.com/nix-community/NUR/commit/2e405be3cc3fb5883a51bd82869986d0e7f1d9cf) | `` automatic update `` |