### PR TITLE
chore(flake/nur): `e2489b4c` -> `a5f0ef29`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717108420,
-        "narHash": "sha256-ohY+gn8jTVnxdpmYRs6eYWMSxZWoiGfAK64LVvNKROE=",
+        "lastModified": 1717110160,
+        "narHash": "sha256-dW9KCBupH1pFBlXPKEHNGzi288QYOMWfIlPaTeSoHtE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e2489b4cc6fbf3c2b6a0cff3fdbc5ebb144522af",
+        "rev": "a5f0ef2970d5045041d56733b6772942747042d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a5f0ef29`](https://github.com/nix-community/NUR/commit/a5f0ef2970d5045041d56733b6772942747042d9) | `` automatic update `` |