### PR TITLE
chore(flake/nur): `df0e3a24` -> `b93b6c0b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717737742,
-        "narHash": "sha256-elS2WJDhkkpI1SVUz1ZS2i8Uydaoubh07j83xI89z8A=",
+        "lastModified": 1717749895,
+        "narHash": "sha256-E6fEND68P37NMIhPyvgZl0jD7KlSg2QKZ1zpsXpobfQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "df0e3a2441cf158e7f9c91eeadefa142dec80f86",
+        "rev": "b93b6c0b706d78ad95d52104728fd6eed3460f80",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b93b6c0b`](https://github.com/nix-community/NUR/commit/b93b6c0b706d78ad95d52104728fd6eed3460f80) | `` automatic update `` |
| [`c1edc052`](https://github.com/nix-community/NUR/commit/c1edc05252cacfe23a04c9b7e687bb1dfaac67f9) | `` automatic update `` |