### PR TITLE
chore(flake/nur): `be0aff76` -> `1758a1f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716349627,
-        "narHash": "sha256-NLI3747D2gjcCvnsEMeNNRDFVoXS7zX3iFFzprBJRJ8=",
+        "lastModified": 1716352574,
+        "narHash": "sha256-WUtRcqOyey8Sav1NuDaSkGd2q895tFRP5bKLxhRpTS4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "be0aff768b24996193504b130b085246188774ec",
+        "rev": "1758a1f557336a35fde42e40f03e8d612b724f19",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1758a1f5`](https://github.com/nix-community/NUR/commit/1758a1f557336a35fde42e40f03e8d612b724f19) | `` automatic update `` |
| [`48847179`](https://github.com/nix-community/NUR/commit/48847179d6b47770a721d5f84dac12a577762f20) | `` automatic update `` |
| [`03c4380f`](https://github.com/nix-community/NUR/commit/03c4380fe7d15cf8ba5e1740b979305dde35b404) | `` automatic update `` |