### PR TITLE
chore(flake/catppuccin): `d34a94a1` -> `9086d390`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1718178283,
-        "narHash": "sha256-Syt2bvPvzcdx+VQEXckhfLw96Q2yY++vw0wHQK1NkhQ=",
+        "lastModified": 1718332233,
+        "narHash": "sha256-rY3CkOIV17tUQwa8gzPUwYsIkQdpe0NZxoSaMkw1el0=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "d34a94a17c6ec4a0c4e24b3e4336ea504d021f6d",
+        "rev": "9086d390586b546bbfe6f4233699a95d4faedca6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                   |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`9086d390`](https://github.com/catppuccin/nix/commit/9086d390586b546bbfe6f4233699a95d4faedca6) | `` chore(modules): update ports (#227) `` |