### PR TITLE
chore(flake/nur): `d640b3ce` -> `ac9b78d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717812410,
-        "narHash": "sha256-wZNuXWpRMDwFd1WpXDbZeA0ttTqjjffiJ0F7kfZAjxc=",
+        "lastModified": 1717815116,
+        "narHash": "sha256-F6Wi+hbUEi+HVbqyFKu1q3YqOC+MrkyZ+IYymMkE4HY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d640b3ced0e7756a022fc720a9784a76a3a4aac9",
+        "rev": "ac9b78d609bcedeaad7630fe89db350b27d521bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ac9b78d6`](https://github.com/nix-community/NUR/commit/ac9b78d609bcedeaad7630fe89db350b27d521bb) | `` automatic update `` |