### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `6f60f87f` -> `f1289c66`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717575444,
-        "narHash": "sha256-Uq4v5Aq5ENHFKBv82nXM8svy0Ip43qQggCwKxqVoDIc=",
+        "lastModified": 1717638691,
+        "narHash": "sha256-o0G0VFgUWTpnUrKJa8ie+4YtCYF++xptv91OYsL4qu8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "67604448a402e3f600e6b921fa6ad34a62c6f55c",
+        "rev": "4f97985d133a12a5991ae8445b0bebbaedf399a6",
         "type": "github"
       },
       "original": {
@@ -519,11 +519,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1717576318,
-        "narHash": "sha256-HwQg9A1ZlCA5faRGJ6tL0eInO0kpke47e03nz4PIK3U=",
+        "lastModified": 1717662765,
+        "narHash": "sha256-XuwMRrH7ParH5SZdZdk9Xqyypq6C4PB6Y6Mg4jTGoTg=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "6f60f87f77322e0523f17981de788db7629af153",
+        "rev": "f1289c66c18bfb21e63b6cb236e2d5af0c50a715",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`f1289c66`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/f1289c66c18bfb21e63b6cb236e2d5af0c50a715) | `` flake.lock: Update `` |