### PR TITLE
chore(flake/nur): `1b50ad57` -> `e8d7e0cd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717533892,
-        "narHash": "sha256-3RSOoXNymhPz9Z+YV/DSPe0SAuOo8Svvezo5wy30ylM=",
+        "lastModified": 1717540489,
+        "narHash": "sha256-rLOvm9eMjybsGfmAYbSs/6SiwBou2ZvWYIL+dRq1x14=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1b50ad57a2b00e018b1cc888b526817190bd72fa",
+        "rev": "e8d7e0cdeba6377051f88a2399140566101153f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e8d7e0cd`](https://github.com/nix-community/NUR/commit/e8d7e0cdeba6377051f88a2399140566101153f9) | `` automatic update `` |