### PR TITLE
chore(flake/nur): `2c305f62` -> `14a2a971`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718012727,
-        "narHash": "sha256-9L/5bqdPCqdWH/SvS536tzoLkUHdZi54gKING4iYvE0=",
+        "lastModified": 1718030519,
+        "narHash": "sha256-eohJistIw+l5AtOp6BYMtQk9Zib8i+mQ02fuNiGR5KU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2c305f624f8812c55301de6842ebeb57e2bf58ca",
+        "rev": "14a2a971f0645dc96740ca8ab30499e3a4ba6f66",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                             |
| -------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`14a2a971`](https://github.com/nix-community/NUR/commit/14a2a971f0645dc96740ca8ab30499e3a4ba6f66) | `` automatic update ``              |
| [`f7e5fe02`](https://github.com/nix-community/NUR/commit/f7e5fe023ea5742a1db039b6ba17f717ef24cc0f) | `` automatic update ``              |
| [`03b65919`](https://github.com/nix-community/NUR/commit/03b6591956ef56a6db583f18d61515cd588e6c6e) | `` automatic update ``              |
| [`9e4eafbe`](https://github.com/nix-community/NUR/commit/9e4eafbe54a58a690e2e1fb61d1090239b127ee3) | `` automatic update ``              |
| [`c8bf4a2c`](https://github.com/nix-community/NUR/commit/c8bf4a2c423ec065a5d094943d586e907945c28d) | `` automatic update ``              |
| [`08bcb894`](https://github.com/nix-community/NUR/commit/08bcb894d70cc0334160afbe5fc91884a0e8caee) | `` chore: add draftea repository `` |
| [`4d1ba62d`](https://github.com/nix-community/NUR/commit/4d1ba62d5f5e03520a3bc0d9e52b2ef8a07af5a9) | `` automatic update ``              |
| [`ffde8369`](https://github.com/nix-community/NUR/commit/ffde83696782020a722eb13d94a46d4915348b7b) | `` automatic update ``              |
| [`57bd6be8`](https://github.com/nix-community/NUR/commit/57bd6be8dd9609e30878faa94ebad5981a6159b5) | `` Update repos.json ``             |
| [`a85745ad`](https://github.com/nix-community/NUR/commit/a85745ad55fdd3d076fb97d2973adb7f4e81606e) | `` Add bhasherbel repository ``     |
| [`12f8288a`](https://github.com/nix-community/NUR/commit/12f8288a47e37630352b77b3564ad57e284d82ff) | `` automatic update ``              |
| [`9338b010`](https://github.com/nix-community/NUR/commit/9338b0106ef706e7feff28bb0da3c14d452d7059) | `` Update repos.json ``             |