### PR TITLE
chore(flake/nur): `f4f3dcd9` -> `f60b8180`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717821758,
-        "narHash": "sha256-9iQreGkOPNBSMloULfv45dzAuaihK9ESR26bRs//tW0=",
+        "lastModified": 1717832812,
+        "narHash": "sha256-YhCZWOo/CLBiUpZLnERoYqaBvxU35Expz5SN+NU+A0o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f4f3dcd9f8be9eee489df9ec268e395cbbd215f3",
+        "rev": "f60b818023380d4efa877a0c1468a23ebb32a008",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f60b8180`](https://github.com/nix-community/NUR/commit/f60b818023380d4efa877a0c1468a23ebb32a008) | `` automatic update `` |
| [`651c5156`](https://github.com/nix-community/NUR/commit/651c5156d639fa3f866373beba44a4a7e9d85fb9) | `` automatic update `` |