### PR TITLE
chore(flake/nur): `43f1006c` -> `e17aa7ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718249997,
-        "narHash": "sha256-dk5vwtdFkPv15KQWalTpWvGMkceNYeNj2BYKIkX100Q=",
+        "lastModified": 1718251446,
+        "narHash": "sha256-sdULXXCTCKVXA2SG9JkrxEYLB2PRlWeELPMxpBixQbU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "43f1006ccff076f50097497e5526dc3eec22d006",
+        "rev": "e17aa7efca8221ce9d9ee3843401e5525a4d3b70",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e17aa7ef`](https://github.com/nix-community/NUR/commit/e17aa7efca8221ce9d9ee3843401e5525a4d3b70) | `` automatic update `` |