### PR TITLE
chore(flake/nur): `a4eff07f` -> `158ba545`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717054761,
-        "narHash": "sha256-LBrHEBC0S7C6zjQTsjahAvxxlDH3cbZmEgHiri9o4SM=",
+        "lastModified": 1717061868,
+        "narHash": "sha256-d0nJvnCPi1dwLuAN5knoYubIPl3r3vevadzIbcl83uA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a4eff07f9bbcf74522c642c72047ed03c3831501",
+        "rev": "158ba545551c2010b358e6fc0661813f1e9460ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`158ba545`](https://github.com/nix-community/NUR/commit/158ba545551c2010b358e6fc0661813f1e9460ef) | `` automatic update `` |
| [`ca064c2e`](https://github.com/nix-community/NUR/commit/ca064c2e0d11f6b5d13e822fac68e72fceb9cfb0) | `` automatic update `` |