### PR TITLE
chore(flake/emacs-overlay): `d5fc3b94` -> `35b305a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1717174367,
-        "narHash": "sha256-srPD861pzkXnp7HrTnigdRuvD6PQSRojkB2TfuUN1nY=",
+        "lastModified": 1717175206,
+        "narHash": "sha256-17HsBesD2dYy7GvXz4FYeDYpcmP72DvGnwnk3fT2Kv0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d5fc3b94668ca9c75c94142dbae6967bb72bfb1b",
+        "rev": "35b305a1706b6fa284f81aa5dc37ccfdbfcb2e99",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`35b305a1`](https://github.com/nix-community/emacs-overlay/commit/35b305a1706b6fa284f81aa5dc37ccfdbfcb2e99) | `` Updated emacs `` |