### PR TITLE
chore(flake/nur): `d33e654d` -> `a4c3bf21`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717560313,
-        "narHash": "sha256-sF9G1QTJRd5NFmRhrmlMCOQGkUtulcSQwA48rcAP67A=",
+        "lastModified": 1717569947,
+        "narHash": "sha256-Z08RxIMAeGbsDoQQbFO0NyY/aYDWfkyDG51El2tQLlQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d33e654d4ecb8c8a16278044056fb6d9925d1170",
+        "rev": "a4c3bf21c528ff86154497203a1f72a75be90b3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a4c3bf21`](https://github.com/nix-community/NUR/commit/a4c3bf21c528ff86154497203a1f72a75be90b3b) | `` automatic update `` |
| [`bf85d216`](https://github.com/nix-community/NUR/commit/bf85d2162e393c97bdb62de264efab6d4d5bfcfa) | `` automatic update `` |