### PR TITLE
chore(flake/nur): `38d5930b` -> `680edb6d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717140397,
-        "narHash": "sha256-X4S8juZRAo/dqISviX8j/45ZxAHDJdTrrP10PYf2bpE=",
+        "lastModified": 1717148766,
+        "narHash": "sha256-w6gJ6jsVe1SN2dyzAW2ZVH0iG+GZiCuaQvE6XBwh57E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "38d5930b44ca419dd7b2eef798251cf3264095d4",
+        "rev": "680edb6d0c1e6928e98286b7d26875348f673883",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`680edb6d`](https://github.com/nix-community/NUR/commit/680edb6d0c1e6928e98286b7d26875348f673883) | `` automatic update `` |