### PR TITLE
chore(flake/nur): `7fcc1873` -> `295436eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717918687,
-        "narHash": "sha256-5NacKyEME3Jr36ubbxudIoNaNDckNiB6NEer2iYJoCE=",
+        "lastModified": 1717922842,
+        "narHash": "sha256-dJz6gBOsBzt+lDCjWg1YG1sncILOCJsOtwtOZ+paYPs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7fcc1873083bdd1cadc0b9ae189c36b71e12d233",
+        "rev": "295436eb1ab9143e29d6360697e92e7dfae61e94",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`295436eb`](https://github.com/nix-community/NUR/commit/295436eb1ab9143e29d6360697e92e7dfae61e94) | `` automatic update `` |
| [`02f829e2`](https://github.com/nix-community/NUR/commit/02f829e2432d4204370445272084ce22761ba4bc) | `` automatic update `` |
| [`2995e749`](https://github.com/nix-community/NUR/commit/2995e749491c80a8064fec6a8e250820936f71e1) | `` automatic update `` |