### PR TITLE
chore(flake/nur): `3ced449a` -> `1791cb91`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716972321,
-        "narHash": "sha256-iB8kNkc+p/9NwmrXgnChB6JFcUtSBSdGESRVliiTCMI=",
+        "lastModified": 1716983575,
+        "narHash": "sha256-eFBmny8Adf3ftu2fRuBf5+pVzOV3budBV/2giYSJt2M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3ced449a2fdd845ffde002790691bedf6958f00c",
+        "rev": "1791cb91c2217e8f44a6f23af2d5a9a6f23a8f7e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1791cb91`](https://github.com/nix-community/NUR/commit/1791cb91c2217e8f44a6f23af2d5a9a6f23a8f7e) | `` automatic update `` |
| [`77cabeff`](https://github.com/nix-community/NUR/commit/77cabeff5d7c131cfd3f800485e9f7ee47eec8e9) | `` automatic update `` |