### PR TITLE
chore(flake/nur): `2accd435` -> `e1b5b402`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716381793,
-        "narHash": "sha256-MEEVJpZBf5qczuGeVOs5gqY2foZSoljgPPJ/WH+Gino=",
+        "lastModified": 1716424553,
+        "narHash": "sha256-gcn3IDjugAsyR1U7k/atVN/F/S4DJphrkpzoyYPIyHg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2accd435c68b16a8c4076cf0de627d6d731b98f1",
+        "rev": "e1b5b402c68cd12c45bfddabe250de1430f02994",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e1b5b402`](https://github.com/nix-community/NUR/commit/e1b5b402c68cd12c45bfddabe250de1430f02994) | `` automatic update `` |
| [`cd2265a9`](https://github.com/nix-community/NUR/commit/cd2265a92c4cb32b3ae23602dfdbe0a9c5833c6a) | `` automatic update `` |
| [`f52674dd`](https://github.com/nix-community/NUR/commit/f52674dd1a7f8539bedd6a0d19ab32e62771619b) | `` automatic update `` |
| [`8357d594`](https://github.com/nix-community/NUR/commit/8357d594efaf5a65897e31c66f82661e2be3533a) | `` automatic update `` |
| [`7d4c8e18`](https://github.com/nix-community/NUR/commit/7d4c8e18ce6901f75b10e4964cc583a06e6b1fbb) | `` automatic update `` |
| [`1e92778f`](https://github.com/nix-community/NUR/commit/1e92778f3c97fdcd154534851306396865d67260) | `` automatic update `` |
| [`0fc25931`](https://github.com/nix-community/NUR/commit/0fc25931d8b84836916160360d4220dc6a5e8da0) | `` automatic update `` |
| [`5e4ee381`](https://github.com/nix-community/NUR/commit/5e4ee38128417d8b854ec791708e484be71e9607) | `` automatic update `` |