### PR TITLE
chore(flake/nur): `bef9e3a0` -> `4455ab52`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717180365,
-        "narHash": "sha256-6BVrnPC3Zc69b9xYghZsnQlcivRuPpNtM14WSp3OavI=",
+        "lastModified": 1717184783,
+        "narHash": "sha256-M9FFzkGUqIP7t8IwRCymfrItumaMZxYYblTCWI5/2X4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bef9e3a0f3ab373b6a60b84c7de4634336d42258",
+        "rev": "4455ab5249d6382c73fa835fac5343f4f5476c74",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4455ab52`](https://github.com/nix-community/NUR/commit/4455ab5249d6382c73fa835fac5343f4f5476c74) | `` automatic update `` |