### PR TITLE
chore(flake/nur): `a37ad092` -> `7285e4ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716950974,
-        "narHash": "sha256-iYdpCtSJnsMDwJ3U+8XL5EBdFAaLks4LRJ9MS2S+su8=",
+        "lastModified": 1716958267,
+        "narHash": "sha256-aymnZNLkchpunYfjVv/BpTrFvJzWUKM9NUPiPpw4eC4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a37ad092619290ba8a495909b6259028ee170d46",
+        "rev": "7285e4ed309bd7239f13d22e65c5dff6daa33564",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7285e4ed`](https://github.com/nix-community/NUR/commit/7285e4ed309bd7239f13d22e65c5dff6daa33564) | `` automatic update `` |
| [`b782592a`](https://github.com/nix-community/NUR/commit/b782592ae7daf5f5fa79e02b94a2ab4292ae6669) | `` automatic update `` |
| [`646f9060`](https://github.com/nix-community/NUR/commit/646f9060aa0c272eb594cf09744852050be90dc8) | `` automatic update `` |