### PR TITLE
chore(flake/nur): `6cd26806` -> `6f79ab70`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716558510,
-        "narHash": "sha256-unODuZBEFO/iOIaUJQhjke1dbGq6NZTKKGWtXJ0VqPI=",
+        "lastModified": 1716565579,
+        "narHash": "sha256-YTp66ZzvGjAs4Tllc4uVLboBlA9RbiveENRa1PNF5hA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6cd26806365e80f8e05cb3ec95b7926e1f8f7832",
+        "rev": "6f79ab7086692a520bd31acf09fa238294c76844",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                          |
| -------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`6f79ab70`](https://github.com/nix-community/NUR/commit/6f79ab7086692a520bd31acf09fa238294c76844) | `` automatic update ``           |
| [`577a1383`](https://github.com/nix-community/NUR/commit/577a1383f6cde64b8bffffbdef0e4a7e56cded7d) | `` automatic update ``           |
| [`f99a1540`](https://github.com/nix-community/NUR/commit/f99a1540f0d221ccd829ae20760eb4ed349ccd07) | `` Ran format-manifest ``        |
| [`6c8d301f`](https://github.com/nix-community/NUR/commit/6c8d301f7348ca3363b83f09beba1f37c3824559) | `` Added myself to repos.json `` |
| [`97bfb99d`](https://github.com/nix-community/NUR/commit/97bfb99db49f9f130a87bbdff8825aeda9e521f4) | `` automatic update ``           |