### PR TITLE
chore(flake/nur): `636897b5` -> `c781302e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717898086,
-        "narHash": "sha256-39HDxlgsdBr1BLQFi8CJ2rUKP+PArV/YqZE+LkFtSW0=",
+        "lastModified": 1717905981,
+        "narHash": "sha256-gxIiqUdSTwLduVsLDQMsgBFpV7RhvJA3s0Tkdr5S/n4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "636897b54e351cf5cafefe977d285aaff12b52a5",
+        "rev": "c781302e17479dc07f54f002ff43580839726f49",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c781302e`](https://github.com/nix-community/NUR/commit/c781302e17479dc07f54f002ff43580839726f49) | `` automatic update `` |
| [`3dd22421`](https://github.com/nix-community/NUR/commit/3dd2242177031506a6265a82398e8d269cbd6026) | `` automatic update `` |
| [`8dd6e227`](https://github.com/nix-community/NUR/commit/8dd6e227cf0ba7072abff849b1ac74af8509ccb6) | `` automatic update `` |
| [`35d2450f`](https://github.com/nix-community/NUR/commit/35d2450f111848b94b1a04a3bca4fd355b5f6fb7) | `` automatic update `` |