### PR TITLE
chore(flake/nur): `9525dff1` -> `56a1950c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717207691,
-        "narHash": "sha256-BHpNfO3Nbx4D236r2pkjaPPhpnZg6tzkDMW8ZXo1uDY=",
+        "lastModified": 1717224886,
+        "narHash": "sha256-aD924UPNg0F+xnsoLngOLsZoE1Pu2koP/pviJ+JDAWw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9525dff1557d46df98a9ed3169d1f32f436e944f",
+        "rev": "56a1950c0e5a242dccd71145080741264e1caaa2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`56a1950c`](https://github.com/nix-community/NUR/commit/56a1950c0e5a242dccd71145080741264e1caaa2) | `` automatic update `` |
| [`387e466f`](https://github.com/nix-community/NUR/commit/387e466ffb9d617e557f53cb6d3a6c3e9584581d) | `` automatic update `` |
| [`a7c4e64c`](https://github.com/nix-community/NUR/commit/a7c4e64cabb63e41ef1c7fee685bbbec19cee2cd) | `` automatic update `` |
| [`3add78e3`](https://github.com/nix-community/NUR/commit/3add78e3c02a40b839fd204aba7848d42593abb2) | `` automatic update `` |
| [`7171d386`](https://github.com/nix-community/NUR/commit/7171d3863ca557e8b4a173bb9c552ef538f8e9a1) | `` automatic update `` |
| [`dfa7a923`](https://github.com/nix-community/NUR/commit/dfa7a923b288ba70ed0ae52029c9e19bc964ec4d) | `` automatic update `` |