### PR TITLE
chore(flake/nur): `efb736f9` -> `43f1006c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718244470,
-        "narHash": "sha256-VuSdCQASqf2YgLYdRopODXN6a5V9b9lRvxEPfAf8+oA=",
+        "lastModified": 1718249997,
+        "narHash": "sha256-dk5vwtdFkPv15KQWalTpWvGMkceNYeNj2BYKIkX100Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "efb736f96038ed8811ff6d3e77a0bed06c6a5d3a",
+        "rev": "43f1006ccff076f50097497e5526dc3eec22d006",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`43f1006c`](https://github.com/nix-community/NUR/commit/43f1006ccff076f50097497e5526dc3eec22d006) | `` automatic update `` |
| [`6b362288`](https://github.com/nix-community/NUR/commit/6b3622889d4bad7a23c3c3995dd93d477f7ee4e2) | `` automatic update `` |
| [`5c7e5270`](https://github.com/nix-community/NUR/commit/5c7e5270b69dae9673ec211372151640b7419118) | `` automatic update `` |