### PR TITLE
chore(flake/nur): `3b134079` -> `2f02fdf3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717872410,
-        "narHash": "sha256-kL4bugfx+R4ozR6t8MrGSdv3LVX7H9IkCxmvjaLAQ7o=",
+        "lastModified": 1717884878,
+        "narHash": "sha256-kw1QV2Cut7Vn5QNlPTGMTx99HvQ/rnJWUeeOj23FvnQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3b134079df522044c0da57f1b7785646a7b76518",
+        "rev": "2f02fdf304cb99298b1f76c45ae19489d47610b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2f02fdf3`](https://github.com/nix-community/NUR/commit/2f02fdf304cb99298b1f76c45ae19489d47610b8) | `` automatic update `` |
| [`12b545c6`](https://github.com/nix-community/NUR/commit/12b545c698e6099c2e0aece4a0a47a884af20f7a) | `` automatic update `` |