### PR TITLE
chore(flake/nur): `447edf15` -> `5d5ad1e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716929170,
-        "narHash": "sha256-QqzXj4kUuPks5wkp8fgWx4LtHg/IpPN9FKDp9LnN5f8=",
+        "lastModified": 1716932685,
+        "narHash": "sha256-y3hqwTWZFyFBtJdkvnhGUvKHYbQgbovnRe5kDVYIOqE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "447edf15e2fb835fa1b6f9c8e64132980e4721fd",
+        "rev": "5d5ad1e79a30ac83020ce935c889ab376e487e78",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5d5ad1e7`](https://github.com/nix-community/NUR/commit/5d5ad1e79a30ac83020ce935c889ab376e487e78) | `` automatic update `` |
| [`ccb437ff`](https://github.com/nix-community/NUR/commit/ccb437ff3801c367b903a866209268734cb7cabd) | `` automatic update `` |