### PR TITLE
chore(flake/srvos): `a1bf1557` -> `5c09f932`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -871,11 +871,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717009015,
-        "narHash": "sha256-xvRXRRF/nCplNZ33Cx5Xpwwp7mDifwtTte/XydZXA0Y=",
+        "lastModified": 1717030164,
+        "narHash": "sha256-2ZElIGiXCXVvF62UpzummNxfAsjN+N2SCzocq3EvEDY=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "a1bf15579ddbb74a5077238e6e9c398e12ba6702",
+        "rev": "5c09f932ebb1c652ac88aff551b1c97ae8a6a4ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`5c09f932`](https://github.com/nix-community/srvos/commit/5c09f932ebb1c652ac88aff551b1c97ae8a6a4ff) | `` dev/private/flake.lock: Update `` |
| [`4db01145`](https://github.com/nix-community/srvos/commit/4db0114548d3a22c15f28b06802d63147e6dd4ae) | `` flake.lock: Update ``             |