### PR TITLE
chore(flake/emacs-overlay): `33b9d0e9` -> `52fc908c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1717434484,
-        "narHash": "sha256-e92iAkqGz3kyCwnGF4Z5MGqxf0hJRH2VjrcoV4Jyjis=",
+        "lastModified": 1717463014,
+        "narHash": "sha256-7iymrKLBnx6NkGTpm31ZC5FXXRV6w/gwHNXKb9TOpFM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "33b9d0e966a2299a38263f2b325a93ea6632d3ed",
+        "rev": "52fc908cbc39f3fa88bba9848511f1ea7a7dfff0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message            |
| ------------------------------------------------------------------------------------------------------------ | ------------------ |
| [`52fc908c`](https://github.com/nix-community/emacs-overlay/commit/52fc908cbc39f3fa88bba9848511f1ea7a7dfff0) | `` Updated elpa `` |