### PR TITLE
chore(flake/nur): `295436eb` -> `83e160a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717922842,
-        "narHash": "sha256-dJz6gBOsBzt+lDCjWg1YG1sncILOCJsOtwtOZ+paYPs=",
+        "lastModified": 1717948052,
+        "narHash": "sha256-2gCnJZoXuNOBRaYKHOemGhktvPxywIQGX4cfb5EB0Bo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "295436eb1ab9143e29d6360697e92e7dfae61e94",
+        "rev": "83e160a6adc2c8bb270b68dd23409d6539e19cb2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`83e160a6`](https://github.com/nix-community/NUR/commit/83e160a6adc2c8bb270b68dd23409d6539e19cb2) | `` automatic update `` |
| [`b7ad32c0`](https://github.com/nix-community/NUR/commit/b7ad32c08641a0ae6167c9c1cd579c7be4b87d39) | `` automatic update `` |
| [`c92cda5c`](https://github.com/nix-community/NUR/commit/c92cda5c72b7c9c2d6ebf53bfdb85b314580f3e6) | `` automatic update `` |
| [`752b702a`](https://github.com/nix-community/NUR/commit/752b702aea877a4bb49bdf91552ed035bf0b820e) | `` automatic update `` |
| [`9b619733`](https://github.com/nix-community/NUR/commit/9b61973380026e2caeea05cbca5382d08e825c1a) | `` automatic update `` |