### PR TITLE
chore(flake/nur): `95edadf3` -> `5228189c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717300007,
-        "narHash": "sha256-rtggYfQX+ooy+5lXBOArmFiPmsemf5jLC8G9WKfGGM0=",
+        "lastModified": 1717311268,
+        "narHash": "sha256-mzonxQobUAAWrllsBuAut53c3DesE4rG9ptArADPhAs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "95edadf3f532643a9dbc55aa21f1fd3a01816007",
+        "rev": "5228189c61f2fe1c0f3f99634eb28cc5ffc05c37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5228189c`](https://github.com/nix-community/NUR/commit/5228189c61f2fe1c0f3f99634eb28cc5ffc05c37) | `` automatic update `` |
| [`615159ec`](https://github.com/nix-community/NUR/commit/615159ecacd163113dd1721deb5ffd09fbf74ecb) | `` automatic update `` |
| [`ca954101`](https://github.com/nix-community/NUR/commit/ca9541014efcbcb00684b0ba9e8dcb50623c637a) | `` automatic update `` |
| [`e39b8e1e`](https://github.com/nix-community/NUR/commit/e39b8e1e0ac2fb7511874303764a543282285c27) | `` automatic update `` |
| [`7333b59f`](https://github.com/nix-community/NUR/commit/7333b59faf568791e59bb9b607056064276ec8fe) | `` automatic update `` |
| [`bc1f54d0`](https://github.com/nix-community/NUR/commit/bc1f54d0b897b238c966f85a995bdea35ab3572d) | `` automatic update `` |
| [`7494b7e7`](https://github.com/nix-community/NUR/commit/7494b7e725b5c56ff47df91e45cb576450aac347) | `` automatic update `` |