### PR TITLE
chore(flake/nur): `9edb0516` -> `5af628cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718221614,
-        "narHash": "sha256-yfYrqKVECU4XBi1q8u7DaEK0QcDQMfjY5/dGeALv4dg=",
+        "lastModified": 1718241676,
+        "narHash": "sha256-BfueLvv7VwzxL3rcOvV7ei3GeBeK5NP1HAo1rKjufGE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9edb05163b86238999c6f6cab06c193e4de951f8",
+        "rev": "5af628cc250dc4ae3329e6beb1d78b76f8afc44b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5af628cc`](https://github.com/nix-community/NUR/commit/5af628cc250dc4ae3329e6beb1d78b76f8afc44b) | `` automatic update `` |
| [`fd7fccf0`](https://github.com/nix-community/NUR/commit/fd7fccf0acd6f92c0fcd58c3ae5c8edf3c2520f3) | `` automatic update `` |