### PR TITLE
chore(flake/nur): `461b91e0` -> `0eff51b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718074627,
-        "narHash": "sha256-yQ9nbAdeXCJnklNR118kJzLPoU0RMopHHxCPsjpPitI=",
+        "lastModified": 1718081410,
+        "narHash": "sha256-Sv7niH+3yIcNc6+L9VA4iKkqq4rIJkOQbN0peeN/YWM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "461b91e03d3d15a05dd29395af474793f7cfef4c",
+        "rev": "0eff51b6dcec04d5776a8dea2628253620729a76",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0eff51b6`](https://github.com/nix-community/NUR/commit/0eff51b6dcec04d5776a8dea2628253620729a76) | `` automatic update `` |
| [`d62ea649`](https://github.com/nix-community/NUR/commit/d62ea649e99cb179e4262bcc2ddf5eaff3cbbcc9) | `` automatic update `` |
| [`17ca35f1`](https://github.com/nix-community/NUR/commit/17ca35f1d12452f5135d0b96a67a78eb72d203ae) | `` automatic update `` |