### PR TITLE
chore(flake/emacs-overlay): `23228436` -> `33b510ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1717203940,
-        "narHash": "sha256-J5Mspla8Jrn2ntuyMvWMYKXhbX/P6/KcgB2L5eRyZo8=",
+        "lastModified": 1717206010,
+        "narHash": "sha256-8J/Db/71k/cN1p3wKFSwrALnuGL+YvSiuUlj59623aQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "232284363384a1fb7be279c9d4c19f81454b4076",
+        "rev": "33b510ef28317acbda6833a498830f46ed9b6a0c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`33b510ef`](https://github.com/nix-community/emacs-overlay/commit/33b510ef28317acbda6833a498830f46ed9b6a0c) | `` Updated melpa `` |