### PR TITLE
chore(flake/catppuccin): `0cdfa29b` -> `85558d16`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1717565621,
-        "narHash": "sha256-uU6GeSbzopVcPga+Fy5n3tKfzUhuw4FVMv7h61/13XY=",
+        "lastModified": 1718053251,
+        "narHash": "sha256-qva+8qR/7xuCqPBfJeK1rvNCKecRmhzDOr5iA/i8VA0=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "0cdfa29b902976fc2941468d326325d24e148437",
+        "rev": "85558d1638a65ed1cc7fb8bd7cfc1a5474b21fdb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                       |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`85558d16`](https://github.com/catppuccin/nix/commit/85558d1638a65ed1cc7fb8bd7cfc1a5474b21fdb) | `` feat(home-manager): add support for newsboat (#217) ``     |
| [`81297f18`](https://github.com/catppuccin/nix/commit/81297f18f16972f17fb53940dcef6f99634af01b) | `` chore: update dev flake inputs (#213) ``                   |
| [`4d4e7ce1`](https://github.com/catppuccin/nix/commit/4d4e7ce1aa53feee2d23e9be97b6a6575693fef9) | `` chore(home-manager): deprecate gtk module (#206) ``        |
| [`c4dac42a`](https://github.com/catppuccin/nix/commit/c4dac42a4fadc49bbd939fb3531673dbb3b0a949) | `` chore(modules): update ports (#211) ``                     |
| [`6336fb8b`](https://github.com/catppuccin/nix/commit/6336fb8ba1d33498869980ba6b8ce44b25eddf91) | `` fix(home-manager): gtk cursors are now lowercase (#212) `` |