### PR TITLE
chore(flake/nur): `9d640916` -> `4266b44c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717678434,
-        "narHash": "sha256-FtS08HwGJrIW5J0+Tdth5MjXDKhBncTvbeO0yS1vqzY=",
+        "lastModified": 1717691888,
+        "narHash": "sha256-YbIJbbPrKWhjM+ZvPelG/iDfSU3/qwPOI3vAIi+lFYI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9d640916ffb1680888b9898d2a26da9715648f60",
+        "rev": "4266b44cd241e3d2baf38bdbe8ce1254defcee6f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4266b44c`](https://github.com/nix-community/NUR/commit/4266b44cd241e3d2baf38bdbe8ce1254defcee6f) | `` automatic update `` |
| [`a4029fb9`](https://github.com/nix-community/NUR/commit/a4029fb9925dd03d8f0f25dd3a10f58b1a67401c) | `` automatic update `` |