### PR TITLE
chore(flake/emacs-overlay): `7ff674d6` -> `007b1e19`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1717811460,
-        "narHash": "sha256-b2HZ9oDtKutADV8WPPsMWozJkNamiRGOqf2K9ekv950=",
+        "lastModified": 1717837577,
+        "narHash": "sha256-/8IH9iKG5lLlpgqMJD9yy3rcv5YgWvfkGleDOE41RlA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7ff674d6a61f4a3af339e82cfebf5e67d24d1714",
+        "rev": "007b1e192409decce73d39948ae862d1b38c6f20",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`007b1e19`](https://github.com/nix-community/emacs-overlay/commit/007b1e192409decce73d39948ae862d1b38c6f20) | `` Updated emacs `` |
| [`c1cb1f0d`](https://github.com/nix-community/emacs-overlay/commit/c1cb1f0d8c41d9eb8a4150259597d692c60b7bbc) | `` Updated melpa `` |