### PR TITLE
chore(flake/srvos): `5e0d94f2` -> `64ae31cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -951,11 +951,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717635218,
-        "narHash": "sha256-1fd4myxpeHrdBuXyjQqEp1lqq1CJeuPXPk67TlD6UKA=",
+        "lastModified": 1717807544,
+        "narHash": "sha256-djHfn29HdlfWdmyeu3rqlVS8k5q/xRh2P0mX2RAafb0=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "5e0d94f2b3608f2d01208e27d4a4db5a0e85b069",
+        "rev": "64ae31cb29923128f27a503a550ee4fb1631c4c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                         |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`64ae31cb`](https://github.com/nix-community/srvos/commit/64ae31cb29923128f27a503a550ee4fb1631c4c6) | `` Revert "ci: remove `max-jobs = 0`" ``        |
| [`f69ed551`](https://github.com/nix-community/srvos/commit/f69ed55135b52113f395c423204b578d3b80aaf8) | `` flake: add nix-community cachix nixConfig `` |