### PR TITLE
chore(flake/nur): `632f6ed4` -> `ae887c17`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717962442,
-        "narHash": "sha256-Y1nUlqqzIkTIIdTdqfCXEpsQSR/lAC5ZyHnPTsLPQ+Y=",
+        "lastModified": 1717966034,
+        "narHash": "sha256-nzthhl2nceXsZNoCKbdJzND7U1d5Ldt0nzHHWH66FOo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "632f6ed45a87b5bf982c8bb9a7e4a0d543726369",
+        "rev": "ae887c17e49e3838aba7085dd310cd14f88e57f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ae887c17`](https://github.com/nix-community/NUR/commit/ae887c17e49e3838aba7085dd310cd14f88e57f1) | `` automatic update `` |