### PR TITLE
chore(flake/nur): `2e519275` -> `c28d5fb6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717328695,
-        "narHash": "sha256-XkpJZkHTljZxHI2Yj5WCXq9uOQn4ZANdb1v2ZCmjHH0=",
+        "lastModified": 1717335999,
+        "narHash": "sha256-PnWTljQXURbXMhpiMvPf7464BOgj1/9Nt8hsnsQfABA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2e5192753f1df775304f9d1ec607b7a0aa452bfd",
+        "rev": "c28d5fb64873b3e9aee15f344de0106edf632abe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c28d5fb6`](https://github.com/nix-community/NUR/commit/c28d5fb64873b3e9aee15f344de0106edf632abe) | `` automatic update `` |
| [`c01a0051`](https://github.com/nix-community/NUR/commit/c01a0051307b6435fd5253f69816ab120a91f1f9) | `` automatic update `` |