### PR TITLE
chore(flake/emacs-overlay): `f916315b` -> `d2404a42`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1718070856,
-        "narHash": "sha256-cZz0E6ADvLkPkOvz5qsC7tibHCfzcO95wiA7kvqf+WY=",
+        "lastModified": 1718096975,
+        "narHash": "sha256-Ud33Yz5o2OJ9mjH5rhbrdR+polxq9QyOLLNbtQ63s4E=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f916315b134a1a752272e7bd91fad9ee2ef6856d",
+        "rev": "d2404a42ad3ae9c5ee5c481b7c7a4c91627d161f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`d2404a42`](https://github.com/nix-community/emacs-overlay/commit/d2404a42ad3ae9c5ee5c481b7c7a4c91627d161f) | `` Updated emacs ``        |
| [`1d8cd0dc`](https://github.com/nix-community/emacs-overlay/commit/1d8cd0dc3cdd20e6b29922b1bcef4587d4579279) | `` Updated melpa ``        |
| [`aa9f52e9`](https://github.com/nix-community/emacs-overlay/commit/aa9f52e9aa1a53e7050bf280bd2634efd86e2a93) | `` Updated flake inputs `` |