### PR TITLE
chore(flake/nur): `2354a3ad` -> `ef091881`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717256998,
-        "narHash": "sha256-/rPK2x9e28uYMt22fT3LSGsRuP95B1hfPIvs0inuQP4=",
+        "lastModified": 1717263915,
+        "narHash": "sha256-vRRk1esPct5Sl2hy4R+1RrEn7Qs7WpTVHzUSBpcaTo0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2354a3adfa376eb09b9a459ef11714dee2d183c1",
+        "rev": "ef09188160dcc539309b8447c9fa4c09f675cdb8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ef091881`](https://github.com/nix-community/NUR/commit/ef09188160dcc539309b8447c9fa4c09f675cdb8) | `` automatic update `` |
| [`39bf5f13`](https://github.com/nix-community/NUR/commit/39bf5f1311fcf35a55df966ae774da7bf8e35d30) | `` automatic update `` |