### PR TITLE
chore(flake/nur): `56a1950c` -> `0a7d504c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717224886,
-        "narHash": "sha256-aD924UPNg0F+xnsoLngOLsZoE1Pu2koP/pviJ+JDAWw=",
+        "lastModified": 1717231546,
+        "narHash": "sha256-qFMtR4NJZPgjAs7HXo7JbXrekQrX9QLNW506YKlz9Xs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "56a1950c0e5a242dccd71145080741264e1caaa2",
+        "rev": "0a7d504ca4d14687d8fbdc07a19efba2a58b87f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0a7d504c`](https://github.com/nix-community/NUR/commit/0a7d504ca4d14687d8fbdc07a19efba2a58b87f7) | `` automatic update `` |