### PR TITLE
chore(flake/nur): `d55622a0` -> `75a188e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717475881,
-        "narHash": "sha256-JCTqmO0Ww1iWjbi+3t1evuN4CPpmz0jURGe/vFbDizM=",
+        "lastModified": 1717483554,
+        "narHash": "sha256-0WXmAi/TbIU+iGt2tzDHi2mAj928xyMDE3G7L/5fOX4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d55622a00d77d2e808e6efa02776f96e6cc6fb8c",
+        "rev": "75a188e6783937d48cece42e40de7b9e2c5c4ba5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`75a188e6`](https://github.com/nix-community/NUR/commit/75a188e6783937d48cece42e40de7b9e2c5c4ba5) | `` automatic update `` |
| [`d1334574`](https://github.com/nix-community/NUR/commit/d13345742fd7ac86a6f9ea167c99bca29177a6e1) | `` automatic update `` |