### PR TITLE
chore(flake/nur): `7cf15b95` -> `9490809a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716997227,
-        "narHash": "sha256-cxXerU7rZ98IYUfgkRU93ZQrF3zdE5pUcDNnNx6mwyk=",
+        "lastModified": 1717000959,
+        "narHash": "sha256-UZ06HN+suOJbp+XMNI6lASF1Z+zPqREsjYPGIr9jqV8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7cf15b95fa41ab8bbeacc8b6759db8650bb6b877",
+        "rev": "9490809a7627160d93e399e0c3d43ee82a84d467",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9490809a`](https://github.com/nix-community/NUR/commit/9490809a7627160d93e399e0c3d43ee82a84d467) | `` automatic update `` |
| [`ef2bdeca`](https://github.com/nix-community/NUR/commit/ef2bdeca4920354686ab6d86c00b66662bf18a73) | `` automatic update `` |
| [`6c768bda`](https://github.com/nix-community/NUR/commit/6c768bdaccfef4c0bf12bc876ba00bcc80d6a847) | `` automatic update `` |