### PR TITLE
chore(flake/nur): `5277a175` -> `0122b0f4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717438492,
-        "narHash": "sha256-7nbvxaQPyZs2LbjsxhnwZi5NK69IyHThfzAVhj+0JFc=",
+        "lastModified": 1717443933,
+        "narHash": "sha256-hKPYAOnbqvy/eZMsp85KRHn5+K3QkGeU8cyLiXtxT48=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5277a17583f5c585f10ee0eae12c7f9aee4185bd",
+        "rev": "0122b0f415811dd2a367f362a595070b6451ff9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0122b0f4`](https://github.com/nix-community/NUR/commit/0122b0f415811dd2a367f362a595070b6451ff9a) | `` automatic update `` |