### PR TITLE
chore(flake/emacs-overlay): `f648fe67` -> `76c6c988`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1717866433,
-        "narHash": "sha256-NYXyErhHxf0v3nHoqhbCKRkgsKRx9MbvZmHb28gnonA=",
+        "lastModified": 1717895332,
+        "narHash": "sha256-DH3fxEoBcyArc6/rM/lWmmNFQaIIqfsBW0ZLWifIStc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f648fe67704b26f123a6a31953957dadec561380",
+        "rev": "76c6c98859267088ee2a906628712c92ddcbb3b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`76c6c988`](https://github.com/nix-community/emacs-overlay/commit/76c6c98859267088ee2a906628712c92ddcbb3b2) | `` Updated elpa ``         |
| [`7f45e461`](https://github.com/nix-community/emacs-overlay/commit/7f45e461db1fd628a9a1df6d99ed0221662c9cb1) | `` Updated flake inputs `` |