### PR TITLE
chore(flake/nur): `f21371e6` -> `5ae71f8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716920912,
-        "narHash": "sha256-IG3ivvlMw3H0OjPWVhSL+kc3+484GBvG4zgLkUOmCKs=",
+        "lastModified": 1716925562,
+        "narHash": "sha256-wDW6+bkL6YbPtuzWDcgvCHinF5K4rbITfdXYkYsZRd0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f21371e68742f67a4e76e535caf782b707e91401",
+        "rev": "5ae71f8eeb0ee60f7a39402557cbc6c2c3c4c9e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5ae71f8e`](https://github.com/nix-community/NUR/commit/5ae71f8eeb0ee60f7a39402557cbc6c2c3c4c9e1) | `` automatic update `` |