### PR TITLE
chore(flake/emacs-overlay): `6d2e1466` -> `b6c62d81`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1716886479,
-        "narHash": "sha256-+3/BXKR0BlUd/0Tv+oHxEmW0j39wLUUNX0sURttm9RY=",
+        "lastModified": 1716916086,
+        "narHash": "sha256-n/uf+jsjrXDUuDE6npM2hFfmPRfoYmEcpcoUuPstwi8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6d2e14666ff067074bb80e32ae9d1383743c6487",
+        "rev": "b6c62d8135f943ea1e2733aa644cbd146afe2d62",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`b6c62d81`](https://github.com/nix-community/emacs-overlay/commit/b6c62d8135f943ea1e2733aa644cbd146afe2d62) | `` Updated emacs `` |
| [`a087aa6a`](https://github.com/nix-community/emacs-overlay/commit/a087aa6a87647ff1b853d5536c8e63761eeb1a1a) | `` Updated melpa `` |
| [`116abf13`](https://github.com/nix-community/emacs-overlay/commit/116abf13437982f49be465151c066f116c9af9ce) | `` Updated elpa ``  |