### PR TITLE
chore(flake/nur): `114b1d96` -> `7963300a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717160230,
-        "narHash": "sha256-414r/0bEWmV8iLPHZMmmisboQv1kLMog9Mp4plH4iKw=",
+        "lastModified": 1717163092,
+        "narHash": "sha256-M6kObY8gQjx6spj5NxJDBZs8glTo32a2pSu0przux+w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "114b1d9629bf87a565d6a61a1536bba5b14e9f18",
+        "rev": "7963300aab117ee31dd5185541ceed009ce3e312",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7963300a`](https://github.com/nix-community/NUR/commit/7963300aab117ee31dd5185541ceed009ce3e312) | `` automatic update `` |