### PR TITLE
chore(flake/srvos): `4098b95d` -> `d6280e5c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -951,11 +951,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718036376,
-        "narHash": "sha256-6hC1LrzXihZ/Tf7YNvICYUFHH+MvuXvpX8uV0hI5/6s=",
+        "lastModified": 1718239576,
+        "narHash": "sha256-Afdz9oCQf8VCGXUhI8KxdJg9gc+fepZK//mYsijfhFw=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "4098b95dde07ec1ef75cd2cba1ebdde0576b59f1",
+        "rev": "d6280e5c12c4ddb26f0807387777786c66e4c552",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`d6280e5c`](https://github.com/nix-community/srvos/commit/d6280e5c12c4ddb26f0807387777786c66e4c552) | `` dev/private/flake.lock: Update `` |
| [`66c2901c`](https://github.com/nix-community/srvos/commit/66c2901cd70267132f8d51a74dd68ad31c623323) | `` flake.lock: Update ``             |