### PR TITLE
chore(flake/emacs-overlay): `30b19743` -> `d3b55246`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1716972855,
-        "narHash": "sha256-u09wfqXJGMpmU6WRo0sYa16wfz/GPr5OQvUFS0VgPJo=",
+        "lastModified": 1717001628,
+        "narHash": "sha256-JVUMPTjQD7pkLLmNIMdB7WkKB3aWdIaCGWBozgxOJ04=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "30b19743d243f97e0a6d71ff9fe3522e1b7bc581",
+        "rev": "d3b55246685cbac16e5c93020b56f6a8bf5c7a29",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`d3b55246`](https://github.com/nix-community/emacs-overlay/commit/d3b55246685cbac16e5c93020b56f6a8bf5c7a29) | `` Updated melpa ``        |
| [`521b7d79`](https://github.com/nix-community/emacs-overlay/commit/521b7d79e98d68fa2d2e4a104f1396613f8e60ca) | `` Updated elpa ``         |
| [`0a555986`](https://github.com/nix-community/emacs-overlay/commit/0a5559861c7b49371d0d36af854ba8353cd05199) | `` Updated flake inputs `` |