### PR TITLE
chore(flake/darwin): `8bf083c9` -> `eac4f250`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -104,11 +104,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716240091,
-        "narHash": "sha256-++gJuNv0X8naF1VkaO2sAiM3T4wLx1NtdfubEsRzX7U=",
+        "lastModified": 1716329735,
+        "narHash": "sha256-ap51w+VqG21vuzyQ04WrhI2YbWHd3UGz0e7dc/QQmoA=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "8bf083c992e2bc0a8c07f5860d3866739b698883",
+        "rev": "eac4f25028c1975a939c8f8fba95c12f8a25e01c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                               |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
| [`251eaabf`](https://github.com/LnL7/nix-darwin/commit/251eaabfa0f421a864e75e6b1a23c2c73e7bc332) | `` hercules-ci-agent: fix crash calling `security` `` |