### PR TITLE
chore(flake/nur): `963de5e4` -> `baa7a135`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717429509,
-        "narHash": "sha256-c7mqDqNUP5BVtUZLTeglj5NjM1jvncUZy9fhydhB8RQ=",
+        "lastModified": 1717433195,
+        "narHash": "sha256-WNFJ/GgRjZmHZ71Ifv+Q5KjGoK8lVX8leKAtSFXN16Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "963de5e47dbd9550a36d90c9075b40002000547a",
+        "rev": "baa7a13543b86979b1f91c88f0bd7879be90dc78",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`baa7a135`](https://github.com/nix-community/NUR/commit/baa7a13543b86979b1f91c88f0bd7879be90dc78) | `` automatic update `` |