### PR TITLE
chore(flake/nur): `09648923` -> `8b41b6db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717731995,
-        "narHash": "sha256-OpwM/Xco5sjl8Gpa6XczuCn0bUHEOsb4Crq263+4QDw=",
+        "lastModified": 1717735945,
+        "narHash": "sha256-FofEsunKsgtVjYPmlJVzE6QxtuLKkyo2ZnNMtu17/Ug=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0964892328de7150f396435c09c5dc576a59abfc",
+        "rev": "8b41b6dbd32db2dc29bc774250728981c0f8918f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8b41b6db`](https://github.com/nix-community/NUR/commit/8b41b6dbd32db2dc29bc774250728981c0f8918f) | `` automatic update `` |
| [`21df6476`](https://github.com/nix-community/NUR/commit/21df6476bce335deb462620ef31def77091b94c7) | `` automatic update `` |
| [`e9bbe7a6`](https://github.com/nix-community/NUR/commit/e9bbe7a6871929167ca03a6bf8cdf53f9ee5706b) | `` automatic update `` |