### PR TITLE
chore(flake/nur): `110c6fdf` -> `08af08b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718114101,
-        "narHash": "sha256-bY1VIMjpfYqweOB0DKmwkKZLHJt5v5hXaaH34GWeFBo=",
+        "lastModified": 1718120696,
+        "narHash": "sha256-zbRgHbpEoYOLoiiYWKk9It+AU0v1zxF65QfEzB4QSH8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "110c6fdf1f2934cbe01ca7066370c654f312a520",
+        "rev": "08af08b78b86c95b2771ff066d6dd4f3feb203c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`08af08b7`](https://github.com/nix-community/NUR/commit/08af08b78b86c95b2771ff066d6dd4f3feb203c5) | `` automatic update `` |
| [`32ef15a2`](https://github.com/nix-community/NUR/commit/32ef15a2f64b3f694caeb0dcb6669af5e2fc1a5d) | `` automatic update `` |