### PR TITLE
chore(flake/nur): `019b07dd` -> `a37ad092`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716947347,
-        "narHash": "sha256-gudW4Q/su1JWELX2yxChgRYLkdkKbq4m57JeACBMOm8=",
+        "lastModified": 1716950974,
+        "narHash": "sha256-iYdpCtSJnsMDwJ3U+8XL5EBdFAaLks4LRJ9MS2S+su8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "019b07dd2644d0fd5adb9b8442d345f150cc3230",
+        "rev": "a37ad092619290ba8a495909b6259028ee170d46",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a37ad092`](https://github.com/nix-community/NUR/commit/a37ad092619290ba8a495909b6259028ee170d46) | `` automatic update `` |
| [`9a88f86b`](https://github.com/nix-community/NUR/commit/9a88f86baa0dd9b7629b213e94d0e7e7f4a8dd3d) | `` automatic update `` |