### PR TITLE
chore(flake/nur): `734be919` -> `3b134079`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717867613,
-        "narHash": "sha256-zb4rHOM9QcoDxSdUR5Y7To0uQ8cYeakPeuVQEvf21fI=",
+        "lastModified": 1717872410,
+        "narHash": "sha256-kL4bugfx+R4ozR6t8MrGSdv3LVX7H9IkCxmvjaLAQ7o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "734be919caf3708f9b3ffcfdfc927c326ab5b5e5",
+        "rev": "3b134079df522044c0da57f1b7785646a7b76518",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3b134079`](https://github.com/nix-community/NUR/commit/3b134079df522044c0da57f1b7785646a7b76518) | `` automatic update `` |
| [`6207a97c`](https://github.com/nix-community/NUR/commit/6207a97ca0d050c26bd1c9bfbe91219b96799116) | `` automatic update `` |