### PR TITLE
chore(flake/nur): `b019e8f6` -> `ce0881c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718372699,
-        "narHash": "sha256-hFHYysQV4rKC1zkkgpPke1MQ2uZUAXLMtJw7ZGVB/5k=",
+        "lastModified": 1718379988,
+        "narHash": "sha256-x6E4v5VWG1YhzLcvjURpkjUzz0Y9eOAN85ys0ei2uTc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b019e8f605265e7b8e548fac2e822cbb1a37309a",
+        "rev": "ce0881c32392276a23b3c69fd45120c498ed0e8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ce0881c3`](https://github.com/nix-community/NUR/commit/ce0881c32392276a23b3c69fd45120c498ed0e8b) | `` automatic update `` |
| [`ff8e1e4d`](https://github.com/nix-community/NUR/commit/ff8e1e4d893f53016006935b31ae44ee36c417f8) | `` automatic update `` |
| [`9b53bd7d`](https://github.com/nix-community/NUR/commit/9b53bd7d8891bcc7e1aefe97db76a910f2cc5644) | `` automatic update `` |