### PR TITLE
chore(flake/catppuccin): `2c7661c9` -> `7518e00f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1717070887,
-        "narHash": "sha256-ZTEMINFqQL+m55kmoDYIKf3i2NGitSkjBnnLu99ezh0=",
+        "lastModified": 1717502698,
+        "narHash": "sha256-EXMMaSJ143ojJVb+xU7tCxbMAlIk0lbKhnOEh8XN7XU=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "2c7661c9fa26a920b8088300ef87d14179c71a27",
+        "rev": "7518e00f232e7b61f514f24dd4fa34b98c8089df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                              |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`7518e00f`](https://github.com/catppuccin/nix/commit/7518e00f232e7b61f514f24dd4fa34b98c8089df) | `` ci: getchoo/update-npins@v0.1.1 -> v0.1.2 (#210) ``               |
| [`aebbd733`](https://github.com/catppuccin/nix/commit/aebbd7335340a4f487eec64ac759c50207fed98e) | `` ci: install npins for port updates (#209) ``                      |
| [`534be878`](https://github.com/catppuccin/nix/commit/534be878b3ab79f6e95f4372f8c8f7d622ce6f1e) | `` ci: split port & flake input updates (#207) ``                    |
| [`dc9553ef`](https://github.com/catppuccin/nix/commit/dc9553ef0b3439f31a9ab5772356bf936895df74) | `` feat(modules)!: bump minimum supported release to 24.05 (#203) `` |