### PR TITLE
chore(flake/nur): `e8d7e0cd` -> `dfceb150`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717540489,
-        "narHash": "sha256-rLOvm9eMjybsGfmAYbSs/6SiwBou2ZvWYIL+dRq1x14=",
+        "lastModified": 1717548551,
+        "narHash": "sha256-AdAqWt3bQlLcv9hVWM7vS78Pfd0YjCGQaM4imFLN2io=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e8d7e0cdeba6377051f88a2399140566101153f9",
+        "rev": "dfceb15024a051ec9ce314851ec525d6f61e92a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dfceb150`](https://github.com/nix-community/NUR/commit/dfceb15024a051ec9ce314851ec525d6f61e92a7) | `` automatic update `` |
| [`ada70f37`](https://github.com/nix-community/NUR/commit/ada70f375ec73f7b3eca12d920d40e0d45dd2071) | `` automatic update `` |