### PR TITLE
chore(flake/nur): `3c49e3c7` -> `2cab87e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717760779,
-        "narHash": "sha256-H+949Zq0DprPcLjLRtZlA4nylrY6aXliavb+SRuNBjg=",
+        "lastModified": 1717767999,
+        "narHash": "sha256-HHirBiaST08LsBCAQOarAQUqEZad1ep5t5YXUkLKeFM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3c49e3c77046d5a1491928814b5e29aa3d6f7750",
+        "rev": "2cab87e8d1b3f2928e7c3fc11ce1ee0268f804a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2cab87e8`](https://github.com/nix-community/NUR/commit/2cab87e8d1b3f2928e7c3fc11ce1ee0268f804a8) | `` automatic update `` |
| [`7509081b`](https://github.com/nix-community/NUR/commit/7509081b1815903eb3e25f04dd26e41df69448eb) | `` automatic update `` |