### PR TITLE
chore(flake/nur): `202df7cb` -> `709e2e33`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718160954,
-        "narHash": "sha256-Gk7gDW9yZ+zEOgyGQKqET9ExpyaS/CbBLgTHlT+7spk=",
+        "lastModified": 1718165045,
+        "narHash": "sha256-flNNxFLIAEvFEbpsDvp8YdkYs/P4BXU+CGSsY8Jy1LE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "202df7cb0231ef6cc664c1aa28b598c814afb324",
+        "rev": "709e2e33b0027bd47002d9fbedd4873a34ebeb45",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`709e2e33`](https://github.com/nix-community/NUR/commit/709e2e33b0027bd47002d9fbedd4873a34ebeb45) | `` automatic update `` |
| [`4bd37780`](https://github.com/nix-community/NUR/commit/4bd3778083cab86f130901b28cc508d2c602dd4a) | `` automatic update `` |
| [`b817839d`](https://github.com/nix-community/NUR/commit/b817839d9e694f40ff98c2f9999af4b8c9c68285) | `` automatic update `` |
| [`2d1d5dbe`](https://github.com/nix-community/NUR/commit/2d1d5dbecb744a207b751d40e5261222c85b565e) | `` automatic update `` |