### PR TITLE
chore(flake/nur): `8232a1f4` -> `b2adfc00`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718091975,
-        "narHash": "sha256-5qpqVsG6zpPta/GQ6SuB/uYxcnC/k0oooc8gPN5QH70=",
+        "lastModified": 1718102237,
+        "narHash": "sha256-5cUm1abWTdXdkP5jWGyUY6IgihpIpbSqem4M/2xwtzc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8232a1f40a2fb366048be1042137f67e67ed7915",
+        "rev": "b2adfc00254cf5bca52f1951955e801534130d63",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b2adfc00`](https://github.com/nix-community/NUR/commit/b2adfc00254cf5bca52f1951955e801534130d63) | `` automatic update `` |
| [`864f64eb`](https://github.com/nix-community/NUR/commit/864f64ebf277e594bb5a64b24026f6ef634daa10) | `` automatic update `` |
| [`5072ee4e`](https://github.com/nix-community/NUR/commit/5072ee4e6961b0d056755011416cd76e20a2005d) | `` automatic update `` |
| [`ac635098`](https://github.com/nix-community/NUR/commit/ac63509814b1a7c9b7093caa42e5a825fc58863e) | `` automatic update `` |
| [`d1c970b5`](https://github.com/nix-community/NUR/commit/d1c970b5275fb45cf32e4eff52afd798b860dbf1) | `` automatic update `` |