### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `1ee01aff` -> `2434b2a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -519,11 +519,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1717749135,
-        "narHash": "sha256-U/sCUr+RglK/O6XVPOU2P4eAftdFInkrz94VcRwRrrY=",
+        "lastModified": 1717758937,
+        "narHash": "sha256-y518PnG9eColi+4sXm+252aIb3moEhawTQgq+rPUtYQ=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "1ee01affd6ccb53870af551afb1dde72204303d2",
+        "rev": "2434b2a97edd96a861a553eab34671ca2925cf37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                                          |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`2434b2a9`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/2434b2a97edd96a861a553eab34671ca2925cf37) | `` Remove doom--help-package-configs override `` |
| [`e69e5ed2`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/e69e5ed23e31c5a6802c34d8ec416fb95d3f288f) | `` Move most shell out of Nix string literals `` |
| [`9f249ae7`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/9f249ae72f91ebf1ee2f52c52a0326aa901c8c5d) | `` Push noProfileHack handling to bash ``        |
| [`55f23cbf`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/55f23cbfcfef0e0a79a83fa837c77a0c431d290b) | `` Add rudimentary tests of my profile hacks ``  |
| [`ce63f7f5`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/ce63f7f54a45a590e24b9662257323b98b691d3b) | `` Prefer --subst-var over --subst-var-by ``     |
| [`48c4531e`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/48c4531e2e0edffee46e2e3f48de853ec6ec648e) | `` Test noProfileHack ``                         |
| [`8f8f118d`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/8f8f118d94ffc6493a74feaa9f0ca8dfe89ddeb8) | `` Use derivation attributes ``                  |
| [`b16774f1`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/b16774f129a88c4d282ca752977e15838f3b7de4) | `` Refactor full init.el building ``             |
| [`9d01c40c`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/9d01c40caf3562b0b71733659c814a3987312963) | `` Split off doomscript execution helper ``      |
| [`e7383f32`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/e7383f325f6a37e83516a4267ff92d31d4c46d78) | `` Assume `emacs` is Emacs 29 ``                 |