### PR TITLE
chore(flake/nur): `c02be2df` -> `73561ec6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717033543,
-        "narHash": "sha256-NPi7ALqH4zqQhO3SGfch6n4BgnA+uom/RhWjKvpqt50=",
+        "lastModified": 1717040754,
+        "narHash": "sha256-/tDkZQop1WxvvgqatBwR+Ar9rl3PdKYhttDcZPdoCjo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c02be2dfaed084a9a0d1cae4d313e681f003971f",
+        "rev": "73561ec69b090bba87019b141b6f5135e172d2b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`73561ec6`](https://github.com/nix-community/NUR/commit/73561ec69b090bba87019b141b6f5135e172d2b2) | `` automatic update `` |
| [`f5637ea4`](https://github.com/nix-community/NUR/commit/f5637ea4eaddf95edc3844466c16c56bd44a7f30) | `` automatic update `` |
| [`965e6f69`](https://github.com/nix-community/NUR/commit/965e6f6998c4f1c0f21b560cbfb9a2e38180d0b3) | `` automatic update `` |