### PR TITLE
chore(flake/nur): `1f78049e` -> `9a69ccee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717670688,
-        "narHash": "sha256-TO2zXDJMP3gpgb3pYI1bMDjLUC8n5+aXs//o//4LCr4=",
+        "lastModified": 1717674846,
+        "narHash": "sha256-3sJbKhfrIEiSjXweoB1Y1vnCxw959eqS8AP20skUL3E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1f78049e327ee7dad5350c258561837dc5398146",
+        "rev": "9a69ccee83b65506d8f3f2e3492ef00642219e69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9a69ccee`](https://github.com/nix-community/NUR/commit/9a69ccee83b65506d8f3f2e3492ef00642219e69) | `` automatic update `` |