### PR TITLE
chore(flake/lanzaboote): `f93f71dd` -> `7cb05fab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -459,11 +459,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1718212504,
-        "narHash": "sha256-N5Oagzm0EAAZ2j9k5l/1BRYTErfYtJjqOKDPeMQE3iQ=",
+        "lastModified": 1718218065,
+        "narHash": "sha256-fKC7Ryg3AYykDrS2ilS1VqA8/9B2m3yFZcshK+7tIEc=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "f93f71dd12d925c860cc22a4bc997a1dfdfb8705",
+        "rev": "7cb05fab896bd542c0ca4260d74d9d664cd7b56e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                           |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`b92cf84a`](https://github.com/nix-community/lanzaboote/commit/b92cf84a064921e8b3b398bab977b1d6f4b0bafe) | `` treewide: add sort-key support ``              |
| [`41583aad`](https://github.com/nix-community/lanzaboote/commit/41583aadc52c7d6ba06b26350610ef00f64b8761) | `` tests: set default boot loader timeout to 0 `` |
| [`ff858022`](https://github.com/nix-community/lanzaboote/commit/ff85802227a9693fb58f1a06713d5e3d2e28ea90) | `` tool: reorganize integration tests ``          |