### PR TITLE
chore(flake/emacs-overlay): `a5143ff8` -> `e520afec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1717923950,
-        "narHash": "sha256-k7WYdsUm4oeFlAC2JLKXDIxp1pS7/mrUyN7ztEF5DGM=",
+        "lastModified": 1717952755,
+        "narHash": "sha256-a40YgjtnWFK2MOmUwkErj36vrryc2X5jexPqDvxuBTE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a5143ff8b6be9201f6b7aabe209a4c2a4a832ae3",
+        "rev": "e520afecae9cce738909a889e560fefaaccce281",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`e520afec`](https://github.com/nix-community/emacs-overlay/commit/e520afecae9cce738909a889e560fefaaccce281) | `` Updated emacs ``  |
| [`cc4cef19`](https://github.com/nix-community/emacs-overlay/commit/cc4cef1937a07bc5131eff526177e3bb10b3e79c) | `` Updated melpa ``  |
| [`7ec95550`](https://github.com/nix-community/emacs-overlay/commit/7ec9555006793730288fcd858291604110a1662b) | `` Updated elpa ``   |
| [`8e5228d7`](https://github.com/nix-community/emacs-overlay/commit/8e5228d792ab72adbca3cb383fcca2df268cccee) | `` Updated nongnu `` |