### PR TITLE
chore(flake/catppuccin): `fea5242c` -> `ed79a45b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1716337435,
-        "narHash": "sha256-eZqH1vLI9eKL/N5toXxOrQO80G0y4pWZrYCp472YBVQ=",
+        "lastModified": 1716879030,
+        "narHash": "sha256-Ve4w/8kKRr1xxFFUmav5IablTMsBHpiVfOabab3VuJc=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "fea5242c0eacc5efa81be0e36206a62e889dbd82",
+        "rev": "ed79a45b47b8c95ed66f8509ab3ce47194d6dc68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                                  |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`ed79a45b`](https://github.com/catppuccin/nix/commit/ed79a45b47b8c95ed66f8509ab3ce47194d6dc68) | `` ci: bump cachix/install-nix-action from 26 to 27 (#197) ``                            |
| [`ba406803`](https://github.com/catppuccin/nix/commit/ba40680357bca0f04f8518ff22349ad89941d81e) | `` feat(home-manager): add support for cava themes with transparent background (#191) `` |
| [`144b70d5`](https://github.com/catppuccin/nix/commit/144b70d50e95e900b29e60c4f64256f8cf29313d) | `` fix(nixos): sddm package not being installed  (#194) ``                               |
| [`f32e5ab2`](https://github.com/catppuccin/nix/commit/f32e5ab2b541b22893cf1ddb2df576d43c9923ba) | `` feat(home-manager): add support for kvantum (#175) ``                                 |