### PR TITLE
chore(flake/emacs-overlay): `177491c0` -> `a381a93c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1717260669,
-        "narHash": "sha256-0+XM3B4nIwUtbbZPIOXzGHtO8JjNgjukAIDa25wmjr8=",
+        "lastModified": 1717261549,
+        "narHash": "sha256-hD5bIEdkcExjfgAvNDVeKgoeey/l5HPgZrjRwIZB8lU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "177491c08fa49c820cb22181f41f6fe85416fe64",
+        "rev": "a381a93c2b94b40013958f180a7228602762ed2c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`a381a93c`](https://github.com/nix-community/emacs-overlay/commit/a381a93c2b94b40013958f180a7228602762ed2c) | `` Updated emacs `` |