### PR TITLE
chore(flake/emacs-overlay): `b95883a0` -> `d5fc3b94`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1717146521,
-        "narHash": "sha256-tO5THLapCBZ7IGEeROvPitB1FYTlZK4RO/uCoTn+0q4=",
+        "lastModified": 1717174367,
+        "narHash": "sha256-srPD861pzkXnp7HrTnigdRuvD6PQSRojkB2TfuUN1nY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b95883a0b9701e7d716e5c298e5d7961076301cd",
+        "rev": "d5fc3b94668ca9c75c94142dbae6967bb72bfb1b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`d5fc3b94`](https://github.com/nix-community/emacs-overlay/commit/d5fc3b94668ca9c75c94142dbae6967bb72bfb1b) | `` Updated melpa ``  |
| [`c10227a9`](https://github.com/nix-community/emacs-overlay/commit/c10227a90c6d0e900ed292c1983fa48c4c149aa2) | `` Updated elpa ``   |
| [`d598b660`](https://github.com/nix-community/emacs-overlay/commit/d598b66018e4653fc95fca5906a855fcd8bf5f03) | `` Updated nongnu `` |