### PR TITLE
chore(flake/emacs-overlay): `3ef2f91f` -> `e3a8a67c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1717981541,
-        "narHash": "sha256-bWyQSK0r4rtcNPOyrrjhNqFCuvF2jOBjerXBsvTwVw4=",
+        "lastModified": 1717984494,
+        "narHash": "sha256-QMFq8UW9P9hh4VcZ23eSi0XZUCiZn7JCvNKcsD3RRug=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3ef2f91f1a4cc0ed11586ed6992e2bf88356c340",
+        "rev": "e3a8a67ce663448e33f01c8dd94c4d7218b634a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`e3a8a67c`](https://github.com/nix-community/emacs-overlay/commit/e3a8a67ce663448e33f01c8dd94c4d7218b634a6) | `` Updated emacs `` |
| [`d0ad609b`](https://github.com/nix-community/emacs-overlay/commit/d0ad609b90b481a70d8e9522e95d1b0b9d917e44) | `` Updated melpa `` |