### PR TITLE
chore(flake/nur): `9490809a` -> `5b959247`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717000959,
-        "narHash": "sha256-UZ06HN+suOJbp+XMNI6lASF1Z+zPqREsjYPGIr9jqV8=",
+        "lastModified": 1717007301,
+        "narHash": "sha256-4PYI8smz7ktvG6Oxq1nLBbbs3b8Uv+kzAdY+Irt+dcQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9490809a7627160d93e399e0c3d43ee82a84d467",
+        "rev": "5b959247c89a0214c113f4a915bf9f3461d0af00",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5b959247`](https://github.com/nix-community/NUR/commit/5b959247c89a0214c113f4a915bf9f3461d0af00) | `` automatic update `` |