### PR TITLE
chore(flake/nur): `24353e32` -> `ad7e99c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718059508,
-        "narHash": "sha256-j34g53biPBh2ke/viQjzVLvXQJKV4dpt2HDmNH+szO8=",
+        "lastModified": 1718068930,
+        "narHash": "sha256-Xd7l3V8d7pni5DkT/5OFs4KIEQv31+YNM0Yac1Uq+Mk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "24353e3288855558d79402d875788ae28f1130b3",
+        "rev": "ad7e99c9ffddb12082ab303e51044143c2e2f6db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ad7e99c9`](https://github.com/nix-community/NUR/commit/ad7e99c9ffddb12082ab303e51044143c2e2f6db) | `` automatic update `` |
| [`d89fbde4`](https://github.com/nix-community/NUR/commit/d89fbde43540b2a9b26528abd5c2759d4e185c6e) | `` automatic update `` |