### PR TITLE
chore(flake/nur): `5ed53394` -> `b9bbe10e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717119949,
-        "narHash": "sha256-Lu4VWYfthjmxoDuUvwXfxdpz7m9/DmPnFCUVwq+Kq7A=",
+        "lastModified": 1717127548,
+        "narHash": "sha256-LCoAzEMacLdNvqlMYxc6L/8+3t7h3loJboY3pdbiGnI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5ed5339485056cf37a468ebfdc9110f6e59b6d8c",
+        "rev": "b9bbe10e4ba58109eacb956ae26cba1deb946cba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b9bbe10e`](https://github.com/nix-community/NUR/commit/b9bbe10e4ba58109eacb956ae26cba1deb946cba) | `` automatic update `` |
| [`f15d9fdd`](https://github.com/nix-community/NUR/commit/f15d9fdd8e5efbf3636c430db7e3781792d5d70a) | `` automatic update `` |
| [`60f826a8`](https://github.com/nix-community/NUR/commit/60f826a8d197a019769cf169faa41ac164c33a0a) | `` automatic update `` |
| [`94096134`](https://github.com/nix-community/NUR/commit/9409613439b6148c0c5dd1983ce9608cbb30a921) | `` automatic update `` |
| [`33d5114a`](https://github.com/nix-community/NUR/commit/33d5114adb24e84cda718913cad8e3241ef6d264) | `` automatic update `` |