### PR TITLE
chore(flake/nur): `680edb6d` -> `144c8c06`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717148766,
-        "narHash": "sha256-w6gJ6jsVe1SN2dyzAW2ZVH0iG+GZiCuaQvE6XBwh57E=",
+        "lastModified": 1717155958,
+        "narHash": "sha256-SFdLFjNx0U5SAeS+h1EZ8BQGnboT8SCKVYM54eYhTuo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "680edb6d0c1e6928e98286b7d26875348f673883",
+        "rev": "144c8c06c983e114eef8c8da825d359ca2c8bf77",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`144c8c06`](https://github.com/nix-community/NUR/commit/144c8c06c983e114eef8c8da825d359ca2c8bf77) | `` automatic update `` |
| [`15538da5`](https://github.com/nix-community/NUR/commit/15538da5cf6023ca7417dc7a8001769e0b2707f5) | `` automatic update `` |