### PR TITLE
chore(flake/nur): `f9d8781e` -> `66eaaceb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718436390,
-        "narHash": "sha256-A+U0A8f3fkkv28ZyfaGeCEYPcDEmi82Cic147H6BCXg=",
+        "lastModified": 1718444688,
+        "narHash": "sha256-5LFSdrTv51/oKpe+xopFV1W0HWv9I+OOyJimYmb19ro=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f9d8781e2581d70f85adb0e67177351c56b6afa8",
+        "rev": "66eaaceb31bcad387db129ef74aa77eb12f45d91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`66eaaceb`](https://github.com/nix-community/NUR/commit/66eaaceb31bcad387db129ef74aa77eb12f45d91) | `` automatic update `` |
| [`0742136b`](https://github.com/nix-community/NUR/commit/0742136b19db938ad5ea021d66d8656c3200b86a) | `` automatic update `` |