### PR TITLE
chore(flake/nur): `ae887c17` -> `92aca848`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717966034,
-        "narHash": "sha256-nzthhl2nceXsZNoCKbdJzND7U1d5Ldt0nzHHWH66FOo=",
+        "lastModified": 1717969507,
+        "narHash": "sha256-PMfPxp+F5h6HteES5ABPDLCnxGneg85iFqWqsfhypSI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ae887c17e49e3838aba7085dd310cd14f88e57f1",
+        "rev": "92aca848c512ea33321e45bb83411798a228b425",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`92aca848`](https://github.com/nix-community/NUR/commit/92aca848c512ea33321e45bb83411798a228b425) | `` automatic update `` |