### PR TITLE
chore(flake/nur): `c5b737c8` -> `217df5fd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718038889,
-        "narHash": "sha256-NZNTXQ9vWoCHsgNehebR7tNTmilOsvTynCwWmgHMbqk=",
+        "lastModified": 1718041571,
+        "narHash": "sha256-dTfVDLOx67qwZxIS30nK/AGbqXLS55xu6PG1Bcrb7Ps=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c5b737c8ecc08954333f60f42907e743aa24c6ae",
+        "rev": "217df5fd2e0e126f505aae8ba20bb83e66fe6c1a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`217df5fd`](https://github.com/nix-community/NUR/commit/217df5fd2e0e126f505aae8ba20bb83e66fe6c1a) | `` automatic update `` |
| [`e567d153`](https://github.com/nix-community/NUR/commit/e567d1535da7906d971ce9b7f6781ea8bacd1218) | `` automatic update `` |
| [`f2cbe3d9`](https://github.com/nix-community/NUR/commit/f2cbe3d9253c42529d79c8f1c8dd644c10aafdef) | `` automatic update `` |