### PR TITLE
chore(flake/nixpkgs): `c7b821ba` -> `57d6973a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1717974879,
-        "narHash": "sha256-GTO3C88+5DX171F/gVS3Qga/hOs/eRMxPFpiHq2t+D8=",
+        "lastModified": 1718160348,
+        "narHash": "sha256-9YrUjdztqi4Gz8n3mBuqvCkMo4ojrA6nASwyIKWMpus=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c7b821ba2e1e635ba5a76d299af62821cbcb09f3",
+        "rev": "57d6973abba7ea108bac64ae7629e7431e0199b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`900ad98d`](https://github.com/NixOS/nixpkgs/commit/900ad98d98ef554734d9c7d8afb3c2822e515e1d) | `` nom: 2.4.0 -> 2.5.0 ``                                                       |
| [`fd95d51c`](https://github.com/NixOS/nixpkgs/commit/fd95d51c69b26b3b3d29f4b89f5d44ca51eb50db) | `` go-ethereum: 1.14.4 -> 1.14.5 ``                                             |
| [`af47703d`](https://github.com/NixOS/nixpkgs/commit/af47703d0de0eacd7c0e992bd51daf5d4eeda3aa) | `` eksctl: 0.181.0 -> 0.182.0 ``                                                |
| [`9a253813`](https://github.com/NixOS/nixpkgs/commit/9a2538136cf04465564319744f3c91028750b2c5) | `` trealla: 2.52.15 -> 2.52.18 ``                                               |
| [`a05ca142`](https://github.com/NixOS/nixpkgs/commit/a05ca14296d182b3d994032327fd18c0ce355396) | `` notesnook: 3.0.6 -> 3.0.8 (#318422) ``                                       |
| [`5c8235e0`](https://github.com/NixOS/nixpkgs/commit/5c8235e0e738b9d02f64ff1edb0fa9183de20e36) | `` python311Packages.tox: 4.15.0 -> 4.15.1 ``                                   |
| [`e111ee8f`](https://github.com/NixOS/nixpkgs/commit/e111ee8f4672e173588af0a2f378ad1cf8a87c34) | `` ctrtool: 0.7 -> 1.2.0 ``                                                     |
| [`93908113`](https://github.com/NixOS/nixpkgs/commit/93908113cbe1c10b685f9bc81d1ec3718342edd2) | `` xidel: Set platforms to platforms.all ``                                     |
| [`6fe3f6bf`](https://github.com/NixOS/nixpkgs/commit/6fe3f6bf8418207eb48944797c6867d1e46ae8a6) | `` blade-formatter: init at 1.41.1 ``                                           |
| [`7ce0c7ab`](https://github.com/NixOS/nixpkgs/commit/7ce0c7abf814852a2e2831da198e1b44dac7c54f) | `` doc: use linuxPackages_custom instead of linuxManualConfig (#319046) ``      |
| [`f8b1f5b2`](https://github.com/NixOS/nixpkgs/commit/f8b1f5b2e165c9d2655ae21615abc2b0e98f1847) | `` python311Packages.gradio: 4.36.0 -> 4.36.1 ``                                |
| [`944eda37`](https://github.com/NixOS/nixpkgs/commit/944eda37f232a22f11c94d738e33e7aca990cfea) | `` vivaldi: 6.7.3329.35 -> 6.7.3329.41 ``                                       |
| [`63058b05`](https://github.com/NixOS/nixpkgs/commit/63058b05311cb344e775b98b9c248b6711edaefd) | `` igvm-tooling: remove accidentally committed log file ``                      |
| [`8b951b9c`](https://github.com/NixOS/nixpkgs/commit/8b951b9cb19a6d589a0c1ac178e50d0874d911d1) | `` centerpiece: add friedow as a maintainer ``                                  |
| [`340f6b83`](https://github.com/NixOS/nixpkgs/commit/340f6b83f187e1f8cb4b69b727ec978e23c86a74) | `` maintainers: add friedow as a maintainer ``                                  |
| [`b79dc362`](https://github.com/NixOS/nixpkgs/commit/b79dc362ea62419fecc9380ad0f924f6458ea2ab) | `` atuin: 18.2.0 -> 18.3.0 ``                                                   |
| [`4698562b`](https://github.com/NixOS/nixpkgs/commit/4698562bf4b7fff5932a0bcb6a194adbe55b32d1) | `` quarkus: 3.11.0 -> 3.11.1 ``                                                 |
| [`f2008d42`](https://github.com/NixOS/nixpkgs/commit/f2008d42983d9e510564f9242de979ab8672e8f2) | `` _0xproto: 2.000 -> 2.100 ``                                                  |
| [`dd8e2c72`](https://github.com/NixOS/nixpkgs/commit/dd8e2c72ad9a3fcaf9b32a80a08010ab6ce3f601) | `` nixosTests.renovate: init vm test ``                                         |
| [`0adb3b80`](https://github.com/NixOS/nixpkgs/commit/0adb3b8033b4b5095103ae01a384733599638d45) | `` nixos/renovate: init ``                                                      |
| [`1032df05`](https://github.com/NixOS/nixpkgs/commit/1032df05d070c7102304f71930b39c505ea226d6) | `` luaPackages.neotest: disable tests on darwin ``                              |
| [`accc33c0`](https://github.com/NixOS/nixpkgs/commit/accc33c07d754517a6f2df510c41580015253762) | `` peertube: parallelize gzip and brotli step (#319092) ``                      |
| [`ed985cf5`](https://github.com/NixOS/nixpkgs/commit/ed985cf5554a16b9f2c3e7c9831bf1579a58fea8) | `` yanic: 1.5.0 -> 1.5.2 ``                                                     |
| [`db1f59ac`](https://github.com/NixOS/nixpkgs/commit/db1f59ac701c9bb22c3ed0bd7114803d0d050000) | `` pmtiles: 1.19.2 -> 1.20.0 ``                                                 |
| [`3b16b337`](https://github.com/NixOS/nixpkgs/commit/3b16b337a01b000da32c6154b9c30cd3da868afd) | `` python311Packages.langchain: remove extra-dependencies ``                    |
| [`7e0f252b`](https://github.com/NixOS/nixpkgs/commit/7e0f252b93f3a036df2d101f246b7f0d1283505b) | `` python311Packages.langchain-core: add comment for disabled tests ``          |
| [`8370411e`](https://github.com/NixOS/nixpkgs/commit/8370411eea14e7e5941f87ab1fa1dc888ab32917) | `` highs: 1.7.0 -> 1.7.1 ``                                                     |
| [`5d726a8e`](https://github.com/NixOS/nixpkgs/commit/5d726a8e5711e2101804cd02767ea73f9d8bcd91) | `` qownnotes: 24.6.0 -> 24.6.1 ``                                               |
| [`ffa85ff3`](https://github.com/NixOS/nixpkgs/commit/ffa85ff3946c19e17026f1f2f720099078889348) | `` goreleaser: 2.0.0 -> 2.0.1 ``                                                |
| [`59f33637`](https://github.com/NixOS/nixpkgs/commit/59f3363718d976f69d1d5c5ef4c6b2f8e4d5474b) | `` uv: 0.2.9 -> 0.2.10 ``                                                       |
| [`604ff7b6`](https://github.com/NixOS/nixpkgs/commit/604ff7b6e7f9b9691c57c53e71bda907a8e4a26e) | `` packwiz: unstable-2023-08-28 -> 0-unstable-2024-05-27 ``                     |
| [`319c97cf`](https://github.com/NixOS/nixpkgs/commit/319c97cfcb0fbf1f2dfd5b48d68d2fa0c62ac63d) | `` nixos/nvidia: fix eval with virtualisation.docker.enableNvidia enabled ``    |
| [`cefbadfd`](https://github.com/NixOS/nixpkgs/commit/cefbadfd3b0ac49e5cbea0d25d7e2d6922be1fe9) | `` devenv: 1.0.5 -> 1.0.6 ``                                                    |
| [`893a4fee`](https://github.com/NixOS/nixpkgs/commit/893a4feeb5749f2072a6ec58ccfe722cd49f7458) | `` dune3d: fix darwin build ``                                                  |
| [`4c69e1f7`](https://github.com/NixOS/nixpkgs/commit/4c69e1f7284626d5c35c935e5610a6a25c6d8289) | `` rasm: 2.2.4 -> 2.2.5 ``                                                      |
| [`88eaf20b`](https://github.com/NixOS/nixpkgs/commit/88eaf20bdb969995dd400d104e4d786e94f825f4) | `` earthly: 0.8.13 -> 0.8.14 ``                                                 |
| [`cc0447ed`](https://github.com/NixOS/nixpkgs/commit/cc0447ed7b84ecde93842f729113269b3e5d1d1d) | `` TiDB: 7.4.0 -> 8.1.0 ``                                                      |
| [`c8364d29`](https://github.com/NixOS/nixpkgs/commit/c8364d29eadefdad1ab092ee69b64214647c5ab2) | `` kubecm: Add meta.mainProgram ``                                              |
| [`0fe724dc`](https://github.com/NixOS/nixpkgs/commit/0fe724dc08c15037673bc49acfbb59c12eddd68c) | `` ocis-bin: 5.0.1 -> 5.0.5 ``                                                  |
| [`15427ed7`](https://github.com/NixOS/nixpkgs/commit/15427ed7cd752ac09afc20c979b7aa543035c647) | `` ocamlPackages.memprof-limits: init at 0.2.1 (#318800) ``                     |
| [`f53d6a0d`](https://github.com/NixOS/nixpkgs/commit/f53d6a0d9e0b1c0183782cb3264f4d8c5a52225a) | `` emacsPackages.ebuild-mode: 1.70 -> 1.71 ``                                   |
| [`de9a49c3`](https://github.com/NixOS/nixpkgs/commit/de9a49c390e6793af604c9a05f8c7015aff32903) | `` buildRustCrate: extensions.sharedLibrary -> extensions.library ``            |
| [`fdb30ac7`](https://github.com/NixOS/nixpkgs/commit/fdb30ac70277a43d1d0e5c17bf411ce6145dd803) | `` molbar: init at 1.1.1 ``                                                     |
| [`5dbdd6f6`](https://github.com/NixOS/nixpkgs/commit/5dbdd6f664c6729664612a8e53d15d568d8ce9a5) | `` python3.pkgs.dscribe: init at 2.1.1 ``                                       |
| [`c570c7fc`](https://github.com/NixOS/nixpkgs/commit/c570c7fcf6190b955084c49bf8228076bfa0db31) | `` calibre: 7.11.0 -> 7.12.0 ``                                                 |
| [`d488acce`](https://github.com/NixOS/nixpkgs/commit/d488acce882e18b6e846797a252b0d11d0cc9597) | `` woodpecker-pipeline-transform: move to pkgs/by-name ``                       |
| [`14c57ce7`](https://github.com/NixOS/nixpkgs/commit/14c57ce7f7c207072ed895c2fad06ef2b2ca1ca3) | `` nixos/public-inbox: make coderepo paths accessible ``                        |
| [`9f488f27`](https://github.com/NixOS/nixpkgs/commit/9f488f27d76140590253896b1a1b85a6b98d01f2) | `` nixos/initrd-ssh: Fix ignoreEmptyHostKeys description ``                     |
| [`f9f62ecf`](https://github.com/NixOS/nixpkgs/commit/f9f62ecf473fc9ebb1add7592635354675f61629) | `` findex: orphan package ``                                                    |
| [`6a83951e`](https://github.com/NixOS/nixpkgs/commit/6a83951e8a77cab1db686a3c8a5b7836d1f46736) | `` woodpecker-pipeline-transform: 0.1.1 → 0.2.0 ``                              |
| [`5aa41078`](https://github.com/NixOS/nixpkgs/commit/5aa410781a41ea9049074f762ade2e2703010ca7) | `` oh-my-posh: 21.0.1 -> 21.3.0 ``                                              |
| [`edd19efe`](https://github.com/NixOS/nixpkgs/commit/edd19efe4ec151cf5a95ae66de86c299dcb2da4b) | `` nixos/shadow: clean up module ``                                             |
| [`72577725`](https://github.com/NixOS/nixpkgs/commit/725777250b7d55d3069abf09f25cb489eb634c7d) | `` nixos/shadow: introduce security.shadow.enable ``                            |
| [`8a998edc`](https://github.com/NixOS/nixpkgs/commit/8a998edc8254967a58c1c9015717198e5ea1cd4c) | `` igvm-tooling: 1.5.0 -> 1.5.0-unstable-2024-06-06 ``                          |
| [`629c05b9`](https://github.com/NixOS/nixpkgs/commit/629c05b967cf34b735d665bd6448c66fcd9ee95e) | `` zabbix-agent2-plugin-postgresql: 6.4.14 -> 6.4.15 ``                         |
| [`9ff9bbdb`](https://github.com/NixOS/nixpkgs/commit/9ff9bbdb34236dc00362a81da5d8985d275633d1) | `` doc: add stdenv passthru chapter (#315909) ``                                |
| [`aa11c688`](https://github.com/NixOS/nixpkgs/commit/aa11c688c0a65b4d1a059e770360ad508575d1e6) | `` galene: 0.8.2 -> 0.9 ``                                                      |
| [`777f234f`](https://github.com/NixOS/nixpkgs/commit/777f234f09b4ebb30789e64fb2dd75f732e0ca0f) | `` dprint: 0.46.1 -> 0.46.2 ``                                                  |
| [`d7fb6a3c`](https://github.com/NixOS/nixpkgs/commit/d7fb6a3c961b20dde4ad8801db54baa683979769) | `` tmsu: migrate to buildGoModule ``                                            |
| [`de7943c9`](https://github.com/NixOS/nixpkgs/commit/de7943c94280d85b918302757c48a4c908620791) | `` tsmu: move to pkgs/by-name ``                                                |
| [`5f6c2b2b`](https://github.com/NixOS/nixpkgs/commit/5f6c2b2b23f5a720354f196f42fe62a9272e62f5) | `` dune3d: refactor ``                                                          |
| [`eabc38de`](https://github.com/NixOS/nixpkgs/commit/eabc38dee86bc951916e722015ab4960268225f7) | `` vimPlugins.nvim-treesitter: update grammars ``                               |
| [`641141a7`](https://github.com/NixOS/nixpkgs/commit/641141a7a72cc728eaee029e12c099a2755dff30) | `` vimPlugins: resolve github repository redirects ``                           |
| [`788939c1`](https://github.com/NixOS/nixpkgs/commit/788939c1ae57e9a58dd4ed3d6b9e8209241d0606) | `` vimPlugins: update on 2024-06-11 ``                                          |
| [`942e3019`](https://github.com/NixOS/nixpkgs/commit/942e30199856da87aedc7c6c825b837e9f6fd626) | `` open-webui: add missing `pydub` dependency ``                                |
| [`25896de3`](https://github.com/NixOS/nixpkgs/commit/25896de3cbcebc98a3a32d47bf2e1480b538a24a) | `` python3Packages.meshtastic: add missing dep, unbreak ``                      |
| [`07fd30b4`](https://github.com/NixOS/nixpkgs/commit/07fd30b47a221117ac3387f612b180440ffa587e) | `` fastly: 10.12.0 -> 10.12.1 ``                                                |
| [`63ac8f59`](https://github.com/NixOS/nixpkgs/commit/63ac8f5915054fba2f7aaaa31112604fefa15e94) | `` waylyrics: 0.3.10 -> 0.3.11 ``                                               |
| [`23930cb8`](https://github.com/NixOS/nixpkgs/commit/23930cb86701bc673fb6c8615a5c9a4fc19ab87e) | `` containerpilot: remove ``                                                    |
| [`cbf8486a`](https://github.com/NixOS/nixpkgs/commit/cbf8486ad3e7f023bebf8b52c9a11af63eb0614d) | `` open-webui: 0.2.5 -> 0.3.2 ``                                                |
| [`2c00323a`](https://github.com/NixOS/nixpkgs/commit/2c00323a32b54272c62f2c044a3123f8992bd317) | `` python312Packages.resend: 2.0.0 -> 2.1.0 ``                                  |
| [`9ec35ed3`](https://github.com/NixOS/nixpkgs/commit/9ec35ed3c1bb668b84c8802d5731058fb79c0b8e) | `` python312Packages.routeros-api: 0.17.0 -> 0.18.1 ``                          |
| [`6cfdf142`](https://github.com/NixOS/nixpkgs/commit/6cfdf142df3be04e110709af9ae2a3931088e612) | `` python312Packages.yfinance: 0.2.38 -> 0.2.40 ``                              |
| [`b82df881`](https://github.com/NixOS/nixpkgs/commit/b82df881636380d673638ae217279803f5d05216) | `` python312Packages.whirlpool-sixth-sense: 0.18.8 -> 0.18.9 ``                 |
| [`a1672c98`](https://github.com/NixOS/nixpkgs/commit/a1672c9877a3c506068be0e396437f5fc075a86e) | `` gnu-efi: add primary consumers to passthru.tests ``                          |
| [`cae5fb3e`](https://github.com/NixOS/nixpkgs/commit/cae5fb3e5cf2d28dd8b4d457d9e921a2877febf7) | `` syslinux: pick proposed patch to fix build on gnu-efi >= 3.0.17 ``           |
| [`51194634`](https://github.com/NixOS/nixpkgs/commit/51194634adb83c0f03a2b86bd8bd4188377b6ac6) | `` aws-env: drop ``                                                             |
| [`ec74c638`](https://github.com/NixOS/nixpkgs/commit/ec74c63861e4a10f0fc6d2a1ae142ed47469c382) | `` python312Packages.nbxmpp: 4.5.4 -> 5.0.0, gajim: 1.8.4 -> 1.9.0 (#318836) `` |
| [`0c135894`](https://github.com/NixOS/nixpkgs/commit/0c135894544c9d4368de878f738037d48ee1b7bb) | `` traefik: 3.0.1 -> 3.0.2 ``                                                   |
| [`9a5fbbc1`](https://github.com/NixOS/nixpkgs/commit/9a5fbbc13786847865088eb39a8de106e461a63b) | `` fzf-make: 0.32.0 -> 0.33.0 ``                                                |
| [`7d6168e8`](https://github.com/NixOS/nixpkgs/commit/7d6168e86c517258c586b612fc0e0a8f2bf55c9c) | `` k3sup: 0.13.5 -> 0.13.6 ``                                                   |
| [`88c080af`](https://github.com/NixOS/nixpkgs/commit/88c080afa6f9933f18d874c142793bcb51563e2e) | `` fn-cli: 0.6.33 -> 0.6.34 ``                                                  |
| [`95191c67`](https://github.com/NixOS/nixpkgs/commit/95191c6702d801bb9cdcf74814ee617820b6962c) | `` rke: 1.5.9 -> 1.5.10 ``                                                      |
| [`3bf5e35f`](https://github.com/NixOS/nixpkgs/commit/3bf5e35facf7127fdad14b8882df4105fc6af0d8) | `` pulumi-esc: 0.9.0 -> 0.9.1 ``                                                |
| [`a1545af0`](https://github.com/NixOS/nixpkgs/commit/a1545af0075cff12ed03453df998e055ed3974ef) | `` kittysay: 0.6.0 -> 0.8.0 ``                                                  |
| [`77665dc3`](https://github.com/NixOS/nixpkgs/commit/77665dc3548eeb9434de61df07530081e5c80931) | `` jsoncons: 0.175.0 -> 0.176.0 ``                                              |
| [`1acb905d`](https://github.com/NixOS/nixpkgs/commit/1acb905d8b9889b8e1ce22cc65829599aa5fb86f) | `` jumppad: 0.11.1 -> 0.11.2 ``                                                 |
| [`b5b35e4c`](https://github.com/NixOS/nixpkgs/commit/b5b35e4c048a7f85c8e46a9c590214fc3a2bb5dc) | `` louvre: 1.2.1-2 -> 2.0.0-1 ``                                                |
| [`c7e43f04`](https://github.com/NixOS/nixpkgs/commit/c7e43f04ebb9e62a1f49d99ceb91d24dca4845e3) | `` ferium: 4.5.2 -> 4.6.0 ``                                                    |
| [`03fa5453`](https://github.com/NixOS/nixpkgs/commit/03fa5453b8419c010770de79ea1897d3e09ad1ec) | `` newman: 6.1.2 -> 6.1.3 ``                                                    |
| [`9a21fd9c`](https://github.com/NixOS/nixpkgs/commit/9a21fd9ceff81ed339e5e975bbb11f76a702f654) | `` hercules-ci-agent: fix justStaticExecutables on aarch64-darwin ``            |
| [`8d305db7`](https://github.com/NixOS/nixpkgs/commit/8d305db7375072a6b63fff7db666cc89c8381acd) | `` cargo-workspaces: 0.3.1 -> 0.3.2 ``                                          |
| [`890603e2`](https://github.com/NixOS/nixpkgs/commit/890603e27f1b599da1fbabbb057b9820b51758fa) | `` cargo-rdme: 1.4.3 -> 1.4.4 ``                                                |
| [`3b8aed7d`](https://github.com/NixOS/nixpkgs/commit/3b8aed7da723872c637550c1742b82a2148bb333) | `` telegraf: 1.30.3 -> 1.31.0 ``                                                |
| [`38108805`](https://github.com/NixOS/nixpkgs/commit/38108805dac5a49526bc06032984482e5f38c81e) | `` xscreensaver: 6.08 -> 6.09 ``                                                |
| [`6c51e12b`](https://github.com/NixOS/nixpkgs/commit/6c51e12bfd710bf0f0235db11d50929af051726e) | `` cppreference-doc: 20230810 -> 20240610 ``                                    |
| [`83d7b12b`](https://github.com/NixOS/nixpkgs/commit/83d7b12b432eac338a242e7f8eacc9a620a85394) | `` claws-mail: 4.2.0 -> 4.3.0 ``                                                |
| [`ce220c22`](https://github.com/NixOS/nixpkgs/commit/ce220c2230de27ba26488d4fe1994ee20008e34b) | `` bore-cli: 0.5.0 -> 0.5.1 ``                                                  |
| [`8aeb30ae`](https://github.com/NixOS/nixpkgs/commit/8aeb30ae73b20a53422fa3190d64e7e7b692ee79) | `` php.packages.composer: 2.7.6 -> 2.7.7 (#318910) ``                           |