### PR TITLE
chore(flake/nur): `6373578e` -> `46f9b946`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716527176,
-        "narHash": "sha256-FhDJ15qhOl1UC6ViP/qXemhegCnr8Lnj82cpH4Gece8=",
+        "lastModified": 1716533197,
+        "narHash": "sha256-S1vpc8RT5AR8TdHoFef9+KBkeLIFiowCmH8F0V0v+9Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6373578ec1883b5a65fd42cc6b9cebd5dcf9838b",
+        "rev": "46f9b9466e104fd75d2b817c36f8b0ed5d5aabee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`46f9b946`](https://github.com/nix-community/NUR/commit/46f9b9466e104fd75d2b817c36f8b0ed5d5aabee) | `` automatic update `` |
| [`d67cdbb6`](https://github.com/nix-community/NUR/commit/d67cdbb61623bd8d8c5273acd71dc11377dab7b4) | `` automatic update `` |