### PR TITLE
chore(flake/srvos): `64ae31cb` -> `7d912e0f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -951,11 +951,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717807544,
-        "narHash": "sha256-djHfn29HdlfWdmyeu3rqlVS8k5q/xRh2P0mX2RAafb0=",
+        "lastModified": 1717980384,
+        "narHash": "sha256-nK1IFT/W/naLOolOdXZkKnvbmkj6tk7B8sIUfgXdhMs=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "64ae31cb29923128f27a503a550ee4fb1631c4c6",
+        "rev": "7d912e0f5d9b1049a748b6257019fa312f4064a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`7d912e0f`](https://github.com/nix-community/srvos/commit/7d912e0f5d9b1049a748b6257019fa312f4064a5) | `` dev/private/flake.lock: Update `` |
| [`20d36f43`](https://github.com/nix-community/srvos/commit/20d36f4377c511304960f793481f41dae85b19b2) | `` flake.lock: Update ``             |