### PR TITLE
chore(flake/nur): `9c66353b` -> `2b326c59`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717166037,
-        "narHash": "sha256-xYD2OhJTgwDzsI1JpWV/wtB5zhW0ctJUjsMYvd0vsIw=",
+        "lastModified": 1717170290,
+        "narHash": "sha256-NTCyGbK740GIGXuLpqXx0JhYJj+lNEqAAngweVNUfMk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9c66353bd3b88dde7850f78346278c3d37a44a35",
+        "rev": "2b326c59b42cb400b2ba7f1d3c51cc145683b1f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2b326c59`](https://github.com/nix-community/NUR/commit/2b326c59b42cb400b2ba7f1d3c51cc145683b1f9) | `` automatic update `` |