### PR TITLE
chore(flake/emacs-overlay): `b6c62d81` -> `1ca845e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1716916086,
-        "narHash": "sha256-n/uf+jsjrXDUuDE6npM2hFfmPRfoYmEcpcoUuPstwi8=",
+        "lastModified": 1716947643,
+        "narHash": "sha256-vbOkT8/eZiaxwgc/oTPlYCi1gCqsFKWOTk2OdbHlzcY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b6c62d8135f943ea1e2733aa644cbd146afe2d62",
+        "rev": "1ca845e99884cb7d515ae7d773a186231cfae242",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`1ca845e9`](https://github.com/nix-community/emacs-overlay/commit/1ca845e99884cb7d515ae7d773a186231cfae242) | `` Updated emacs `` |
| [`74a67c68`](https://github.com/nix-community/emacs-overlay/commit/74a67c68d0b6ec02ff7c300a7f6a0b50abc116d6) | `` Updated melpa `` |
| [`27cda0d5`](https://github.com/nix-community/emacs-overlay/commit/27cda0d551a0d064f88112c1501a6d4a00e0c20a) | `` Updated elpa ``  |