### PR TITLE
chore(flake/emacs-overlay): `891d7b17` -> `e09d25d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1717120303,
-        "narHash": "sha256-RhEsU8psJ6ibWan4OO7+XBWu1jm31Ncan6aOkx6Y9Q8=",
+        "lastModified": 1717145516,
+        "narHash": "sha256-zAYC/Yb6mADf5SzFuTSnLsS1hQ2TneHsqFTw3ZFAkfg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "891d7b17960d98be8cd9115927290f7c527ae97e",
+        "rev": "e09d25d8f76dbf4bc5dc1b1ff6dbe01ee80f3d7a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`e09d25d8`](https://github.com/nix-community/emacs-overlay/commit/e09d25d8f76dbf4bc5dc1b1ff6dbe01ee80f3d7a) | `` Updated melpa `` |