### PR TITLE
chore(flake/nur): `59128780` -> `2fe75ecf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718346966,
-        "narHash": "sha256-GGBfNB32Ejivv3jmWmtKv6g+KibPRccM3gQyUTvqM2A=",
+        "lastModified": 1718354773,
+        "narHash": "sha256-p0pjm5l6LOYoEzSMLZv0QSE4vgGwfhkCz7VN58IUjzc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "591287807aec3143bc822d56a3d6ee0f22337a95",
+        "rev": "2fe75ecfd4dd1d2063fcc31ccb5db6d9f2b6b33c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2fe75ecf`](https://github.com/nix-community/NUR/commit/2fe75ecfd4dd1d2063fcc31ccb5db6d9f2b6b33c) | `` automatic update `` |
| [`04cb4b1c`](https://github.com/nix-community/NUR/commit/04cb4b1cbb9361c99b7fb69368eafa1bf73e09f4) | `` automatic update `` |