### PR TITLE
chore(flake/nur): `e943ef5f` -> `740f37c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717703178,
-        "narHash": "sha256-8QWl6c3clSJdA4pF73gx5sY8a5T81kc5dj279vvM2Ds=",
+        "lastModified": 1717705628,
+        "narHash": "sha256-dGZf83rhzKwFbTPaaPBmT9aC3OYqAffMay0eVz+cRFw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e943ef5fc65fd3bd41be354ab3bddc9b7743a598",
+        "rev": "740f37c959c6f3369e9261d47b2d590a7a8a2312",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`740f37c9`](https://github.com/nix-community/NUR/commit/740f37c959c6f3369e9261d47b2d590a7a8a2312) | `` automatic update `` |