### PR TITLE
chore(flake/nur): `d8646b0f` -> `6a4735b0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717397685,
-        "narHash": "sha256-AHR5ZiYVLX6Z1u6lb6dzMjhmTH5JrRl+2DSm9qZnZI4=",
+        "lastModified": 1717407905,
+        "narHash": "sha256-amk6TEqtiTSmPvFLnbsuk+5kZN0zeLj/wjgptFiLvYM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d8646b0f5045c13011a6cb284db320ade72b92d2",
+        "rev": "6a4735b07f0353e512980352facb8e9373d85986",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6a4735b0`](https://github.com/nix-community/NUR/commit/6a4735b07f0353e512980352facb8e9373d85986) | `` automatic update `` |
| [`f352a10c`](https://github.com/nix-community/NUR/commit/f352a10cea770365f97a11d87d095356cc161e0a) | `` automatic update `` |
| [`355cd991`](https://github.com/nix-community/NUR/commit/355cd991c7fc2e49179498a029c9e19c5cc05075) | `` automatic update `` |
| [`7276fed8`](https://github.com/nix-community/NUR/commit/7276fed828ba99d659af8ccae48e30e325ea97c2) | `` automatic update `` |
| [`1cc9edb7`](https://github.com/nix-community/NUR/commit/1cc9edb753de700491cf6122e6e669dc1718128d) | `` automatic update `` |
| [`bf139c97`](https://github.com/nix-community/NUR/commit/bf139c97aaf94adbaa9bac52629aafaba8f193d1) | `` automatic update `` |
| [`4993ee7a`](https://github.com/nix-community/NUR/commit/4993ee7aba93c960b037b7b29588b99bc225ae3d) | `` automatic update `` |