### PR TITLE
chore(flake/nur): `cde8790a` -> `632f6ed4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717957842,
-        "narHash": "sha256-TT32s5ld/FKFQiIvp5Sw3ttL8Zg07Imdot9UzW7OntE=",
+        "lastModified": 1717962442,
+        "narHash": "sha256-Y1nUlqqzIkTIIdTdqfCXEpsQSR/lAC5ZyHnPTsLPQ+Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cde8790a722cb51016333989f35ec403d21a18f3",
+        "rev": "632f6ed45a87b5bf982c8bb9a7e4a0d543726369",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`632f6ed4`](https://github.com/nix-community/NUR/commit/632f6ed45a87b5bf982c8bb9a7e4a0d543726369) | `` automatic update `` |