### PR TITLE
chore(flake/nur): `4bb9a433` -> `8587d6c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717340497,
-        "narHash": "sha256-+ZfIvx4U48tB4LVkPysmotz+O9CzRD/jcc2/VevRDiI=",
+        "lastModified": 1717346712,
+        "narHash": "sha256-QjFwg6M1dBj+2DhTvDOhvvybvSxXK0fJn1FuqbWhi1o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4bb9a433d6f5a261fc0a47306b29664c28687740",
+        "rev": "8587d6c2d6bef3775387336a8456702789cbfb0b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8587d6c2`](https://github.com/nix-community/NUR/commit/8587d6c2d6bef3775387336a8456702789cbfb0b) | `` automatic update `` |
| [`2addb3c5`](https://github.com/nix-community/NUR/commit/2addb3c55d2fc356c44798cdcf81891ee13456a5) | `` automatic update `` |