### PR TITLE
chore(flake/darwin): `b2ee0b3c` -> `ff988d78`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -104,11 +104,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718305085,
-        "narHash": "sha256-Ft0v0tbnNeWqYuZT68z9nuyJO2N8V7Xf65MiZbeWv4A=",
+        "lastModified": 1718345812,
+        "narHash": "sha256-FJhA+YFsOFrAYe6EaiTEfomNf7jeURaPiG5/+a3DRSc=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "b2ee0b3c03b06bd70e4280c65ab8803c3456bb0f",
+        "rev": "ff988d78f2f55641efacdf9a585d2937f7e32a9b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                          |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`2406909d`](https://github.com/LnL7/nix-darwin/commit/2406909d7a2aa50f907a82e553d6e923814e978a) | `` Reapply "eval-config: set `class`" ``         |
| [`53992709`](https://github.com/LnL7/nix-darwin/commit/5399270903f6e95e5a5b083391e910dfed226f3a) | `` treewide: remove shims for Nixpkgs ≤ 23.05 `` |
| [`cbde36ce`](https://github.com/LnL7/nix-darwin/commit/cbde36ce624cfc7009b6f8a5970bf7a57580ef07) | `` readme: update stable Nixpkgs to 24.05 ``     |
| [`be18b76f`](https://github.com/LnL7/nix-darwin/commit/be18b76f8df1b173ef1646be5ae060d44a37f1d1) | `` flake.lock: update ``                         |