### PR TITLE
chore(flake/nur): `5d5ad1e7` -> `aa34ae54`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716932685,
-        "narHash": "sha256-y3hqwTWZFyFBtJdkvnhGUvKHYbQgbovnRe5kDVYIOqE=",
+        "lastModified": 1716945988,
+        "narHash": "sha256-UGPM8fbvREwITg/XIUVHdE0bEIjyRojvwLyXkCnFSUw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5d5ad1e79a30ac83020ce935c889ab376e487e78",
+        "rev": "aa34ae540912cadd8936e2340d4f23ad82a88b81",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`aa34ae54`](https://github.com/nix-community/NUR/commit/aa34ae540912cadd8936e2340d4f23ad82a88b81) | `` automatic update `` |
| [`e0b2bf40`](https://github.com/nix-community/NUR/commit/e0b2bf40b315dbf13f05d03c0ea2b6fa174c6aad) | `` automatic update `` |