### PR TITLE
chore(flake/srvos): `5d4550de` -> `a1bf1557`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -871,11 +871,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716771198,
-        "narHash": "sha256-vRDCDuFMvkvCjGT/N9K2lxG1E61vvq3TiU/4ZM36p8k=",
+        "lastModified": 1717009015,
+        "narHash": "sha256-xvRXRRF/nCplNZ33Cx5Xpwwp7mDifwtTte/XydZXA0Y=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "5d4550de420ee501d7fa0e6cd9031cd00354554c",
+        "rev": "a1bf15579ddbb74a5077238e6e9c398e12ba6702",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                        |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`b42461b4`](https://github.com/nix-community/srvos/commit/b42461b481c3c80e370f3244208c50fe7a1e2293) | `` common: use new rust-based switch script `` |