### PR TITLE
chore(flake/nur): `c170f285` -> `d640b3ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717805329,
-        "narHash": "sha256-/QfJN9PkD0HAXCbn46uI0hcbzwNvC3U95V7NJ0RuZSs=",
+        "lastModified": 1717812410,
+        "narHash": "sha256-wZNuXWpRMDwFd1WpXDbZeA0ttTqjjffiJ0F7kfZAjxc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c170f285f35b652f95606e62350dd8ae2829b39e",
+        "rev": "d640b3ced0e7756a022fc720a9784a76a3a4aac9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d640b3ce`](https://github.com/nix-community/NUR/commit/d640b3ced0e7756a022fc720a9784a76a3a4aac9) | `` automatic update `` |
| [`31a8d37d`](https://github.com/nix-community/NUR/commit/31a8d37dd4e60859214b7c168b214dedb7ce9ac2) | `` automatic update `` |