### PR TITLE
chore(flake/lanzaboote): `56ed078d` -> `b627ccd9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -459,11 +459,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1717943411,
-        "narHash": "sha256-43QN3+P7UjAz5ZjjUeYGKAyRfv6BLw7jjdc8Ric/6UQ=",
+        "lastModified": 1718178907,
+        "narHash": "sha256-eSZyrQ9uoPB9iPQ8Y5H7gAmAgAvCw3InStmU3oEjqsE=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "56ed078dc92baf72813d55dcfe399715a632bc41",
+        "rev": "b627ccd97d0159214cee5c7db1412b75e4be6086",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                        |
| --------------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`ce9c2a60`](https://github.com/nix-community/lanzaboote/commit/ce9c2a605c0ab19e3a3e25fbce1b6dfad18e3ac9) | `` treewide: 0.3.0 -> 0.4.1 `` |