### PR TITLE
chore(flake/nur): `c4f24fd0` -> `97757c4e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717452470,
-        "narHash": "sha256-8sbx/PhdKokC7FzogVk/fDVaKlJp9RNhE53tmSpZJyg=",
+        "lastModified": 1717473371,
+        "narHash": "sha256-mqX0f3xEyG0EtFVA50oroeo1X+2SmGJYzjU648D0PRU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c4f24fd0d45f73f969e58dfccfea5e5fa068d872",
+        "rev": "97757c4e3230202055aba7ca786913484a32fc2e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`97757c4e`](https://github.com/nix-community/NUR/commit/97757c4e3230202055aba7ca786913484a32fc2e) | `` automatic update `` |
| [`38c98213`](https://github.com/nix-community/NUR/commit/38c9821336c01130ca61af78b00528ec48465f50) | `` automatic update `` |