### PR TITLE
chore(flake/nur): `2cab87e8` -> `ab2ef186`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717767999,
-        "narHash": "sha256-HHirBiaST08LsBCAQOarAQUqEZad1ep5t5YXUkLKeFM=",
+        "lastModified": 1717771953,
+        "narHash": "sha256-i/i/CiyWK7trUMoAlzLXGVr0BnVXD0rf2Rs+S/MC8Ck=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2cab87e8d1b3f2928e7c3fc11ce1ee0268f804a8",
+        "rev": "ab2ef186fc85fb7731b428fdffebca3e7e8b651a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ab2ef186`](https://github.com/nix-community/NUR/commit/ab2ef186fc85fb7731b428fdffebca3e7e8b651a) | `` automatic update `` |
| [`22a85f49`](https://github.com/nix-community/NUR/commit/22a85f49072989b2996a18dff4931b6a404286dd) | `` automatic update `` |
| [`35c3f36f`](https://github.com/nix-community/NUR/commit/35c3f36f393924afab54709e2b6edbf90f8c6448) | `` automatic update `` |