### PR TITLE
chore(flake/emacs-overlay): `794d2f94` -> `e83840bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1716455259,
-        "narHash": "sha256-b+7zKkadL5e7kb5NoXQU8kjYHyAVOphemo87K6lPgRo=",
+        "lastModified": 1716483251,
+        "narHash": "sha256-HsHgtWtvQErDhBRkGp5rrb9BnxbPKZ8vN1vkI6a0Hv4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "794d2f9436e63c33350caf36f5009dd81f465d38",
+        "rev": "e83840bf9ee76be3b3481f844d2b7ebde08f32dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`e83840bf`](https://github.com/nix-community/emacs-overlay/commit/e83840bf9ee76be3b3481f844d2b7ebde08f32dd) | `` Updated melpa ``  |
| [`3b77704a`](https://github.com/nix-community/emacs-overlay/commit/3b77704a0f293ca6e29346045c896d734e941f51) | `` Updated elpa ``   |
| [`32e74f9a`](https://github.com/nix-community/emacs-overlay/commit/32e74f9af9beaa8359dd606d152034904b43b6e4) | `` Updated nongnu `` |