### PR TITLE
chore(flake/nur): `ff136f03` -> `979427e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718323718,
-        "narHash": "sha256-9rL8gsL+mn79q9YBINZB+RtdHW5rQK2fH1qlCzOe8pQ=",
+        "lastModified": 1718329671,
+        "narHash": "sha256-iiALsbdCLU0xkIhFj9riSlHceaX8UvdLl894sb8uPsg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ff136f03422e271c38bc0c3c22a6a19f7bff3442",
+        "rev": "979427e942f96d90eb949a0bf82e9f1d86a06ecf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`979427e9`](https://github.com/nix-community/NUR/commit/979427e942f96d90eb949a0bf82e9f1d86a06ecf) | `` automatic update `` |