### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `f1289c66` -> `5cd18447`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -519,11 +519,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1717662765,
-        "narHash": "sha256-XuwMRrH7ParH5SZdZdk9Xqyypq6C4PB6Y6Mg4jTGoTg=",
+        "lastModified": 1717680117,
+        "narHash": "sha256-BxHm6Jmrw2d4wCTXboOu0T9dTSQ1jNDpzmev3NsLTJk=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "f1289c66c18bfb21e63b6cb236e2d5af0c50a715",
+        "rev": "5cd184470e252488c2e8109d1e23ea51d8f2df44",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                                                |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`85caf780`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/85caf780e861199f82c637dd18124caaf9a5c377) | `` Add paragraph: Doom Emacs upcoming native TS ``     |
| [`6c1574dd`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/6c1574dda8cb67050a61a0a073337cae3b687299) | `` Update section about "add package foo" ``           |
| [`b562c6d6`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/b562c6d6534286c9c62a1200180a975fb26aa9cc) | `` Add tree-sitter bug and workaround to readme ``     |
| [`596d1c89`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/596d1c89742280ec9653a01c7ad0622e43e8b249) | `` Add extraPackages to readme under home-manager ``   |
| [`4df8b7be`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/4df8b7be1519b39ef2a0a54c0ded694229d431cb) | `` Add doomTest 'extraPackages' ``                     |
| [`cdd7af00`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/cdd7af00b80d90b7c0c93389f0af424af2452948) | `` Improve description of 'extraPackages' option ``    |
| [`4715b1e1`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/4715b1e1277c25159f4bbc0f6044b6ab7729ddf9) | `` Fix extraneous whitespaces ``                       |
| [`9aca28b0`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/9aca28b01253da5b182d5b75ed269da3de87c813) | `` Support specifying extra emacs pkgs from nixpkgs `` |