### PR TITLE
chore(flake/nixpkgs): `bfb7a882` -> `9ca3f649`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -669,11 +669,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1716509168,
-        "narHash": "sha256-4zSIhSRRIoEBwjbPm3YiGtbd8HDWzFxJjw5DYSDy1n8=",
+        "lastModified": 1716769173,
+        "narHash": "sha256-7EXDb5WBw+d004Agt+JHC/Oyh/KTUglOaQ4MNjBbo5w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bfb7a882678e518398ce9a31a881538679f6f092",
+        "rev": "9ca3f649614213b2aaf5f1e16ec06952fe4c2632",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`610ee378`](https://github.com/NixOS/nixpkgs/commit/610ee378fcf718b9cc655efa81dc34cf907c72ad) | `` Revert "srcOnly: reflink if possible and preserve attributes" ``           |
| [`e0c43a96`](https://github.com/NixOS/nixpkgs/commit/e0c43a96d20d8604b84f07d016aeb90e2ff0e437) | `` testers.lycheeLinkCheck: init (#298665) ``                                 |
| [`a7b6a466`](https://github.com/NixOS/nixpkgs/commit/a7b6a4663a457c7c5af925955171b551d0c693e0) | `` trash-cli: 0.24.4.17 -> 0.24.5.26 ``                                       |
| [`a8dfb82c`](https://github.com/NixOS/nixpkgs/commit/a8dfb82cb40ee7661abd0ac2f73b8c376dedd496) | `` okonomiyaki: Mark as broken on Python 3.12 (#314561) ``                    |
| [`69b7f701`](https://github.com/NixOS/nixpkgs/commit/69b7f701f9e9c994e5cb58fe705ffcd90ab30542) | `` zipfile2: Mark as broken on Python 3.12 (#314557) ``                       |
| [`a292fa38`](https://github.com/NixOS/nixpkgs/commit/a292fa38bdd437d6a99d4e5513e613d1f00c51bc) | `` corretto17: fix eval on darwin ``                                          |
| [`07709ea9`](https://github.com/NixOS/nixpkgs/commit/07709ea9366b44e50f124562cb387722c152b4cc) | `` teleport_13: remove ``                                                     |
| [`7173eb87`](https://github.com/NixOS/nixpkgs/commit/7173eb87b8720da79989bbf1ed1fa72465323778) | `` srcOnly: reflink if possible and preserve attributes ``                    |
| [`6536fbb1`](https://github.com/NixOS/nixpkgs/commit/6536fbb145502acbc97939f0fd0e63976570f724) | `` ibus-engines.bamboo: clean up code ``                                      |
| [`50be4052`](https://github.com/NixOS/nixpkgs/commit/50be40524b38e05afb12441f8ffbf74a023b8367) | `` ibus-engines.bamboo: remove superbo as maintainer ``                       |
| [`dfb4af7f`](https://github.com/NixOS/nixpkgs/commit/dfb4af7f3e1ff8b840e33d209b0fea596ce2b450) | `` python3Packages.scikit-fmm: fix build on Python 3.12+ ``                   |
| [`5faa416d`](https://github.com/NixOS/nixpkgs/commit/5faa416d1da39d71b92ee271ad21c4dac11b337d) | `` plantuml: 1.2024.4 -> 1.2024.5 ``                                          |
| [`609f2019`](https://github.com/NixOS/nixpkgs/commit/609f201988736b9f16ead388988c1154cdd9042c) | `` python312Packages.pyxnat: 1.6 -> 1.6.2 ``                                  |
| [`7619c969`](https://github.com/NixOS/nixpkgs/commit/7619c9693e023375b37c91a0634817189e711447) | `` gnu-smalltalk: Numbered the patch ``                                       |
| [`92416bb8`](https://github.com/NixOS/nixpkgs/commit/92416bb8d9d60d025cc7282f685a2296f5a37da0) | `` python311Packages.snakemake: 8.11.4 -> 8.11.6 ``                           |
| [`e97fd87d`](https://github.com/NixOS/nixpkgs/commit/e97fd87d4fb8b3f51d2d1f69474da266dc49445b) | `` python3Packages.xyzservices: adopted by geospatial team ``                 |
| [`f96f74c8`](https://github.com/NixOS/nixpkgs/commit/f96f74c81f4d5db469ba15e4c0a457495faed48e) | `` python311Packages.oslo-db: 15.0.0 -> 15.1.0 ``                             |
| [`164f6616`](https://github.com/NixOS/nixpkgs/commit/164f66169a0bae512fc445d4f888f78012f05781) | `` nixos/steam: add option fontPackages ``                                    |
| [`ba209107`](https://github.com/NixOS/nixpkgs/commit/ba209107bd965711fa735b73719341e17cbf89e4) | `` mini-calc: 3.0.1 -> 3.1.0 ``                                               |
| [`bd7ccc7a`](https://github.com/NixOS/nixpkgs/commit/bd7ccc7a7d64b4959b29f641931ce68b5cc1bbb9) | `` reproxy: 1.1.1 → 1.2.2 ``                                                  |
| [`efef69a5`](https://github.com/NixOS/nixpkgs/commit/efef69a51dd48a12beb518b67c534238842249d8) | `` nixos/steam: add option `extraPackages` ``                                 |
| [`32f8f2df`](https://github.com/NixOS/nixpkgs/commit/32f8f2dfd9cf27ea2895b1c6c822670ef840d3fb) | `` jnv: 0.2.2 -> 0.2.3 ``                                                     |
| [`1109e8dc`](https://github.com/NixOS/nixpkgs/commit/1109e8dc2a3254a650075998a38c108f38be1059) | `` kde-rounded-corners: 0.6.5 -> 0.6.6 ``                                     |
| [`637bdc3d`](https://github.com/NixOS/nixpkgs/commit/637bdc3d2f5216a9bb53d99c52bc7874a458bae4) | `` wldash: init at 0.3.0 (#313098) ``                                         |
| [`b0898457`](https://github.com/NixOS/nixpkgs/commit/b0898457fd4fd2c46bf741d570a886c6830bab23) | `` flashmq: 1.13.0 -> 1.13.1 ``                                               |
| [`fa871cb7`](https://github.com/NixOS/nixpkgs/commit/fa871cb79db7cec8c5307644e1abf88d7ab281f0) | `` python311Packages.django-modeltranslation: 0.18.13 -> 0.19.0 ``            |
| [`b40e2877`](https://github.com/NixOS/nixpkgs/commit/b40e28775bc702f894d3a7da1fcf4aeaa2eff28c) | `` pyradio: 0.9.3.6 -> 0.9.3.7 ``                                             |
| [`f7e2b6d7`](https://github.com/NixOS/nixpkgs/commit/f7e2b6d7287c0526beb14a886b5f48cbcfd30d9b) | `` clash-verge-rev: 1.6.2 -> 1.6.3 ``                                         |
| [`3c7578c4`](https://github.com/NixOS/nixpkgs/commit/3c7578c4d041f9164a7057e2d7c8721c9b2a6f66) | `` firebase-tools: 13.10.0 -> 13.10.1 ``                                      |
| [`10a7ecf1`](https://github.com/NixOS/nixpkgs/commit/10a7ecf1943d076296484499ac02bef5759277a7) | `` juju: 3.3.5 -> 3.5.0 ``                                                    |
| [`b995ae73`](https://github.com/NixOS/nixpkgs/commit/b995ae738ca179cc2033cc20712f382986afad03) | `` python311Packages.pytubefix, python312Packages.pytubefix: init at 5.6.3 `` |
| [`59a29eef`](https://github.com/NixOS/nixpkgs/commit/59a29eef1ab56decdbcfdec84b48f4f6d6a93e19) | `` pachyderm: 2.9.5 -> 2.10.1 ``                                              |
| [`fc055378`](https://github.com/NixOS/nixpkgs/commit/fc055378fd1196910c6bbbf39cb75b32122483fd) | `` tidal-hifi: 5.12.0 -> 5.13.0 ``                                            |
| [`b2b8177d`](https://github.com/NixOS/nixpkgs/commit/b2b8177d9a283ca19781a4a5a68ab767d3f54a01) | `` earthly: 0.8.11 -> 0.8.12 ``                                               |
| [`6fbe8ce1`](https://github.com/NixOS/nixpkgs/commit/6fbe8ce16bfcaaf6227f8ea5851ea58010d6893b) | `` zoom-us: 6.0.2.4680 -> 6.0.10.5325 ``                                      |
| [`65a87eee`](https://github.com/NixOS/nixpkgs/commit/65a87eee9cc1c8e3985389333903ae08bba6ad95) | `` linux: use uinstall for all arm architectures ``                           |
| [`676d4969`](https://github.com/NixOS/nixpkgs/commit/676d4969924a5fc10c2accda7acdb81651a5a616) | `` python3Packages.pygeos: drop package ``                                    |
| [`577e7851`](https://github.com/NixOS/nixpkgs/commit/577e785181be148e46b067c57efcaa78448e4e09) | `` gnu-smalltalk: fix-build ``                                                |
| [`fb8c5930`](https://github.com/NixOS/nixpkgs/commit/fb8c5930cb6cc7ca37dcb7a478e52ab218b566dc) | `` shattered-pixel-dungeon: 2.4.0 -> 2.4.1 ``                                 |
| [`5cb8d902`](https://github.com/NixOS/nixpkgs/commit/5cb8d902726b64e954ad06581832737cf4090320) | `` dayon: 14.0.0 -> 14.0.1 ``                                                 |
| [`12009b15`](https://github.com/NixOS/nixpkgs/commit/12009b15b6d46e89e4755ad395b8c473b963e558) | `` klipper: 0.12.0-unstable-2024-05-16 -> 0.12.0-unstable-2024-05-25 ``       |
| [`f36397c5`](https://github.com/NixOS/nixpkgs/commit/f36397c53ca5f46550de31cb471b1b2211bb0a2a) | `` geos: disable failing test in geos_3_11 ``                                 |
| [`4f1739c8`](https://github.com/NixOS/nixpkgs/commit/4f1739c86a4aa17f6d65eafd041baa0b6cfe1a84) | `` bcachefs-tools: replace -> replace-fail ``                                 |
| [`beb7b9b0`](https://github.com/NixOS/nixpkgs/commit/beb7b9b0dc6f2cb574797d9b40de9ab587cc5b1d) | `` bcachefs-tools: 1.7.0 -> 1.7.0-unstable-2024-05-09 ``                      |
| [`33bfd9f3`](https://github.com/NixOS/nixpkgs/commit/33bfd9f34aad3003672b535dc881c0ce3617ff8a) | `` bcachefs-tools: move to pkgs/by-name ``                                    |
| [`eebd3f37`](https://github.com/NixOS/nixpkgs/commit/eebd3f374bfbaff96c31cd42fade3bb88209173a) | `` pyright: 1.1.362 -> 1.1.364 ``                                             |
| [`0be5a16b`](https://github.com/NixOS/nixpkgs/commit/0be5a16bb37359e3e005319d4d7641f81b2d7b47) | `` bento4: fix build on darwin (#314361) ``                                   |
| [`7798ba62`](https://github.com/NixOS/nixpkgs/commit/7798ba62491e699f84cd65b3661a29a2a76bcf98) | `` vscode-extensions.myriad-dreamin.tinymist: 0.11.9 -> 0.11.10 ``            |
| [`ee8e2cb7`](https://github.com/NixOS/nixpkgs/commit/ee8e2cb7568eeebf2da32a46edce54ac92fda4e0) | `` mpvScripts.modernx-zydezu: 0.3.5 -> 0.3.5.5 ``                             |
| [`85417abb`](https://github.com/NixOS/nixpkgs/commit/85417abb3e9b60d430fa2d456a4c0d9c96e89a3e) | `` python311Packages.ytmusicapi: 1.7.1 -> 1.7.2 ``                            |
| [`3df2bf1b`](https://github.com/NixOS/nixpkgs/commit/3df2bf1b8cef8cb1b2e3d23bf933b0ecde401117) | `` python311Packages.elasticsearch8: 8.13.1 -> 8.13.2 ``                      |
| [`d96ff8a4`](https://github.com/NixOS/nixpkgs/commit/d96ff8a4c95ebc41204c1d029272ed35f95d8a89) | `` tinymist: 0.11.9 -> 0.11.10 ``                                             |
| [`a93e6df7`](https://github.com/NixOS/nixpkgs/commit/a93e6df76412d5a6e9e87fa1764cf9454beff00b) | `` binutils: Add --undefined-version on lld 17+ ``                            |
| [`16ea2bf2`](https://github.com/NixOS/nixpkgs/commit/16ea2bf2581db501059216dff6b62878b8e88d04) | `` smbmap: 1.10.2 -> 1.10.3 ``                                                |
| [`92b5f652`](https://github.com/NixOS/nixpkgs/commit/92b5f652b07230f6de71dbe55e5dfe11be165ef5) | `` python312Packages.teslajsonpy: 3.10.3 -> 3.11.0 ``                         |
| [`4c1e8e60`](https://github.com/NixOS/nixpkgs/commit/4c1e8e6062edc3344988e0e90557caa92a871274) | `` python312Packages.pyexploitdb: 0.2.18 -> 0.2.19 ``                         |
| [`81b58cb9`](https://github.com/NixOS/nixpkgs/commit/81b58cb9b101902dd58bdc8589a1d3efa3b9ffc7) | `` python312Packages.plugwise: 0.37.8 -> 0.37.9 ``                            |
| [`4dfe48fb`](https://github.com/NixOS/nixpkgs/commit/4dfe48fbed1200f109eef4bc9ab2c891f783778e) | `` python312Packages.aioswitcher: 3.4.2 -> 3.4.3 ``                           |
| [`0eacecad`](https://github.com/NixOS/nixpkgs/commit/0eacecad3652580b4fb7990ed7f360f095ab5065) | `` python312Packages.hyppo: unbreak ``                                        |
| [`bd580000`](https://github.com/NixOS/nixpkgs/commit/bd580000a3c539676723308cffeb20eba49ab021) | `` gpxsee: 13.19 -> 13.20 ``                                                  |
| [`9b80ba3b`](https://github.com/NixOS/nixpkgs/commit/9b80ba3b97f9f019eebf0567a92a6700935bfe1f) | `` vhdl-ls: 0.80.0 -> 0.81.0 ``                                               |
| [`fbe2e945`](https://github.com/NixOS/nixpkgs/commit/fbe2e94553c9b1d9b13a110add9c38dc1c4a3340) | `` sameboy: 0.16.3 -> 0.16.5 ``                                               |
| [`555d0f0b`](https://github.com/NixOS/nixpkgs/commit/555d0f0b321f39ffbd3042b6f8a317c19e7f2453) | `` python311Packages.clickgen: 2.2.2 -> 2.2.3 ``                              |
| [`61e89d10`](https://github.com/NixOS/nixpkgs/commit/61e89d1002b268f1c0edf23b7d0255fd47bc7e12) | `` tetex: fix darwin build ``                                                 |
| [`5a625130`](https://github.com/NixOS/nixpkgs/commit/5a625130003cbe8192e83a76582971ca74cbfa65) | `` python312Packages.netapp-ontap: refactor ``                                |
| [`e9c6dbb8`](https://github.com/NixOS/nixpkgs/commit/e9c6dbb887db72e491164cf3e1c8e14f848c3215) | `` python311Packages.netapp-ontap: 9.14.1.0 -> 9.15.1.0 ``                    |
| [`40351f91`](https://github.com/NixOS/nixpkgs/commit/40351f91230748d65c569c17cf77f69ed28f7bd5) | `` python312Packages.stripe: refactor ``                                      |
| [`a693864b`](https://github.com/NixOS/nixpkgs/commit/a693864b710186fe8642c2e26d035d0c592bd212) | `` python311Packages.stripe: 9.6.0 -> 9.7.0 ``                                |
| [`e54355ea`](https://github.com/NixOS/nixpkgs/commit/e54355ea20462adc67388f95980797f628acc774) | `` python3Packages.trainer: fix Python 3.12+ ``                               |
| [`1074d2f9`](https://github.com/NixOS/nixpkgs/commit/1074d2f93f5da3e85f5339a75e8d5b93db1fc49b) | `` mlib: 0.7.2 -> 0.7.3 ``                                                    |
| [`e152d121`](https://github.com/NixOS/nixpkgs/commit/e152d121a28249d6c34638ee6389f62c9ab91c89) | `` iosevka: 30.0.1 -> 30.1.0 ``                                               |
| [`3a58b736`](https://github.com/NixOS/nixpkgs/commit/3a58b7369169641be6ea9e3409f5acc06b94c930) | `` markdownlint-cli: 0.40.0 -> 0.41.0 ``                                      |
| [`4e5a485d`](https://github.com/NixOS/nixpkgs/commit/4e5a485d6ae990636bf9685cc0ba26c5d98788e9) | `` firefoxpwa: 2.12.0 -> 2.12.1 ``                                            |
| [`d3b9ef59`](https://github.com/NixOS/nixpkgs/commit/d3b9ef596236214acab04d51db8925a1caff13e2) | `` python3Packages.python-twitter: fix ``                                     |
| [`ee8d21f2`](https://github.com/NixOS/nixpkgs/commit/ee8d21f21cc89b39960d79ca7b92a00fccd06f35) | `` cardinal: 24.04 -> 24.05 ``                                                |
| [`66fd70a9`](https://github.com/NixOS/nixpkgs/commit/66fd70a9faa3599b82e3fe1beca88083d9d17b1a) | `` python312Packages.python-fontconfig: fix build ``                          |