### PR TITLE
chore(flake/nur): `fc70a1f1` -> `d33e654d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717559843,
-        "narHash": "sha256-mdFig9D4zzAtWIXKD1mZ3HrTa3F5mtPTuJYhPtsRXU0=",
+        "lastModified": 1717560313,
+        "narHash": "sha256-sF9G1QTJRd5NFmRhrmlMCOQGkUtulcSQwA48rcAP67A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fc70a1f1f0e8a5b74e124a85261ce5b3e574850e",
+        "rev": "d33e654d4ecb8c8a16278044056fb6d9925d1170",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d33e654d`](https://github.com/nix-community/NUR/commit/d33e654d4ecb8c8a16278044056fb6d9925d1170) | `` automatic update `` |