### PR TITLE
chore(flake/nur): `0244c484` -> `66557801`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716435964,
-        "narHash": "sha256-p9tKqc12SZz1mcUHuT/R1zvKiJqDoyXRMnYLKFRQaik=",
+        "lastModified": 1716437062,
+        "narHash": "sha256-OpjrV078IJa40UgW9KDohDOt7EMaFseLXMeHuB0TVpA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0244c4845211125cc41e3f8ba47527949ee4d40b",
+        "rev": "66557801d3fa3b79ff2eed52584340f1a1ce20d8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`66557801`](https://github.com/nix-community/NUR/commit/66557801d3fa3b79ff2eed52584340f1a1ce20d8) | `` automatic update `` |