### PR TITLE
chore(flake/emacs-overlay): `0b6f0831` -> `9a589248`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1717347982,
-        "narHash": "sha256-ZMgwX8MPKY1vjEWIaDCqyY1vmc1xjqODQvqZGYAgUsA=",
+        "lastModified": 1717376631,
+        "narHash": "sha256-J1vbs/VPXyXcP64vt0P8nWSCRLL3UTRpLDmouKXvyT4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0b6f083187662135ddad8b6b28f4713e372c3572",
+        "rev": "9a589248a3211cd25ca96b8dd879610bf17ea9a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`9a589248`](https://github.com/nix-community/emacs-overlay/commit/9a589248a3211cd25ca96b8dd879610bf17ea9a5) | `` Updated elpa ``   |
| [`1380b7b1`](https://github.com/nix-community/emacs-overlay/commit/1380b7b1b0519dd5f7d410a4a090a5e13e0f2346) | `` Updated nongnu `` |