### PR TITLE
chore(flake/emacs-overlay): `3ba06331` -> `1d3e117f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1716515434,
-        "narHash": "sha256-5vw5OwHoTkuyZS1EBnhxGgB/h0jMmO+xND6i9GLEQA8=",
+        "lastModified": 1716540789,
+        "narHash": "sha256-74mBbYD3AnOtRN3NJRg8jPs27mu8QkR4WhAl2MPCHvE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3ba06331405227702c827478f0aee79ba0b917fb",
+        "rev": "1d3e117fd927a1a66c80f1667b6b7983dd7bec40",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`1d3e117f`](https://github.com/nix-community/emacs-overlay/commit/1d3e117fd927a1a66c80f1667b6b7983dd7bec40) | `` Updated melpa `` |