### PR TITLE
chore(flake/nur): `92aca848` -> `3cf425f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717969507,
-        "narHash": "sha256-PMfPxp+F5h6HteES5ABPDLCnxGneg85iFqWqsfhypSI=",
+        "lastModified": 1717972418,
+        "narHash": "sha256-m+cC6wTUJfJAdcS4c5AxXUe/Sys6OOYjnivk2RCQD9w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "92aca848c512ea33321e45bb83411798a228b425",
+        "rev": "3cf425f28b2bfa18b12a989a41d319c94edf5d3d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3cf425f2`](https://github.com/nix-community/NUR/commit/3cf425f28b2bfa18b12a989a41d319c94edf5d3d) | `` automatic update `` |