### PR TITLE
chore(flake/home-manager): `07b2c41d` -> `2cacdd6a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -410,11 +410,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717476107,
-        "narHash": "sha256-q2StzUV3Rm9LoUj6neRkIbxK9eXEieZji5bIVu17DSM=",
+        "lastModified": 1717483170,
+        "narHash": "sha256-Xr/oYk3vmyv2a/nY8o/Wd0MdLsI5vaC38Kris7CWunM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "07b2c41d2df2878a5c71229a66fb1f8ccef71c47",
+        "rev": "2cacdd6a27477f1fa46b7026dd806de30f164d3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`2cacdd6a`](https://github.com/nix-community/home-manager/commit/2cacdd6a27477f1fa46b7026dd806de30f164d3b) | `` ci/labeler: fix upgrade to v5 format `` |
| [`1a577c13`](https://github.com/nix-community/home-manager/commit/1a577c135cad84eb0cd5a922efe2de9cc467772a) | `` ci/labeler: upgrade to v5 format ``     |