### PR TITLE
chore(flake/srvos): `7d912e0f` -> `4098b95d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -951,11 +951,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717980384,
-        "narHash": "sha256-nK1IFT/W/naLOolOdXZkKnvbmkj6tk7B8sIUfgXdhMs=",
+        "lastModified": 1718036376,
+        "narHash": "sha256-6hC1LrzXihZ/Tf7YNvICYUFHH+MvuXvpX8uV0hI5/6s=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "7d912e0f5d9b1049a748b6257019fa312f4064a5",
+        "rev": "4098b95dde07ec1ef75cd2cba1ebdde0576b59f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                               |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`4098b95d`](https://github.com/nix-community/srvos/commit/4098b95dde07ec1ef75cd2cba1ebdde0576b59f1) | `` amazon: drop redundant cloud-init.enable (#438) `` |