### PR TITLE
chore(flake/nur): `334c02af` -> `2b6c4027`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718423787,
-        "narHash": "sha256-hfPWNmhzEJ1Dr7PVAqKg55l+CBO+QsudsdbfmXxd2EE=",
+        "lastModified": 1718429921,
+        "narHash": "sha256-gWMq/lOBsdMENiH5Ogp5MiHFuXlGI66kcw2v3C/8N5s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "334c02afb278f358e14972c7a3bff7b486abc206",
+        "rev": "2b6c40279d293d53714333949aa9dcd40f9acf9d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                    |
| -------------------------------------------------------------------------------------------------- | -------------------------- |
| [`2b6c4027`](https://github.com/nix-community/NUR/commit/2b6c40279d293d53714333949aa9dcd40f9acf9d) | `` automatic update ``     |
| [`2fded1cf`](https://github.com/nix-community/NUR/commit/2fded1cf5264516dac158360b4d1d26713b04af4) | `` Gotta love github... `` |
| [`c7221c0b`](https://github.com/nix-community/NUR/commit/c7221c0b760f42918437659c421e5d0daa53cc59) | `` automatic update ``     |
| [`19f7b522`](https://github.com/nix-community/NUR/commit/19f7b522845319a602165039a4531fb498c6ca75) | `` automatic update ``     |