### PR TITLE
chore(flake/nur): `1758a1f5` -> `b10b4923`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716352574,
-        "narHash": "sha256-WUtRcqOyey8Sav1NuDaSkGd2q895tFRP5bKLxhRpTS4=",
+        "lastModified": 1716356652,
+        "narHash": "sha256-2HB9aRf19P4IT/FsIWKo0Jc0o01lZvElFSqCDvCz758=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1758a1f557336a35fde42e40f03e8d612b724f19",
+        "rev": "b10b4923683ae04497737bd770cdd83c6f4918dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b10b4923`](https://github.com/nix-community/NUR/commit/b10b4923683ae04497737bd770cdd83c6f4918dc) | `` automatic update `` |
| [`4fa19e97`](https://github.com/nix-community/NUR/commit/4fa19e977047856f32ffd38a007f58a5bf61671e) | `` automatic update `` |