### PR TITLE
chore(flake/nur): `eb00c376` -> `bcfbaa1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717854510,
-        "narHash": "sha256-P7bfi9qvBr79i0vcLYM4g2XdLmZF04qgO2oZo4ynKIc=",
+        "lastModified": 1717857394,
+        "narHash": "sha256-cFIod8vGScvmizwuRjmrvU+D0dFbV2rwjZcqW+FnxRk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eb00c37663b49832d1e0a8fd2680980d9c5ac291",
+        "rev": "bcfbaa1b80c88d8c3ba75076f28fae4d5cb20c2e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bcfbaa1b`](https://github.com/nix-community/NUR/commit/bcfbaa1b80c88d8c3ba75076f28fae4d5cb20c2e) | `` automatic update `` |