### PR TITLE
chore(flake/nur): `6ea5084a` -> `49bca246`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716519264,
-        "narHash": "sha256-F59HaYxXTPHRwBZMzR22lObVdR6ikw4vtIRFSUyiBjI=",
+        "lastModified": 1716522687,
+        "narHash": "sha256-JrIC8IAvN0kCBr3iPDHyGihgBb07wbpIixnzRjJqbAk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6ea5084a1dfd864a31f64ee818ca7f1b8e08ea35",
+        "rev": "49bca246d749e7b8dc7307a5ebdf3fa4ec808086",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`49bca246`](https://github.com/nix-community/NUR/commit/49bca246d749e7b8dc7307a5ebdf3fa4ec808086) | `` automatic update `` |
| [`3df7ae10`](https://github.com/nix-community/NUR/commit/3df7ae108cee407a49a17bde564ac29a4d599dc6) | `` automatic update `` |
| [`23226996`](https://github.com/nix-community/NUR/commit/232269966113407002e592f40bc0950f2b6a652b) | `` automatic update `` |
| [`d59a7e69`](https://github.com/nix-community/NUR/commit/d59a7e69fa885ce02b6fd708c742bb60edd66f68) | `` automatic update `` |