### PR TITLE
chore(flake/nixpkgs): `6c0b7a92` -> `5710852b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -669,11 +669,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1716137900,
-        "narHash": "sha256-sowPU+tLQv8GlqtVtsXioTKeaQvlMz/pefcdwg8MvfM=",
+        "lastModified": 1716330097,
+        "narHash": "sha256-8BO3B7e3BiyIDsaKA0tY8O88rClYRTjvAp66y+VBUeU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6c0b7a92c30122196a761b440ac0d46d3d9954f1",
+        "rev": "5710852ba686cc1fd0d3b8e22b3117d43ba374c2",
         "type": "github"
       },
       "original": {

--- a/users/bbigras/graphical/default.nix
+++ b/users/bbigras/graphical/default.nix
@@ -37,7 +37,7 @@
     mangohud
     # heroic
 
-    dbeaver
+    dbeaver-bin
     josm
 
 


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`bff37b64`](https://github.com/NixOS/nixpkgs/commit/bff37b6408d2488e603d5d62a87f3a5a381f0e0c) | `` kdePackages.bluedevil: work around broken upstream tarball ``              |
| [`4fe704b1`](https://github.com/NixOS/nixpkgs/commit/4fe704b10f61f51ae063cea32e07d098b86dc2b9) | `` kdePackages.krfb: fix build ``                                             |
| [`fe783b3d`](https://github.com/NixOS/nixpkgs/commit/fe783b3d8c94f3da5b789e9b03cab0a6b28f65fb) | `` python312Packages.lacuscore: format with nixfmt ``                         |
| [`1e2f3766`](https://github.com/NixOS/nixpkgs/commit/1e2f37664bc13e2da2365826d131a81ffb6de9a4) | `` python312Packages.lacuscore: refactor ``                                   |
| [`b9e9ca26`](https://github.com/NixOS/nixpkgs/commit/b9e9ca26c49c9dd968bf30bffdc72349ff5545cf) | `` python312Packages.lacuscore: 1.9.3 -> 1.9.4 ``                             |
| [`aaac4a9e`](https://github.com/NixOS/nixpkgs/commit/aaac4a9ea8ebb3852b4eeed6ad96e9078ef6050b) | `` python312Packages.playwrightcapture: 1.24.9 -> 1.24.10 ``                  |
| [`183f42dc`](https://github.com/NixOS/nixpkgs/commit/183f42dc67f2380b18ed5c88a245eec69355800a) | `` python312Packages.fastcore: 1.5.35 -> 1.5.38 ``                            |
| [`cfbbf54f`](https://github.com/NixOS/nixpkgs/commit/cfbbf54f8943c074a15cea682e1ac8751b80fe87) | `` python312Packages.lmtpd: format with nixfmt ``                             |
| [`bbe77ffd`](https://github.com/NixOS/nixpkgs/commit/bbe77ffdfaedc10a95d0b1bc704d20cefdf7a5fc) | `` python312Packages.lmtpd: disable on Python 3.12 ``                         |
| [`90916525`](https://github.com/NixOS/nixpkgs/commit/90916525a65e072d8e0f2db33f316827309ebcb0) | `` nixos/navidrome: set empty settings default ``                             |
| [`f953913c`](https://github.com/NixOS/nixpkgs/commit/f953913c65d89ba06997c3a7dac090914fb70c10) | `` nixos/gnupg: remove dead code ``                                           |
| [`af4a3914`](https://github.com/NixOS/nixpkgs/commit/af4a3914244acd72bb12530e4907e81bc2fb2499) | `` nixos/vector: Added DNSTAP testcase ``                                     |
| [`25995c9f`](https://github.com/NixOS/nixpkgs/commit/25995c9ff8c079fb28e11a34ada6c4164ae9fff2) | `` zigbee2mqtt: make systemd support optional ``                              |
| [`8dc825ca`](https://github.com/NixOS/nixpkgs/commit/8dc825ca3681a602f6414134cda35cc513e2443c) | `` nixos/vector: Added nginx→clickhouse test case ``                          |
| [`1b27c588`](https://github.com/NixOS/nixpkgs/commit/1b27c58827309f3f75cb659d6982f1836740723b) | `` nixos/vector: Added testcase for verifying API endpoint ``                 |
| [`f8d18977`](https://github.com/NixOS/nixpkgs/commit/f8d18977df6eda5e2c4a49522b1762d75ba3db93) | `` kdePackages.plasma6: 6.0.4 -> 6.0.5 ``                                     |
| [`158e5353`](https://github.com/NixOS/nixpkgs/commit/158e53535300c8307cb866560f7dc29d29d9e88f) | `` libreoffice: fix build, big expression cleanup ``                          |
| [`87cb2655`](https://github.com/NixOS/nixpkgs/commit/87cb26558857e505b15549e854f7bc63575ee1f9) | `` nixos/vector: Moved existing test to subdirectory ``                       |
| [`f70f8f7c`](https://github.com/NixOS/nixpkgs/commit/f70f8f7c5507484770d31d39f919d1b479b2244a) | `` libreoffice-still: 7.5.9.2 -> 7.6.7.2 ``                                   |
| [`4a4e7449`](https://github.com/NixOS/nixpkgs/commit/4a4e74498ee8043157231d251065d47ea6a16915) | `` libreoffice-fresh: 7.6.4.1 -> 24.2.3.2 ``                                  |
| [`da4abb90`](https://github.com/NixOS/nixpkgs/commit/da4abb904acc2e90be93fee7d08c8fe5c7e66606) | `` libetonyek: init at 0.1.10 ``                                              |
| [`b1f998f5`](https://github.com/NixOS/nixpkgs/commit/b1f998f5c7704ec0f88586d4f77a012ee3c9c444) | `` libertine-g: init at 2012-01-16 ``                                         |
| [`c387b633`](https://github.com/NixOS/nixpkgs/commit/c387b6338f332a781bf0b9ab622b5bad4d4db0f4) | `` libepubgen: init at 0.1.1 ``                                               |
| [`91174e6a`](https://github.com/NixOS/nixpkgs/commit/91174e6a2cc65438a17f9ddfb2c6075a4d0cf233) | `` liborcus: init at 0.19.2 ``                                                |
| [`03d505df`](https://github.com/NixOS/nixpkgs/commit/03d505df0c3c7ea719a4c1586bc5be358f5607f9) | `` libixion: init at 0.19.0 ``                                                |
| [`13678d2d`](https://github.com/NixOS/nixpkgs/commit/13678d2dd23bfc229c07572b9f1b67b2a2e9eced) | `` libreoffice-bin: 7.6.4 -> 7.6.7 ``                                         |
| [`8e8d3f96`](https://github.com/NixOS/nixpkgs/commit/8e8d3f961e648616ae372fa9e12af41f9100ca01) | `` werf: 2.0.4 -> 2.1.0 ``                                                    |
| [`d62141d0`](https://github.com/NixOS/nixpkgs/commit/d62141d024493276446fed8faf92dcc29d51a049) | `` pietrasanta-traceroute: init at `0.0.5-unstable-2023-11-28` (#313400) ``   |
| [`c2bdcca6`](https://github.com/NixOS/nixpkgs/commit/c2bdcca62e72571e2b4956b8ca60a00f3485901c) | `` vscode-extensions.shd101wyy.markdown-preview-enhanced: 0.8.12 -> 0.8.13 `` |
| [`3df8dcc4`](https://github.com/NixOS/nixpkgs/commit/3df8dcc487f2838e62a040e5abf9bbd9ee823720) | `` telegraf: 1.30.2 -> 1.30.3 ``                                              |
| [`6397ca49`](https://github.com/NixOS/nixpkgs/commit/6397ca49b73d6593397716ebbb3e6dcb9fa439fb) | `` kaufkauflist: 3.3.0 → 4.0.0 (#310337) ``                                   |
| [`1f069c65`](https://github.com/NixOS/nixpkgs/commit/1f069c65c2838f46c3ccb301ca7399209a6849b2) | `` polkadot: 1.11.0 -> 1.12.0 ``                                              |
| [`f26e8f43`](https://github.com/NixOS/nixpkgs/commit/f26e8f439c4a335989a00542b479fecc223ff4d0) | `` llama-cpp: 2901 -> 2953 ``                                                 |
| [`4212454a`](https://github.com/NixOS/nixpkgs/commit/4212454a63fe8dc092f6901dd95b9809ea7354f4) | `` alephone-marathon: disable nixpkgs-update ``                               |
| [`ddd0c8f0`](https://github.com/NixOS/nixpkgs/commit/ddd0c8f0e140af21a779ffb818e2657f1aae34c0) | `` liblapin: init at 0-unstable-2024-05-20 ``                                 |
| [`dfcccd13`](https://github.com/NixOS/nixpkgs/commit/dfcccd136664dacabb84363536cdf12d705bcc7e) | `` extism-cli: 1.3.0 -> 1.4.0 ``                                              |
| [`84d5f56a`](https://github.com/NixOS/nixpkgs/commit/84d5f56ad73bde560c45b12b0d7a2cf3b8fbb594) | `` linuxKernel.kernels.linux_lqx: 6.8.6-lqx2 -> 6.8.10-lqx1 ``                |
| [`5516382a`](https://github.com/NixOS/nixpkgs/commit/5516382a648754f67b41215ad55656790fbcf2ab) | `` linuxKernel.kernels.linux_zen: 6.8.6-zen1 -> 6.9.1-zen1 ``                 |
| [`1f1a9bb1`](https://github.com/NixOS/nixpkgs/commit/1f1a9bb15d60905d1d52f49f5e153e6279124e26) | `` netscanner: 0.4.5 -> 0.5.1 ``                                              |
| [`f6a9c1fe`](https://github.com/NixOS/nixpkgs/commit/f6a9c1fede7dd66ce8bacf928ade552a93183ca2) | `` python312Packages.pycookiecheat: format with nixfmt ``                     |
| [`22c9a528`](https://github.com/NixOS/nixpkgs/commit/22c9a528315dad96f7dbc9bb4757503fe6b01996) | `` python312Packages.pycookiecheat: refactor ``                               |
| [`7c348f0a`](https://github.com/NixOS/nixpkgs/commit/7c348f0ab6647b33996810747cf665413b351460) | `` qt6.qtmqtt: 6.7.0 -> 6.7.1 ``                                              |
| [`486219cc`](https://github.com/NixOS/nixpkgs/commit/486219cc137b90a97b1607691ff9a04b694ba609) | `` python312Packages.pycookiecheat: 0.6.0 -> 0.7.0 ``                         |
| [`6aea91e1`](https://github.com/NixOS/nixpkgs/commit/6aea91e153aae4c2e9bb59068a9c20caef56bab1) | `` python312Packages.lnkparse3: refactor ``                                   |
| [`9f9610c3`](https://github.com/NixOS/nixpkgs/commit/9f9610c3140b4a0321451f9fe6bf3989137f537f) | `` python312Packages.lnkparse3: format with nixfmt ``                         |
| [`ccf57ee1`](https://github.com/NixOS/nixpkgs/commit/ccf57ee1ec618e8ff15b53d15acce59167dcded9) | `` python312Packages.lnkparse3: 1.4.0 -> 1.5.0 ``                             |
| [`a1c37a6a`](https://github.com/NixOS/nixpkgs/commit/a1c37a6a58d6b62c64c820b54d75bc54f47dc30f) | `` bpftrace: 0.20.3 -> 0.20.4 ``                                              |
| [`ddc323ab`](https://github.com/NixOS/nixpkgs/commit/ddc323abffac8c95121bfca839fce3a4f96532ec) | `` gamescope: 3.14.15 -> 3.14.16 ``                                           |
| [`a1f4cd31`](https://github.com/NixOS/nixpkgs/commit/a1f4cd3113870138d1a9632580b1ffbb90255e00) | `` python312Packages.crownstone-cloud: format with nixfmt ``                  |
| [`baeeded2`](https://github.com/NixOS/nixpkgs/commit/baeeded2c6de36a9d47615455d583ffb3eeda1ef) | `` python312Packages.crownstone-cloud: refactor ``                            |
| [`a854d724`](https://github.com/NixOS/nixpkgs/commit/a854d724c4618b27872171e62db17353769f1ee7) | `` python312Packages.crownstone-cloud: 1.4.9 -> 1.4.11 ``                     |
| [`f0f3609d`](https://github.com/NixOS/nixpkgs/commit/f0f3609dd58796ec100b8d2f0228ddb98a5c7c29) | `` python312Packages.crownstone-sse: format with nixfmt ``                    |
| [`ee6abbad`](https://github.com/NixOS/nixpkgs/commit/ee6abbad3bab49f7adcc00fe57ae07156d3cfe3f) | `` python312Packages.crownstone-sse: refactor ``                              |
| [`e971750c`](https://github.com/NixOS/nixpkgs/commit/e971750c2466440366730f1330ae321278f27d85) | `` python312Packages.crownstone-sse: 2.0.4 -> 2.0.5 ``                        |
| [`be774f01`](https://github.com/NixOS/nixpkgs/commit/be774f013b27225880d8e60796b1bd00b8a87dd3) | `` obs-studio-plugins.advanced-scene-switcher: 1.26.1 -> 1.26.2 ``            |
| [`567125c6`](https://github.com/NixOS/nixpkgs/commit/567125c65ad1b38ace66f0c4d1434a96ade039d5) | `` jikespg: fixed darwin build ``                                             |
| [`3ff593a5`](https://github.com/NixOS/nixpkgs/commit/3ff593a54d58295b5940207dea2fb4b6923928a3) | `` raycast: 1.74.0 -> 1.74.1 ``                                               |
| [`47da0aee`](https://github.com/NixOS/nixpkgs/commit/47da0aee5616a063015f10ea593688646f2377e4) | `` qt6: 6.7.0 -> 6.7.1 ``                                                     |
| [`317e4083`](https://github.com/NixOS/nixpkgs/commit/317e40837c114dff6efd8f13ad182764da1d994c) | `` python312Packages.walrus: fix python 3.12 build ``                         |
| [`c23df6a7`](https://github.com/NixOS/nixpkgs/commit/c23df6a70c9b16d67c3dc0b0d5c42e050d404bdf) | `` python311Packages.rokuecp: 0.19.3 -> 0.19.4 ``                             |
| [`a0b1f286`](https://github.com/NixOS/nixpkgs/commit/a0b1f28661d4d7bce6ca86276bb8a64c8720f6be) | `` povray: add fgaz to maintainers ``                                         |
| [`58d34a87`](https://github.com/NixOS/nixpkgs/commit/58d34a875cbc1c0cef91958adcbd21958dc25461) | `` povray: use NixOS as vendor id ``                                          |
| [`e2dd91f4`](https://github.com/NixOS/nixpkgs/commit/e2dd91f4dc541e11428c3725b8ad7ec40b0becd7) | `` povray: update SDL and use pkg-config ``                                   |
| [`fe2fc076`](https://github.com/NixOS/nixpkgs/commit/fe2fc07656d137a3ba2038e7a975bc373b3c2ca8) | `` povray: use finalAttrs pattern ``                                          |
| [`bc4e19a5`](https://github.com/NixOS/nixpkgs/commit/bc4e19a57001c00fd5cf53b74dd5318771c5446d) | `` povray: 3.8.0-x.10064738 -> 3.8.0-beta.2 ``                                |
| [`0234bac7`](https://github.com/NixOS/nixpkgs/commit/0234bac73cf53bee97ccdddef71748be10a88479) | `` docker_26: 26.0.0 -> 26.1.3 ``                                             |
| [`3e14c44e`](https://github.com/NixOS/nixpkgs/commit/3e14c44e21ee1c1d41888e7c39acb834be5e7b23) | `` nixos/simplesamlphp: init module ``                                        |
| [`14985fa5`](https://github.com/NixOS/nixpkgs/commit/14985fa51b1e96838d434331294d9d0b115d5705) | `` python311Packages.plugwise: 0.37.5 -> 0.37.8 ``                            |
| [`fc4e93e2`](https://github.com/NixOS/nixpkgs/commit/fc4e93e2ee612b08448e5d6a6181bc6f31597793) | `` python312Packages.colormath: format with nixfmt ``                         |
| [`7fb25efa`](https://github.com/NixOS/nixpkgs/commit/7fb25efa8b8d6739a71e52162041f7ea980603bc) | `` python312Packages.colormath: refactor ``                                   |
| [`944c377e`](https://github.com/NixOS/nixpkgs/commit/944c377e0fc3e2ed6e4eee924010c07469d26ff3) | `` python312Packages.glances-api: 0.6.0 -> 0.7.0 ``                           |
| [`a066405c`](https://github.com/NixOS/nixpkgs/commit/a066405ce11ccc41e8343265257ba684fb6d6b65) | `` python312Packages.hyrule: format with nixfmt ``                            |
| [`e7023684`](https://github.com/NixOS/nixpkgs/commit/e70236849739e24c983c5074f33ef682fd0c2d8c) | `` python312Packages.hyrule: refactor ``                                      |
| [`d3d1bdc6`](https://github.com/NixOS/nixpkgs/commit/d3d1bdc66ca0323fb80a760e7778e4521a92d366) | `` python312Packages.hyrule: 0.5.0 -> 0.6.0 ``                                |
| [`2b2ccb78`](https://github.com/NixOS/nixpkgs/commit/2b2ccb78165b29d79765d7d69d7dfb22f177e81f) | `` python312Packages.hy:format with nixfmt ``                                 |
| [`778e6403`](https://github.com/NixOS/nixpkgs/commit/778e640394681fe7c9b746308ca62de7a5aa30cc) | `` python312Packages.hy: remove myself from maintainers ``                    |
| [`35ef00b5`](https://github.com/NixOS/nixpkgs/commit/35ef00b58686ce9ba58100ecb0ef87d5af3aed90) | `` ocamlPackages.eio: fix homepage and changelog ``                           |
| [`007a604a`](https://github.com/NixOS/nixpkgs/commit/007a604add6adf325c47bce1c762261aa9bb04bc) | `` typstyle: 0.11.21 -> 0.11.22 ``                                            |
| [`276e86d8`](https://github.com/NixOS/nixpkgs/commit/276e86d8ab624a75b86f0f78ae0ee3727e80e700) | `` python311Packages.hy: refactor ``                                          |
| [`0fc78b93`](https://github.com/NixOS/nixpkgs/commit/0fc78b936e98c11e6be4f3cbb5922b5b81ac1e83) | `` python312Packages.stickytape: format with nixfmt ``                        |
| [`533ce4cf`](https://github.com/NixOS/nixpkgs/commit/533ce4cf057fdff5573c5cf7d5c6197b1b9fc997) | `` osu-lazer: avoid rebuild when meta changes ``                              |
| [`2cd17d14`](https://github.com/NixOS/nixpkgs/commit/2cd17d14bc9f4ae4e3e9207016431a2772dbdb93) | `` osu-lazer: 2024.412.1 -> 2024.521.2 ``                                     |
| [`376309fc`](https://github.com/NixOS/nixpkgs/commit/376309fc14fed804c295638991b24c65ff735534) | `` python312Packages.stickytape: refactor ``                                  |
| [`c259efb1`](https://github.com/NixOS/nixpkgs/commit/c259efb16db863cdd07df5dec4f12a4af6ac699c) | `` osu-lazer-bin: 2024.412.1 -> 2024.521.2 ``                                 |
| [`fb03c9c5`](https://github.com/NixOS/nixpkgs/commit/fb03c9c55887d714c41b09fac4947942c4a442de) | `` asusctl: 6.0.6 -> 6.0.9 ``                                                 |
| [`e379db6e`](https://github.com/NixOS/nixpkgs/commit/e379db6ea9334243480f0899bed6bfb7caa29965) | `` python312Packages.monzopy: init at 1.2.0 ``                                |
| [`9d5ff613`](https://github.com/NixOS/nixpkgs/commit/9d5ff613e55f231a122982d033624c6c0f178f51) | `` perlPackages: fix wine-staging build on i686 ``                            |
| [`136720f1`](https://github.com/NixOS/nixpkgs/commit/136720f1eae931e6d29bcd97931145d2e0b08bb1) | `` vscode-extensions.elixir-lsp.vscode-elixir-ls: 0.21.1 -> 0.21.2 ``         |
| [`58df87c0`](https://github.com/NixOS/nixpkgs/commit/58df87c09be27760a13c9960dd75673b43edf56c) | `` metals: 1.3.0 -> 1.3.1 ``                                                  |
| [`c6005d83`](https://github.com/NixOS/nixpkgs/commit/c6005d83736d66ef80075f9c00494a287f1017ef) | `` python312Packages.boto3-stubs: 1.34.108 -> 1.34.109 ``                     |
| [`2482fc8b`](https://github.com/NixOS/nixpkgs/commit/2482fc8bd116f2c97e4ea82199e743a898d6c0c5) | `` python311Packages.piep: refactor and drop nose ``                          |
| [`129b9ad2`](https://github.com/NixOS/nixpkgs/commit/129b9ad2368522b9723a87fc5cb9a12f636d4b49) | `` exploitdb: 2024-05-16 -> 2024-05-20 ``                                     |
| [`2105dab7`](https://github.com/NixOS/nixpkgs/commit/2105dab750a93ae2bec9328f350b075615001af8) | `` python312Packages.dbus-fast: 2.21.2 -> 2.21.3 ``                           |
| [`99a3774a`](https://github.com/NixOS/nixpkgs/commit/99a3774a0ffb19eac8beeb951512a84b555d09c7) | `` python312Packages.tencentcloud-sdk-python: 3.0.1150 -> 3.0.1151 ``         |
| [`0bc0302b`](https://github.com/NixOS/nixpkgs/commit/0bc0302b1889f53a5ee1979bcbf90209c09a6ba2) | `` simplesamlphp: init at 1.19.7 ``                                           |
| [`ea50ab34`](https://github.com/NixOS/nixpkgs/commit/ea50ab34f64d82a4bb852eadc21f235ce4f3dced) | `` python311Packages.piep: format with nixfmt ``                              |
| [`bcb6d785`](https://github.com/NixOS/nixpkgs/commit/bcb6d7853fea69a42e41e9555978a0e82febe21a) | `` malwoverview: 5.4.2 -> 5.4.3 ``                                            |
| [`e9208d70`](https://github.com/NixOS/nixpkgs/commit/e9208d701c2f3aae444cf3bad415fecf82c0db1f) | `` python312Packages.azure-mgmt-security: format with nixfmt ``               |
| [`8d13b5ea`](https://github.com/NixOS/nixpkgs/commit/8d13b5ea99408f45a0781881ecb933e390ed2fd5) | `` python312Packages.azure-mgmt-security: refactor ``                         |
| [`7d37713f`](https://github.com/NixOS/nixpkgs/commit/7d37713f0b7ed82299c65cf748cef63b7e55a4c3) | `` python312Packages.python-telegram-bot: format with nixfmt ``               |
| [`18c46374`](https://github.com/NixOS/nixpkgs/commit/18c46374da9d48b33173982d6682608aa62d4f6f) | `` python312Packages.python-telegram-bot: refactor ``                         |
| [`1f820208`](https://github.com/NixOS/nixpkgs/commit/1f82020865a982a3f82934b420165ceb331a3505) | `` nixos/tests/keepalived: use openFirewall option ``                         |
| [`785aef54`](https://github.com/NixOS/nixpkgs/commit/785aef54cf95ca2c219af52bcc5345fdb1abfcbc) | `` python311Packages.dask-image: 2024.5.1 -> 2024.5.2 ``                      |
| [`718b237d`](https://github.com/NixOS/nixpkgs/commit/718b237d0b8afd4e0b3423b20d8c516c08842457) | `` bintools: Add dynamic loader path for FreeBSD native ``                    |
| [`8073fc75`](https://github.com/NixOS/nixpkgs/commit/8073fc75a89da020c40069f2e8d8a08b5e102612) | `` bintools: Add an assertion which produces better error messages ``         |