### PR TITLE
chore(flake/impermanence): `a33ef102` -> `27979f1c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -425,11 +425,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1708968331,
-        "narHash": "sha256-VUXLaPusCBvwM3zhGbRIJVeYluh2uWuqtj4WirQ1L9Y=",
+        "lastModified": 1717932370,
+        "narHash": "sha256-7C5lCpiWiyPoIACOcu2mukn/1JRtz6HC/1aEMhUdcw0=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "a33ef102a02ce77d3e39c25197664b7a636f9c30",
+        "rev": "27979f1c3a0d3b9617a3563e2839114ba7d48d3f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`27979f1c`](https://github.com/nix-community/impermanence/commit/27979f1c3a0d3b9617a3563e2839114ba7d48d3f) | `` README: Grammar fix ``                                 |
| [`f6a5d85f`](https://github.com/nix-community/impermanence/commit/f6a5d85f70f66a40907f7e6ef06b2d78e9de1880) | `` README: Document the NixOS module's `enable` option `` |