### PR TITLE
chore(flake/nur): `c6e5cfb7` -> `c16ad983`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718052272,
-        "narHash": "sha256-LBQohxKarNsRRdAVAn3qWU8w91pgJep4OzQHaTvFQ6c=",
+        "lastModified": 1718053354,
+        "narHash": "sha256-xQa7PZbGxVNo1O1pIvGeaTLbN8nrJI4zEQq3zzBsbiw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c6e5cfb7afae8cd5457fed2b967917e9daf0629c",
+        "rev": "c16ad983637f9171769ddf102be60dd3ecbfd04c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c16ad983`](https://github.com/nix-community/NUR/commit/c16ad983637f9171769ddf102be60dd3ecbfd04c) | `` automatic update `` |