### PR TITLE
chore(flake/emacs-overlay): `d846281f` -> `c6686aae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1717088882,
-        "narHash": "sha256-tiNEtOBgZuE4zxg46JvZkq95H3BZQjmDBrJ6BiE0ZEA=",
+        "lastModified": 1717117413,
+        "narHash": "sha256-ZblqS4wqR6n1viPpSckj1eDgYxp/9Woy097YjOsUetY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d846281fcce0a7a9a51dd10a57d6f53417a358c0",
+        "rev": "c6686aae1070e491e43310ba392f48b422277c39",
         "type": "github"
       },
       "original": {
@@ -621,11 +621,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1716633019,
-        "narHash": "sha256-xim1b5/HZYbWaZKyI7cn9TJCM6ewNVZnesRr00mXeS4=",
+        "lastModified": 1716991068,
+        "narHash": "sha256-Av0UWCCiIGJxsZ6TFc+OiKCJNqwoxMNVYDBChmhjNpo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9d29cd266cebf80234c98dd0b87256b6be0af44e",
+        "rev": "25cf937a30bf0801447f6bf544fc7486c6309234",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`c6686aae`](https://github.com/nix-community/emacs-overlay/commit/c6686aae1070e491e43310ba392f48b422277c39) | `` Updated elpa ``         |
| [`ce2b59df`](https://github.com/nix-community/emacs-overlay/commit/ce2b59df2742620e297e94c51d1467d60af0901b) | `` Updated nongnu ``       |
| [`ad68f81c`](https://github.com/nix-community/emacs-overlay/commit/ad68f81c44e5dda35a4e32a76b117e21f3e2b1db) | `` Updated flake inputs `` |