### PR TITLE
chore(flake/nur): `144c8c06` -> `114b1d96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717155958,
-        "narHash": "sha256-SFdLFjNx0U5SAeS+h1EZ8BQGnboT8SCKVYM54eYhTuo=",
+        "lastModified": 1717160230,
+        "narHash": "sha256-414r/0bEWmV8iLPHZMmmisboQv1kLMog9Mp4plH4iKw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "144c8c06c983e114eef8c8da825d359ca2c8bf77",
+        "rev": "114b1d9629bf87a565d6a61a1536bba5b14e9f18",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`114b1d96`](https://github.com/nix-community/NUR/commit/114b1d9629bf87a565d6a61a1536bba5b14e9f18) | `` automatic update `` |