### PR TITLE
chore(flake/nur): `77ec5a12` -> `103f678f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718171044,
-        "narHash": "sha256-Edcw19o5Ek2759U34/2pnr5qP4nKWNXNnRrMsDQhnrE=",
+        "lastModified": 1718174675,
+        "narHash": "sha256-iKwf2nm0sJT5yWGZTiMtbgzQNwbXjppN14c4CDddSLY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "77ec5a12c93dbcae7c42151b2e74162954347764",
+        "rev": "103f678f9fb92c35471fc8582974359d83398d1c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`103f678f`](https://github.com/nix-community/NUR/commit/103f678f9fb92c35471fc8582974359d83398d1c) | `` automatic update `` |