### PR TITLE
chore(flake/nur): `99c33cfb` -> `f9d8781e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718433645,
-        "narHash": "sha256-6UK1YSQB/NprZOoN3ZBUFL67CXzlb5u6sUB1jSEB+CQ=",
+        "lastModified": 1718436390,
+        "narHash": "sha256-A+U0A8f3fkkv28ZyfaGeCEYPcDEmi82Cic147H6BCXg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "99c33cfb904e1479f139b06d543e1e40de3adcac",
+        "rev": "f9d8781e2581d70f85adb0e67177351c56b6afa8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f9d8781e`](https://github.com/nix-community/NUR/commit/f9d8781e2581d70f85adb0e67177351c56b6afa8) | `` automatic update `` |