### PR TITLE
chore(flake/emacs-overlay): `9be87fae` -> `9bb64872`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1718390211,
-        "narHash": "sha256-UvqJfD3SHtj3xG9Dc2DVaTlZofkyBJ2wk5WL35iWTgY=",
+        "lastModified": 1718398584,
+        "narHash": "sha256-XUQ/N82GzR/4GOGMHdxLAoZLTV1tl6kJ5Boy+G2l8/g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9be87fae5515892871716818dbdc303d76bb8540",
+        "rev": "9bb6487200f40f132cff145c2c22aa1d2b91af25",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                            |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
| [`67905f5d`](https://github.com/nix-community/emacs-overlay/commit/67905f5d4bb4eb057f5061d5a50b87aba7bb92b3) | `` Bump cachix/install-nix-action from 20 to 27 `` |
| [`68faf314`](https://github.com/nix-community/emacs-overlay/commit/68faf3145d3359fc6d0b7cf153d37f59cd5153f1) | `` Bump actions/checkout from 4.1.1 to 4.1.7 ``    |
| [`74c6cf77`](https://github.com/nix-community/emacs-overlay/commit/74c6cf777743ddd173b7cc54a58483f2bb35dd02) | `` Bump cachix/cachix-action from 13 to 15 ``      |