### PR TITLE
chore(flake/nur): `da0cb74f` -> `1889957a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717357486,
-        "narHash": "sha256-7lRZjv5NJAJQsEv1x4k+TJSbWEJG27gi4XDzZbq+fvY=",
+        "lastModified": 1717365121,
+        "narHash": "sha256-f1hpmzUpZ+7fX0SEpHVPb5eSLeC1GvtV4U1znqtcdHM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "da0cb74fd7d4bf8744bc2cbc1e2ed02adc50ed69",
+        "rev": "1889957aff6f9e7d6b76052a0a37739b15a7a711",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1889957a`](https://github.com/nix-community/NUR/commit/1889957aff6f9e7d6b76052a0a37739b15a7a711) | `` automatic update `` |