### PR TITLE
chore(flake/treefmt): `3eb96ca1` -> `4fc1c45a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1046,11 +1046,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717278143,
-        "narHash": "sha256-u10aDdYrpiGOLoxzY/mJ9llST9yO8Q7K/UlROoNxzDw=",
+        "lastModified": 1717850719,
+        "narHash": "sha256-npYqVg+Wk4oxnWrnVG7416fpfrlRhp/lQ6wQ4DHI8YE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "3eb96ca1ae9edf792a8e0963cc92fddfa5a87706",
+        "rev": "4fc1c45a5f50169f9f29f6a98a438fb910b834ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                       |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`4fc1c45a`](https://github.com/numtide/treefmt-nix/commit/4fc1c45a5f50169f9f29f6a98a438fb910b834ed) | `` go: exclude the vendor/ folder (#181) ``   |
| [`ab12b891`](https://github.com/numtide/treefmt-nix/commit/ab12b891c5784ea0296076e6ac819c27975f9db8) | `` add support for --tree-root-file (#183) `` |