### PR TITLE
chore(flake/nur): `574fe531` -> `2975c092`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718083203,
-        "narHash": "sha256-EbV/EWO3VBjZMhY+yrtTay5xGAxS4bnvIg7jPbgYEZU=",
+        "lastModified": 1718088447,
+        "narHash": "sha256-edBY0CM3e9HgFaYAoyBWKgOk1CbCMm2vXv5nFG+epF0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "574fe531cb78197ba6d97e2d0f12d9ae7e4798fd",
+        "rev": "2975c092fc0723e452003030364f869045d02ece",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2975c092`](https://github.com/nix-community/NUR/commit/2975c092fc0723e452003030364f869045d02ece) | `` automatic update `` |
| [`fe4ba0f9`](https://github.com/nix-community/NUR/commit/fe4ba0f9b9eab96bde1923a199d69ab376536089) | `` automatic update `` |