### PR TITLE
chore(flake/nur): `bc037454` -> `f267ad8a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717246606,
-        "narHash": "sha256-4TPG39aCSXhtbSJKTFdUNwx+CYdd6lhdUoh3R4kyfG4=",
+        "lastModified": 1717249505,
+        "narHash": "sha256-dprfeFpLbxOl4T8Len1+oXoJdPEjPldnHTeJIf86WXU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bc037454bfaab10a46088d0d2de9d5768c7c221f",
+        "rev": "f267ad8addc9f5dd2cce435a2200146e6efc800e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f267ad8a`](https://github.com/nix-community/NUR/commit/f267ad8addc9f5dd2cce435a2200146e6efc800e) | `` automatic update `` |