### PR TITLE
chore(flake/nixos-hardware): `9a20e17a` -> `806e9d4a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -548,11 +548,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1716798306,
-        "narHash": "sha256-s8+OhT1WSPMoqbTawT30hj4NVMg+w03/a+2HVqcNhY0=",
+        "lastModified": 1716881121,
+        "narHash": "sha256-oTf3enbe/lbiNzsyZ8ria+422hx4e/FB3xQcY2LPnJw=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "9a20e17a73b052d6be912adcee220cb483477094",
+        "rev": "806e9d4a933dd1e75592e88894d4bd2f296f5bbf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                       |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`806e9d4a`](https://github.com/NixOS/nixos-hardware/commit/806e9d4a933dd1e75592e88894d4bd2f296f5bbf) | `` Fix typo for IdeaPad 3 15alc6 in README.md ``              |
| [`d664fb04`](https://github.com/NixOS/nixos-hardware/commit/d664fb04deaa8e344ce86b485a7a8d685238a4c3) | `` add Lenovo IdeaPad 3 15alc6 ``                             |
| [`a44ddc27`](https://github.com/NixOS/nixos-hardware/commit/a44ddc27b1180dfa1037201871d1c717e8f69372) | `` Revert "starfive visionfive2: Increase mtd0 to fit spl" `` |
| [`03e1d2d5`](https://github.com/NixOS/nixos-hardware/commit/03e1d2d5842a730713ab1fdbf0f25d3735019b8c) | `` starfive visionfive2: enable required drivers ``           |
| [`41345261`](https://github.com/NixOS/nixos-hardware/commit/413452614f52f3f5e7038f8456b6c0082a5594dc) | `` starfive visionfive2: use mainline kernel ``               |