### PR TITLE
chore(flake/emacs-overlay): `e618bb81` -> `27232402`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1718010608,
-        "narHash": "sha256-UdQqYGtvFfovH1PfsNWIuzEXxqpeqILCXIoJIhC3Q9M=",
+        "lastModified": 1718039378,
+        "narHash": "sha256-hSboZZ3ULUDEx4Q0XPvieXl6artsiqJhKkNxVUjd30A=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e618bb81b46a182758c649c734294f55d73e05bc",
+        "rev": "272324023f7740c2c615b42283d46770f9b24bc2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`27232402`](https://github.com/nix-community/emacs-overlay/commit/272324023f7740c2c615b42283d46770f9b24bc2) | `` Updated emacs `` |
| [`d6b46a7b`](https://github.com/nix-community/emacs-overlay/commit/d6b46a7b91b519cccd69ab92f70cb441cdbedec7) | `` Updated melpa `` |
| [`def15ece`](https://github.com/nix-community/emacs-overlay/commit/def15ece48a4902188ece92b094b3aaae9ca5530) | `` Updated elpa ``  |