### PR TITLE
chore(flake/nur): `96ce9b44` -> `6a935155`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716875170,
-        "narHash": "sha256-kEiqYLAlqkMnNTyOIRp0M2g2e23mUwRUiXQEZvNlcig=",
+        "lastModified": 1716878867,
+        "narHash": "sha256-17wra1O+tJJaBodd6O2QMdaaEiyvye9G4K1T+6xKe84=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "96ce9b445deade508efc3cc31ebaa54397cf447f",
+        "rev": "6a93515564cd8d2e26ef2cdb4be62e2f44de4362",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6a935155`](https://github.com/nix-community/NUR/commit/6a93515564cd8d2e26ef2cdb4be62e2f44de4362) | `` automatic update `` |