### PR TITLE
chore(flake/nur): `2e405be3` -> `e0236ab8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716314331,
-        "narHash": "sha256-+8SgZ2Uj6dMmNNNFEfrirJbB0L8yUdcUkN83mIrGmHE=",
+        "lastModified": 1716320222,
+        "narHash": "sha256-0HJp9kEUlXwBllRohTufguC41YP4KdMUPHQtU1unDbw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2e405be3cc3fb5883a51bd82869986d0e7f1d9cf",
+        "rev": "e0236ab8bf7d1b6cfbe3cb9e54e05d335ab548d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e0236ab8`](https://github.com/nix-community/NUR/commit/e0236ab8bf7d1b6cfbe3cb9e54e05d335ab548d1) | `` automatic update `` |
| [`83bfd9ae`](https://github.com/nix-community/NUR/commit/83bfd9ae2490c05fac7381100a13211cd27c3109) | `` automatic update `` |
| [`e87f34df`](https://github.com/nix-community/NUR/commit/e87f34df3bbfa64d58a2ea0a6f4a6174b6256744) | `` automatic update `` |