### PR TITLE
chore(flake/nur): `aad3c386` -> `fc70a1f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717552052,
-        "narHash": "sha256-75os45909VXZfmntTVIWkQ5q6swd7e9Jk+MnqMsqLic=",
+        "lastModified": 1717559843,
+        "narHash": "sha256-mdFig9D4zzAtWIXKD1mZ3HrTa3F5mtPTuJYhPtsRXU0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aad3c386cfbf9e304c3dfae40e8106e392b9d378",
+        "rev": "fc70a1f1f0e8a5b74e124a85261ce5b3e574850e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fc70a1f1`](https://github.com/nix-community/NUR/commit/fc70a1f1f0e8a5b74e124a85261ce5b3e574850e) | `` automatic update `` |
| [`889f3e6b`](https://github.com/nix-community/NUR/commit/889f3e6bee2653249ac41c62868063281748039f) | `` automatic update `` |
| [`d3011ae4`](https://github.com/nix-community/NUR/commit/d3011ae46711cc203061f941496829b63bed9d4b) | `` automatic update `` |
| [`66bbceb2`](https://github.com/nix-community/NUR/commit/66bbceb23947951e6be409eaf0e79f2a6a6399bc) | `` automatic update `` |
| [`d7966377`](https://github.com/nix-community/NUR/commit/d7966377ed86b824d720e7a14aa260212a5dfedc) | `` automatic update `` |
| [`71521f19`](https://github.com/nix-community/NUR/commit/71521f197ce65dadcc2338ab3ebbd1c5fe7f7807) | `` automatic update `` |