### PR TITLE
chore(flake/nur): `b9bbe10e` -> `588016ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717127548,
-        "narHash": "sha256-LCoAzEMacLdNvqlMYxc6L/8+3t7h3loJboY3pdbiGnI=",
+        "lastModified": 1717129993,
+        "narHash": "sha256-L2PIm03dGq7avceDKlR8BDQTTgESYQx4LzqauKGq/BU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b9bbe10e4ba58109eacb956ae26cba1deb946cba",
+        "rev": "588016adcc9deadbda62f78919d17be9c8caf467",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`588016ad`](https://github.com/nix-community/NUR/commit/588016adcc9deadbda62f78919d17be9c8caf467) | `` automatic update `` |
| [`5087d4ff`](https://github.com/nix-community/NUR/commit/5087d4ff41071cbc7d2f376df89d81bde2e00745) | `` automatic update `` |