### PR TITLE
chore(flake/nur): `6e8ae8d6` -> `e51723bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717274801,
-        "narHash": "sha256-S4pz7vSZ4M+rKtn8bPBx3RjkkYO66cBRsacpZJVTVCk=",
+        "lastModified": 1717292957,
+        "narHash": "sha256-eW2gigO4bZMT4p+t/+MwNCejbrzVxNnHCfXU25dGRH0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6e8ae8d6738d7f739baa91dbc0b48a0e16f04f55",
+        "rev": "e51723bdba9c1917d7b15053bac714f3546675bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e51723bd`](https://github.com/nix-community/NUR/commit/e51723bdba9c1917d7b15053bac714f3546675bb) | `` automatic update `` |