### PR TITLE
chore(flake/nur): `2b6c4027` -> `99c33cfb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718429921,
-        "narHash": "sha256-gWMq/lOBsdMENiH5Ogp5MiHFuXlGI66kcw2v3C/8N5s=",
+        "lastModified": 1718433645,
+        "narHash": "sha256-6UK1YSQB/NprZOoN3ZBUFL67CXzlb5u6sUB1jSEB+CQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2b6c40279d293d53714333949aa9dcd40f9acf9d",
+        "rev": "99c33cfb904e1479f139b06d543e1e40de3adcac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`99c33cfb`](https://github.com/nix-community/NUR/commit/99c33cfb904e1479f139b06d543e1e40de3adcac) | `` automatic update `` |