### PR TITLE
chore(flake/nur): `8b41b6db` -> `df0e3a24`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717735945,
-        "narHash": "sha256-FofEsunKsgtVjYPmlJVzE6QxtuLKkyo2ZnNMtu17/Ug=",
+        "lastModified": 1717737742,
+        "narHash": "sha256-elS2WJDhkkpI1SVUz1ZS2i8Uydaoubh07j83xI89z8A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8b41b6dbd32db2dc29bc774250728981c0f8918f",
+        "rev": "df0e3a2441cf158e7f9c91eeadefa142dec80f86",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`df0e3a24`](https://github.com/nix-community/NUR/commit/df0e3a2441cf158e7f9c91eeadefa142dec80f86) | `` automatic update `` |
| [`f664c67f`](https://github.com/nix-community/NUR/commit/f664c67fc71ce8089b2484af68ba27a8c964ba14) | `` automatic update `` |