### PR TITLE
chore(flake/nur): `2a5e0671` -> `1b50ad57`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717529128,
-        "narHash": "sha256-S0W4Btlhq4xOHY0gJzlTFzbnNGwQQPXo/fJvuVcP0ro=",
+        "lastModified": 1717533892,
+        "narHash": "sha256-3RSOoXNymhPz9Z+YV/DSPe0SAuOo8Svvezo5wy30ylM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2a5e0671a9a7aea688bc7e3a50cabb23d54e6d11",
+        "rev": "1b50ad57a2b00e018b1cc888b526817190bd72fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1b50ad57`](https://github.com/nix-community/NUR/commit/1b50ad57a2b00e018b1cc888b526817190bd72fa) | `` automatic update `` |
| [`d7179450`](https://github.com/nix-community/NUR/commit/d7179450e2607764fd7f6d25894acec6d1ae44f9) | `` automatic update `` |