### PR TITLE
chore(flake/nur): `f4432890` -> `fb711041`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717638413,
-        "narHash": "sha256-grtPXIm2yrKwQJqloAgK6jF7OhZNKiGnbEICtGczx04=",
+        "lastModified": 1717645573,
+        "narHash": "sha256-1xGv4T6E/HfxKb9F8rD1MLKDhd63xNJx/ZcKZ52h/nc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f44328905cbc45371ec489aa0b55306090bb1c82",
+        "rev": "fb71104191719fd9674efbb87ce4320cc6eacbc5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fb711041`](https://github.com/nix-community/NUR/commit/fb71104191719fd9674efbb87ce4320cc6eacbc5) | `` automatic update `` |
| [`5d8d55ed`](https://github.com/nix-community/NUR/commit/5d8d55ed270228d1548214265ce036333cd2120b) | `` automatic update `` |