### PR TITLE
chore(flake/catppuccin): `ac87622f` -> `fea5242c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1716329368,
-        "narHash": "sha256-QIKojhHcuoN7cU7Y/vZ1end8ogIfcm/ch59/A4Yjq68=",
+        "lastModified": 1716337435,
+        "narHash": "sha256-eZqH1vLI9eKL/N5toXxOrQO80G0y4pWZrYCp472YBVQ=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "ac87622fa4b515c741a745390b83df29815cb856",
+        "rev": "fea5242c0eacc5efa81be0e36206a62e889dbd82",
         "type": "github"
       },
       "original": {

--- a/hosts/desktop/default.nix
+++ b/hosts/desktop/default.nix
@@ -53,7 +53,7 @@ in
     ] ++ (if builtins.pathExists (builtins.getEnv "PWD" + "/secrets/at_home.nix") then [ (builtins.getEnv "PWD" + "/secrets/at_home.nix") ] else [ ])
     ++ (if builtins.pathExists (builtins.getEnv "PWD" + "/secrets/desktop.nix") then [ (builtins.getEnv "PWD" + "/secrets/desktop.nix") ] else [ ]);
 
-  catppuccin.flavour = "mocha";
+  catppuccin.flavor = "mocha";
 
   nix = {
     extraOptions = ''

--- a/hosts/pixel6/default.nix
+++ b/hosts/pixel6/default.nix
@@ -98,7 +98,7 @@ in
 
       home.language.base = "fr_CA.UTF-8";
 
-      catppuccin.flavour = "mocha";
+      catppuccin.flavor = "mocha";
 
       # insert home-manager config
       programs = {

--- a/users/bbigras/core/default.nix
+++ b/users/bbigras/core/default.nix
@@ -45,7 +45,7 @@
     ./zsh.nix
   ];
 
-  catppuccin.flavour = "mocha";
+  catppuccin.flavor = "mocha";
 
   # XXX: Manually enabled in the graphic module
   dconf.enable = false;


### PR DESCRIPTION
| Commit                                                                                          | Message                                        |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`fea5242c`](https://github.com/catppuccin/nix/commit/fea5242c0eacc5efa81be0e36206a62e889dbd82) | `` feat(modules)!: flavour -> flavor (#190) `` |