### PR TITLE
chore(flake/catppuccin): `9086d390` -> `73e06d5b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1718332233,
-        "narHash": "sha256-rY3CkOIV17tUQwa8gzPUwYsIkQdpe0NZxoSaMkw1el0=",
+        "lastModified": 1718339789,
+        "narHash": "sha256-Q3fgY7huFE+uaw7BNsAl1x+FvjDAi3EDWPnlALJt5pM=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "9086d390586b546bbfe6f4233699a95d4faedca6",
+        "rev": "73e06d5bd7ed34bdd0168030893ef8364fdc1d4a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                     |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`73e06d5b`](https://github.com/catppuccin/nix/commit/73e06d5bd7ed34bdd0168030893ef8364fdc1d4a) | `` chore: update dev flake inputs (#226) `` |