### PR TITLE
chore(flake/nur): `f45a1ca9` -> `eed57c02`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716892974,
-        "narHash": "sha256-THmLi8tNElts9aPkHV68tyON6LgaMvfrmu8j4h4v6Aw=",
+        "lastModified": 1716896763,
+        "narHash": "sha256-dpA0rnou4E7blgDy0QWcpf7NnzlYYyNDsz46YLWs/0U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f45a1ca97c3e7b5ec5d970977b5ec44b5f466857",
+        "rev": "eed57c02849fe16262f2482508e8ca43926b3699",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`eed57c02`](https://github.com/nix-community/NUR/commit/eed57c02849fe16262f2482508e8ca43926b3699) | `` automatic update `` |