### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `f0a82827` -> `8cec134a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717811460,
-        "narHash": "sha256-b2HZ9oDtKutADV8WPPsMWozJkNamiRGOqf2K9ekv950=",
+        "lastModified": 1717898256,
+        "narHash": "sha256-wyOhcS5jIE0J39G95Pls+/t/DNYRZFJHv+FlO/HbrJs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7ff674d6a61f4a3af339e82cfebf5e67d24d1714",
+        "rev": "4530e5dd23f6a07a229a7bc351e936d628543684",
         "type": "github"
       },
       "original": {
@@ -519,11 +519,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1717835396,
-        "narHash": "sha256-M28duxt7TPX+iv9bxgEJxU5Wha0BtupWBz5cqIJFYmY=",
+        "lastModified": 1717921812,
+        "narHash": "sha256-/PY73i5dwKHg+6FVEH+/S08EijgkDqNUNyNlQkcTYYM=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "f0a828277e8d1c099b30262f96756accfb9683d3",
+        "rev": "8cec134a92ba54be6ca4efbe4b3e992c6913e849",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`8cec134a`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/8cec134a92ba54be6ca4efbe4b3e992c6913e849) | `` flake.lock: Update `` |