### PR TITLE
chore(flake/home-manager): `9b53a10f` -> `07b2c41d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -410,11 +410,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717316182,
-        "narHash": "sha256-Xi0EpZcu39N0eW7apLjFfUOR9y80toyjYizez7J1wMI=",
+        "lastModified": 1717476107,
+        "narHash": "sha256-q2StzUV3Rm9LoUj6neRkIbxK9eXEieZji5bIVu17DSM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9b53a10f4c91892f5af87cf55d08fba59ca086af",
+        "rev": "07b2c41d2df2878a5c71229a66fb1f8ccef71c47",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                       |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`07b2c41d`](https://github.com/nix-community/home-manager/commit/07b2c41d2df2878a5c71229a66fb1f8ccef71c47) | `` ci: bump all actions versions (#5496) ``   |
| [`83bfe1ba`](https://github.com/nix-community/home-manager/commit/83bfe1bac8e0d930f36cee6874bd17e77c8754d1) | `` nix-gc: add `persistent` option (#5490) `` |