### PR TITLE
chore(flake/emacs-overlay): `e83840bf` -> `20090620`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1716483251,
-        "narHash": "sha256-HsHgtWtvQErDhBRkGp5rrb9BnxbPKZ8vN1vkI6a0Hv4=",
+        "lastModified": 1716484068,
+        "narHash": "sha256-c8GrVY0kNG4cH39HH4WlhtHzYrgbYkizsJnsNiQQMFk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e83840bf9ee76be3b3481f844d2b7ebde08f32dd",
+        "rev": "200906203163742224c35b827e0f3c8adc9454d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`20090620`](https://github.com/nix-community/emacs-overlay/commit/200906203163742224c35b827e0f3c8adc9454d0) | `` Updated emacs `` |