### PR TITLE
chore(flake/nur): `341b00e4` -> `6ea5084a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716507882,
-        "narHash": "sha256-/nOeyzEvW7kNDSLjBTSajV6BUDX1V2N6I63jwPkwA/8=",
+        "lastModified": 1716519264,
+        "narHash": "sha256-F59HaYxXTPHRwBZMzR22lObVdR6ikw4vtIRFSUyiBjI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "341b00e4275d17419aa379df934ebd19ab697632",
+        "rev": "6ea5084a1dfd864a31f64ee818ca7f1b8e08ea35",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6ea5084a`](https://github.com/nix-community/NUR/commit/6ea5084a1dfd864a31f64ee818ca7f1b8e08ea35) | `` automatic update `` |
| [`bc28f02d`](https://github.com/nix-community/NUR/commit/bc28f02d21caf030769d000bcd2ec754f6fd47b9) | `` automatic update `` |
| [`8b33b57c`](https://github.com/nix-community/NUR/commit/8b33b57c6815f2c788a961570fb86c70f3cfad26) | `` automatic update `` |
| [`c4d41e8a`](https://github.com/nix-community/NUR/commit/c4d41e8a6f5f1617682747655aeb0ac262ba4cc0) | `` automatic update `` |