### PR TITLE
chore(flake/catppuccin): `ed79a45b` -> `296adaf9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1716879030,
-        "narHash": "sha256-Ve4w/8kKRr1xxFFUmav5IablTMsBHpiVfOabab3VuJc=",
+        "lastModified": 1716884128,
+        "narHash": "sha256-hzTzcX/qIGf93WVvk2jlLL3N7IgIlWylOBQkgwfTq8w=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "ed79a45b47b8c95ed66f8509ab3ce47194d6dc68",
+        "rev": "296adaf9331cd2c1eb479a25d5207508fbd06188",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                      |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`296adaf9`](https://github.com/catppuccin/nix/commit/296adaf9331cd2c1eb479a25d5207508fbd06188) | `` feat(modules): add declarations (#198) `` |