### PR TITLE
chore(flake/nur): `da20efde` -> `9426a453`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717991159,
-        "narHash": "sha256-NkQrFffBrG3UwtJgW74i0NVNvsVuggp2Pl1exItAWVI=",
+        "lastModified": 1717993378,
+        "narHash": "sha256-M/ZRPJVRbKl3ZSwaAtdHPmCDvMogTtecgvuUjYfOJJw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "da20efde85aaa5a35f85f9b2e7b84b028efce895",
+        "rev": "9426a453f391546c8c0a361d9ba8457f724d6764",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9426a453`](https://github.com/nix-community/NUR/commit/9426a453f391546c8c0a361d9ba8457f724d6764) | `` automatic update `` |
| [`af0531e7`](https://github.com/nix-community/NUR/commit/af0531e78d41d5b324ee8b641723db14c7817dd3) | `` automatic update `` |