### PR TITLE
chore(flake/nur): `2c45b4a2` -> `71b118c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717721451,
-        "narHash": "sha256-dgX7A/c5fbmZCv1i/J+dg2jMeWFmPZebXuaHa3YdwyI=",
+        "lastModified": 1717728742,
+        "narHash": "sha256-2EAjQHSu2cGT786M/hkTd5+oTkyChG9b/Szv+aJ8xGE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2c45b4a221bc1eb5a1bc1cb94875563463baf586",
+        "rev": "71b118c388d8ba7d6cc955e531833503ea2d41b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`71b118c3`](https://github.com/nix-community/NUR/commit/71b118c388d8ba7d6cc955e531833503ea2d41b9) | `` automatic update `` |