### PR TITLE
chore(flake/nur): `cda88f28` -> `ca312c14`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718308742,
-        "narHash": "sha256-vPjqNPoGOA3Ybk0nPw7Crwn1g4VBk4TUasCEJ0dngVE=",
+        "lastModified": 1718310343,
+        "narHash": "sha256-jD2XqvofA5hdROv8OSTss/vjJi164Mjavgh2yJf2ej4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cda88f28c76d44b19ba894aecd18da5e0bca37e0",
+        "rev": "ca312c14ad9abbb8736b9f9fd6fa8b8f60b2f1b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ca312c14`](https://github.com/nix-community/NUR/commit/ca312c14ad9abbb8736b9f9fd6fa8b8f60b2f1b2) | `` automatic update `` |