### PR TITLE
chore(flake/nur): `2975c092` -> `8232a1f4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718088447,
-        "narHash": "sha256-edBY0CM3e9HgFaYAoyBWKgOk1CbCMm2vXv5nFG+epF0=",
+        "lastModified": 1718091975,
+        "narHash": "sha256-5qpqVsG6zpPta/GQ6SuB/uYxcnC/k0oooc8gPN5QH70=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2975c092fc0723e452003030364f869045d02ece",
+        "rev": "8232a1f40a2fb366048be1042137f67e67ed7915",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8232a1f4`](https://github.com/nix-community/NUR/commit/8232a1f40a2fb366048be1042137f67e67ed7915) | `` automatic update `` |