### PR TITLE
chore(flake/nur): `ef091881` -> `acc92a3d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717263915,
-        "narHash": "sha256-vRRk1esPct5Sl2hy4R+1RrEn7Qs7WpTVHzUSBpcaTo0=",
+        "lastModified": 1717266611,
+        "narHash": "sha256-D3is1ukeAV9w4P+wPw8bx/XfbpoecTDRQKQ597WNnAg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ef09188160dcc539309b8447c9fa4c09f675cdb8",
+        "rev": "acc92a3df6c0578d176c18b555b1f7e609507924",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`acc92a3d`](https://github.com/nix-community/NUR/commit/acc92a3df6c0578d176c18b555b1f7e609507924) | `` automatic update `` |