### PR TITLE
chore(flake/nix-index-database): `ff80cb4a` -> `972a52be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -587,11 +587,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716772633,
-        "narHash": "sha256-Idcye44UW+EgjbjCoklf2IDF+XrehV6CVYvxR1omst4=",
+        "lastModified": 1717297675,
+        "narHash": "sha256-43UmlS1Ifx17y93/Vc258U7bOlAAIZbu8dsGDHOIIr0=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "ff80cb4a11bb87f3ce8459be6f16a25ac86eb2ac",
+        "rev": "972a52bee3991ae1f1899e6452e0d7c01ee566d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`972a52be`](https://github.com/nix-community/nix-index-database/commit/972a52bee3991ae1f1899e6452e0d7c01ee566d9) | `` update packages.nix to release 2024-06-02-030640 `` |
| [`bc96f07c`](https://github.com/nix-community/nix-index-database/commit/bc96f07c804e4c6983b63716ead93e0416bf9cf0) | `` flake.lock: Update ``                               |