### PR TITLE
chore(flake/emacs-overlay): `87be032a` -> `76c2bc6a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1716858129,
-        "narHash": "sha256-lazwWoBos+YsBcBayXvQTQt3VzktWql+cjHa6c0/Jg8=",
+        "lastModified": 1716861039,
+        "narHash": "sha256-I2dJOniVeMDnMDIAYXvGLhOOG8pD1YLGtS5Kn6wwxB8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "87be032a80d6aef6948bededf825c79c60d80374",
+        "rev": "76c2bc6a106076a377fca4334a612d2fad5d49b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`76c2bc6a`](https://github.com/nix-community/emacs-overlay/commit/76c2bc6a106076a377fca4334a612d2fad5d49b0) | `` Updated emacs `` |
| [`cb5c8a74`](https://github.com/nix-community/emacs-overlay/commit/cb5c8a74fe070dc40ffd3536df99752fe6e489bc) | `` Updated melpa `` |