### PR TITLE
chore(flake/nur): `0ed3297e` -> `2accd435`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716375775,
-        "narHash": "sha256-2X4zwYV6Xudaqo3IhlwsMAQT+bZHs2nBD8Gv3ENHqTg=",
+        "lastModified": 1716381793,
+        "narHash": "sha256-MEEVJpZBf5qczuGeVOs5gqY2foZSoljgPPJ/WH+Gino=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0ed3297ed7a3d5308db5a57ccd067beaf196e4a7",
+        "rev": "2accd435c68b16a8c4076cf0de627d6d731b98f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2accd435`](https://github.com/nix-community/NUR/commit/2accd435c68b16a8c4076cf0de627d6d731b98f1) | `` automatic update `` |
| [`ba1ee5ee`](https://github.com/nix-community/NUR/commit/ba1ee5ee440816b631c9817fb71e1ba4d46a2b04) | `` automatic update `` |