### PR TITLE
chore(flake/nur): `dfceb150` -> `aad3c386`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717548551,
-        "narHash": "sha256-AdAqWt3bQlLcv9hVWM7vS78Pfd0YjCGQaM4imFLN2io=",
+        "lastModified": 1717552052,
+        "narHash": "sha256-75os45909VXZfmntTVIWkQ5q6swd7e9Jk+MnqMsqLic=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dfceb15024a051ec9ce314851ec525d6f61e92a7",
+        "rev": "aad3c386cfbf9e304c3dfae40e8106e392b9d378",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`aad3c386`](https://github.com/nix-community/NUR/commit/aad3c386cfbf9e304c3dfae40e8106e392b9d378) | `` automatic update `` |