### PR TITLE
chore(flake/nur): `f68cde56` -> `334c02af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718416004,
-        "narHash": "sha256-C6x2My4OtlKyz9hwrN1tj6xsbMia285lp70KqfFM3PI=",
+        "lastModified": 1718423787,
+        "narHash": "sha256-hfPWNmhzEJ1Dr7PVAqKg55l+CBO+QsudsdbfmXxd2EE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f68cde56d90668355df1b26d5de4bcaf77962f03",
+        "rev": "334c02afb278f358e14972c7a3bff7b486abc206",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`334c02af`](https://github.com/nix-community/NUR/commit/334c02afb278f358e14972c7a3bff7b486abc206) | `` automatic update `` |
| [`69c4953d`](https://github.com/nix-community/NUR/commit/69c4953deb522227569f4da031549b368d4b28ea) | `` automatic update `` |
| [`add64595`](https://github.com/nix-community/NUR/commit/add645958de20518285ad5e38e49e029ae4e3e67) | `` automatic update `` |
| [`774ddbac`](https://github.com/nix-community/NUR/commit/774ddbacf5080bc1b21241c37f0a150bb79c805a) | `` automatic update `` |
| [`808001e3`](https://github.com/nix-community/NUR/commit/808001e33c4339eaa5597c54e1d1f56f59a0c5ad) | `` automatic update `` |