### PR TITLE
chore(flake/nur): `a5f0ef29` -> `5ed53394`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717110160,
-        "narHash": "sha256-dW9KCBupH1pFBlXPKEHNGzi288QYOMWfIlPaTeSoHtE=",
+        "lastModified": 1717119949,
+        "narHash": "sha256-Lu4VWYfthjmxoDuUvwXfxdpz7m9/DmPnFCUVwq+Kq7A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a5f0ef2970d5045041d56733b6772942747042d9",
+        "rev": "5ed5339485056cf37a468ebfdc9110f6e59b6d8c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5ed53394`](https://github.com/nix-community/NUR/commit/5ed5339485056cf37a468ebfdc9110f6e59b6d8c) | `` automatic update `` |