### PR TITLE
chore(flake/nur): `f47e2ef0` -> `38d5930b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717137954,
-        "narHash": "sha256-coRwojhix3oG/8+dcibxy5AfX9HUJXPYPar8qfjP5Zo=",
+        "lastModified": 1717140397,
+        "narHash": "sha256-X4S8juZRAo/dqISviX8j/45ZxAHDJdTrrP10PYf2bpE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f47e2ef0b6e6a25d99f04506c042b8c3eba18790",
+        "rev": "38d5930b44ca419dd7b2eef798251cf3264095d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`38d5930b`](https://github.com/nix-community/NUR/commit/38d5930b44ca419dd7b2eef798251cf3264095d4) | `` automatic update `` |