### PR TITLE
chore(flake/nur): `4653b84b` -> `7fcc1873`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717916164,
-        "narHash": "sha256-MiTc7+UDKpxSNAJbSDta83HAWD9IqeTbW95ZolbbNJ8=",
+        "lastModified": 1717918687,
+        "narHash": "sha256-5NacKyEME3Jr36ubbxudIoNaNDckNiB6NEer2iYJoCE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4653b84be1864e1ddf391893875f216280387c45",
+        "rev": "7fcc1873083bdd1cadc0b9ae189c36b71e12d233",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7fcc1873`](https://github.com/nix-community/NUR/commit/7fcc1873083bdd1cadc0b9ae189c36b71e12d233) | `` automatic update `` |