### PR TITLE
chore(flake/nur): `103f678f` -> `a881f3b9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718174675,
-        "narHash": "sha256-iKwf2nm0sJT5yWGZTiMtbgzQNwbXjppN14c4CDddSLY=",
+        "lastModified": 1718189173,
+        "narHash": "sha256-PVau5Ijdz6DNjUUBpZ5QwygfyqiK+imr62q4+kxJkzo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "103f678f9fb92c35471fc8582974359d83398d1c",
+        "rev": "a881f3b94209d231585fba2c435ebe0437a6b217",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a881f3b9`](https://github.com/nix-community/NUR/commit/a881f3b94209d231585fba2c435ebe0437a6b217) | `` automatic update `` |
| [`4b71c3c6`](https://github.com/nix-community/NUR/commit/4b71c3c633d0a1784960a2350012dbb809bb4dac) | `` automatic update `` |
| [`92a8ef4b`](https://github.com/nix-community/NUR/commit/92a8ef4bafd7d01f491b722a291767242468bc12) | `` automatic update `` |
| [`c2f8a7fb`](https://github.com/nix-community/NUR/commit/c2f8a7fbf24d1164ab3ca05df4b4515a96974116) | `` automatic update `` |
| [`4b5cb23b`](https://github.com/nix-community/NUR/commit/4b5cb23bf23145600c6211d21d7647daea9fb4dd) | `` automatic update `` |
| [`503813f3`](https://github.com/nix-community/NUR/commit/503813f356c89ef9b136edd5410d3cc02610f158) | `` automatic update `` |