### PR TITLE
chore(flake/nur): `a881f3b9` -> `b0b498f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718189173,
-        "narHash": "sha256-PVau5Ijdz6DNjUUBpZ5QwygfyqiK+imr62q4+kxJkzo=",
+        "lastModified": 1718204008,
+        "narHash": "sha256-rPyGNXZtWquP3HkZU5REnIuCgLdKmFPExm29pBtXGjo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a881f3b94209d231585fba2c435ebe0437a6b217",
+        "rev": "b0b498f819352d922f8d4e4d6ac0b0fe094ad687",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b0b498f8`](https://github.com/nix-community/NUR/commit/b0b498f819352d922f8d4e4d6ac0b0fe094ad687) | `` automatic update `` |
| [`f2fe9f51`](https://github.com/nix-community/NUR/commit/f2fe9f517de74059cc7dd9d9be9c2dd4858ea0da) | `` automatic update `` |