### PR TITLE
chore(flake/nur): `5b704d93` -> `bc037454`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717242279,
-        "narHash": "sha256-ovx7RavkxxTXRokC5h1rmKtMZj8QautKLw9XhwGs8R4=",
+        "lastModified": 1717246606,
+        "narHash": "sha256-4TPG39aCSXhtbSJKTFdUNwx+CYdd6lhdUoh3R4kyfG4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5b704d93015b0e73a5d528fc97598b33e71cda69",
+        "rev": "bc037454bfaab10a46088d0d2de9d5768c7c221f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bc037454`](https://github.com/nix-community/NUR/commit/bc037454bfaab10a46088d0d2de9d5768c7c221f) | `` automatic update `` |