### PR TITLE
chore(flake/nur): `ec5f6c8a` -> `b3d163c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716474903,
-        "narHash": "sha256-cKXhdxWx1TOkJXf8rO9KYbc9VHioUBW0+0LVUm8koEE=",
+        "lastModified": 1716479105,
+        "narHash": "sha256-O5vAr3D1Kxo+BCzL25bR6H3IwLZISj/B29OVGon216k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ec5f6c8af1604fbed13debb8a34699ab5543781b",
+        "rev": "b3d163c563387c70d9a4ee1055e6c9def436f529",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b3d163c5`](https://github.com/nix-community/NUR/commit/b3d163c563387c70d9a4ee1055e6c9def436f529) | `` automatic update `` |
| [`9d6da149`](https://github.com/nix-community/NUR/commit/9d6da14929e97e4794acd6cc33b6488a4c220190) | `` automatic update `` |
| [`8eed11d8`](https://github.com/nix-community/NUR/commit/8eed11d82e183643c49080782f1ff112826d690c) | `` automatic update `` |