### PR TITLE
chore(flake/nur): `709e2e33` -> `77ec5a12`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718165045,
-        "narHash": "sha256-flNNxFLIAEvFEbpsDvp8YdkYs/P4BXU+CGSsY8Jy1LE=",
+        "lastModified": 1718171044,
+        "narHash": "sha256-Edcw19o5Ek2759U34/2pnr5qP4nKWNXNnRrMsDQhnrE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "709e2e33b0027bd47002d9fbedd4873a34ebeb45",
+        "rev": "77ec5a12c93dbcae7c42151b2e74162954347764",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                            |
| -------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`77ec5a12`](https://github.com/nix-community/NUR/commit/77ec5a12c93dbcae7c42151b2e74162954347764) | `` automatic update ``             |
| [`ba3dbc87`](https://github.com/nix-community/NUR/commit/ba3dbc877d8c18a3376b2f12b04181b80702f9db) | `` add phandox/nur-package repo `` |
| [`48bac299`](https://github.com/nix-community/NUR/commit/48bac29969e0e9508f6a203f001fe606960cbacd) | `` automatic update ``             |
| [`4139f886`](https://github.com/nix-community/NUR/commit/4139f886685fa328fba267f131105e5bd15f70e2) | `` add sn0wm1x repository ``       |