### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `98f1e86f` -> `c5c32670`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718183320,
-        "narHash": "sha256-L0b6hyf9EWeWKhmUwTQvbLtBtLBblyYJ3llOTsLIr0s=",
+        "lastModified": 1718416383,
+        "narHash": "sha256-aM9MIuNE7v/vDAuPkYdjHXxfpDzyCYomWgHaqQE8dZ0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7aa1c14402a09fc043110d6477aa5cc90e60e409",
+        "rev": "9a4bbb3e6b3a1f7c4f870c2906d404d16f65bc44",
         "type": "github"
       },
       "original": {
@@ -519,11 +519,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1718267547,
-        "narHash": "sha256-TG6q1DoYPt69oD8GMiV5+vh7Jk6B+MrDPTChzzfyQTc=",
+        "lastModified": 1718440264,
+        "narHash": "sha256-L7GLWbS46jhuux5dyFWitUXqdMy0VnoqDw1QeDKrgd8=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "98f1e86fe310865148774d6a5ec6c87779a1d4dd",
+        "rev": "c5c32670b1fcf16c6b1b5f8bbf9ed3c642184f03",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`c5c32670`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/c5c32670b1fcf16c6b1b5f8bbf9ed3c642184f03) | `` flake.lock: Update `` |