### PR TITLE
chore(flake/emacs-overlay): `76c2bc6a` -> `6d2e1466`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1716861039,
-        "narHash": "sha256-I2dJOniVeMDnMDIAYXvGLhOOG8pD1YLGtS5Kn6wwxB8=",
+        "lastModified": 1716886479,
+        "narHash": "sha256-+3/BXKR0BlUd/0Tv+oHxEmW0j39wLUUNX0sURttm9RY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "76c2bc6a106076a377fca4334a612d2fad5d49b0",
+        "rev": "6d2e14666ff067074bb80e32ae9d1383743c6487",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`6d2e1466`](https://github.com/nix-community/emacs-overlay/commit/6d2e14666ff067074bb80e32ae9d1383743c6487) | `` Updated melpa `` |