### PR TITLE
chore(flake/nur): `740f37c9` -> `745e6720`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717705628,
-        "narHash": "sha256-dGZf83rhzKwFbTPaaPBmT9aC3OYqAffMay0eVz+cRFw=",
+        "lastModified": 1717710689,
+        "narHash": "sha256-kAZuiKUgpbr4fMiupXm3aI3EgaizbOjSlroZZaA3zh4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "740f37c959c6f3369e9261d47b2d590a7a8a2312",
+        "rev": "745e67205fbaf1887f1ecf945080f9f1ec8faae0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`745e6720`](https://github.com/nix-community/NUR/commit/745e67205fbaf1887f1ecf945080f9f1ec8faae0) | `` automatic update `` |