### PR TITLE
chore(flake/emacs-overlay): `9a4bbb3e` -> `2d878eb0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1718416383,
-        "narHash": "sha256-aM9MIuNE7v/vDAuPkYdjHXxfpDzyCYomWgHaqQE8dZ0=",
+        "lastModified": 1718442450,
+        "narHash": "sha256-2xg/4YPezwTRRPlGQEAw+qj1RBEwrurrnzW8zVeMLWA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9a4bbb3e6b3a1f7c4f870c2906d404d16f65bc44",
+        "rev": "2d878eb04f770effe1fe9828e0391edb8e5f3df9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`2d878eb0`](https://github.com/nix-community/emacs-overlay/commit/2d878eb04f770effe1fe9828e0391edb8e5f3df9) | `` Updated emacs `` |
| [`e38459a3`](https://github.com/nix-community/emacs-overlay/commit/e38459a340d92451592a3156287a99c510d65904) | `` Updated melpa `` |