### PR TITLE
chore(flake/nur): `981b8204` -> `6cd26806`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716555488,
-        "narHash": "sha256-6pqYAkzOanbzlrvuHv4sTGOeq58jhRCYfR5/xo/vOb0=",
+        "lastModified": 1716558510,
+        "narHash": "sha256-unODuZBEFO/iOIaUJQhjke1dbGq6NZTKKGWtXJ0VqPI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "981b820421231af53ab1b07e80bf12ca35d4357b",
+        "rev": "6cd26806365e80f8e05cb3ec95b7926e1f8f7832",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6cd26806`](https://github.com/nix-community/NUR/commit/6cd26806365e80f8e05cb3ec95b7926e1f8f7832) | `` automatic update `` |