### PR TITLE
chore(flake/nur): `9426a453` -> `d55100a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1717993378,
-        "narHash": "sha256-M/ZRPJVRbKl3ZSwaAtdHPmCDvMogTtecgvuUjYfOJJw=",
+        "lastModified": 1718004350,
+        "narHash": "sha256-FVemmoFccqgzd12gvUr6tIqOu1wYdhxaALRKzW6lAbk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9426a453f391546c8c0a361d9ba8457f724d6764",
+        "rev": "d55100a32fa6e3c8abb23f2070bf32ac8b4cee1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d55100a3`](https://github.com/nix-community/NUR/commit/d55100a32fa6e3c8abb23f2070bf32ac8b4cee1f) | `` automatic update `` |
| [`3fa21e2e`](https://github.com/nix-community/NUR/commit/3fa21e2eb106febf493eafba31b2933ce622fca4) | `` automatic update `` |
| [`b527101a`](https://github.com/nix-community/NUR/commit/b527101a4231fd7e2fbaf3bc1f724e595243d7b1) | `` automatic update `` |