### PR TITLE
chore(flake/nur): `8587d6c2` -> `da0cb74f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717346712,
-        "narHash": "sha256-QjFwg6M1dBj+2DhTvDOhvvybvSxXK0fJn1FuqbWhi1o=",
+        "lastModified": 1717357486,
+        "narHash": "sha256-7lRZjv5NJAJQsEv1x4k+TJSbWEJG27gi4XDzZbq+fvY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8587d6c2d6bef3775387336a8456702789cbfb0b",
+        "rev": "da0cb74fd7d4bf8744bc2cbc1e2ed02adc50ed69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`da0cb74f`](https://github.com/nix-community/NUR/commit/da0cb74fd7d4bf8744bc2cbc1e2ed02adc50ed69) | `` automatic update `` |
| [`756b17f7`](https://github.com/nix-community/NUR/commit/756b17f743a367349abe7a120d485db4c340d352) | `` automatic update `` |