### PR TITLE
chore(flake/sops-nix): `d071c74a` -> `c279dec1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -931,11 +931,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1718058322,
-        "narHash": "sha256-d5jLlAwVi4NzT9yc5UrPiOpDxTRhu8GGh0IIfeFcdrM=",
+        "lastModified": 1718137936,
+        "narHash": "sha256-psA+1Q5fPaK6yI3vzlLINNtb6EeXj111zQWnZYyJS9c=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "d071c74a7de1e26d211b69b6fbae37ae2e31a87f",
+        "rev": "c279dec105dd53df13a5e57525da97905cc0f0d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                  |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`c279dec1`](https://github.com/Mic92/sops-nix/commit/c279dec105dd53df13a5e57525da97905cc0f0d6) | `` update vendorHash ``                                                  |
| [`b60b567d`](https://github.com/Mic92/sops-nix/commit/b60b567d50e494edcd6cab19ae3d993ea84a77e4) | `` build(deps): bump github.com/Azure/azure-sdk-for-go/sdk/azidentity `` |