### PR TITLE
chore(flake/nur): `1da48688` -> `86ae1584`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717067177,
-        "narHash": "sha256-1lCatVD3GNGYLMxoL/4EvL32ufpgce17O5k8WovrUxo=",
+        "lastModified": 1717085380,
+        "narHash": "sha256-YPK3MoAXtoz9tR/ww60bp9Jw9sxV/YyylaQhgwG2m8k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1da486889c3abe79342f915cea72869da9a1c704",
+        "rev": "86ae15848bbbe9e6405d34d9431946d1abd2167f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`86ae1584`](https://github.com/nix-community/NUR/commit/86ae15848bbbe9e6405d34d9431946d1abd2167f) | `` automatic update `` |
| [`1a7bbb23`](https://github.com/nix-community/NUR/commit/1a7bbb238afcada295aabc758941ce82e6b1d292) | `` automatic update `` |
| [`69b2b95e`](https://github.com/nix-community/NUR/commit/69b2b95ef06173a9d86345c84dee30f86d89ba96) | `` automatic update `` |