### PR TITLE
chore(flake/emacs-overlay): `04c759ff` -> `00c0d859`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1716311169,
-        "narHash": "sha256-hCt9zCXnuvra2X0+fQiejAfpr6nNdR1hSfl63UxmVbM=",
+        "lastModified": 1716339720,
+        "narHash": "sha256-IO0dtLZBkikoinpxBUh2B4VNl4tCHj9Tp8gm29VW7/M=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "04c759ffb7af09dbce3c9068c4da7f2f0343da89",
+        "rev": "00c0d859072429157c21484dc525361ff33ddea3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`00c0d859`](https://github.com/nix-community/emacs-overlay/commit/00c0d859072429157c21484dc525361ff33ddea3) | `` Updated elpa ``         |
| [`ccc9f43a`](https://github.com/nix-community/emacs-overlay/commit/ccc9f43a8b06969f775dabed9c03c2e8c780e8de) | `` Updated nongnu ``       |
| [`bff0644e`](https://github.com/nix-community/emacs-overlay/commit/bff0644ec3157050821cfe784cde74a4caa522e7) | `` Updated flake inputs `` |