### PR TITLE
chore(flake/nur): `a4c3bf21` -> `b730aaff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717569947,
-        "narHash": "sha256-Z08RxIMAeGbsDoQQbFO0NyY/aYDWfkyDG51El2tQLlQ=",
+        "lastModified": 1717577731,
+        "narHash": "sha256-ZNishOAKb9OGyR6EFobl8eEI2JqtrVDJHZvI6lczzuE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a4c3bf21c528ff86154497203a1f72a75be90b3b",
+        "rev": "b730aaff8a4645c9e063993cf2504dd60cc8abbe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b730aaff`](https://github.com/nix-community/NUR/commit/b730aaff8a4645c9e063993cf2504dd60cc8abbe) | `` automatic update `` |
| [`7bc0243f`](https://github.com/nix-community/NUR/commit/7bc0243f482a01679bb5726689d8e77366aab814) | `` automatic update `` |
| [`e7e5528f`](https://github.com/nix-community/NUR/commit/e7e5528f4b418fdc4855fd37c0d33cf9e2a986b6) | `` automatic update `` |
| [`95606477`](https://github.com/nix-community/NUR/commit/95606477949bccd62fea1fa1e5a74696ca21e5c0) | `` automatic update `` |
| [`2626fc2f`](https://github.com/nix-community/NUR/commit/2626fc2f032d64dd6ed199ad5d2ad060ed29a1f2) | `` automatic update `` |