### PR TITLE
chore(flake/nur): `49bca246` -> `6373578e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716522687,
-        "narHash": "sha256-JrIC8IAvN0kCBr3iPDHyGihgBb07wbpIixnzRjJqbAk=",
+        "lastModified": 1716527176,
+        "narHash": "sha256-FhDJ15qhOl1UC6ViP/qXemhegCnr8Lnj82cpH4Gece8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "49bca246d749e7b8dc7307a5ebdf3fa4ec808086",
+        "rev": "6373578ec1883b5a65fd42cc6b9cebd5dcf9838b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6373578e`](https://github.com/nix-community/NUR/commit/6373578ec1883b5a65fd42cc6b9cebd5dcf9838b) | `` automatic update `` |
| [`af7c0410`](https://github.com/nix-community/NUR/commit/af7c0410ff8c9ae289df925f946f63c0dc3bd724) | `` automatic update `` |