### PR TITLE
chore(flake/srvos): `d6280e5c` -> `b724a9ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -951,11 +951,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718239576,
-        "narHash": "sha256-Afdz9oCQf8VCGXUhI8KxdJg9gc+fepZK//mYsijfhFw=",
+        "lastModified": 1718459800,
+        "narHash": "sha256-oRkHJbp/jIljo+yXY6sSjMMTBqWNhIjd4qhs0pTjwbs=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "d6280e5c12c4ddb26f0807387777786c66e4c552",
+        "rev": "b724a9ad24945a4d6fb11a42f1c2ce072fa3c4c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                       |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`b724a9ad`](https://github.com/nix-community/srvos/commit/b724a9ad24945a4d6fb11a42f1c2ce072fa3c4c2) | `` remove 24.05 ``                            |
| [`34a93900`](https://github.com/nix-community/srvos/commit/34a9390047439d7310b54768bdc8366c1772688e) | `` remove 23.11 ``                            |
| [`24361cb3`](https://github.com/nix-community/srvos/commit/24361cb3fe86e9d96a95461ad36efa00bf7f4f13) | `` dev/private/flake: bump stable to 24.05 `` |