### PR TITLE
chore(flake/nur): `ad7e99c9` -> `461b91e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718068930,
-        "narHash": "sha256-Xd7l3V8d7pni5DkT/5OFs4KIEQv31+YNM0Yac1Uq+Mk=",
+        "lastModified": 1718074627,
+        "narHash": "sha256-yQ9nbAdeXCJnklNR118kJzLPoU0RMopHHxCPsjpPitI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ad7e99c9ffddb12082ab303e51044143c2e2f6db",
+        "rev": "461b91e03d3d15a05dd29395af474793f7cfef4c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`461b91e0`](https://github.com/nix-community/NUR/commit/461b91e03d3d15a05dd29395af474793f7cfef4c) | `` automatic update `` |
| [`759a0a16`](https://github.com/nix-community/NUR/commit/759a0a16dfb46dfa4b1df7aeffd680d66d5955ac) | `` automatic update `` |
| [`f8dff9e4`](https://github.com/nix-community/NUR/commit/f8dff9e4011636dd44d30398a1de0e0f4968b1ef) | `` automatic update `` |