### PR TITLE
chore(flake/nur): `f90c0edd` -> `fc8ce2f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716903916,
-        "narHash": "sha256-kjodJgHDprBBwQ7WHRPaTtJ4cgxHKycquhwO9tlWcjI=",
+        "lastModified": 1716914193,
+        "narHash": "sha256-QeiZSJMidN2aAChpyanA7nnGLqQjmjlWkkkkMxZcNY0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f90c0edd68fd388dfbaa310789a13bccfd06b005",
+        "rev": "fc8ce2f8054e3d33486f20d9baebc65010f1941a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fc8ce2f8`](https://github.com/nix-community/NUR/commit/fc8ce2f8054e3d33486f20d9baebc65010f1941a) | `` automatic update `` |
| [`a569fb54`](https://github.com/nix-community/NUR/commit/a569fb54cfba9894b0ecb6ffbe2141b18c37d773) | `` automatic update `` |
| [`71c2220a`](https://github.com/nix-community/NUR/commit/71c2220a9cd8209dc19e13243af46f11c54ab87a) | `` automatic update `` |
| [`b442d062`](https://github.com/nix-community/NUR/commit/b442d0626452dd228f9addae77d19e6f76ae079a) | `` automatic update `` |