### PR TITLE
chore(flake/nur): `a3916edb` -> `a2835066`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716866219,
-        "narHash": "sha256-lbXVSjGXbD5+YicZI3JmSCVzKAZAWp7Vbfghl83YVMo=",
+        "lastModified": 1716871734,
+        "narHash": "sha256-1vzQuXN0OnQcEotd2RwyylunWLaF18Jvt/0fSh1H27w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a3916edbf6f454e68ef0b12c49a5779c0ed8ceab",
+        "rev": "a2835066ab63278e983ff3696ad3324e8548652e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a2835066`](https://github.com/nix-community/NUR/commit/a2835066ab63278e983ff3696ad3324e8548652e) | `` automatic update `` |
| [`3b224357`](https://github.com/nix-community/NUR/commit/3b2243570321676f9ae52e043930574acb0aa27d) | `` automatic update `` |
| [`8a92ade7`](https://github.com/nix-community/NUR/commit/8a92ade733741699bdb3af3f64b82998be5c300c) | `` automatic update `` |