### PR TITLE
chore(flake/nur): `f3495133` -> `e2eac9df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718387178,
-        "narHash": "sha256-qm2gBUI7y/eblOgbl8qLgOzz3EXozA5X1/ePdJ8TDKA=",
+        "lastModified": 1718391791,
+        "narHash": "sha256-l7Ow+MXGqSYr7WliALyRw+5hOH/kSsuC5qswAXU/PP4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f34951337ff9c0a8d466ecbc40e0262d7138130f",
+        "rev": "e2eac9df491c35b114641a3f4d66210953a623c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e2eac9df`](https://github.com/nix-community/NUR/commit/e2eac9df491c35b114641a3f4d66210953a623c3) | `` automatic update `` |