### PR TITLE
chore(flake/catppuccin): `5e1a6796` -> `ac87622f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1716328426,
-        "narHash": "sha256-v5JjJkr1XtQfA/8JOCpLXnhpu5OOeTeA2LPFLbXpQS8=",
+        "lastModified": 1716329368,
+        "narHash": "sha256-QIKojhHcuoN7cU7Y/vZ1end8ogIfcm/ch59/A4Yjq68=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "5e1a679604b3de7bcacbfad798922b87cbc51d25",
+        "rev": "ac87622fa4b515c741a745390b83df29815cb856",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                              |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`ac87622f`](https://github.com/catppuccin/nix/commit/ac87622fa4b515c741a745390b83df29815cb856) | `` ci: require website build before deploy (#189) `` |
| [`7b893f72`](https://github.com/catppuccin/nix/commit/7b893f72c85c069313f0b31b0501cf7f6dd11e6d) | `` style: format 4f978e6 ``                          |
| [`4f978e61`](https://github.com/catppuccin/nix/commit/4f978e617369a0ff85f60b06570151cc640374b3) | `` ci: don't use graphql to commit (#188) ``         |