### PR TITLE
chore(flake/nur): `6a935155` -> `f45a1ca9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716878867,
-        "narHash": "sha256-17wra1O+tJJaBodd6O2QMdaaEiyvye9G4K1T+6xKe84=",
+        "lastModified": 1716892974,
+        "narHash": "sha256-THmLi8tNElts9aPkHV68tyON6LgaMvfrmu8j4h4v6Aw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6a93515564cd8d2e26ef2cdb4be62e2f44de4362",
+        "rev": "f45a1ca97c3e7b5ec5d970977b5ec44b5f466857",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f45a1ca9`](https://github.com/nix-community/NUR/commit/f45a1ca97c3e7b5ec5d970977b5ec44b5f466857) | `` automatic update `` |
| [`731eb0c9`](https://github.com/nix-community/NUR/commit/731eb0c95af5efa7a8ffb3ca1b5f1a00d8e5db13) | `` automatic update `` |