### PR TITLE
chore(flake/nur): `678d5b99` -> `a3916edb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716860735,
-        "narHash": "sha256-Lr1E8KLwo1uZ3GGSSn5BlwTqjq1+3AspQcVRNjNBTwY=",
+        "lastModified": 1716866219,
+        "narHash": "sha256-lbXVSjGXbD5+YicZI3JmSCVzKAZAWp7Vbfghl83YVMo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "678d5b99e2d7623100e133fe74ffb13c75cc9a4d",
+        "rev": "a3916edbf6f454e68ef0b12c49a5779c0ed8ceab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a3916edb`](https://github.com/nix-community/NUR/commit/a3916edbf6f454e68ef0b12c49a5779c0ed8ceab) | `` automatic update `` |
| [`13b46294`](https://github.com/nix-community/NUR/commit/13b462943bf8a390ff24153b5cdb40d1bc4944f3) | `` automatic update `` |
| [`88621907`](https://github.com/nix-community/NUR/commit/88621907672876cee81007c67a201a0300d7f8d5) | `` automatic update `` |