### PR TITLE
chore(flake/nur): `98970040` -> `fd23e3e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717586799,
-        "narHash": "sha256-L8CxvRaxj/zoNwKp0hTiLclRyTgbzqbvr2u1Cu7F+8Y=",
+        "lastModified": 1717592277,
+        "narHash": "sha256-YW8WzXyHacsVlkbDsseoa/eBXjlBmti6caO+J9Dcvd8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "98970040a99890846159ed93c1fa83d93591a843",
+        "rev": "fd23e3e77e1333fc374edc83ad1222584e3808b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fd23e3e7`](https://github.com/nix-community/NUR/commit/fd23e3e77e1333fc374edc83ad1222584e3808b9) | `` automatic update `` |
| [`a364b6de`](https://github.com/nix-community/NUR/commit/a364b6de0f2bd5ed5614ee3827f2ad135c69c73d) | `` automatic update `` |