### PR TITLE
chore(flake/home-manager): `a9b36cbe` -> `1b589257`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -352,11 +352,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716930911,
-        "narHash": "sha256-t4HT5j3Jy7skRB5PINnxcEBCkgE89rGBpwTI7YS4Ffo=",
+        "lastModified": 1717020155,
+        "narHash": "sha256-Xpyv9i02ineeGakmmzd45hkBgy2a7Zf/3d6amM6MUb4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a9b36cbe9292a649222b89fdb9ae9907e9c74086",
+        "rev": "1b589257f72c9c54e92d1d631e988e5346156736",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`1b589257`](https://github.com/nix-community/home-manager/commit/1b589257f72c9c54e92d1d631e988e5346156736) | `` home-manager: check FQDN for '--flake .' attribute `` |
| [`04bc391a`](https://github.com/nix-community/home-manager/commit/04bc391a90f8ae2a953035f33ddebaeccbc0a36b) | `` yazi: support plugins and flavors ``                  |