### PR TITLE
chore(flake/emacs-overlay): `00c0d859` -> `6eb679f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1716339720,
-        "narHash": "sha256-IO0dtLZBkikoinpxBUh2B4VNl4tCHj9Tp8gm29VW7/M=",
+        "lastModified": 1716342612,
+        "narHash": "sha256-D8Zj8ftu5Zpgkb3wbQoxsRfJ9cGJxDdauFtuPHenD8E=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "00c0d859072429157c21484dc525361ff33ddea3",
+        "rev": "6eb679f5e75b80580e8d3fa1594369e128b37911",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`6eb679f5`](https://github.com/nix-community/emacs-overlay/commit/6eb679f5e75b80580e8d3fa1594369e128b37911) | `` Updated emacs `` |
| [`32905ebb`](https://github.com/nix-community/emacs-overlay/commit/32905ebbe68418ed897572318c94fe21f632afaa) | `` Updated melpa `` |