### PR TITLE
chore(flake/catppuccin): `96681f62` -> `2c7661c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1716934277,
-        "narHash": "sha256-BTRLOEcZnj2jLttdOq3AfKSvsFZNVKkrTpdpINDGW4k=",
+        "lastModified": 1717070887,
+        "narHash": "sha256-ZTEMINFqQL+m55kmoDYIKf3i2NGitSkjBnnLu99ezh0=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "96681f62faa285ad0c8dce2cdae6b0a1d0a8f094",
+        "rev": "2c7661c9fa26a920b8088300ef87d14179c71a27",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                     |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`2c7661c9`](https://github.com/catppuccin/nix/commit/2c7661c9fa26a920b8088300ef87d14179c71a27) | `` ci(release-please): use action from googleapis (#201) `` |