### PR TITLE
chore(flake/nur): `2f663043` -> `a4eff07f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717047680,
-        "narHash": "sha256-xYzabO/nKOv3vWFapl+WSwS/QPjiFHgzGV4+PUZGBxo=",
+        "lastModified": 1717054761,
+        "narHash": "sha256-LBrHEBC0S7C6zjQTsjahAvxxlDH3cbZmEgHiri9o4SM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2f66304363674a7aeb11c7616d8c046ea6c82003",
+        "rev": "a4eff07f9bbcf74522c642c72047ed03c3831501",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a4eff07f`](https://github.com/nix-community/NUR/commit/a4eff07f9bbcf74522c642c72047ed03c3831501) | `` automatic update `` |
| [`10776ecb`](https://github.com/nix-community/NUR/commit/10776ecb01bffd43f44d71866c3c73c6cc058ac6) | `` automatic update `` |
| [`98839f4a`](https://github.com/nix-community/NUR/commit/98839f4a6eef80ca2f499f7317fbdf710e326834) | `` automatic update `` |
| [`5853fae4`](https://github.com/nix-community/NUR/commit/5853fae482b70088b684dd34a0d8de52c9fd2e8d) | `` automatic update `` |