### PR TITLE
chore(flake/nur): `308c45ba` -> `d8646b0f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717387779,
-        "narHash": "sha256-v/DE+41QW1qaJzqlbcuor00YlpZ6zv35XrIGXggHHmM=",
+        "lastModified": 1717397685,
+        "narHash": "sha256-AHR5ZiYVLX6Z1u6lb6dzMjhmTH5JrRl+2DSm9qZnZI4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "308c45bae53f5ec91fa35f6790cbfc4541326ad0",
+        "rev": "d8646b0f5045c13011a6cb284db320ade72b92d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d8646b0f`](https://github.com/nix-community/NUR/commit/d8646b0f5045c13011a6cb284db320ade72b92d2) | `` automatic update `` |
| [`322a8dd2`](https://github.com/nix-community/NUR/commit/322a8dd20c20758170619aab6fc8a49281f55b46) | `` automatic update `` |
| [`487cd280`](https://github.com/nix-community/NUR/commit/487cd2807f1f4faf9ef0aaa06e26172f210f9824) | `` automatic update `` |