### PR TITLE
chore(flake/nur): `337ab268` -> `2f663043`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717041867,
-        "narHash": "sha256-6dO8m84H6rnYYzDw9sWfVKp0sgyKR/7hMYkRzClR5cg=",
+        "lastModified": 1717047680,
+        "narHash": "sha256-xYzabO/nKOv3vWFapl+WSwS/QPjiFHgzGV4+PUZGBxo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "337ab26883d065251b917a6a047ea6dc3f94e8cd",
+        "rev": "2f66304363674a7aeb11c7616d8c046ea6c82003",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2f663043`](https://github.com/nix-community/NUR/commit/2f66304363674a7aeb11c7616d8c046ea6c82003) | `` automatic update `` |