### PR TITLE
chore(flake/sops-nix): `fddd5246` -> `b5498327`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -851,11 +851,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1716244104,
-        "narHash": "sha256-XXbqfkyWe0d0O+zqRQWi2oXi6wYDmTzXedFkBRwx1VI=",
+        "lastModified": 1716400300,
+        "narHash": "sha256-0lMkIk9h3AzOHs1dCL9RXvvN4PM8VBKb+cyGsqOKa4c=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "fddd52460e3332eedd8a0043af5675338a5b3e0b",
+        "rev": "b549832718b8946e875c016a4785d204fcfc2e53",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                  |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`b5498327`](https://github.com/Mic92/sops-nix/commit/b549832718b8946e875c016a4785d204fcfc2e53) | `` darwin: Mount hfs+ case-sensitive ``                  |
| [`0cd7cac7`](https://github.com/Mic92/sops-nix/commit/0cd7cac74467c3028cc974e8f41108a5e78a56d5) | `` sops-install-secrets: add mount options for darwin `` |