### PR TITLE
chore(flake/nur): `90af31fe` -> `e2489b4c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717104916,
-        "narHash": "sha256-L4YDx/gnSYJhMjlDQqxmYEJFBLHtX2TKQDwZVNOYEsA=",
+        "lastModified": 1717108420,
+        "narHash": "sha256-ohY+gn8jTVnxdpmYRs6eYWMSxZWoiGfAK64LVvNKROE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "90af31fec74c7f9ca02b9786ed96ee43d5c824b6",
+        "rev": "e2489b4cc6fbf3c2b6a0cff3fdbc5ebb144522af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e2489b4c`](https://github.com/nix-community/NUR/commit/e2489b4cc6fbf3c2b6a0cff3fdbc5ebb144522af) | `` automatic update `` |