### PR TITLE
chore(flake/nur): `b3d163c5` -> `d699726e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716479105,
-        "narHash": "sha256-O5vAr3D1Kxo+BCzL25bR6H3IwLZISj/B29OVGon216k=",
+        "lastModified": 1716486322,
+        "narHash": "sha256-tzLbQ+7t9kDOqOIAnF76O2lZGKRwI1XLMWegGzr5/8M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b3d163c563387c70d9a4ee1055e6c9def436f529",
+        "rev": "d699726e6ddcf05fb0f8a2550f67a89ba2939188",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d699726e`](https://github.com/nix-community/NUR/commit/d699726e6ddcf05fb0f8a2550f67a89ba2939188) | `` automatic update `` |
| [`800631ae`](https://github.com/nix-community/NUR/commit/800631aeaf588ce5d6a452ecf0ff59279c879331) | `` automatic update `` |