### PR TITLE
chore(flake/emacs-overlay): `b4b62725` -> `e618bb81`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1718009715,
-        "narHash": "sha256-Jh83fitSVRZkeW6IKYvC/emmBNpsG4LQ/tgljp3Am/Q=",
+        "lastModified": 1718010608,
+        "narHash": "sha256-UdQqYGtvFfovH1PfsNWIuzEXxqpeqILCXIoJIhC3Q9M=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b4b62725d288c93301666852fb87c924263370f0",
+        "rev": "e618bb81b46a182758c649c734294f55d73e05bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`e618bb81`](https://github.com/nix-community/emacs-overlay/commit/e618bb81b46a182758c649c734294f55d73e05bc) | `` Updated emacs `` |