### PR TITLE
chore(flake/nur): `5ae71f8e` -> `447edf15`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716925562,
-        "narHash": "sha256-wDW6+bkL6YbPtuzWDcgvCHinF5K4rbITfdXYkYsZRd0=",
+        "lastModified": 1716929170,
+        "narHash": "sha256-QqzXj4kUuPks5wkp8fgWx4LtHg/IpPN9FKDp9LnN5f8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5ae71f8eeb0ee60f7a39402557cbc6c2c3c4c9e1",
+        "rev": "447edf15e2fb835fa1b6f9c8e64132980e4721fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`447edf15`](https://github.com/nix-community/NUR/commit/447edf15e2fb835fa1b6f9c8e64132980e4721fd) | `` automatic update `` |
| [`5e9c9a70`](https://github.com/nix-community/NUR/commit/5e9c9a702f621010e2c8a76c9b79c3781bd9479e) | `` automatic update `` |