### PR TITLE
chore(flake/nur): `ce0881c3` -> `f3495133`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718379988,
-        "narHash": "sha256-x6E4v5VWG1YhzLcvjURpkjUzz0Y9eOAN85ys0ei2uTc=",
+        "lastModified": 1718387178,
+        "narHash": "sha256-qm2gBUI7y/eblOgbl8qLgOzz3EXozA5X1/ePdJ8TDKA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ce0881c32392276a23b3c69fd45120c498ed0e8b",
+        "rev": "f34951337ff9c0a8d466ecbc40e0262d7138130f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f3495133`](https://github.com/nix-community/NUR/commit/f34951337ff9c0a8d466ecbc40e0262d7138130f) | `` automatic update `` |