### PR TITLE
chore(flake/nur): `c2587118` -> `3ced449a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716968982,
-        "narHash": "sha256-QcxSBqQjt7jGmXKTz/R/BGzXHqjaAiBYJnEeX96AZE0=",
+        "lastModified": 1716972321,
+        "narHash": "sha256-iB8kNkc+p/9NwmrXgnChB6JFcUtSBSdGESRVliiTCMI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c258711858c6a8506a121308d3a6834c3379cd0d",
+        "rev": "3ced449a2fdd845ffde002790691bedf6958f00c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3ced449a`](https://github.com/nix-community/NUR/commit/3ced449a2fdd845ffde002790691bedf6958f00c) | `` automatic update `` |
| [`e5659468`](https://github.com/nix-community/NUR/commit/e5659468084f29a642f79e01bab9e747bada9753) | `` automatic update `` |