### PR TITLE
chore(flake/emacs-overlay): `2453a7df` -> `441ed869`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1717002469,
-        "narHash": "sha256-61GjHuOTNslybF0sQ1xaGv+q0N5B7xaLrJ4qqT8CmDg=",
+        "lastModified": 1717033835,
+        "narHash": "sha256-m+5EQOjc7AKKrPYD+GkAn2W52z92+9IBdIVtTu0WJTY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2453a7df92d199d96c198320d493cbabb8312b2e",
+        "rev": "441ed86922224973b0853255785d3ce88b683b1a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`441ed869`](https://github.com/nix-community/emacs-overlay/commit/441ed86922224973b0853255785d3ce88b683b1a) | `` Updated emacs `` |
| [`937b7305`](https://github.com/nix-community/emacs-overlay/commit/937b73051a869f54030b1a45600389950aba01b2) | `` Updated melpa `` |