### PR TITLE
chore(flake/nur): `b2adfc00` -> `110c6fdf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718102237,
-        "narHash": "sha256-5cUm1abWTdXdkP5jWGyUY6IgihpIpbSqem4M/2xwtzc=",
+        "lastModified": 1718114101,
+        "narHash": "sha256-bY1VIMjpfYqweOB0DKmwkKZLHJt5v5hXaaH34GWeFBo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b2adfc00254cf5bca52f1951955e801534130d63",
+        "rev": "110c6fdf1f2934cbe01ca7066370c654f312a520",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`110c6fdf`](https://github.com/nix-community/NUR/commit/110c6fdf1f2934cbe01ca7066370c654f312a520) | `` automatic update `` |
| [`524fec1a`](https://github.com/nix-community/NUR/commit/524fec1afb6f640cf235b5839b35d87b8d595b7f) | `` automatic update `` |
| [`12d9f880`](https://github.com/nix-community/NUR/commit/12d9f880727d6e3664dc5a76c7cba23f3c6e6a7c) | `` automatic update `` |