### PR TITLE
chore(flake/nur): `ab2ef186` -> `043c7d96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717771953,
-        "narHash": "sha256-i/i/CiyWK7trUMoAlzLXGVr0BnVXD0rf2Rs+S/MC8Ck=",
+        "lastModified": 1717774985,
+        "narHash": "sha256-Ctc3tBLojWOMoDGvjs7R6PWaMzOaa5bPl0VjjzVK6cg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ab2ef186fc85fb7731b428fdffebca3e7e8b651a",
+        "rev": "043c7d966ee60e68ce597d1cadc15060b5f7dbb3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`043c7d96`](https://github.com/nix-community/NUR/commit/043c7d966ee60e68ce597d1cadc15060b5f7dbb3) | `` automatic update `` |