### PR TITLE
chore(flake/nur): `f6ccdc2d` -> `963de5e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717424654,
-        "narHash": "sha256-ykA3J2jnLpB9jGGijKbfP4Q0VNClpXW1tylg1yGWX3o=",
+        "lastModified": 1717429509,
+        "narHash": "sha256-c7mqDqNUP5BVtUZLTeglj5NjM1jvncUZy9fhydhB8RQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f6ccdc2d63a2e1df63e71d594f7f4b925493c2e6",
+        "rev": "963de5e47dbd9550a36d90c9075b40002000547a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`963de5e4`](https://github.com/nix-community/NUR/commit/963de5e47dbd9550a36d90c9075b40002000547a) | `` automatic update `` |