### PR TITLE
chore(flake/nur): `baa7a135` -> `5277a175`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717433195,
-        "narHash": "sha256-WNFJ/GgRjZmHZ71Ifv+Q5KjGoK8lVX8leKAtSFXN16Y=",
+        "lastModified": 1717438492,
+        "narHash": "sha256-7nbvxaQPyZs2LbjsxhnwZi5NK69IyHThfzAVhj+0JFc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "baa7a13543b86979b1f91c88f0bd7879be90dc78",
+        "rev": "5277a17583f5c585f10ee0eae12c7f9aee4185bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5277a175`](https://github.com/nix-community/NUR/commit/5277a17583f5c585f10ee0eae12c7f9aee4185bd) | `` automatic update `` |
| [`099df24c`](https://github.com/nix-community/NUR/commit/099df24c1d615a916bf44edd771e955a79f1fe85) | `` automatic update `` |