### PR TITLE
chore(flake/nur): `3cf425f2` -> `da20efde`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717972418,
-        "narHash": "sha256-m+cC6wTUJfJAdcS4c5AxXUe/Sys6OOYjnivk2RCQD9w=",
+        "lastModified": 1717991159,
+        "narHash": "sha256-NkQrFffBrG3UwtJgW74i0NVNvsVuggp2Pl1exItAWVI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3cf425f28b2bfa18b12a989a41d319c94edf5d3d",
+        "rev": "da20efde85aaa5a35f85f9b2e7b84b028efce895",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`da20efde`](https://github.com/nix-community/NUR/commit/da20efde85aaa5a35f85f9b2e7b84b028efce895) | `` automatic update `` |
| [`137e99cd`](https://github.com/nix-community/NUR/commit/137e99cd08fd6444815615401f9139069bb30c70) | `` automatic update `` |
| [`445db6f4`](https://github.com/nix-community/NUR/commit/445db6f40c3945f705294f53bc4717836c23faaa) | `` automatic update `` |
| [`d785bdeb`](https://github.com/nix-community/NUR/commit/d785bdebf0cf91e848c98106c28494de108e3eeb) | `` automatic update `` |
| [`755382a2`](https://github.com/nix-community/NUR/commit/755382a27afc56c6ecda36b4a48f7d6bb4adaac4) | `` automatic update `` |
| [`f78ff440`](https://github.com/nix-community/NUR/commit/f78ff440eec05d49992f979dd2cc8af1c461b482) | `` automatic update `` |
| [`0fcbda9c`](https://github.com/nix-community/NUR/commit/0fcbda9c31c471965eb64fdea939894adea71626) | `` automatic update `` |