### PR TITLE
chore(flake/nur): `ea7dee62` -> `9ba2d64f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716446227,
-        "narHash": "sha256-PrajIED3L3lBk2ooooE8TPNDtOdKb4wKXBGIJXwnb7s=",
+        "lastModified": 1716450268,
+        "narHash": "sha256-+17HVPL8OoiOb0zyNbluXFBWyTx4HEjHh1+A8pd4ci8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ea7dee62009297354c43fce51ecc4a07f52a9ada",
+        "rev": "9ba2d64f6f377694b0299db2fbae1ad37d3ce065",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9ba2d64f`](https://github.com/nix-community/NUR/commit/9ba2d64f6f377694b0299db2fbae1ad37d3ce065) | `` automatic update `` |
| [`a1816792`](https://github.com/nix-community/NUR/commit/a181679294fc68e19c429a840d6d771aaeda435b) | `` automatic update `` |