### PR TITLE
chore(flake/nur): `e40ae768` -> `f4432890`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717636536,
-        "narHash": "sha256-FEB2vWclhx9qRSKeMj20VlzwFLGZlVmYH8DzeO7tudE=",
+        "lastModified": 1717638413,
+        "narHash": "sha256-grtPXIm2yrKwQJqloAgK6jF7OhZNKiGnbEICtGczx04=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e40ae7686b01f4d0c84ca0ce5df20efdae1df3bc",
+        "rev": "f44328905cbc45371ec489aa0b55306090bb1c82",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f4432890`](https://github.com/nix-community/NUR/commit/f44328905cbc45371ec489aa0b55306090bb1c82) | `` automatic update `` |