### PR TITLE
chore(flake/nur): `588016ad` -> `6604cae8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717129993,
-        "narHash": "sha256-L2PIm03dGq7avceDKlR8BDQTTgESYQx4LzqauKGq/BU=",
+        "lastModified": 1717134271,
+        "narHash": "sha256-ZWAph2c4uY2Y3oOn8cJCQYbbZX/e3xjXMr678HbPlV8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "588016adcc9deadbda62f78919d17be9c8caf467",
+        "rev": "6604cae8724a6373a238eac9b2ae4afb0aca1d4d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6604cae8`](https://github.com/nix-community/NUR/commit/6604cae8724a6373a238eac9b2ae4afb0aca1d4d) | `` automatic update `` |