### PR TITLE
chore(flake/emacs-overlay): `1d3e117f` -> `b0e58504`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1716540789,
-        "narHash": "sha256-74mBbYD3AnOtRN3NJRg8jPs27mu8QkR4WhAl2MPCHvE=",
+        "lastModified": 1716569495,
+        "narHash": "sha256-OkMBP2nSNRCHS0F3iowUouyyd0ZLZUW8yk2KqrA6EeE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1d3e117fd927a1a66c80f1667b6b7983dd7bec40",
+        "rev": "b0e585048dcc3468a9c8a9b6e5862b74730cdd75",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`b0e58504`](https://github.com/nix-community/emacs-overlay/commit/b0e585048dcc3468a9c8a9b6e5862b74730cdd75) | `` Updated melpa ``  |
| [`9f951330`](https://github.com/nix-community/emacs-overlay/commit/9f9513304aec104557bee0e17474543b312211ce) | `` Updated elpa ``   |
| [`a424973c`](https://github.com/nix-community/emacs-overlay/commit/a424973c6bb1d08171cf53e70e75afde0501e97a) | `` Updated nongnu `` |