### PR TITLE
chore(flake/nur): `97757c4e` -> `d55622a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717473371,
-        "narHash": "sha256-mqX0f3xEyG0EtFVA50oroeo1X+2SmGJYzjU648D0PRU=",
+        "lastModified": 1717475881,
+        "narHash": "sha256-JCTqmO0Ww1iWjbi+3t1evuN4CPpmz0jURGe/vFbDizM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "97757c4e3230202055aba7ca786913484a32fc2e",
+        "rev": "d55622a00d77d2e808e6efa02776f96e6cc6fb8c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d55622a0`](https://github.com/nix-community/NUR/commit/d55622a00d77d2e808e6efa02776f96e6cc6fb8c) | `` automatic update `` |
| [`9c974fde`](https://github.com/nix-community/NUR/commit/9c974fde78aec91fb9cf0a071afa141b488f5f90) | `` automatic update `` |
| [`e570da02`](https://github.com/nix-community/NUR/commit/e570da020eec2a30688d303e591bed0335274618) | `` automatic update `` |