### PR TITLE
chore(flake/nur): `66557801` -> `0a42cc21`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716437062,
-        "narHash": "sha256-OpjrV078IJa40UgW9KDohDOt7EMaFseLXMeHuB0TVpA=",
+        "lastModified": 1716443739,
+        "narHash": "sha256-jdMiz1cpRU4TZ5uCTzhc4phyTOENFq1QjSrzU1VXVwo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "66557801d3fa3b79ff2eed52584340f1a1ce20d8",
+        "rev": "0a42cc21a78317204d91eec014649962f2cedd87",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0a42cc21`](https://github.com/nix-community/NUR/commit/0a42cc21a78317204d91eec014649962f2cedd87) | `` automatic update `` |
| [`584ecfdf`](https://github.com/nix-community/NUR/commit/584ecfdf32296a975310ee8c244958534e0ce4e6) | `` automatic update `` |
| [`a96a4543`](https://github.com/nix-community/NUR/commit/a96a45431e080b268efa2c67daeec36f64fec411) | `` automatic update `` |