### PR TITLE
chore(flake/nixpkgs): `ad57eef4` -> `e8057b67`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1716948383,
-        "narHash": "sha256-SzDKxseEcHR5KzPXLwsemyTR/kaM9whxeiJohbL04rs=",
+        "lastModified": 1717602782,
+        "narHash": "sha256-pL9jeus5QpX5R+9rsp3hhZ+uplVHscNJh8n8VpqscM0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ad57eef4ef0659193044870c731987a6df5cf56b",
+        "rev": "e8057b67ebf307f01bdcc8fba94d94f75039d1f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                  |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`bb0a4e87`](https://github.com/NixOS/nixpkgs/commit/bb0a4e8786730b156d4a06c54e7d1957f0fd4b9f) | `` nixos/release-combined: fix evaluation ``                                             |
| [`34f416de`](https://github.com/NixOS/nixpkgs/commit/34f416de629c3ece68ecb80b98a75e4dc6a16263) | `` easyaudiosync: init at 1.1.1 ``                                                       |
| [`420f104c`](https://github.com/NixOS/nixpkgs/commit/420f104c4020ffd4d9e4778869a5e0b21b1d46f3) | `` Revert "python311Packages.cmdstanpy: 1.2.1 -> 1.2.3" ``                               |
| [`ee54d80c`](https://github.com/NixOS/nixpkgs/commit/ee54d80c9bb7fdd15cb8f2684a44f0b2ec7095c6) | `` ols: refactor ``                                                                      |
| [`8a0c5748`](https://github.com/NixOS/nixpkgs/commit/8a0c57481fc08009235bd3f28bd7af5b13075835) | `` python311Packages.cmdstanpy: 1.2.1 -> 1.2.3 ``                                        |
| [`5b754445`](https://github.com/NixOS/nixpkgs/commit/5b754445df92a01677f802b66bb395759f57158f) | `` woodpecker: 2.4.1 -> 2.5.0 ``                                                         |
| [`375ac09e`](https://github.com/NixOS/nixpkgs/commit/375ac09eed173a3ac002af8bb6a6ea4383bd4e8d) | `` perlPackages.Apppapersway: init at 1.001 ``                                           |
| [`9aeb7ee0`](https://github.com/NixOS/nixpkgs/commit/9aeb7ee0696eebd7daa24d560b425e4598b5c2ed) | `` dnscontrol: install shell completions ``                                              |
| [`406e613b`](https://github.com/NixOS/nixpkgs/commit/406e613b95eb1e9a84f1753925bbaf7c16c99c02) | `` nixos/virtualbox-host: fix typo in assertion ``                                       |
| [`a8e5c604`](https://github.com/NixOS/nixpkgs/commit/a8e5c604cccfa65423bea577879abfe15443f5d4) | `` mousai: move to pkgs/by-name ``                                                       |
| [`01817930`](https://github.com/NixOS/nixpkgs/commit/0181793068ea05e7e88132e8397bf87cd1851790) | `` mousai: 0.7.6 -> 0.7.7 ``                                                             |
| [`3e691b26`](https://github.com/NixOS/nixpkgs/commit/3e691b261844d9b8661304709e5f493ffea8e66f) | `` signal-desktop: 7.10.0 -> 7.11.1 ``                                                   |
| [`ef6fea2d`](https://github.com/NixOS/nixpkgs/commit/ef6fea2d8617258bff16f5ea8a6db858870ecb29) | `` openssh: move Kerberos support into a dedicated package ``                            |
| [`3720a8b3`](https://github.com/NixOS/nixpkgs/commit/3720a8b3ffc9f532aa20e946df546d825f14609d) | `` fooyin: 0.4.3 -> 0.4.4 ``                                                             |
| [`9509a3b6`](https://github.com/NixOS/nixpkgs/commit/9509a3b68c62449dfcdf28a9d1364eb9ff04b09c) | `` kitty-themes: add passthru update script ``                                           |
| [`ca1b61ca`](https://github.com/NixOS/nixpkgs/commit/ca1b61cac8056e5d0fc87551d8c8ca939b25f62f) | `` kitty-themes: unstable-2024-04-23 -> 0-unstable-2024-05-28 ``                         |
| [`96f6a37b`](https://github.com/NixOS/nixpkgs/commit/96f6a37b84a5f028aff95f96213853197beee4a2) | `` corefonts: move to pkgs/by-name ``                                                    |
| [`ac3d5c97`](https://github.com/NixOS/nixpkgs/commit/ac3d5c97b10c86011f403be69ba6ab0e72d4eda7) | `` corefonts: fix build ``                                                               |
| [`5078d4e4`](https://github.com/NixOS/nixpkgs/commit/5078d4e440a95ecfaf9b6f8f12f58aa2b9f45b99) | `` files-cli: 2.13.53 -> 2.13.65 ``                                                      |
| [`635d02bf`](https://github.com/NixOS/nixpkgs/commit/635d02bfeb02a5e85b3efccce886b7de90bde99b) | `` limine: 7.5.3 -> 7.7.0 ``                                                             |
| [`c07d54d1`](https://github.com/NixOS/nixpkgs/commit/c07d54d1e1cf23f40c78d70d0c57f57eeb08118a) | `` cdecl: 16.3 -> 16.4.1 ``                                                              |
| [`30945112`](https://github.com/NixOS/nixpkgs/commit/309451127f372e35354665063411fbfe6739a965) | `` nixos/open-webui: update options default values ``                                    |
| [`5664bb78`](https://github.com/NixOS/nixpkgs/commit/5664bb78991bffa5f86ad951ebbe95dd414b7c32) | `` nixos/open-webui: add example in options ``                                           |
| [`a8670536`](https://github.com/NixOS/nixpkgs/commit/a8670536e5d3c6ee9561372f0f94bb1d788fb351) | `` nixos/open-webui: remove `preStart` step ``                                           |
| [`61ab4de9`](https://github.com/NixOS/nixpkgs/commit/61ab4de94c4fa4daf7af7520c114404723862994) | `` nixos/open-webui: update option and service descriptions ``                           |
| [`709eb8eb`](https://github.com/NixOS/nixpkgs/commit/709eb8ebaf385269866963928e5b97c8ed68f408) | `` nixos/open-webui: add `openFirewall` option ``                                        |
| [`8ea26260`](https://github.com/NixOS/nixpkgs/commit/8ea262601a3dca68369f5ce1a3f2ff44e3c6d011) | `` nixos/open-webui: add release note entry ``                                           |
| [`c54890e2`](https://github.com/NixOS/nixpkgs/commit/c54890e2263658f5f73b11fb451ea35d9bb69ee2) | `` nixos/ollama: update `port` option, use `types.port` ``                               |
| [`47e87986`](https://github.com/NixOS/nixpkgs/commit/47e879862cbc9c1aba6ae2a6a3dd6e597bb81290) | `` dune_3: 3.15.2 -> 3.15.3 ``                                                           |
| [`cb867046`](https://github.com/NixOS/nixpkgs/commit/cb8670469be17ae0a658385de59ee55c3a293faf) | `` nixos/ollama: add `openFirewall` option ``                                            |
| [`020ad564`](https://github.com/NixOS/nixpkgs/commit/020ad56467ec24b2a637fa34a3a8fa22e1cc8910) | `` ocamlPackages.functoria: disable tests ``                                             |
| [`55ebbb53`](https://github.com/NixOS/nixpkgs/commit/55ebbb5329c9cf3b1d7badd0239621e7f1ec6619) | `` tbls: 1.75.0 -> 1.76.0 ``                                                             |
| [`d76ed627`](https://github.com/NixOS/nixpkgs/commit/d76ed627b259173fe8f8b1a3d30568541a23b98e) | `` syncthingtray: 1.5.3 -> 1.5.4 ``                                                      |
| [`5209c849`](https://github.com/NixOS/nixpkgs/commit/5209c84957e0e932f25575c64b9b4db5c4bfa3b6) | `` nixos/activation/bootspec: fix style ``                                               |
| [`4f05b8e2`](https://github.com/NixOS/nixpkgs/commit/4f05b8e213041cc8effb0815ac101d854e8f1d7c) | `` nixos/activation/bootspec: rephrase ``                                                |
| [`3a475386`](https://github.com/NixOS/nixpkgs/commit/3a4753867dfcb8b0fa9b0c64736a99bd2d035dd9) | `` nixos/activation/bootspec: no longer experimental ``                                  |
| [`0aaccaa5`](https://github.com/NixOS/nixpkgs/commit/0aaccaa59609db2ee63b5e83567d53008d20cd83) | `` nixos/activation/bootspec: now enabled by default ``                                  |
| [`c9bc471f`](https://github.com/NixOS/nixpkgs/commit/c9bc471f8bf83303867b7c4e56b4bff5f51510d8) | `` cpp-utilities: 5.24.8 -> 5.24.9 ``                                                    |
| [`b06777f0`](https://github.com/NixOS/nixpkgs/commit/b06777f0d576f95dbfe32b8f845e07ce10de08c9) | `` kdePackages.qtutilities: 6.14.0 -> 6.14.1 ``                                          |
| [`4a4839a2`](https://github.com/NixOS/nixpkgs/commit/4a4839a2ea237a144fec17ad2f77cc84782248c7) | `` rabbitmq-server: 3.12.13 -> 3.13.3 ``                                                 |
| [`8ee0212a`](https://github.com/NixOS/nixpkgs/commit/8ee0212aba4222d5ca1228a0424698a4552e0cc1) | `` lfe: 2.1.3 -> 2.1.4 ``                                                                |
| [`e73d7ffc`](https://github.com/NixOS/nixpkgs/commit/e73d7ffc6b9c2524a3ee172f0c0eb745890db70e) | `` erlang_27: fix missing reference ``                                                   |
| [`6e2956f1`](https://github.com/NixOS/nixpkgs/commit/6e2956f10bc12aaa893e0c81a73aa43171197793) | `` clasp-common-lisp: 2.2.0 -> 2.6.0 ``                                                  |
| [`eb042ccd`](https://github.com/NixOS/nixpkgs/commit/eb042ccd8d2000c4bfc51351212589491d242a16) | `` steamPackages.steamcmd: add mainProgram, fix fetch url to use an archive (#312753) `` |
| [`5405ff96`](https://github.com/NixOS/nixpkgs/commit/5405ff960292269c01c96212a1e8591254509c14) | `` erlang_{24,25,26}_{odbc,javac,odbc_javac}: remove ``                                  |
| [`85a3f9b3`](https://github.com/NixOS/nixpkgs/commit/85a3f9b3da1c8ded9ea9024001e5fab33f746ba8) | `` terraform-providers.harbor: init at v3.10.10 ``                                       |
| [`ac202195`](https://github.com/NixOS/nixpkgs/commit/ac20219508f680c45e118b99c5c0787ec9ef3651) | `` nixos/rl-2411: add `services.forgejo.secrets` ``                                      |
| [`5515dd00`](https://github.com/NixOS/nixpkgs/commit/5515dd00e7fd9583cf12d2138b803ac884803d5d) | `` python3Packages.fastembed: 0.2.2 -> 0.2.7; fixups ``                                  |
| [`fd58d229`](https://github.com/NixOS/nixpkgs/commit/fd58d2299bd10ce7e798ce77502c9f117a00f61c) | `` nixos/tests/forgejo: test `cfg.secrets` using /metrics endpoint ``                    |
| [`694db856`](https://github.com/NixOS/nixpkgs/commit/694db856ed343d28d98f2b91a0c0b46344ea246c) | `` nixos/forgejo: refactor secrets, add `cfg.secrets` ``                                 |
| [`ae8404ff`](https://github.com/NixOS/nixpkgs/commit/ae8404ff58896d51f839ef2d8cc9a66c74407f6e) | `` forgejo: build `environment-to-ini` for use in nixos/forgejo secret refactor ``       |
| [`9b3d0c78`](https://github.com/NixOS/nixpkgs/commit/9b3d0c78e50d194bc18a129b9dc9c288f0d27ed8) | `` radicle-node: 1.0.0-rc.9 → 1.0.0-rc.10 ``                                             |
| [`ba96c1f7`](https://github.com/NixOS/nixpkgs/commit/ba96c1f7e5a7cdd6dac19d2936981e9313792cf3) | `` doc: fix make-disk-image.nix example ``                                               |
| [`932c8db5`](https://github.com/NixOS/nixpkgs/commit/932c8db5959d320940cfb67845bf73b193e5fdef) | `` shikane: 0.2.0 -> 1.0.1 ``                                                            |
| [`eb192617`](https://github.com/NixOS/nixpkgs/commit/eb192617c8424e10ea930ff89ac009594ea4ecea) | `` dump_syms: 2.3.1 -> 2.3.3 ``                                                          |
| [`1feda3cc`](https://github.com/NixOS/nixpkgs/commit/1feda3cc9480d2ff82472239556b0f8a48a2f578) | `` ryujinx: 1.1.1298 -> 1.1.1330 ``                                                      |
| [`3a4a5cba`](https://github.com/NixOS/nixpkgs/commit/3a4a5cbaf3edbcb7467739be12e5f33bfcad8b0e) | `` radicle-node: Wrappers and a better package test ``                                   |