### PR TITLE
chore(flake/emacs-overlay): `27232402` -> `f916315b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1718039378,
-        "narHash": "sha256-hSboZZ3ULUDEx4Q0XPvieXl6artsiqJhKkNxVUjd30A=",
+        "lastModified": 1718070856,
+        "narHash": "sha256-cZz0E6ADvLkPkOvz5qsC7tibHCfzcO95wiA7kvqf+WY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "272324023f7740c2c615b42283d46770f9b24bc2",
+        "rev": "f916315b134a1a752272e7bd91fad9ee2ef6856d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`f916315b`](https://github.com/nix-community/emacs-overlay/commit/f916315b134a1a752272e7bd91fad9ee2ef6856d) | `` Updated emacs ``  |
| [`dc9f6720`](https://github.com/nix-community/emacs-overlay/commit/dc9f67207661f911db7d474214bbfa567b3e721c) | `` Updated melpa ``  |
| [`41b5e012`](https://github.com/nix-community/emacs-overlay/commit/41b5e01283907444ca08b9dd4f53e049b27e2fca) | `` Updated elpa ``   |
| [`7ea79179`](https://github.com/nix-community/emacs-overlay/commit/7ea791798cd20dd222f26ebb62f9dc6ad8d07e9b) | `` Updated nongnu `` |