### PR TITLE
chore(flake/nur): `e17aa7ef` -> `2fe639ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718251446,
-        "narHash": "sha256-sdULXXCTCKVXA2SG9JkrxEYLB2PRlWeELPMxpBixQbU=",
+        "lastModified": 1718261196,
+        "narHash": "sha256-1Yh7sT4ztKbPSxpyRdlOSy7PkQo6joM8oTsON14fWfU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e17aa7efca8221ce9d9ee3843401e5525a4d3b70",
+        "rev": "2fe639ef4c8286046c926566ee5a069c718aee3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2fe639ef`](https://github.com/nix-community/NUR/commit/2fe639ef4c8286046c926566ee5a069c718aee3e) | `` automatic update `` |