### PR TITLE
chore(flake/emacs-overlay): `c0c22226` -> `83a065a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1716426096,
-        "narHash": "sha256-I0iaWkskQEYcxibAQtyO0XMxbp27eXc/DCWsgPf+fQM=",
+        "lastModified": 1716428110,
+        "narHash": "sha256-1uCU39q8MVPYxAoC2Q6S2+z0iXSWozvN6kKZuMKoKuA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c0c222260782cae1995b4c4d9a6d6808f873ca91",
+        "rev": "83a065a16db7cf1f69339d5a6a0443129e20a7b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`83a065a1`](https://github.com/nix-community/emacs-overlay/commit/83a065a16db7cf1f69339d5a6a0443129e20a7b8) | `` Updated melpa `` |