### PR TITLE
chore(flake/nur): `745e6720` -> `b04f3815`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717710689,
-        "narHash": "sha256-kAZuiKUgpbr4fMiupXm3aI3EgaizbOjSlroZZaA3zh4=",
+        "lastModified": 1717713191,
+        "narHash": "sha256-kOPimQTcgsc9j8X/OK4wF+fCUOXqpr8J/V57TqBGLCE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "745e67205fbaf1887f1ecf945080f9f1ec8faae0",
+        "rev": "b04f3815c4f83814bef8495a7c633fb533fec2af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b04f3815`](https://github.com/nix-community/NUR/commit/b04f3815c4f83814bef8495a7c633fb533fec2af) | `` automatic update `` |