### PR TITLE
chore(flake/nur): `e5977bad` -> `1f78049e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717657737,
-        "narHash": "sha256-myg6ipTz0xlTpUqLuD4gTlICKZYu0lVzvmZ59qQG+FE=",
+        "lastModified": 1717670688,
+        "narHash": "sha256-TO2zXDJMP3gpgb3pYI1bMDjLUC8n5+aXs//o//4LCr4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e5977bad88accf47917613390ff4bf71e0326120",
+        "rev": "1f78049e327ee7dad5350c258561837dc5398146",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1f78049e`](https://github.com/nix-community/NUR/commit/1f78049e327ee7dad5350c258561837dc5398146) | `` automatic update `` |
| [`839057ad`](https://github.com/nix-community/NUR/commit/839057ad2725dbd87af40edc596b798c2a1428cc) | `` automatic update `` |
| [`632f719f`](https://github.com/nix-community/NUR/commit/632f719f43f5ac471548b614d73977334cebf417) | `` automatic update `` |
| [`5083e028`](https://github.com/nix-community/NUR/commit/5083e028e69ccd63d92db9a5834ebc999692a1b4) | `` automatic update `` |