### PR TITLE
chore(flake/nur): `14a2a971` -> `e614348f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718030519,
-        "narHash": "sha256-eohJistIw+l5AtOp6BYMtQk9Zib8i+mQ02fuNiGR5KU=",
+        "lastModified": 1718034680,
+        "narHash": "sha256-i6+D11kYXTF6WbGdVCDzModgpIdQKJZiro7k+xhKIls=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "14a2a971f0645dc96740ca8ab30499e3a4ba6f66",
+        "rev": "e614348f2248692fad52c28dad7ee04fbc51df51",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e614348f`](https://github.com/nix-community/NUR/commit/e614348f2248692fad52c28dad7ee04fbc51df51) | `` automatic update `` |
| [`b7854ad1`](https://github.com/nix-community/NUR/commit/b7854ad10e058f3ff30f02feade593a3cc4a3714) | `` automatic update `` |