### PR TITLE
chore(flake/nur): `bcfbaa1b` -> `734be919`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717857394,
-        "narHash": "sha256-cFIod8vGScvmizwuRjmrvU+D0dFbV2rwjZcqW+FnxRk=",
+        "lastModified": 1717867613,
+        "narHash": "sha256-zb4rHOM9QcoDxSdUR5Y7To0uQ8cYeakPeuVQEvf21fI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bcfbaa1b80c88d8c3ba75076f28fae4d5cb20c2e",
+        "rev": "734be919caf3708f9b3ffcfdfc927c326ab5b5e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`734be919`](https://github.com/nix-community/NUR/commit/734be919caf3708f9b3ffcfdfc927c326ab5b5e5) | `` automatic update `` |
| [`e2125411`](https://github.com/nix-community/NUR/commit/e212541138b753c7bc5215524215e2a07403df8d) | `` automatic update `` |