### PR TITLE
chore(flake/nur): `24894edd` -> `7cf15b95`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716987531,
-        "narHash": "sha256-TQvj1LnaDMawNVrwF6ov6d3JRLegvfUZMywEi5XcPc0=",
+        "lastModified": 1716997227,
+        "narHash": "sha256-cxXerU7rZ98IYUfgkRU93ZQrF3zdE5pUcDNnNx6mwyk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "24894eddf0aab2f3ad0b486f42a57074ae35382a",
+        "rev": "7cf15b95fa41ab8bbeacc8b6759db8650bb6b877",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7cf15b95`](https://github.com/nix-community/NUR/commit/7cf15b95fa41ab8bbeacc8b6759db8650bb6b877) | `` automatic update `` |
| [`bf6562f9`](https://github.com/nix-community/NUR/commit/bf6562f9a0d02ea4f88c0e6abb7c65fab7b69681) | `` automatic update `` |