### PR TITLE
chore(flake/nur): `b93b6c0b` -> `3c49e3c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717749895,
-        "narHash": "sha256-E6fEND68P37NMIhPyvgZl0jD7KlSg2QKZ1zpsXpobfQ=",
+        "lastModified": 1717760779,
+        "narHash": "sha256-H+949Zq0DprPcLjLRtZlA4nylrY6aXliavb+SRuNBjg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b93b6c0b706d78ad95d52104728fd6eed3460f80",
+        "rev": "3c49e3c77046d5a1491928814b5e29aa3d6f7750",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3c49e3c7`](https://github.com/nix-community/NUR/commit/3c49e3c77046d5a1491928814b5e29aa3d6f7750) | `` automatic update `` |