### PR TITLE
chore(flake/nur): `ac9b78d6` -> `f4f3dcd9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717815116,
-        "narHash": "sha256-F6Wi+hbUEi+HVbqyFKu1q3YqOC+MrkyZ+IYymMkE4HY=",
+        "lastModified": 1717821758,
+        "narHash": "sha256-9iQreGkOPNBSMloULfv45dzAuaihK9ESR26bRs//tW0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ac9b78d609bcedeaad7630fe89db350b27d521bb",
+        "rev": "f4f3dcd9f8be9eee489df9ec268e395cbbd215f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f4f3dcd9`](https://github.com/nix-community/NUR/commit/f4f3dcd9f8be9eee489df9ec268e395cbbd215f3) | `` automatic update `` |
| [`0725a3bf`](https://github.com/nix-community/NUR/commit/0725a3bf2ccdfd3bade3ea2e193cf8022b12b1b2) | `` automatic update `` |
| [`d187f47c`](https://github.com/nix-community/NUR/commit/d187f47ca9019566dad32f179a0efac9d10d97c0) | `` automatic update `` |
| [`a909ad75`](https://github.com/nix-community/NUR/commit/a909ad75ea8638fe2b4e7922549919a08d34c41a) | `` automatic update `` |
| [`88411d2e`](https://github.com/nix-community/NUR/commit/88411d2e95e267b7f0037e552403ca5d76b70a81) | `` automatic update `` |