### PR TITLE
chore(flake/nur): `c16ad983` -> `24353e32`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718053354,
-        "narHash": "sha256-xQa7PZbGxVNo1O1pIvGeaTLbN8nrJI4zEQq3zzBsbiw=",
+        "lastModified": 1718059508,
+        "narHash": "sha256-j34g53biPBh2ke/viQjzVLvXQJKV4dpt2HDmNH+szO8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c16ad983637f9171769ddf102be60dd3ecbfd04c",
+        "rev": "24353e3288855558d79402d875788ae28f1130b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`24353e32`](https://github.com/nix-community/NUR/commit/24353e3288855558d79402d875788ae28f1130b3) | `` automatic update `` |
| [`9dc846fb`](https://github.com/nix-community/NUR/commit/9dc846fb0a263c59f5ee55ad096fa01eece8adbc) | `` automatic update `` |