### PR TITLE
chore(flake/nur): `d50ea270` -> `f68cde56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718400242,
-        "narHash": "sha256-gLX2eyWb8lVxwI5Uv0F5WKb+YwvlDYnI+sSQB2xMqhw=",
+        "lastModified": 1718416004,
+        "narHash": "sha256-C6x2My4OtlKyz9hwrN1tj6xsbMia285lp70KqfFM3PI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d50ea2706590f0edce9f49d8990dbcf82cdb66ec",
+        "rev": "f68cde56d90668355df1b26d5de4bcaf77962f03",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f68cde56`](https://github.com/nix-community/NUR/commit/f68cde56d90668355df1b26d5de4bcaf77962f03) | `` automatic update `` |