### PR TITLE
chore(flake/emacs-overlay): `bc6f0184` -> `3ba06331`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1716512527,
-        "narHash": "sha256-3zEqGlrXglIETCHbNBiomT9k98mbahTlUNzdIpOzxFk=",
+        "lastModified": 1716515434,
+        "narHash": "sha256-5vw5OwHoTkuyZS1EBnhxGgB/h0jMmO+xND6i9GLEQA8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bc6f018463f357bf040605eaee474928594a316f",
+        "rev": "3ba06331405227702c827478f0aee79ba0b917fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`3ba06331`](https://github.com/nix-community/emacs-overlay/commit/3ba06331405227702c827478f0aee79ba0b917fb) | `` Updated emacs `` |
| [`f76e194a`](https://github.com/nix-community/emacs-overlay/commit/f76e194a9a4bf032a74c544abfe3fbf9119476d2) | `` Updated melpa `` |