### PR TITLE
chore(flake/emacs-overlay): `52fc908c` -> `7ff674d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1717463014,
-        "narHash": "sha256-7iymrKLBnx6NkGTpm31ZC5FXXRV6w/gwHNXKb9TOpFM=",
+        "lastModified": 1717811460,
+        "narHash": "sha256-b2HZ9oDtKutADV8WPPsMWozJkNamiRGOqf2K9ekv950=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "52fc908cbc39f3fa88bba9848511f1ea7a7dfff0",
+        "rev": "7ff674d6a61f4a3af339e82cfebf5e67d24d1714",
         "type": "github"
       },
       "original": {
@@ -700,11 +700,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1717159533,
-        "narHash": "sha256-oamiKNfr2MS6yH64rUn99mIZjc45nGJlj9eGth/3Xuw=",
+        "lastModified": 1717530100,
+        "narHash": "sha256-b4Dn+PnrZoVZ/BoR9JN2fTxXxplJrAsdSUIePf4Cacs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
+        "rev": "a2e1d0414259a144ebdc048408a807e69e0565af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`7ff674d6`](https://github.com/nix-community/emacs-overlay/commit/7ff674d6a61f4a3af339e82cfebf5e67d24d1714) | `` Updated emacs ``        |
| [`1382dd1c`](https://github.com/nix-community/emacs-overlay/commit/1382dd1cfd1bbcab56e870a7aea99c6c479e934a) | `` Updated melpa ``        |
| [`671703d6`](https://github.com/nix-community/emacs-overlay/commit/671703d6eae67d2a836e6f5c4d6f74b2937b8c44) | `` Updated elpa ``         |
| [`f755987d`](https://github.com/nix-community/emacs-overlay/commit/f755987d23a4581cdcc1999b0b3c1a6806de20c9) | `` Updated nongnu ``       |
| [`ac3c2954`](https://github.com/nix-community/emacs-overlay/commit/ac3c29547bf7a87fe5911694f45a5192aaaf92ee) | `` Updated emacs ``        |
| [`34b757de`](https://github.com/nix-community/emacs-overlay/commit/34b757de8b5ffd9631f5875e7fae0af37e7c1f91) | `` Updated melpa ``        |
| [`3f06166e`](https://github.com/nix-community/emacs-overlay/commit/3f06166ed11a7b774a01cd2e4fd86dc74cb5c373) | `` Updated elpa ``         |
| [`7a24ecfb`](https://github.com/nix-community/emacs-overlay/commit/7a24ecfb43f2c223bb171358ee1858fa1bcf568d) | `` Updated nongnu ``       |
| [`101db880`](https://github.com/nix-community/emacs-overlay/commit/101db880b015dd8e7b49c54da99f8d6ffaefc0b2) | `` Updated emacs ``        |
| [`6ed3efc8`](https://github.com/nix-community/emacs-overlay/commit/6ed3efc83a696461fcfdac5b075913522aa96dce) | `` Updated melpa ``        |
| [`b6765fc0`](https://github.com/nix-community/emacs-overlay/commit/b6765fc07d26b716af4193faa60b1da2d3406518) | `` Updated emacs ``        |
| [`54d02051`](https://github.com/nix-community/emacs-overlay/commit/54d020519c696e9a11179a25b2a989bef156a741) | `` Updated melpa ``        |
| [`535a9385`](https://github.com/nix-community/emacs-overlay/commit/535a9385c072bd3e781e0f5cceaa157759d89749) | `` Updated elpa ``         |
| [`ce89a70d`](https://github.com/nix-community/emacs-overlay/commit/ce89a70dcb4b243be6acb31578cd82a50d380dd6) | `` Updated flake inputs `` |
| [`aa9303c7`](https://github.com/nix-community/emacs-overlay/commit/aa9303c7769729a544a6c69ee531b9e6ae0e672d) | `` Updated emacs ``        |
| [`c2f34064`](https://github.com/nix-community/emacs-overlay/commit/c2f3406485193e96371e792f83770429a92a73a5) | `` Updated melpa ``        |
| [`e511f80c`](https://github.com/nix-community/emacs-overlay/commit/e511f80cc31ba3f6b447d962016648178dfd5e32) | `` Updated elpa ``         |
| [`27dbf1db`](https://github.com/nix-community/emacs-overlay/commit/27dbf1db4515f663e761af229067f7e103cd3b35) | `` Updated nongnu ``       |
| [`29545023`](https://github.com/nix-community/emacs-overlay/commit/29545023b76d3e4196908f66a5cfc9b2b3bd764e) | `` Updated flake inputs `` |
| [`28779a7a`](https://github.com/nix-community/emacs-overlay/commit/28779a7abf781d387806f2567b578af6fd165705) | `` Updated emacs ``        |
| [`338d2aa0`](https://github.com/nix-community/emacs-overlay/commit/338d2aa007b87ff16210935d3ac3a16ab3dd5efa) | `` Updated melpa ``        |
| [`4f97985d`](https://github.com/nix-community/emacs-overlay/commit/4f97985d133a12a5991ae8445b0bebbaedf399a6) | `` Updated emacs ``        |
| [`f6c8bd1e`](https://github.com/nix-community/emacs-overlay/commit/f6c8bd1e52d9ebf8435956fab29e024180bf067e) | `` Updated melpa ``        |
| [`013bdc70`](https://github.com/nix-community/emacs-overlay/commit/013bdc70be91a26cef4a12c6b2a703df2dcc0d06) | `` Updated elpa ``         |
| [`6411a583`](https://github.com/nix-community/emacs-overlay/commit/6411a583159b7baeb6230f5fa2ed6524b5456c2a) | `` Updated emacs ``        |
| [`fbdd576e`](https://github.com/nix-community/emacs-overlay/commit/fbdd576e9d6ec9d93178cf3369930040818eafe3) | `` Updated melpa ``        |
| [`27e23bcd`](https://github.com/nix-community/emacs-overlay/commit/27e23bcded29d416b8edf1e1ed984e86212297a9) | `` Updated elpa ``         |
| [`fc1036d1`](https://github.com/nix-community/emacs-overlay/commit/fc1036d1a2463e7aa9e4cb7bac8b5e1e4b58556d) | `` Updated nongnu ``       |
| [`a0991adb`](https://github.com/nix-community/emacs-overlay/commit/a0991adb1ef4b29c4c8623bbb2a1fb99da48cf85) | `` Updated flake inputs `` |
| [`63688083`](https://github.com/nix-community/emacs-overlay/commit/6368808339236389daf8eec2e187094647e1f203) | `` Updated emacs ``        |
| [`47f5d84a`](https://github.com/nix-community/emacs-overlay/commit/47f5d84a429df497a8df488a114b4976509ee44b) | `` Updated melpa ``        |
| [`67604448`](https://github.com/nix-community/emacs-overlay/commit/67604448a402e3f600e6b921fa6ad34a62c6f55c) | `` Updated flake inputs `` |
| [`d619b5b5`](https://github.com/nix-community/emacs-overlay/commit/d619b5b5ba751d6e3c16da1ca8178a31ef130047) | `` Updated emacs ``        |
| [`d7476f25`](https://github.com/nix-community/emacs-overlay/commit/d7476f259d0ec19134e5bf957cfcc1325e585182) | `` Updated melpa ``        |
| [`c9aca5d4`](https://github.com/nix-community/emacs-overlay/commit/c9aca5d40537037b1b20d4f6cc1e8516f4100d00) | `` Updated elpa ``         |
| [`783d5b31`](https://github.com/nix-community/emacs-overlay/commit/783d5b3143f7ee264ecd5258f606fb99a93e8243) | `` Updated nongnu ``       |
| [`a433759c`](https://github.com/nix-community/emacs-overlay/commit/a433759c9f9d46c02e0818ca88f1f35d4c204afb) | `` Updated emacs ``        |
| [`ef36cb44`](https://github.com/nix-community/emacs-overlay/commit/ef36cb44e5db28cadcfb13780d681419287512dd) | `` Updated melpa ``        |
| [`70263b28`](https://github.com/nix-community/emacs-overlay/commit/70263b28668b915ec509f7bc6e975bee66065099) | `` Updated elpa ``         |
| [`84d45dec`](https://github.com/nix-community/emacs-overlay/commit/84d45decb6ee4cfee67c27e0237edaae2d95af79) | `` Updated emacs ``        |
| [`418c50b0`](https://github.com/nix-community/emacs-overlay/commit/418c50b09bd9ec9c008e8c7a2b38b4e853c1b401) | `` Updated melpa ``        |
| [`170a4920`](https://github.com/nix-community/emacs-overlay/commit/170a49203727005b68444786bea716039aa332bf) | `` Updated emacs ``        |
| [`abdbe2c1`](https://github.com/nix-community/emacs-overlay/commit/abdbe2c108ba01e201a2f793281f571fd418e171) | `` Updated melpa ``        |