### PR TITLE
chore(flake/emacs-overlay): `6eb679f5` -> `35e5b442`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1716342612,
-        "narHash": "sha256-D8Zj8ftu5Zpgkb3wbQoxsRfJ9cGJxDdauFtuPHenD8E=",
+        "lastModified": 1716368878,
+        "narHash": "sha256-lo7AHe+F4+VJshf4AZWtXpnHUvJsrMJxnqCfeIBn/54=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6eb679f5e75b80580e8d3fa1594369e128b37911",
+        "rev": "35e5b442c1602ed30b588addb66d3289f33dfb76",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`35e5b442`](https://github.com/nix-community/emacs-overlay/commit/35e5b442c1602ed30b588addb66d3289f33dfb76) | `` Updated emacs `` |
| [`e038ab50`](https://github.com/nix-community/emacs-overlay/commit/e038ab5096e0487d9916ac2435c34c807f364ef6) | `` Updated melpa `` |