### PR TITLE
chore(flake/nur): `b9ad9f11` -> `b019e8f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718369904,
-        "narHash": "sha256-sQbGFOkXE7R29S6CFsCHqckh5hBxcxKFvVoQpOx1Dh8=",
+        "lastModified": 1718372699,
+        "narHash": "sha256-hFHYysQV4rKC1zkkgpPke1MQ2uZUAXLMtJw7ZGVB/5k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b9ad9f11b51b97db392ae241b736a334988fc925",
+        "rev": "b019e8f605265e7b8e548fac2e822cbb1a37309a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b019e8f6`](https://github.com/nix-community/NUR/commit/b019e8f605265e7b8e548fac2e822cbb1a37309a) | `` automatic update `` |