### PR TITLE
chore(flake/emacs-overlay): `4530e5dd` -> `a5143ff8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1717898256,
-        "narHash": "sha256-wyOhcS5jIE0J39G95Pls+/t/DNYRZFJHv+FlO/HbrJs=",
+        "lastModified": 1717923950,
+        "narHash": "sha256-k7WYdsUm4oeFlAC2JLKXDIxp1pS7/mrUyN7ztEF5DGM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4530e5dd23f6a07a229a7bc351e936d628543684",
+        "rev": "a5143ff8b6be9201f6b7aabe209a4c2a4a832ae3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`a5143ff8`](https://github.com/nix-community/emacs-overlay/commit/a5143ff8b6be9201f6b7aabe209a4c2a4a832ae3) | `` Updated emacs `` |
| [`03489b65`](https://github.com/nix-community/emacs-overlay/commit/03489b65f30d0b0920bad58790dbf00f2f2086a9) | `` Updated melpa `` |