### PR TITLE
chore(flake/nur): `3d9afb60` -> `4e7a2f26`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717502379,
-        "narHash": "sha256-f5KUvg4Ia4J0PLkDk5OaiBduwQj/IB1t8XUs4Ta5IoU=",
+        "lastModified": 1717504708,
+        "narHash": "sha256-Gys2zgCYe2XGkb25hM46Oa3TAUPkay+XWUph28ciYVM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3d9afb600a4d936dfe261c96109d5d7b8ee8149d",
+        "rev": "4e7a2f26c246f795ee386acbdd45353c22417e89",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4e7a2f26`](https://github.com/nix-community/NUR/commit/4e7a2f26c246f795ee386acbdd45353c22417e89) | `` automatic update `` |