### PR TITLE
chore(flake/nur): `7f1686d0` -> `2e519275`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717321478,
-        "narHash": "sha256-o1P3CimhfV8ku0rj5JYBBkyuUF+7RntvlTaDyhU8csA=",
+        "lastModified": 1717328695,
+        "narHash": "sha256-XkpJZkHTljZxHI2Yj5WCXq9uOQn4ZANdb1v2ZCmjHH0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7f1686d0db853d95be469efb2f9bbb464be72bf5",
+        "rev": "2e5192753f1df775304f9d1ec607b7a0aa452bfd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2e519275`](https://github.com/nix-community/NUR/commit/2e5192753f1df775304f9d1ec607b7a0aa452bfd) | `` automatic update `` |
| [`7f8d9720`](https://github.com/nix-community/NUR/commit/7f8d9720afb627dd4ec4ebabdeabc40eef1a3ff8) | `` automatic update `` |
| [`559dd086`](https://github.com/nix-community/NUR/commit/559dd086b4664df0807d78b96bdb1053875b07dd) | `` automatic update `` |
| [`47cac455`](https://github.com/nix-community/NUR/commit/47cac455a88783de36ddd73c9781b5efd4d12a19) | `` automatic update `` |