### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `2ea32ba1` -> `777dfc9e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717293262,
-        "narHash": "sha256-ZZ1ZGpYjS++QPadI472Kw+i+/rAS1Og6rqDfZHbp/+s=",
+        "lastModified": 1717402716,
+        "narHash": "sha256-rDNIPlRCH7gYLy6aNGECY6X0D9NFiiaz2tnx+9Ijl6M=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bcccabf80dbeaa8cfad827c6ff29ae8672405792",
+        "rev": "fefb7504e796296ee5b8202823cc07c82f90e169",
         "type": "github"
       },
       "original": {
@@ -519,11 +519,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1717299284,
-        "narHash": "sha256-bcGiiUAkHf78UPPG9szYgzby/D7OkTDLIVZuk4zaaKc=",
+        "lastModified": 1717403571,
+        "narHash": "sha256-cLSh9/L+v9WzZ3rLPn+pm4j9G1oOtUJct9NWK/iFC+E=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "2ea32ba190bdcef1ec1835058b47921526e639f4",
+        "rev": "777dfc9e36d96b739330ea5fc284c21c00264771",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`777dfc9e`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/777dfc9e36d96b739330ea5fc284c21c00264771) | `` flake.lock: Update `` |