### PR TITLE
chore(flake/nur): `acc92a3d` -> `803e2370`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717266611,
-        "narHash": "sha256-D3is1ukeAV9w4P+wPw8bx/XfbpoecTDRQKQ597WNnAg=",
+        "lastModified": 1717271186,
+        "narHash": "sha256-BEVwC1UI1Zh3b1jh43Fz9JGchxla98mkceDKs0TmZyk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "acc92a3df6c0578d176c18b555b1f7e609507924",
+        "rev": "803e2370d6ca2a0a5f06a7a936bdf238d93a861a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`803e2370`](https://github.com/nix-community/NUR/commit/803e2370d6ca2a0a5f06a7a936bdf238d93a861a) | `` automatic update `` |