### PR TITLE
chore(flake/nur): `0cd060f5` -> `59128780`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718343604,
-        "narHash": "sha256-RcDCVKrw+AUHHkxBf/fetMOWECKVovV6RMKnXRZ7zBM=",
+        "lastModified": 1718346966,
+        "narHash": "sha256-GGBfNB32Ejivv3jmWmtKv6g+KibPRccM3gQyUTvqM2A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0cd060f561047f4639639b0c21934312aff06de6",
+        "rev": "591287807aec3143bc822d56a3d6ee0f22337a95",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`59128780`](https://github.com/nix-community/NUR/commit/591287807aec3143bc822d56a3d6ee0f22337a95) | `` automatic update `` |