### PR TITLE
chore(flake/emacs-overlay): `76c6c988` -> `4530e5dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1717895332,
-        "narHash": "sha256-DH3fxEoBcyArc6/rM/lWmmNFQaIIqfsBW0ZLWifIStc=",
+        "lastModified": 1717898256,
+        "narHash": "sha256-wyOhcS5jIE0J39G95Pls+/t/DNYRZFJHv+FlO/HbrJs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "76c6c98859267088ee2a906628712c92ddcbb3b2",
+        "rev": "4530e5dd23f6a07a229a7bc351e936d628543684",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`4530e5dd`](https://github.com/nix-community/emacs-overlay/commit/4530e5dd23f6a07a229a7bc351e936d628543684) | `` Updated emacs `` |
| [`46764f40`](https://github.com/nix-community/emacs-overlay/commit/46764f40d8c0f8a1b2113ec3bc6e7e828fa0f401) | `` Updated melpa `` |