### PR TITLE
chore(flake/nur): `ab534f14` -> `3d9afb60`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717488989,
-        "narHash": "sha256-BRbBBMEdsAQSjFTvC8bal0WloVK1iv9ndQPBV4PRiMk=",
+        "lastModified": 1717502379,
+        "narHash": "sha256-f5KUvg4Ia4J0PLkDk5OaiBduwQj/IB1t8XUs4Ta5IoU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ab534f14c307f729de6954e36837e9febdbda97e",
+        "rev": "3d9afb600a4d936dfe261c96109d5d7b8ee8149d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3d9afb60`](https://github.com/nix-community/NUR/commit/3d9afb600a4d936dfe261c96109d5d7b8ee8149d) | `` automatic update `` |
| [`65b5bcde`](https://github.com/nix-community/NUR/commit/65b5bcdeee6f0005b946541f6614e45a7262d8a4) | `` automatic update `` |
| [`dc06c1d3`](https://github.com/nix-community/NUR/commit/dc06c1d30c6e4a441fca29e997a40df7d6d6e9ce) | `` automatic update `` |