### PR TITLE
chore(flake/nur): `f60b8180` -> `16b3c5f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717832812,
-        "narHash": "sha256-YhCZWOo/CLBiUpZLnERoYqaBvxU35Expz5SN+NU+A0o=",
+        "lastModified": 1717836446,
+        "narHash": "sha256-FuKSeYYBpMQVffV59dWX9g2UWQaNzB/gDCg4nOoxyvU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f60b818023380d4efa877a0c1468a23ebb32a008",
+        "rev": "16b3c5f1c9da737b6706678a52c76c1b9209cbb7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`16b3c5f1`](https://github.com/nix-community/NUR/commit/16b3c5f1c9da737b6706678a52c76c1b9209cbb7) | `` automatic update `` |
| [`e231bf75`](https://github.com/nix-community/NUR/commit/e231bf75d665195752d6fd5e9674cdae37d4106c) | `` automatic update `` |