### PR TITLE
chore(flake/nur): `74146e6d` -> `8d56a7c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716540307,
-        "narHash": "sha256-qZBnR2aAgZHyajBYc5OCIrUnK3upE1JoOpDiPxTdM5k=",
+        "lastModified": 1716543979,
+        "narHash": "sha256-uGp1xBxjPL2ACagXOkazhYtE4WujXwXUI6nKiXrlEZ0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "74146e6dbb66e162fbc7409b718dffd04ec106ce",
+        "rev": "8d56a7c71dd362321002041a704978e3dc23e51f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8d56a7c7`](https://github.com/nix-community/NUR/commit/8d56a7c71dd362321002041a704978e3dc23e51f) | `` automatic update `` |
| [`0e260da3`](https://github.com/nix-community/NUR/commit/0e260da34a869053d598346aedd020e4b171ad4b) | `` automatic update `` |