### PR TITLE
chore(flake/nur): `ccff8778` -> `f90c0edd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716900473,
-        "narHash": "sha256-nrpeMzN0KiFfJMIVXICjyrACs32kg8gADHiEvr5yo20=",
+        "lastModified": 1716903916,
+        "narHash": "sha256-kjodJgHDprBBwQ7WHRPaTtJ4cgxHKycquhwO9tlWcjI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ccff87784df1242df48fc8dd25119491f584bba2",
+        "rev": "f90c0edd68fd388dfbaa310789a13bccfd06b005",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f90c0edd`](https://github.com/nix-community/NUR/commit/f90c0edd68fd388dfbaa310789a13bccfd06b005) | `` automatic update `` |