### PR TITLE
chore(flake/nur): `6604cae8` -> `f47e2ef0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717134271,
-        "narHash": "sha256-ZWAph2c4uY2Y3oOn8cJCQYbbZX/e3xjXMr678HbPlV8=",
+        "lastModified": 1717137954,
+        "narHash": "sha256-coRwojhix3oG/8+dcibxy5AfX9HUJXPYPar8qfjP5Zo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6604cae8724a6373a238eac9b2ae4afb0aca1d4d",
+        "rev": "f47e2ef0b6e6a25d99f04506c042b8c3eba18790",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f47e2ef0`](https://github.com/nix-community/NUR/commit/f47e2ef0b6e6a25d99f04506c042b8c3eba18790) | `` automatic update `` |
| [`085a1405`](https://github.com/nix-community/NUR/commit/085a140577819db1d2dbc08dcc7d39cab29af604) | `` automatic update `` |
| [`83d68f75`](https://github.com/nix-community/NUR/commit/83d68f7515cf4915933e6c9a431baf81110433f9) | `` automatic update `` |