### PR TITLE
chore(flake/nur): `6a09d5a3` -> `0cd060f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718337354,
-        "narHash": "sha256-gbkVNpb2cnt5uVrxWykzIO4xCC/FtUhtKNPJ/792Uh8=",
+        "lastModified": 1718343604,
+        "narHash": "sha256-RcDCVKrw+AUHHkxBf/fetMOWECKVovV6RMKnXRZ7zBM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6a09d5a34d9f535b2b03c62ea6e4b23d12d5ea83",
+        "rev": "0cd060f561047f4639639b0c21934312aff06de6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0cd060f5`](https://github.com/nix-community/NUR/commit/0cd060f561047f4639639b0c21934312aff06de6) | `` automatic update `` |
| [`0ef9c5ed`](https://github.com/nix-community/NUR/commit/0ef9c5ede0ed044be738087bedbcc161f92b1d48) | `` automatic update `` |