### PR TITLE
chore(flake/nur): `d92ab8b1` -> `cda88f28`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718296741,
-        "narHash": "sha256-8nybMpOymJSDfrV7MiCOY7ROFc+nyo2wJ/0VmL+ZyNo=",
+        "lastModified": 1718308742,
+        "narHash": "sha256-vPjqNPoGOA3Ybk0nPw7Crwn1g4VBk4TUasCEJ0dngVE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d92ab8b18aa8c6936b946c344df34efc4fc73141",
+        "rev": "cda88f28c76d44b19ba894aecd18da5e0bca37e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                                          |
| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`cda88f28`](https://github.com/nix-community/NUR/commit/cda88f28c76d44b19ba894aecd18da5e0bca37e0) | `` move repo back to github, since other forges do not seem to be implemented `` |
| [`ab6a53f6`](https://github.com/nix-community/NUR/commit/ab6a53f69d8baa1b454fecffb271015588466e51) | `` automatic update ``                                                           |