### PR TITLE
chore(flake/nur): `b730aaff` -> `98970040`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717577731,
-        "narHash": "sha256-ZNishOAKb9OGyR6EFobl8eEI2JqtrVDJHZvI6lczzuE=",
+        "lastModified": 1717586799,
+        "narHash": "sha256-L8CxvRaxj/zoNwKp0hTiLclRyTgbzqbvr2u1Cu7F+8Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b730aaff8a4645c9e063993cf2504dd60cc8abbe",
+        "rev": "98970040a99890846159ed93c1fa83d93591a843",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`98970040`](https://github.com/nix-community/NUR/commit/98970040a99890846159ed93c1fa83d93591a843) | `` automatic update `` |