### PR TITLE
chore(flake/nur): `d55100a3` -> `2c305f62`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718004350,
-        "narHash": "sha256-FVemmoFccqgzd12gvUr6tIqOu1wYdhxaALRKzW6lAbk=",
+        "lastModified": 1718012727,
+        "narHash": "sha256-9L/5bqdPCqdWH/SvS536tzoLkUHdZi54gKING4iYvE0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d55100a32fa6e3c8abb23f2070bf32ac8b4cee1f",
+        "rev": "2c305f624f8812c55301de6842ebeb57e2bf58ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2c305f62`](https://github.com/nix-community/NUR/commit/2c305f624f8812c55301de6842ebeb57e2bf58ca) | `` automatic update `` |
| [`7b94cdba`](https://github.com/nix-community/NUR/commit/7b94cdba57caac6f7fd15a207bc4c43313a533a7) | `` automatic update `` |