### PR TITLE
chore(flake/emacs-overlay): `35b305a1` -> `23228436`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1717175206,
-        "narHash": "sha256-17HsBesD2dYy7GvXz4FYeDYpcmP72DvGnwnk3fT2Kv0=",
+        "lastModified": 1717203940,
+        "narHash": "sha256-J5Mspla8Jrn2ntuyMvWMYKXhbX/P6/KcgB2L5eRyZo8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "35b305a1706b6fa284f81aa5dc37ccfdbfcb2e99",
+        "rev": "232284363384a1fb7be279c9d4c19f81454b4076",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`23228436`](https://github.com/nix-community/emacs-overlay/commit/232284363384a1fb7be279c9d4c19f81454b4076) | `` Updated nongnu `` |