### PR TITLE
chore(flake/nur): `9ba2d64f` -> `748074b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716450268,
-        "narHash": "sha256-+17HVPL8OoiOb0zyNbluXFBWyTx4HEjHh1+A8pd4ci8=",
+        "lastModified": 1716464673,
+        "narHash": "sha256-BDQA0Z2nXYsprkHpvnVGRcpVKt3cxQniMWfpnnvkYDs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ba2d64f6f377694b0299db2fbae1ad37d3ce065",
+        "rev": "748074b2362bc8af19c294382b3e5ca36a9ad6fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`748074b2`](https://github.com/nix-community/NUR/commit/748074b2362bc8af19c294382b3e5ca36a9ad6fe) | `` automatic update `` |
| [`ed78f86c`](https://github.com/nix-community/NUR/commit/ed78f86c4c6615cd0e34b44c5a836d309dcddad7) | `` automatic update `` |
| [`95a497c8`](https://github.com/nix-community/NUR/commit/95a497c879f5aa88170a0e4391bf84191dc5c9b4) | `` automatic update `` |
| [`1b149eb7`](https://github.com/nix-community/NUR/commit/1b149eb74a398261f6dc05bed91b39a5af040285) | `` automatic update `` |
| [`21685c88`](https://github.com/nix-community/NUR/commit/21685c881fbf7ad840d2ea1b98c50e10caa6f947) | `` automatic update `` |
| [`413c223e`](https://github.com/nix-community/NUR/commit/413c223e0034f8f5d6690bae912bf98b10f83334) | `` automatic update `` |