### PR TITLE
chore(flake/nur): `217df5fd` -> `c6e5cfb7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718041571,
-        "narHash": "sha256-dTfVDLOx67qwZxIS30nK/AGbqXLS55xu6PG1Bcrb7Ps=",
+        "lastModified": 1718052272,
+        "narHash": "sha256-LBQohxKarNsRRdAVAn3qWU8w91pgJep4OzQHaTvFQ6c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "217df5fd2e0e126f505aae8ba20bb83e66fe6c1a",
+        "rev": "c6e5cfb7afae8cd5457fed2b967917e9daf0629c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c6e5cfb7`](https://github.com/nix-community/NUR/commit/c6e5cfb7afae8cd5457fed2b967917e9daf0629c) | `` automatic update `` |
| [`c2592547`](https://github.com/nix-community/NUR/commit/c259254742217b3278f251c92945b49ac7f1d6a4) | `` automatic update `` |
| [`e0a88089`](https://github.com/nix-community/NUR/commit/e0a8808959e17605f953c3475f0aff035f3d2487) | `` automatic update `` |
| [`a09030d4`](https://github.com/nix-community/NUR/commit/a09030d4186c064dab2eb3cfb7b31cd3839b5568) | `` automatic update `` |