### PR TITLE
chore(flake/nur): `d699726e` -> `1a46c09b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716486322,
-        "narHash": "sha256-tzLbQ+7t9kDOqOIAnF76O2lZGKRwI1XLMWegGzr5/8M=",
+        "lastModified": 1716496302,
+        "narHash": "sha256-77SBmhlUNEyUqkhFMqUIAdusbJ3hILC4D7i4FtgfAvc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d699726e6ddcf05fb0f8a2550f67a89ba2939188",
+        "rev": "1a46c09b606f9152e20534c7a27c4facf1422bf2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1a46c09b`](https://github.com/nix-community/NUR/commit/1a46c09b606f9152e20534c7a27c4facf1422bf2) | `` automatic update `` |
| [`0af22749`](https://github.com/nix-community/NUR/commit/0af22749e03327aad7f205d16bd3a88c10a221f9) | `` automatic update `` |