### PR TITLE
chore(flake/nixpkgs): `051f9206` -> `c7b821ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1717786204,
-        "narHash": "sha256-4q0s6m0GUcN7q+Y2DqD27iLvbcd1G50T2lv08kKxkSI=",
+        "lastModified": 1717974879,
+        "narHash": "sha256-GTO3C88+5DX171F/gVS3Qga/hOs/eRMxPFpiHq2t+D8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "051f920625ab5aabe37c920346e3e69d7d34400e",
+        "rev": "c7b821ba2e1e635ba5a76d299af62821cbcb09f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`c7b821ba`](https://github.com/NixOS/nixpkgs/commit/c7b821ba2e1e635ba5a76d299af62821cbcb09f3) | `` luaPackages.neotest: enable tests ``                                         |
| [`4b08ae13`](https://github.com/NixOS/nixpkgs/commit/4b08ae13db65671f72072885810250c103c3da2b) | `` linux_testing: 6.10-rc1 -> 6.10-rc2 ``                                       |
| [`fd6ca8d0`](https://github.com/NixOS/nixpkgs/commit/fd6ca8d0f59a0a76bafb1212b22e2a41a7db3486) | `` treewide: Improve wording of meta.description ``                             |
| [`f8c4a98e`](https://github.com/NixOS/nixpkgs/commit/f8c4a98e8e138e21353a2c33b90db3359f539b37) | `` treewide: Remove the definite article from meta.description ``               |
| [`755b915a`](https://github.com/NixOS/nixpkgs/commit/755b915a158c9d588f08e9b08da9f7f3422070cc) | `` treewide: Remove indefinite article from meta.description ``                 |
| [`bf995e36`](https://github.com/NixOS/nixpkgs/commit/bf995e3641950f4183c1dd9010349263dfa0123b) | `` treewide: Remove ending period from meta.description ``                      |
| [`c5916c86`](https://github.com/NixOS/nixpkgs/commit/c5916c86e95a2dab1ce5c4bfbbd22aab6d7eaef9) | `` hellmaker: init at 0-unstable-2023-03-18 ``                                  |
| [`0887cfc6`](https://github.com/NixOS/nixpkgs/commit/0887cfc6b5f800099abf8c54e5ec318bd4dbf1c8) | `` home-assistant-custom-components.yassi: 0.4.0b4 -> 0.4.0 ``                  |
| [`a5caaecf`](https://github.com/NixOS/nixpkgs/commit/a5caaecfaef3c48c91945392673d95b5fdf449b2) | `` nhost-cli: init at 1.18.1 ``                                                 |
| [`b937d377`](https://github.com/NixOS/nixpkgs/commit/b937d377424ef8e1b42fcff29fea61bb428bfce3) | `` vzic: init at 0-unstable-2024-06-04 ``                                       |
| [`07096293`](https://github.com/NixOS/nixpkgs/commit/070962936b3de1e3feb84e34721943fe97c4a65c) | `` typst-preview: 0.11.6 -> 0.11.7 ``                                           |
| [`c49c31fc`](https://github.com/NixOS/nixpkgs/commit/c49c31fc90c90332c0564dfa59e6b325a877c419) | `` python311Packages.tensordict: disable flaky test on aarch64-linux ``         |
| [`e1c6c042`](https://github.com/NixOS/nixpkgs/commit/e1c6c042fdd2626e443ff73cb433e415206c0efa) | `` python311Packages.plugwise: 0.38.0 -> 0.38.2 ``                              |
| [`ebed000f`](https://github.com/NixOS/nixpkgs/commit/ebed000ff0e3e2c924b1d2d5ba101f49fea237db) | `` quark-engine: 24.5.1 -> 24.6.1 ``                                            |
| [`42a580f7`](https://github.com/NixOS/nixpkgs/commit/42a580f70aa101e973d33f6d79af3e7ff32aa580) | `` php81Packages.php-parallel-lint: 1.3.2.999 -> 1.4.0 ``                       |
| [`f9fffaf9`](https://github.com/NixOS/nixpkgs/commit/f9fffaf96e14602171342779b3b91eb854d8a78d) | `` polkadot: tighten platforms ``                                               |
| [`e69ce065`](https://github.com/NixOS/nixpkgs/commit/e69ce065cf19c1f122d941c6aed72f318f07e483) | `` vscode-extensions.mgt19937.typst-preview: 0.11.6 -> 0.11.7 ``                |
| [`990107a3`](https://github.com/NixOS/nixpkgs/commit/990107a3d345c6ff6db60d07ed82731e9a5ab658) | `` python311Packages.repl-python-wakatime: refactor ``                          |
| [`b09b1844`](https://github.com/NixOS/nixpkgs/commit/b09b1844d3f85758719619352556d5c3bbca5e0b) | `` php81: restore patch for libxml2 on darwin ``                                |
| [`59435f1f`](https://github.com/NixOS/nixpkgs/commit/59435f1fa3f820634b192da10e1917840f566a6e) | `` python311Packages.forbiddenfruit: add changelog to meta ``                   |
| [`52ae9cfc`](https://github.com/NixOS/nixpkgs/commit/52ae9cfc24f8322f29a1ddb353b4d392e3aad944) | `` php81Packages.php-cs-fixer: 3.51.0 -> 3.58.1 ``                              |
| [`391cd778`](https://github.com/NixOS/nixpkgs/commit/391cd77844013256415328c2814bf703193c8ca7) | `` python311Packages.griffe: 0.45.2 -> 0.45.3 ``                                |
| [`ed95dfac`](https://github.com/NixOS/nixpkgs/commit/ed95dface292bcc53f2f5a89c070f5b635fbb9f8) | `` fulcrum: 1.10.0 -> 1.11.0 ``                                                 |
| [`5fca6e1e`](https://github.com/NixOS/nixpkgs/commit/5fca6e1eafa6db00a22a139bc02089b667569ea7) | `` artalk: 2.8.6 -> 2.8.7 ``                                                    |
| [`245aee34`](https://github.com/NixOS/nixpkgs/commit/245aee34d95b7a03619d0b7ef42a179b1b7e8de0) | `` mir_2_15: init at 2.15.0 ``                                                  |
| [`3526d8c1`](https://github.com/NixOS/nixpkgs/commit/3526d8c1a6762bb21a32ebd68fc7138e4e67db2e) | `` python311Packages.gradio: disable flaky tests on darwin ``                   |
| [`25430e07`](https://github.com/NixOS/nixpkgs/commit/25430e07d7ef240da8bafac908a800c9809751f3) | `` python311Packages.torchWithRocm: enhance broken reason phrasing ``           |
| [`b9ce5c3c`](https://github.com/NixOS/nixpkgs/commit/b9ce5c3cee29609519d6029c34b9ba54f6b2ea36) | `` typstyle: 0.11.24 -> 0.11.25 ``                                              |
| [`45f09ea7`](https://github.com/NixOS/nixpkgs/commit/45f09ea72130efdcc5de49a80e6c80cea45ddf4a) | `` tkrzw: 1.0.29 -> 1.0.31 ``                                                   |
| [`bea1d0e3`](https://github.com/NixOS/nixpkgs/commit/bea1d0e3c04159372da4bdaff59891cb60d209fc) | `` python312Packages.pylint-django: disable failing tests ``                    |
| [`b4d62a95`](https://github.com/NixOS/nixpkgs/commit/b4d62a957eb361e24118960e9e8567730daa13b5) | `` screen: change license to gpl3Plus ``                                        |
| [`b0fa99c0`](https://github.com/NixOS/nixpkgs/commit/b0fa99c099f7fed3b75ae02c15ce154ff237fe4b) | `` refind: make the build reproducible ``                                       |
| [`0b8a5573`](https://github.com/NixOS/nixpkgs/commit/0b8a5573c54d4f3dbcb456d29a7ce187c05d0277) | `` nomad_1_6: 1.6.8 -> 1.6.10 ``                                                |
| [`f43fcc42`](https://github.com/NixOS/nixpkgs/commit/f43fcc42007c017734ec6e927e901239d3b6e877) | `` python312Packages.canmatrix: refactor ``                                     |
| [`5e012949`](https://github.com/NixOS/nixpkgs/commit/5e01294920aaa58d096926367159e11e1f8027af) | `` python312Packages.xlwt: refactor ``                                          |
| [`899a94a0`](https://github.com/NixOS/nixpkgs/commit/899a94a0877294ed0986f0937628d670301c74a6) | `` md-tui: init at 0.8.1 ``                                                     |
| [`42bacda2`](https://github.com/NixOS/nixpkgs/commit/42bacda2d1b6e643467d698b514e906f6867637c) | `` cargo-cyclonedx: 0.5.1 -> 0.5.3 ``                                           |
| [`0fa642ae`](https://github.com/NixOS/nixpkgs/commit/0fa642aebc80ca40d4e205db74228dea5abc7edf) | `` python312Packages.hpccm: 22.10.0 -> 23.11.0 ``                               |
| [`67a3e195`](https://github.com/NixOS/nixpkgs/commit/67a3e1953b06d3aaef4acba7817357f3f0f2a122) | `` pur: refactor ``                                                             |
| [`c4a02aec`](https://github.com/NixOS/nixpkgs/commit/c4a02aec5a55cb10a278c7fbd94c1f27531a7e8e) | `` python311Packages.datafusion: 35.0.0 -> 38.0.1 ``                            |
| [`6d204ca7`](https://github.com/NixOS/nixpkgs/commit/6d204ca776c7d4c531ecf947b69e22df0f97caec) | `` checkov: 3.2.128 -> 3.2.129 ``                                               |
| [`29fe3af6`](https://github.com/NixOS/nixpkgs/commit/29fe3af6163d5ca214a6b04f9cb644e48615c76a) | `` python311Packages.archspec: 0.2.3 -> 0.2.4 ``                                |
| [`9df79fc5`](https://github.com/NixOS/nixpkgs/commit/9df79fc51f34c1dc66f3386e5b229cfef4e7ed65) | `` python311Packages.aiowaqi: refactor ``                                       |
| [`82d0392c`](https://github.com/NixOS/nixpkgs/commit/82d0392ce563934a9c050314425f25ff02f3dd72) | `` python311Packages.aiowaqi: 3.0.1 -> 3.1.0 ``                                 |
| [`2c23eae8`](https://github.com/NixOS/nixpkgs/commit/2c23eae85dd5d67aafc9ac956d97dcd8838b556c) | `` python311Packages.aiostream: 0.5.2 -> 0.6.1 ``                               |
| [`d931bea4`](https://github.com/NixOS/nixpkgs/commit/d931bea4931490014d69d5bfa30dd6687433dd40) | `` ladybird: 0-unstable-2024-05-26 -> 0-unstable-2024-06-04 ``                  |
| [`4085796c`](https://github.com/NixOS/nixpkgs/commit/4085796c8c582f2a64d3c366199efa599ce61a6b) | `` nixosTests.ladybird: use programs.ladybird option ``                         |
| [`92227c71`](https://github.com/NixOS/nixpkgs/commit/92227c7113e41da83c57b71e65182fd5634113b9) | `` python311Packages.adb-enhanced: 2.5.22 -> 2.5.24 ``                          |
| [`bdcb30d5`](https://github.com/NixOS/nixpkgs/commit/bdcb30d5dbcf42b172c34bd09f9081359d40a15a) | `` ollama: add roydubnium as maintainer ``                                      |
| [`daa7d21b`](https://github.com/NixOS/nixpkgs/commit/daa7d21b4c166d6a2ad53dc098e13c695296e86b) | `` python311Packages.pyexploitdb: 0.2.20 -> 0.2.21 ``                           |
| [`6c6e4b27`](https://github.com/NixOS/nixpkgs/commit/6c6e4b2789212fe931c3416e752fdb10ea17d885) | `` remind: 04.03.07 -> 05.00.01 ``                                              |
| [`c5c48031`](https://github.com/NixOS/nixpkgs/commit/c5c480318855780baf87c8dd718a0c9c391d12cf) | `` radcli: 1.3.1 -> 1.4.0 ``                                                    |
| [`acafec98`](https://github.com/NixOS/nixpkgs/commit/acafec98324a2632e0c459033e39768ceef1f8f3) | `` kanshi: 1.6.0 -> 1.7.0 ``                                                    |
| [`9d157dd9`](https://github.com/NixOS/nixpkgs/commit/9d157dd9a1d7b3664dbb453f4e3476a9654a8394) | `` python311Packages.opower: 0.4.6 -> 0.4.7 ``                                  |
| [`08b05722`](https://github.com/NixOS/nixpkgs/commit/08b057228432e4d5c2952b107766afe4977b5dfa) | `` python311Packages.laundrify-aio: 1.1.2 -> 1.2.0 ``                           |
| [`1703676f`](https://github.com/NixOS/nixpkgs/commit/1703676fed2354f5f95efa5d42197d3df18fa45c) | `` python311Packages.fastcore: 1.5.44 -> 1.5.45 ``                              |
| [`6db6908a`](https://github.com/NixOS/nixpkgs/commit/6db6908a61cdca0e7694815495023691badfa6cb) | `` python311Packages.aioshelly: 10.0.0 -> 10.0.1 ``                             |
| [`ac2f1527`](https://github.com/NixOS/nixpkgs/commit/ac2f1527c6127113bb2b47f0d740cfa238f141e5) | `` python311Packages.torchWithRocm: mark as broken ``                           |
| [`1109db26`](https://github.com/NixOS/nixpkgs/commit/1109db26e10decb8f3aad8bc2b7888c6a7c4ee71) | `` tpnote: add manpage ``                                                       |
| [`4de740f6`](https://github.com/NixOS/nixpkgs/commit/4de740f6dc2748dd118304219b6ef3960411b6ab) | `` vscode-extensions.github.copilot-chat: 0.14.2024032901 -> 0.16.2024060502 `` |
| [`734ae407`](https://github.com/NixOS/nixpkgs/commit/734ae40716085d7c254c347040a8910587367ee7) | `` c-ares: update source URL ``                                                 |
| [`1a9aa864`](https://github.com/NixOS/nixpkgs/commit/1a9aa8640ad718beebee5c3051d41f078b444644) | `` vscode-extensions.github.copilot: 1.180.827 -> 1.200.920 ``                  |
| [`3db5358e`](https://github.com/NixOS/nixpkgs/commit/3db5358e35319c5aae6805ac6970413a4d720719) | `` abcmidi: 2024.04.30 -> 2024.06.03 ``                                         |
| [`2921686e`](https://github.com/NixOS/nixpkgs/commit/2921686e0fac52c738995ca4cc6f425864f289e8) | `` python3Packages.momepy: init at 0.7.0 ``                                     |
| [`77927b3f`](https://github.com/NixOS/nixpkgs/commit/77927b3fe3c591e73e856bd1eaf7a10ab4e1bffd) | `` python3Packages.inequality: init at 1.0.1 ``                                 |
| [`1dda3b95`](https://github.com/NixOS/nixpkgs/commit/1dda3b95d24d0af26ec9640393c854abd4a0fa76) | `` debianutils: 5.17 -> 5.18 ``                                                 |
| [`533f1ff1`](https://github.com/NixOS/nixpkgs/commit/533f1ff136d8036db0561bb3f94ba02682efc0b0) | `` btrfs-progs: 6.8.1 -> 6.9 ``                                                 |
| [`270cf648`](https://github.com/NixOS/nixpkgs/commit/270cf648af9e29e9f759a37a5cb2d59dcfe64307) | `` libsForQt5.angelfish: fix build with corrosion 0.5 ``                        |
| [`e10b8c55`](https://github.com/NixOS/nixpkgs/commit/e10b8c551f4979a96ee47c153e762b59cfc58d08) | `` xmedcon: 0.23.0 -> 0.24.0 ``                                                 |
| [`60c04968`](https://github.com/NixOS/nixpkgs/commit/60c04968a27a7dcaddbd1be9caf880a3b0dae7a3) | `` planify: 4.8 -> 4.8.2 ``                                                     |
| [`ec61fcb5`](https://github.com/NixOS/nixpkgs/commit/ec61fcb5157c5df1fa454ca6aea5a305003ca474) | `` jazz2: 2.6.0 -> 2.7.0 ``                                                     |
| [`ba02c4b4`](https://github.com/NixOS/nixpkgs/commit/ba02c4b4ac960667c73c036a968bf277df0552ed) | `` lefthook: 1.6.14 -> 1.6.15 ``                                                |
| [`d716e1e2`](https://github.com/NixOS/nixpkgs/commit/d716e1e2675dc05b4dc926a73f35e73f7e5ab690) | `` nu_scripts: 0-unstable-2024-06-01 -> 0-unstable-2024-06-08 ``                |
| [`155853df`](https://github.com/NixOS/nixpkgs/commit/155853df70900c42f0c42e614b8cb046b3c5328e) | `` elasticmq-server-bin: 1.6.2 -> 1.6.3 ``                                      |
| [`2479faff`](https://github.com/NixOS/nixpkgs/commit/2479fafff6236fb5be55c6149d4d79f4ac7c007f) | `` vale: 3.4.2 -> 3.5.0 ``                                                      |
| [`2f3c5fad`](https://github.com/NixOS/nixpkgs/commit/2f3c5fad66fbab80fa9c2430287ee105344568c0) | `` scriptisto: 2.1.1 -> 2.2.0 ``                                                |
| [`f1a30ef2`](https://github.com/NixOS/nixpkgs/commit/f1a30ef283ccb19cce74581afdd55ee9c269f078) | `` python311Packages.edk2-pytool-library: 0.21.6 -> 0.21.7 ``                   |
| [`c0249a27`](https://github.com/NixOS/nixpkgs/commit/c0249a278c7fdc98758410a22541b3c3b5a0d336) | `` multiviewer-for-f1: 1.31.3 -> 1.32.1 ``                                      |
| [`c34e92bb`](https://github.com/NixOS/nixpkgs/commit/c34e92bbed42f0295bf79af63adc8bacb8673e70) | `` pyenv: 2.4.1 -> 2.4.2 ``                                                     |
| [`8426035b`](https://github.com/NixOS/nixpkgs/commit/8426035ba3955f096428485d635166ffe85d5dd7) | `` okolors: 0.5.1 -> 0.7.0 ``                                                   |
| [`b841ec01`](https://github.com/NixOS/nixpkgs/commit/b841ec01230dea96c7d0ab8c2f8e175e28823003) | `` nulloy: 0.9.8.7 -> 0.9.9 ``                                                  |
| [`11c02679`](https://github.com/NixOS/nixpkgs/commit/11c02679cdc328ba6bf584555dcef5e8ae1203de) | `` freedv: 1.9.9.1 -> 1.9.9.2 ``                                                |
| [`4279683d`](https://github.com/NixOS/nixpkgs/commit/4279683dcddbb38f35ae22e85afbc39c0b773ed3) | `` faas-cli: 0.16.27 -> 0.16.29 ``                                              |
| [`ffe2580c`](https://github.com/NixOS/nixpkgs/commit/ffe2580cfa5c63d224316b884056d76722906812) | `` git-toolbelt: 1.9.1 -> 1.9.2 ``                                              |
| [`1bef9c7f`](https://github.com/NixOS/nixpkgs/commit/1bef9c7f26d8a8c524bd7a65806323220eec0448) | `` mcdreforged: init at 2.12.3 ``                                               |
| [`b3d6ef71`](https://github.com/NixOS/nixpkgs/commit/b3d6ef71b91a748e7347128da7b228e0b4207994) | `` nb-cli: init at 1.4.1 ``                                                     |
| [`77fc6692`](https://github.com/NixOS/nixpkgs/commit/77fc6692f7f499db2b76443740b4eb82cf78f87a) | `` python312Packages.noneprompt: init at 0.1.9 ``                               |
| [`9b255814`](https://github.com/NixOS/nixpkgs/commit/9b255814ca0d0877a2c101562d0a9481a1e56942) | `` python312Packages.cashews: init at 7.1.0 ``                                  |
| [`3f9551fe`](https://github.com/NixOS/nixpkgs/commit/3f9551fe7db81d09e25bc3c904eec2882173d8e6) | `` hexxy: 0-unstable-2024-02-24 -> 0-unstable-2024-02-23 ``                     |
| [`e48143d7`](https://github.com/NixOS/nixpkgs/commit/e48143d7a6b17c9c470b120a9352076e304d6cc1) | `` python3Packages.matplotlib-venn: init at 0.11.10 ``                          |
| [`70ccc541`](https://github.com/NixOS/nixpkgs/commit/70ccc541654d8d6c364732cfbb6caedf99bc7ca0) | `` python311Packages.nbdev: 2.3.23 -> 2.3.25 ``                                 |
| [`a24f97bf`](https://github.com/NixOS/nixpkgs/commit/a24f97bf27cb69a3a696b211a1cf17a275026c6a) | `` haskellPackages: Pass ghc-options in generic-builder when cross-compiling `` |
| [`f07f2b3c`](https://github.com/NixOS/nixpkgs/commit/f07f2b3c4ab2d0a7bbb2f5faa07cc625433a32e1) | `` fzf: 0.52.1 -> 0.53.0 ``                                                     |
| [`d31cbbee`](https://github.com/NixOS/nixpkgs/commit/d31cbbee832ba1269123aeaab81acf521a7117ea) | `` clickhouse-backup: 2.5.11 -> 2.5.12 ``                                       |
| [`33735150`](https://github.com/NixOS/nixpkgs/commit/337351501d02d6b3a1a91f3d2eaef60e4d0417f3) | `` maintainers: add RoyDubnium ``                                               |
| [`5f43f4f7`](https://github.com/NixOS/nixpkgs/commit/5f43f4f78abbcc0e928b361e10a783b9f53ad3df) | `` croc: 10.0.7 -> 10.0.8 ``                                                    |
| [`a02e3252`](https://github.com/NixOS/nixpkgs/commit/a02e3252b3399c31cac3cfba4b05ba2e0a38135a) | `` klaus: 2.0.3 -> 3.0.0 ``                                                     |
| [`41e0af6f`](https://github.com/NixOS/nixpkgs/commit/41e0af6ff40eab16c11391e4cf5093179a26e48c) | `` neocmakelsp: 0.6.27 -> 0.7.3 ``                                              |
| [`1f577fc0`](https://github.com/NixOS/nixpkgs/commit/1f577fc00a75e6e586d98e7ab72f3d9757219d5f) | `` obsidian: 1.5.12 -> 1.6.3 ``                                                 |