### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `b2a3db03` -> `e611b275`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717033835,
-        "narHash": "sha256-m+5EQOjc7AKKrPYD+GkAn2W52z92+9IBdIVtTu0WJTY=",
+        "lastModified": 1717120303,
+        "narHash": "sha256-RhEsU8psJ6ibWan4OO7+XBWu1jm31Ncan6aOkx6Y9Q8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "441ed86922224973b0853255785d3ce88b683b1a",
+        "rev": "891d7b17960d98be8cd9115927290f7c527ae97e",
         "type": "github"
       },
       "original": {
@@ -519,11 +519,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1717057942,
-        "narHash": "sha256-L5Nm1r1eGBQWolRLiZ87TI8fhsidRFAAeEtvYZhyR+I=",
+        "lastModified": 1717144333,
+        "narHash": "sha256-j6yaRaAeWUn5ahHjV5U6mCDlxOsWAP3Lp11o8XH+yvw=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "b2a3db03fa9cbf53cc8cb39e32495155318145c0",
+        "rev": "e611b27529f24bdec3cf4c29dd2a674272890870",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`e611b275`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/e611b27529f24bdec3cf4c29dd2a674272890870) | `` flake.lock: Update `` |