### PR TITLE
chore(flake/nur): `cfbf06a2` -> `8960c67a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716469054,
-        "narHash": "sha256-zLnslIIztDHElT0eF5A4WXH8/acIhtVWLl3EAHnl5KI=",
+        "lastModified": 1716471898,
+        "narHash": "sha256-TV3J55onkoHJEZjJHJplf5nSWRy30Oi70eAwS2DY7fI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cfbf06a2a7e99d63805c92c147c09daef416eced",
+        "rev": "8960c67a7bf3fa66abe62c45ad945ac24d6fc42c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8960c67a`](https://github.com/nix-community/NUR/commit/8960c67a7bf3fa66abe62c45ad945ac24d6fc42c) | `` automatic update `` |