### PR TITLE
chore(flake/nur): `a2835066` -> `96ce9b44`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716871734,
-        "narHash": "sha256-1vzQuXN0OnQcEotd2RwyylunWLaF18Jvt/0fSh1H27w=",
+        "lastModified": 1716875170,
+        "narHash": "sha256-kEiqYLAlqkMnNTyOIRp0M2g2e23mUwRUiXQEZvNlcig=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a2835066ab63278e983ff3696ad3324e8548652e",
+        "rev": "96ce9b445deade508efc3cc31ebaa54397cf447f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`96ce9b44`](https://github.com/nix-community/NUR/commit/96ce9b445deade508efc3cc31ebaa54397cf447f) | `` automatic update `` |