### PR TITLE
chore(flake/nur): `a522b6b5` -> `90af31fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717101890,
-        "narHash": "sha256-4sAkcpKd0nx2p1dpBDgCWWQtVTJ5Do08p0M1zDA7vps=",
+        "lastModified": 1717104916,
+        "narHash": "sha256-L4YDx/gnSYJhMjlDQqxmYEJFBLHtX2TKQDwZVNOYEsA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a522b6b5bb843fb5061ad23728bb2f6239c07d9d",
+        "rev": "90af31fec74c7f9ca02b9786ed96ee43d5c824b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`90af31fe`](https://github.com/nix-community/NUR/commit/90af31fec74c7f9ca02b9786ed96ee43d5c824b6) | `` automatic update `` |