### PR TITLE
chore(flake/nur): `7963300a` -> `9c66353b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717163092,
-        "narHash": "sha256-M6kObY8gQjx6spj5NxJDBZs8glTo32a2pSu0przux+w=",
+        "lastModified": 1717166037,
+        "narHash": "sha256-xYD2OhJTgwDzsI1JpWV/wtB5zhW0ctJUjsMYvd0vsIw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7963300aab117ee31dd5185541ceed009ce3e312",
+        "rev": "9c66353bd3b88dde7850f78346278c3d37a44a35",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9c66353b`](https://github.com/nix-community/NUR/commit/9c66353bd3b88dde7850f78346278c3d37a44a35) | `` automatic update `` |