### PR TITLE
chore(flake/catppuccin): `1f11b0ae` -> `5e1a6796`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1716325071,
-        "narHash": "sha256-8Af4YMLRB4ca+fKPFB+R6eB9xQrlAl+UJesOsFJuj2s=",
+        "lastModified": 1716328426,
+        "narHash": "sha256-v5JjJkr1XtQfA/8JOCpLXnhpu5OOeTeA2LPFLbXpQS8=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "1f11b0aeb0a321e427f491aa2c5270daf0b13c1f",
+        "rev": "5e1a679604b3de7bcacbfad798922b87cbc51d25",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                   |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`5e1a6796`](https://github.com/catppuccin/nix/commit/5e1a679604b3de7bcacbfad798922b87cbc51d25) | `` style: format ff4ea84 ``               |
| [`ff4ea84b`](https://github.com/catppuccin/nix/commit/ff4ea84b11efe678a026f4578c2e728b099b5b07) | `` style: nixpkgs-fmt -> nixfmt (#187) `` |