### PR TITLE
chore(flake/emacs-overlay): `e520afec` -> `3ef2f91f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1717952755,
-        "narHash": "sha256-a40YgjtnWFK2MOmUwkErj36vrryc2X5jexPqDvxuBTE=",
+        "lastModified": 1717981541,
+        "narHash": "sha256-bWyQSK0r4rtcNPOyrrjhNqFCuvF2jOBjerXBsvTwVw4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e520afecae9cce738909a889e560fefaaccce281",
+        "rev": "3ef2f91f1a4cc0ed11586ed6992e2bf88356c340",
         "type": "github"
       },
       "original": {
@@ -700,11 +700,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1717530100,
-        "narHash": "sha256-b4Dn+PnrZoVZ/BoR9JN2fTxXxplJrAsdSUIePf4Cacs=",
+        "lastModified": 1717880976,
+        "narHash": "sha256-BRvSCsKtDUr83NEtbGfHLUOdDK0Cgbezj2PtcHnz+sQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a2e1d0414259a144ebdc048408a807e69e0565af",
+        "rev": "4913a7c3d8b8d00cb9476a6bd730ff57777f740c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`3ef2f91f`](https://github.com/nix-community/emacs-overlay/commit/3ef2f91f1a4cc0ed11586ed6992e2bf88356c340) | `` Updated elpa ``         |
| [`6c9771b2`](https://github.com/nix-community/emacs-overlay/commit/6c9771b25e77789cda08b2b2bf291754fe6abba1) | `` Updated flake inputs `` |