### PR TITLE
chore(flake/nur): `2f02fdf3` -> `636897b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717884878,
-        "narHash": "sha256-kw1QV2Cut7Vn5QNlPTGMTx99HvQ/rnJWUeeOj23FvnQ=",
+        "lastModified": 1717898086,
+        "narHash": "sha256-39HDxlgsdBr1BLQFi8CJ2rUKP+PArV/YqZE+LkFtSW0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2f02fdf304cb99298b1f76c45ae19489d47610b8",
+        "rev": "636897b54e351cf5cafefe977d285aaff12b52a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`636897b5`](https://github.com/nix-community/NUR/commit/636897b54e351cf5cafefe977d285aaff12b52a5) | `` automatic update `` |
| [`0922a278`](https://github.com/nix-community/NUR/commit/0922a278274aa4638df7b2d24cc8efe3d63d981c) | `` automatic update `` |