### PR TITLE
chore(flake/nur): `012f328c` -> `a522b6b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717088923,
-        "narHash": "sha256-1UG5Nj/wXVj4K0nKK6sILN5VX174xqu+rbue8Xdod1I=",
+        "lastModified": 1717101890,
+        "narHash": "sha256-4sAkcpKd0nx2p1dpBDgCWWQtVTJ5Do08p0M1zDA7vps=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "012f328c74e06dc80742d2f435aeaa2a73357a69",
+        "rev": "a522b6b5bb843fb5061ad23728bb2f6239c07d9d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a522b6b5`](https://github.com/nix-community/NUR/commit/a522b6b5bb843fb5061ad23728bb2f6239c07d9d) | `` automatic update `` |
| [`e8940a37`](https://github.com/nix-community/NUR/commit/e8940a37e6f58b50677d0254c29f8ae1144c1514) | `` automatic update `` |
| [`a4f0829f`](https://github.com/nix-community/NUR/commit/a4f0829ff37b3acef7fb6644d9ba0a661261c903) | `` automatic update `` |
| [`ec0355a6`](https://github.com/nix-community/NUR/commit/ec0355a6632146cf5f8f12d311ad0c5f83e662c1) | `` automatic update `` |