### PR TITLE
chore(flake/emacs-overlay): `2d878eb0` -> `b31222ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1718442450,
-        "narHash": "sha256-2xg/4YPezwTRRPlGQEAw+qj1RBEwrurrnzW8zVeMLWA=",
+        "lastModified": 1718470476,
+        "narHash": "sha256-XjVv1EL+UpWSYWY06jmwJAC6FwZk1spnB9llnXQeU3M=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2d878eb04f770effe1fe9828e0391edb8e5f3df9",
+        "rev": "b31222ee9f1d93680514325f818f7adac4db5852",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`b31222ee`](https://github.com/nix-community/emacs-overlay/commit/b31222ee9f1d93680514325f818f7adac4db5852) | `` Updated melpa `` |
| [`df7d6fef`](https://github.com/nix-community/emacs-overlay/commit/df7d6fef0acd97af7ae3d00e8625d1ded3452ac7) | `` Updated elpa ``  |