### PR TITLE
chore(flake/emacs-overlay): `441ed869` -> `6162935b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1717033835,
-        "narHash": "sha256-m+5EQOjc7AKKrPYD+GkAn2W52z92+9IBdIVtTu0WJTY=",
+        "lastModified": 1717060122,
+        "narHash": "sha256-6dEQVBJks7RWEwTHcahF8k3UAL8dDJ0Mq0LV6pirJzM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "441ed86922224973b0853255785d3ce88b683b1a",
+        "rev": "6162935b3e287a34e4432d35dbbccbddc5491cfe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`6162935b`](https://github.com/nix-community/emacs-overlay/commit/6162935b3e287a34e4432d35dbbccbddc5491cfe) | `` Updated emacs `` |
| [`9207151d`](https://github.com/nix-community/emacs-overlay/commit/9207151d430aa8514e72acf98ccfe7dc6235cc4c) | `` Updated melpa `` |