### PR TITLE
chore(flake/nix-index-database): `412a5428` -> `a157a81d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -587,11 +587,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717901846,
-        "narHash": "sha256-PmuGHv86tMknr6l0sCaU1oz0oCRrsslA3MtyjEz/T5I=",
+        "lastModified": 1717919703,
+        "narHash": "sha256-4i/c31+dnpv6KdUA3BhbMDS9Lvg/CDin78caYJlq0bY=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "412a5428da031950f767db91bf7864ac442cdcd8",
+        "rev": "a157a81d0a4bc909b2b6666dd71909bcdc8cd0d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`a157a81d`](https://github.com/nix-community/nix-index-database/commit/a157a81d0a4bc909b2b6666dd71909bcdc8cd0d6) | `` update generated.nix to release 2024-06-09-074536 `` |
| [`25d61492`](https://github.com/nix-community/nix-index-database/commit/25d61492b32cc4eb46b0854c8a0c79b685d5e9f2) | `` reformat with nixfmt ``                              |
| [`b26661c0`](https://github.com/nix-community/nix-index-database/commit/b26661c0b9d25622ff70030f77e6c91d817471e0) | `` switch to nixfmt as a formatter ``                   |
| [`2d96e703`](https://github.com/nix-community/nix-index-database/commit/2d96e70391edb6a2e17211cfd21aacd943486e2f) | `` add nix 2.18 as a requirement ``                     |
| [`2a2e1acc`](https://github.com/nix-community/nix-index-database/commit/2a2e1acc4a1d698c72fb77c69798c4894174a935) | `` misc: remove dead code ``                            |
| [`24089882`](https://github.com/nix-community/nix-index-database/commit/2408988240f6706906f7b1c6e36424e81e8e3431) | `` flake: warn about legacyPackages ``                  |
| [`7e312cd4`](https://github.com/nix-community/nix-index-database/commit/7e312cd4442a63228c8008d0300c9438f4dc7118) | `` packages: use nixpkgs fetchers ``                    |
| [`b6dddcb5`](https://github.com/nix-community/nix-index-database/commit/b6dddcb5bed8af7e748131424d5062e8aec76882) | `` workflow: rework ``                                  |
| [`ca7e10c6`](https://github.com/nix-community/nix-index-database/commit/ca7e10c63d06c7a66d58a1db48b3ba3bd1fd0adf) | `` modules: don't set _module.args ``                   |
| [`afc8f5a6`](https://github.com/nix-community/nix-index-database/commit/afc8f5a6a2c00a89a6d6bdcaf4157797960f10f7) | `` flake: capitalize NixOS ``                           |
| [`4949c3ea`](https://github.com/nix-community/nix-index-database/commit/4949c3eac75f949bf3a0f8cb40e63b98009dff67) | `` modules: lint and standardize ``                     |
| [`a1578050`](https://github.com/nix-community/nix-index-database/commit/a1578050b6d24e3525135d60c227d322c70abed9) | `` wrappers: rework to use symlinkJoin ``               |
| [`55184c76`](https://github.com/nix-community/nix-index-database/commit/55184c7660d580878f7a2bc344629b1b36b5de1c) | `` update packages.nix to release 2024-06-09-030647 ``  |