### PR TITLE
chore(flake/nixos-hardware): `d7500313` -> `ae5c8dcc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -627,11 +627,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1718265846,
-        "narHash": "sha256-h4MnTID6ciFxtTvtl+ibXMKaG6iLMezCtUvKIfFG7r0=",
+        "lastModified": 1718349360,
+        "narHash": "sha256-SuPne4BMqh9/IkKIAG47Cu5qfmntAaqlHdX1yuFoDO0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "d75003136c0fc94ee60e51806c2801ff572d06a6",
+        "rev": "ae5c8dcc4d0182d07d75df2dc97112de822cb9d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                  |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`ae5c8dcc`](https://github.com/NixOS/nixos-hardware/commit/ae5c8dcc4d0182d07d75df2dc97112de822cb9d6) | `` fix unbalanced quoting ``             |
| [`62d41cb4`](https://github.com/NixOS/nixos-hardware/commit/62d41cb488e1a83b94c84800043b13c135f9b959) | `` add gigabyte-b550 to flake outputs `` |