### PR TITLE
chore(flake/nur): `979427e9` -> `6a09d5a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718329671,
-        "narHash": "sha256-iiALsbdCLU0xkIhFj9riSlHceaX8UvdLl894sb8uPsg=",
+        "lastModified": 1718337354,
+        "narHash": "sha256-gbkVNpb2cnt5uVrxWykzIO4xCC/FtUhtKNPJ/792Uh8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "979427e942f96d90eb949a0bf82e9f1d86a06ecf",
+        "rev": "6a09d5a34d9f535b2b03c62ea6e4b23d12d5ea83",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6a09d5a3`](https://github.com/nix-community/NUR/commit/6a09d5a34d9f535b2b03c62ea6e4b23d12d5ea83) | `` automatic update `` |
| [`a9d055ec`](https://github.com/nix-community/NUR/commit/a9d055ecf36fe21b3d2e2a01803d64244dd4bd4f) | `` automatic update `` |