### PR TITLE
chore(flake/nixos-hardware): `9e848e17` -> `d7500313`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -627,11 +627,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1718207430,
-        "narHash": "sha256-/eO2NTRvrrdYWMI06plS8ANDGOhTZBA+C3H3KwbBI1w=",
+        "lastModified": 1718265846,
+        "narHash": "sha256-h4MnTID6ciFxtTvtl+ibXMKaG6iLMezCtUvKIfFG7r0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "9e848e173ca83adf884815c66edc08652ef9ade8",
+        "rev": "d75003136c0fc94ee60e51806c2801ff572d06a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                  |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`d7500313`](https://github.com/NixOS/nixos-hardware/commit/d75003136c0fc94ee60e51806c2801ff572d06a6) | `` framework: Better firmware update instructions and troubleshooting `` |