### PR TITLE
chore(flake/nur): `187e2a96` -> `202df7cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718156864,
-        "narHash": "sha256-DM9L3bzvZzRCzk6qqIygDwfptuwN2LnHBl972gpobyU=",
+        "lastModified": 1718160954,
+        "narHash": "sha256-Gk7gDW9yZ+zEOgyGQKqET9ExpyaS/CbBLgTHlT+7spk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "187e2a9691229d9b04502b688cae7dda1db6901b",
+        "rev": "202df7cb0231ef6cc664c1aa28b598c814afb324",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`202df7cb`](https://github.com/nix-community/NUR/commit/202df7cb0231ef6cc664c1aa28b598c814afb324) | `` automatic update `` |
| [`ea985888`](https://github.com/nix-community/NUR/commit/ea9858881579d1a9c819840857d312b1bfbc5869) | `` automatic update `` |