### PR TITLE
chore(flake/treefmt): `2fba33a1` -> `52b66cad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -936,11 +936,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715940852,
-        "narHash": "sha256-wJqHMg/K6X3JGAE9YLM0LsuKrKb4XiBeVaoeMNlReZg=",
+        "lastModified": 1717078125,
+        "narHash": "sha256-V68CsekhPCF6Oz84t2FHY5jin4smKrmsS208Xw057zs=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "2fba33a182602b9d49f0b2440513e5ee091d838b",
+        "rev": "52b66cade760e93276146eb057122b8011ab9057",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                                     |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`752ef440`](https://github.com/numtide/treefmt-nix/commit/752ef44008444e9f3e449459a8d5f96276170a7a) | `` Fix issue where options to ruff could end up before the verb in the generated command `` |