### PR TITLE
chore(flake/nur): `e0236ab8` -> `22090077`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716320222,
-        "narHash": "sha256-0HJp9kEUlXwBllRohTufguC41YP4KdMUPHQtU1unDbw=",
+        "lastModified": 1716343711,
+        "narHash": "sha256-P/k+P4iMVFGuBocGAsXoJFURratEoeOqwqPom+dcPos=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e0236ab8bf7d1b6cfbe3cb9e54e05d335ab548d1",
+        "rev": "2209007770c4ba531322ca899717b8de05f5fa21",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`22090077`](https://github.com/nix-community/NUR/commit/2209007770c4ba531322ca899717b8de05f5fa21) | `` automatic update `` |
| [`9346797c`](https://github.com/nix-community/NUR/commit/9346797c253724ee4bc7f7a0a26867dfcc0f948a) | `` automatic update `` |
| [`8c638792`](https://github.com/nix-community/NUR/commit/8c6387929efaf99a5b44ec704503f65983880a9c) | `` automatic update `` |
| [`836ed1eb`](https://github.com/nix-community/NUR/commit/836ed1eb1d8c7f69874c09003f3f482664cb4dad) | `` automatic update `` |
| [`26c7ac1a`](https://github.com/nix-community/NUR/commit/26c7ac1a5959bd14fe782c88d576d69a146cf7b7) | `` automatic update `` |