### PR TITLE
chore(flake/emacs-overlay): `76082b22` -> `088f3035`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1717379613,
-        "narHash": "sha256-EzL1xZoyj946hb7DtcPxXFkzuiGcQMSlSRr1+MzRfCA=",
+        "lastModified": 1717405832,
+        "narHash": "sha256-MTNKQYg07C3lGzdrP9jonWbLZXpwc2kuCtyw++HZSDw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "76082b226e29dd266a67b6f4df4fcaa771152f9c",
+        "rev": "088f3035f29f2de3cc2d666ff6cbcee248eb3d43",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`088f3035`](https://github.com/nix-community/emacs-overlay/commit/088f3035f29f2de3cc2d666ff6cbcee248eb3d43) | `` Updated emacs ``        |
| [`c9c813d0`](https://github.com/nix-community/emacs-overlay/commit/c9c813d0721caaefa4bdbce2eed4f5a2b2c35d89) | `` Updated melpa ``        |
| [`fefb7504`](https://github.com/nix-community/emacs-overlay/commit/fefb7504e796296ee5b8202823cc07c82f90e169) | `` Updated flake inputs `` |