### PR TITLE
chore(flake/emacs-overlay): `2f61d16c` -> `87be032a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1716829580,
-        "narHash": "sha256-AjurIGzI/3Y5uuKvdr3mIZTjrW2ZRb+GmP+R8fX4Obw=",
+        "lastModified": 1716858129,
+        "narHash": "sha256-lazwWoBos+YsBcBayXvQTQt3VzktWql+cjHa6c0/Jg8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2f61d16c26d7f54753eeb93d3c39fe7040ef99c9",
+        "rev": "87be032a80d6aef6948bededf825c79c60d80374",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`87be032a`](https://github.com/nix-community/emacs-overlay/commit/87be032a80d6aef6948bededf825c79c60d80374) | `` Updated elpa ``   |
| [`2086eb3b`](https://github.com/nix-community/emacs-overlay/commit/2086eb3b9b6bb72a45b0efb9957ff0d9cb8d7d98) | `` Updated nongnu `` |