### PR TITLE
chore(flake/nur): `cbd11617` -> `9525dff1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717199086,
-        "narHash": "sha256-kgzk8Nyda0s0nJAtOmuXVa0BBLfjfHJXL5XhkF3GszU=",
+        "lastModified": 1717207691,
+        "narHash": "sha256-BHpNfO3Nbx4D236r2pkjaPPhpnZg6tzkDMW8ZXo1uDY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cbd1161796fef3f5f2b274c11199181a7025ffed",
+        "rev": "9525dff1557d46df98a9ed3169d1f32f436e944f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9525dff1`](https://github.com/nix-community/NUR/commit/9525dff1557d46df98a9ed3169d1f32f436e944f) | `` automatic update `` |
| [`8f436338`](https://github.com/nix-community/NUR/commit/8f436338aab82f95aba7f762436ebdec81de807a) | `` automatic update `` |