### PR TITLE
chore(flake/nur): `1a46c09b` -> `b7a68434`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716496302,
-        "narHash": "sha256-77SBmhlUNEyUqkhFMqUIAdusbJ3hILC4D7i4FtgfAvc=",
+        "lastModified": 1716500755,
+        "narHash": "sha256-KbOpKmPaPCV949WhJPfHwoD6Zev/xPy1+mx4a5QIKr4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1a46c09b606f9152e20534c7a27c4facf1422bf2",
+        "rev": "b7a68434d425221761e03d83790b0c73b8046769",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b7a68434`](https://github.com/nix-community/NUR/commit/b7a68434d425221761e03d83790b0c73b8046769) | `` automatic update `` |
| [`fea1e66a`](https://github.com/nix-community/NUR/commit/fea1e66af63b2e95d3461631464889d9ee77fae8) | `` automatic update `` |