### PR TITLE
chore(flake/srvos): `5c09f932` -> `414d1039`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -871,11 +871,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717030164,
-        "narHash": "sha256-2ZElIGiXCXVvF62UpzummNxfAsjN+N2SCzocq3EvEDY=",
+        "lastModified": 1717058062,
+        "narHash": "sha256-R8Gb2MlJzfBE76DVWFmfZWODMdAanqxFnK+OOmkoQ7E=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "5c09f932ebb1c652ac88aff551b1c97ae8a6a4ff",
+        "rev": "414d1039a58b667e4512ad9f7068aa935ebf8d59",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`f912140d`](https://github.com/nix-community/srvos/commit/f912140df9a08551cda638ad5ccea9a7afcb4e0e) | `` common: fix accidentially disabling switch on old nixos versions `` |