### PR TITLE
chore(flake/nur): `aa34ae54` -> `019b07dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716945988,
-        "narHash": "sha256-UGPM8fbvREwITg/XIUVHdE0bEIjyRojvwLyXkCnFSUw=",
+        "lastModified": 1716947347,
+        "narHash": "sha256-gudW4Q/su1JWELX2yxChgRYLkdkKbq4m57JeACBMOm8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aa34ae540912cadd8936e2340d4f23ad82a88b81",
+        "rev": "019b07dd2644d0fd5adb9b8442d345f150cc3230",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`019b07dd`](https://github.com/nix-community/NUR/commit/019b07dd2644d0fd5adb9b8442d345f150cc3230) | `` automatic update `` |