### PR TITLE
chore(flake/nur): `e2eac9df` -> `d50ea270`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718391791,
-        "narHash": "sha256-l7Ow+MXGqSYr7WliALyRw+5hOH/kSsuC5qswAXU/PP4=",
+        "lastModified": 1718400242,
+        "narHash": "sha256-gLX2eyWb8lVxwI5Uv0F5WKb+YwvlDYnI+sSQB2xMqhw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e2eac9df491c35b114641a3f4d66210953a623c3",
+        "rev": "d50ea2706590f0edce9f49d8990dbcf82cdb66ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d50ea270`](https://github.com/nix-community/NUR/commit/d50ea2706590f0edce9f49d8990dbcf82cdb66ec) | `` automatic update `` |
| [`c6325c8d`](https://github.com/nix-community/NUR/commit/c6325c8dee7dd1f58e1b4884672c670d6b541845) | `` automatic update `` |
| [`24123cf5`](https://github.com/nix-community/NUR/commit/24123cf5fea48b71954e81b0f4fe5db127109979) | `` automatic update `` |