### PR TITLE
chore(flake/emacs-overlay): `b79423d0` -> `177491c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1717232830,
-        "narHash": "sha256-UphDkQ1SrBs4VyWSZ8/wqNXQDLVcWqEongQ1PJEjGk0=",
+        "lastModified": 1717260669,
+        "narHash": "sha256-0+XM3B4nIwUtbbZPIOXzGHtO8JjNgjukAIDa25wmjr8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b79423d0334e6397528aa3b4f5ff97b4adeadef5",
+        "rev": "177491c08fa49c820cb22181f41f6fe85416fe64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`177491c0`](https://github.com/nix-community/emacs-overlay/commit/177491c08fa49c820cb22181f41f6fe85416fe64) | `` Updated melpa `` |
| [`bfe71a04`](https://github.com/nix-community/emacs-overlay/commit/bfe71a041403577234417b51632cbfb56330d08a) | `` Updated elpa ``  |