### PR TITLE
chore(flake/nur): `e1b5b402` -> `0244c484`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716424553,
-        "narHash": "sha256-gcn3IDjugAsyR1U7k/atVN/F/S4DJphrkpzoyYPIyHg=",
+        "lastModified": 1716435964,
+        "narHash": "sha256-p9tKqc12SZz1mcUHuT/R1zvKiJqDoyXRMnYLKFRQaik=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e1b5b402c68cd12c45bfddabe250de1430f02994",
+        "rev": "0244c4845211125cc41e3f8ba47527949ee4d40b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0244c484`](https://github.com/nix-community/NUR/commit/0244c4845211125cc41e3f8ba47527949ee4d40b) | `` automatic update `` |
| [`7fb905b9`](https://github.com/nix-community/NUR/commit/7fb905b912077ac3527cff2a98788e53e11d9258) | `` automatic update `` |