### PR TITLE
chore(flake/emacs-overlay): `c6686aae` -> `891d7b17`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1717117413,
-        "narHash": "sha256-ZblqS4wqR6n1viPpSckj1eDgYxp/9Woy097YjOsUetY=",
+        "lastModified": 1717120303,
+        "narHash": "sha256-RhEsU8psJ6ibWan4OO7+XBWu1jm31Ncan6aOkx6Y9Q8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c6686aae1070e491e43310ba392f48b422277c39",
+        "rev": "891d7b17960d98be8cd9115927290f7c527ae97e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`891d7b17`](https://github.com/nix-community/emacs-overlay/commit/891d7b17960d98be8cd9115927290f7c527ae97e) | `` Updated emacs `` |
| [`69069178`](https://github.com/nix-community/emacs-overlay/commit/69069178a14d1a475a5ada9a1f5d9e747631d3f4) | `` Updated melpa `` |