### PR TITLE
chore(flake/nur): `71b118c3` -> `09648923`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717728742,
-        "narHash": "sha256-2EAjQHSu2cGT786M/hkTd5+oTkyChG9b/Szv+aJ8xGE=",
+        "lastModified": 1717731995,
+        "narHash": "sha256-OpwM/Xco5sjl8Gpa6XczuCn0bUHEOsb4Crq263+4QDw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "71b118c388d8ba7d6cc955e531833503ea2d41b9",
+        "rev": "0964892328de7150f396435c09c5dc576a59abfc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`09648923`](https://github.com/nix-community/NUR/commit/0964892328de7150f396435c09c5dc576a59abfc) | `` automatic update `` |
| [`51787b4a`](https://github.com/nix-community/NUR/commit/51787b4a5fc7f7c27a8420294919880711dcdbda) | `` automatic update `` |