### PR TITLE
chore(flake/nur): `66eaaceb` -> `a83029a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718444688,
-        "narHash": "sha256-5LFSdrTv51/oKpe+xopFV1W0HWv9I+OOyJimYmb19ro=",
+        "lastModified": 1718451878,
+        "narHash": "sha256-DOt6b0+N0ea3DYJ83phSGtkKwgJbN+NA4ozXoVv6k8g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "66eaaceb31bcad387db129ef74aa77eb12f45d91",
+        "rev": "a83029a20d97e0d4713255b7eba1736c38ec9c14",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a83029a2`](https://github.com/nix-community/NUR/commit/a83029a20d97e0d4713255b7eba1736c38ec9c14) | `` automatic update `` |
| [`812a9105`](https://github.com/nix-community/NUR/commit/812a9105aab175e523b0eee2f49285cc978a93ad) | `` automatic update `` |
| [`33e61fa0`](https://github.com/nix-community/NUR/commit/33e61fa0c96330985e302a0800fdc550caf5f1d7) | `` automatic update `` |