### PR TITLE
chore(flake/emacs-overlay): `7aa1c144` -> `9be87fae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1718183320,
-        "narHash": "sha256-L0b6hyf9EWeWKhmUwTQvbLtBtLBblyYJ3llOTsLIr0s=",
+        "lastModified": 1718390211,
+        "narHash": "sha256-UvqJfD3SHtj3xG9Dc2DVaTlZofkyBJ2wk5WL35iWTgY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7aa1c14402a09fc043110d6477aa5cc90e60e409",
+        "rev": "9be87fae5515892871716818dbdc303d76bb8540",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------ |
| [`6323b404`](https://github.com/nix-community/emacs-overlay/commit/6323b40449eb7cf809d7b204f118ec4916b96576) | `` add dependabot to keep github actions up to date `` |