### PR TITLE
chore(flake/emacs-overlay): `6162935b` -> `d846281f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1717060122,
-        "narHash": "sha256-6dEQVBJks7RWEwTHcahF8k3UAL8dDJ0Mq0LV6pirJzM=",
+        "lastModified": 1717088882,
+        "narHash": "sha256-tiNEtOBgZuE4zxg46JvZkq95H3BZQjmDBrJ6BiE0ZEA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6162935b3e287a34e4432d35dbbccbddc5491cfe",
+        "rev": "d846281fcce0a7a9a51dd10a57d6f53417a358c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`d846281f`](https://github.com/nix-community/emacs-overlay/commit/d846281fcce0a7a9a51dd10a57d6f53417a358c0) | `` Updated emacs ``        |
| [`e674f65c`](https://github.com/nix-community/emacs-overlay/commit/e674f65caed9780a87ea6fa51e66bf1a79919528) | `` Updated melpa ``        |
| [`48a482db`](https://github.com/nix-community/emacs-overlay/commit/48a482db3cc3ed0895a52cf89ea9874efce31a09) | `` Updated elpa ``         |
| [`7a959dc4`](https://github.com/nix-community/emacs-overlay/commit/7a959dc4f78eb0bfc815bec18fd4f468a05024f4) | `` Updated flake inputs `` |