### PR TITLE
chore(flake/darwin): `eac4f250` -> `0bea8222`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -104,11 +104,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716329735,
-        "narHash": "sha256-ap51w+VqG21vuzyQ04WrhI2YbWHd3UGz0e7dc/QQmoA=",
+        "lastModified": 1716511055,
+        "narHash": "sha256-5Fe/DGgvMhPEMl9VdVxv3zvwRcwNDmW5eRJ0gk72w7U=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "eac4f25028c1975a939c8f8fba95c12f8a25e01c",
+        "rev": "0bea8222f6e83247dd13b055d83e64bce02ee532",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                     |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
| [`7f897008`](https://github.com/LnL7/nix-darwin/commit/7f897008d4f3c7dda86e19106169eb947a0ac308) | `` environment: Adjust systemPath order to allow injecting in the middle `` |
| [`bd0ed859`](https://github.com/LnL7/nix-darwin/commit/bd0ed8599fd4871e79543e09075dac2c2c25ff2a) | `` environment: Test how order of systemPath and profiles manifests ``      |
| [`9b6f7720`](https://github.com/LnL7/nix-darwin/commit/9b6f77200f8a88c8b5e5da47e90b73f86aab27b9) | `` environment: Rework test to assert against full $PATH ``                 |