### PR TITLE
chore(flake/nur): `0a42cc21` -> `ea7dee62`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716443739,
-        "narHash": "sha256-jdMiz1cpRU4TZ5uCTzhc4phyTOENFq1QjSrzU1VXVwo=",
+        "lastModified": 1716446227,
+        "narHash": "sha256-PrajIED3L3lBk2ooooE8TPNDtOdKb4wKXBGIJXwnb7s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0a42cc21a78317204d91eec014649962f2cedd87",
+        "rev": "ea7dee62009297354c43fce51ecc4a07f52a9ada",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ea7dee62`](https://github.com/nix-community/NUR/commit/ea7dee62009297354c43fce51ecc4a07f52a9ada) | `` automatic update `` |