### PR TITLE
chore(flake/nur): `043c7d96` -> `958dff18`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717774985,
-        "narHash": "sha256-Ctc3tBLojWOMoDGvjs7R6PWaMzOaa5bPl0VjjzVK6cg=",
+        "lastModified": 1717778450,
+        "narHash": "sha256-67mOMgQp+H53YezyG/ZBgc5UVGox4j5iKREoX7WbrHQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "043c7d966ee60e68ce597d1cadc15060b5f7dbb3",
+        "rev": "958dff187725a5ef45a485f950ed3f43718b4559",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`958dff18`](https://github.com/nix-community/NUR/commit/958dff187725a5ef45a485f950ed3f43718b4559) | `` automatic update `` |