### PR TITLE
chore(flake/emacs-overlay): `35e5b442` -> `c0c22226`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1716368878,
-        "narHash": "sha256-lo7AHe+F4+VJshf4AZWtXpnHUvJsrMJxnqCfeIBn/54=",
+        "lastModified": 1716426096,
+        "narHash": "sha256-I0iaWkskQEYcxibAQtyO0XMxbp27eXc/DCWsgPf+fQM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "35e5b442c1602ed30b588addb66d3289f33dfb76",
+        "rev": "c0c222260782cae1995b4c4d9a6d6808f873ca91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`c0c22226`](https://github.com/nix-community/emacs-overlay/commit/c0c222260782cae1995b4c4d9a6d6808f873ca91) | `` Updated elpa ``         |
| [`3cc252cd`](https://github.com/nix-community/emacs-overlay/commit/3cc252cd574f1be29d63868e0c672fc1a07e749c) | `` Updated flake inputs `` |
| [`7481fce8`](https://github.com/nix-community/emacs-overlay/commit/7481fce8f1bec8f8478c06142f75a6f4703dbba5) | `` Updated emacs ``        |
| [`36563a42`](https://github.com/nix-community/emacs-overlay/commit/36563a429d6bb373271ae634d32fc144f3baa0de) | `` Updated melpa ``        |
| [`03779f3d`](https://github.com/nix-community/emacs-overlay/commit/03779f3d809d42b7376c42dac99e74c57d9a497e) | `` Updated elpa ``         |
| [`4b244d63`](https://github.com/nix-community/emacs-overlay/commit/4b244d6333f6f1dfe73e7af316e9bc8bdd958a1a) | `` Updated nongnu ``       |