### PR TITLE
chore(flake/nur): `a83029a2` -> `5abdb09c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718451878,
-        "narHash": "sha256-DOt6b0+N0ea3DYJ83phSGtkKwgJbN+NA4ozXoVv6k8g=",
+        "lastModified": 1718473585,
+        "narHash": "sha256-ywJIP4GaQa//RDvH/cYJ+uOxyZkRunl4YTwRf9lhv3U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a83029a20d97e0d4713255b7eba1736c38ec9c14",
+        "rev": "5abdb09c77d9f713504f4cbaac2bb83eb42245e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5abdb09c`](https://github.com/nix-community/NUR/commit/5abdb09c77d9f713504f4cbaac2bb83eb42245e7) | `` automatic update `` |
| [`64e08255`](https://github.com/nix-community/NUR/commit/64e082553acfaebc14fc539e4d6b2abcc4dbd0f6) | `` automatic update `` |
| [`2bd3dc9a`](https://github.com/nix-community/NUR/commit/2bd3dc9a317faceb2a0964d49e1ff8ddcaff7b97) | `` automatic update `` |
| [`d30e2d47`](https://github.com/nix-community/NUR/commit/d30e2d47f7ac6243356f698c367123932af4475d) | `` automatic update `` |
| [`575ac803`](https://github.com/nix-community/NUR/commit/575ac803a0f764aca61b449422a83507f987094c) | `` automatic update `` |
| [`4d2b5b9b`](https://github.com/nix-community/NUR/commit/4d2b5b9bb7bd747d5c721f6fdd0629da21d13eef) | `` automatic update `` |
| [`d64b542f`](https://github.com/nix-community/NUR/commit/d64b542f7f8f621ffcce3209184232024654bbac) | `` automatic update `` |