### PR TITLE
chore(flake/nix-index-database): `972a52be` -> `4ac3639c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -587,11 +587,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717297675,
-        "narHash": "sha256-43UmlS1Ifx17y93/Vc258U7bOlAAIZbu8dsGDHOIIr0=",
+        "lastModified": 1717744769,
+        "narHash": "sha256-1usk5faO+KRn/03xKW3G3ex9/wHeLfwKTa7x8QNcygc=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "972a52bee3991ae1f1899e6452e0d7c01ee566d9",
+        "rev": "4ac3639cebb6286f1a68d015b80e9e0c6c869ce6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                            |
| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`4ac3639c`](https://github.com/nix-community/nix-index-database/commit/4ac3639cebb6286f1a68d015b80e9e0c6c869ce6) | `` Use corepkgs fetchurl for fetching the index `` |