### PR TITLE
chore(flake/srvos): `414d1039` -> `96998137`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -951,11 +951,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717058062,
-        "narHash": "sha256-R8Gb2MlJzfBE76DVWFmfZWODMdAanqxFnK+OOmkoQ7E=",
+        "lastModified": 1717376170,
+        "narHash": "sha256-603uKDAsg8KKVvMzNxIgTrHvXu6vRYx32NO3tuQCIg4=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "414d1039a58b667e4512ad9f7068aa935ebf8d59",
+        "rev": "96998137e26a92debda49fc2a32d4852d754abb4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`96998137`](https://github.com/nix-community/srvos/commit/96998137e26a92debda49fc2a32d4852d754abb4) | `` dev/private/flake.lock: Update `` |
| [`2043ba8e`](https://github.com/nix-community/srvos/commit/2043ba8e3e9da42f561e21f154821764c6b31bc4) | `` flake.lock: Update ``             |