### PR TITLE
chore(flake/emacs-overlay): `007b1e19` -> `f7b523a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1717837577,
-        "narHash": "sha256-/8IH9iKG5lLlpgqMJD9yy3rcv5YgWvfkGleDOE41RlA=",
+        "lastModified": 1717865632,
+        "narHash": "sha256-lFJLOhjuyZ+vANXazvvRveEjzVEbgvDW/AY5Sef7TZQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "007b1e192409decce73d39948ae862d1b38c6f20",
+        "rev": "f7b523a65d6c4e215319266957005908f27dc731",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`f7b523a6`](https://github.com/nix-community/emacs-overlay/commit/f7b523a65d6c4e215319266957005908f27dc731) | `` Updated melpa `` |
| [`defefd9e`](https://github.com/nix-community/emacs-overlay/commit/defefd9ee454ba8edad86e4ba1cc7294916c26bc) | `` Updated elpa ``  |