### PR TITLE
chore(flake/nur): `ff68d8b4` -> `c2587118`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716964378,
-        "narHash": "sha256-YZumv+YR7J5NLY3qu2qNR+pfacZ3esyzOpXRNkVoNpY=",
+        "lastModified": 1716968982,
+        "narHash": "sha256-QcxSBqQjt7jGmXKTz/R/BGzXHqjaAiBYJnEeX96AZE0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ff68d8b496fa66bbb31b8b54f54fdd98279b37b0",
+        "rev": "c258711858c6a8506a121308d3a6834c3379cd0d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c2587118`](https://github.com/nix-community/NUR/commit/c258711858c6a8506a121308d3a6834c3379cd0d) | `` automatic update `` |
| [`b3cfbe0f`](https://github.com/nix-community/NUR/commit/b3cfbe0fa21310140fcc5aecc2f2248c1d081abc) | `` automatic update `` |
| [`bc13045a`](https://github.com/nix-community/NUR/commit/bc13045a76a2b6bf7f1dfb1f87e4384be952dfe2) | `` automatic update `` |