### PR TITLE
chore(flake/srvos): `c8022a61` -> `1122cd50`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -871,11 +871,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716233075,
-        "narHash": "sha256-XG+BujRzINjMEPg8FevP2UnFgT4UyTaOEZq/d2r9LYQ=",
+        "lastModified": 1716425501,
+        "narHash": "sha256-BSLhmGYY1khyyBAjraR+N0Pa9Nha/et5yQQlEZxcfkU=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "c8022a61950cb41db586ab4ae7079b68cbc18fff",
+        "rev": "1122cd50a23647e09c3e7a679d37ec02113bc412",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`1122cd50`](https://github.com/nix-community/srvos/commit/1122cd50a23647e09c3e7a679d37ec02113bc412) | `` dev/private/flake.lock: Update `` |
| [`f9d9e5bc`](https://github.com/nix-community/srvos/commit/f9d9e5bc12609b9906bbea0aef1f6ea967f1fecc) | `` flake.lock: Update ``             |