### PR TITLE
chore(flake/nur): `c28d5fb6` -> `4bb9a433`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717335999,
-        "narHash": "sha256-PnWTljQXURbXMhpiMvPf7464BOgj1/9Nt8hsnsQfABA=",
+        "lastModified": 1717340497,
+        "narHash": "sha256-+ZfIvx4U48tB4LVkPysmotz+O9CzRD/jcc2/VevRDiI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c28d5fb64873b3e9aee15f344de0106edf632abe",
+        "rev": "4bb9a433d6f5a261fc0a47306b29664c28687740",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4bb9a433`](https://github.com/nix-community/NUR/commit/4bb9a433d6f5a261fc0a47306b29664c28687740) | `` automatic update `` |
| [`dc9cdc98`](https://github.com/nix-community/NUR/commit/dc9cdc98c3cf8f6b5956e7754927400482b2e140) | `` automatic update `` |
| [`0b73bc56`](https://github.com/nix-community/NUR/commit/0b73bc56a5ebe29a86681575da423f50a9026a64) | `` automatic update `` |