### PR TITLE
chore(flake/nur): `eed57c02` -> `ccff8778`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716896763,
-        "narHash": "sha256-dpA0rnou4E7blgDy0QWcpf7NnzlYYyNDsz46YLWs/0U=",
+        "lastModified": 1716900473,
+        "narHash": "sha256-nrpeMzN0KiFfJMIVXICjyrACs32kg8gADHiEvr5yo20=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eed57c02849fe16262f2482508e8ca43926b3699",
+        "rev": "ccff87784df1242df48fc8dd25119491f584bba2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ccff8778`](https://github.com/nix-community/NUR/commit/ccff87784df1242df48fc8dd25119491f584bba2) | `` automatic update `` |