### PR TITLE
chore(flake/emacs-overlay): `1b9813a3` -> `7aa1c144`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1718157194,
-        "narHash": "sha256-LKRwoxzWIBzlkWHsYh5DknPmaFuHak6wAOibmPauRwA=",
+        "lastModified": 1718183320,
+        "narHash": "sha256-L0b6hyf9EWeWKhmUwTQvbLtBtLBblyYJ3llOTsLIr0s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1b9813a3822e4187f5a62c4a897ded4cdae5f648",
+        "rev": "7aa1c14402a09fc043110d6477aa5cc90e60e409",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`7aa1c144`](https://github.com/nix-community/emacs-overlay/commit/7aa1c14402a09fc043110d6477aa5cc90e60e409) | `` Updated emacs `` |
| [`c5bafd07`](https://github.com/nix-community/emacs-overlay/commit/c5bafd07d0c30da00a82880228008f00c1abb6f7) | `` Updated melpa `` |