### PR TITLE
chore(flake/nur): `f65b760b` -> `b9ad9f11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718365537,
-        "narHash": "sha256-RiAhVWv1XcQyRlaIcuNS2rXIAIVD+yyiXIHeiXZOfpo=",
+        "lastModified": 1718369904,
+        "narHash": "sha256-sQbGFOkXE7R29S6CFsCHqckh5hBxcxKFvVoQpOx1Dh8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f65b760be31076d4b2306726db799339be613501",
+        "rev": "b9ad9f11b51b97db392ae241b736a334988fc925",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b9ad9f11`](https://github.com/nix-community/NUR/commit/b9ad9f11b51b97db392ae241b736a334988fc925) | `` automatic update `` |
| [`270dd96e`](https://github.com/nix-community/NUR/commit/270dd96e30a3a74f3bc263e84c0846fcf9859603) | `` automatic update `` |