### PR TITLE
chore(flake/nur): `66ea1a5f` -> `e5977bad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717656540,
-        "narHash": "sha256-RSpbyI1z6bOr6avgxYWG25eg54tWrvkg6z28KhmgT08=",
+        "lastModified": 1717657737,
+        "narHash": "sha256-myg6ipTz0xlTpUqLuD4gTlICKZYu0lVzvmZ59qQG+FE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "66ea1a5f7118747d2eb7eeaed7461bb7a9f95e23",
+        "rev": "e5977bad88accf47917613390ff4bf71e0326120",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e5977bad`](https://github.com/nix-community/NUR/commit/e5977bad88accf47917613390ff4bf71e0326120) | `` automatic update `` |
| [`e9cd237b`](https://github.com/nix-community/NUR/commit/e9cd237bcb9600b3dc4186e8a30f52307ddbfe4a) | `` automatic update `` |