### PR TITLE
chore(flake/nur): `7ae874b8` -> `308c45ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717378975,
-        "narHash": "sha256-7HwGQPeoRXKsu64aGhh7NGuMxDNa/PPPYrWpxuvjTUI=",
+        "lastModified": 1717387779,
+        "narHash": "sha256-v/DE+41QW1qaJzqlbcuor00YlpZ6zv35XrIGXggHHmM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7ae874b80479c475c6b74e8f8615e03b4062c71c",
+        "rev": "308c45bae53f5ec91fa35f6790cbfc4541326ad0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`308c45ba`](https://github.com/nix-community/NUR/commit/308c45bae53f5ec91fa35f6790cbfc4541326ad0) | `` automatic update `` |
| [`cd4dcab8`](https://github.com/nix-community/NUR/commit/cd4dcab868b94c16bf00cf9ced8de7ed1caba128) | `` automatic update `` |