### PR TITLE
chore(flake/emacs-overlay): `08dd5fc2` -> `b79423d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1717231963,
-        "narHash": "sha256-SJSA0ME/LIRKVXM5YZdn1f3bIWg1aYZxgxZjNRmvqjI=",
+        "lastModified": 1717232830,
+        "narHash": "sha256-UphDkQ1SrBs4VyWSZ8/wqNXQDLVcWqEongQ1PJEjGk0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "08dd5fc2b327774d7b605a39273b23af7d4af08f",
+        "rev": "b79423d0334e6397528aa3b4f5ff97b4adeadef5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`b79423d0`](https://github.com/nix-community/emacs-overlay/commit/b79423d0334e6397528aa3b4f5ff97b4adeadef5) | `` Updated emacs `` |