### PR TITLE
chore(flake/nur): `c781302e` -> `4653b84b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717905981,
-        "narHash": "sha256-gxIiqUdSTwLduVsLDQMsgBFpV7RhvJA3s0Tkdr5S/n4=",
+        "lastModified": 1717916164,
+        "narHash": "sha256-MiTc7+UDKpxSNAJbSDta83HAWD9IqeTbW95ZolbbNJ8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c781302e17479dc07f54f002ff43580839726f49",
+        "rev": "4653b84be1864e1ddf391893875f216280387c45",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4653b84b`](https://github.com/nix-community/NUR/commit/4653b84be1864e1ddf391893875f216280387c45) | `` automatic update `` |
| [`d73e0389`](https://github.com/nix-community/NUR/commit/d73e0389dedd1284f7f8f486fa7a352f894f9ea1) | `` automatic update `` |
| [`ac9cd520`](https://github.com/nix-community/NUR/commit/ac9cd52088831fbf1a032c973c44b85150f029f9) | `` automatic update `` |
| [`192515e9`](https://github.com/nix-community/NUR/commit/192515e9dd9d875f70c2b8d1a04cbc6842f83a59) | `` automatic update `` |