### PR TITLE
chore(flake/nur): `7285e4ed` -> `ff68d8b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716958267,
-        "narHash": "sha256-aymnZNLkchpunYfjVv/BpTrFvJzWUKM9NUPiPpw4eC4=",
+        "lastModified": 1716964378,
+        "narHash": "sha256-YZumv+YR7J5NLY3qu2qNR+pfacZ3esyzOpXRNkVoNpY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7285e4ed309bd7239f13d22e65c5dff6daa33564",
+        "rev": "ff68d8b496fa66bbb31b8b54f54fdd98279b37b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ff68d8b4`](https://github.com/nix-community/NUR/commit/ff68d8b496fa66bbb31b8b54f54fdd98279b37b0) | `` automatic update `` |