### PR TITLE
chore(flake/srvos): `96998137` -> `5e0d94f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -951,11 +951,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717376170,
-        "narHash": "sha256-603uKDAsg8KKVvMzNxIgTrHvXu6vRYx32NO3tuQCIg4=",
+        "lastModified": 1717635218,
+        "narHash": "sha256-1fd4myxpeHrdBuXyjQqEp1lqq1CJeuPXPk67TlD6UKA=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "96998137e26a92debda49fc2a32d4852d754abb4",
+        "rev": "5e0d94f2b3608f2d01208e27d4a4db5a0e85b069",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`5e0d94f2`](https://github.com/nix-community/srvos/commit/5e0d94f2b3608f2d01208e27d4a4db5a0e85b069) | `` dev/private/flake.lock: Update `` |
| [`731c3f6d`](https://github.com/nix-community/srvos/commit/731c3f6de0de6fabcf28fd19ff4c5406f1a31728) | `` flake.lock: Update ``             |