### PR TITLE
chore(flake/nur): `5af628cc` -> `efb736f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718241676,
-        "narHash": "sha256-BfueLvv7VwzxL3rcOvV7ei3GeBeK5NP1HAo1rKjufGE=",
+        "lastModified": 1718244470,
+        "narHash": "sha256-VuSdCQASqf2YgLYdRopODXN6a5V9b9lRvxEPfAf8+oA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5af628cc250dc4ae3329e6beb1d78b76f8afc44b",
+        "rev": "efb736f96038ed8811ff6d3e77a0bed06c6a5d3a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`efb736f9`](https://github.com/nix-community/NUR/commit/efb736f96038ed8811ff6d3e77a0bed06c6a5d3a) | `` automatic update `` |