### PR TITLE
chore(flake/nur): `22090077` -> `be0aff76`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716343711,
-        "narHash": "sha256-P/k+P4iMVFGuBocGAsXoJFURratEoeOqwqPom+dcPos=",
+        "lastModified": 1716349627,
+        "narHash": "sha256-NLI3747D2gjcCvnsEMeNNRDFVoXS7zX3iFFzprBJRJ8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2209007770c4ba531322ca899717b8de05f5fa21",
+        "rev": "be0aff768b24996193504b130b085246188774ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`be0aff76`](https://github.com/nix-community/NUR/commit/be0aff768b24996193504b130b085246188774ec) | `` automatic update `` |
| [`15505f69`](https://github.com/nix-community/NUR/commit/15505f693c3e7fa7ed456a6c67deb6da7c39c82b) | `` automatic update `` |
| [`d69724e2`](https://github.com/nix-community/NUR/commit/d69724e2c7a808d107407f38f99c56fa50394df4) | `` automatic update `` |