### PR TITLE
chore(flake/emacs-overlay): `b31222ee` -> `7154c01a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1718470476,
-        "narHash": "sha256-XjVv1EL+UpWSYWY06jmwJAC6FwZk1spnB9llnXQeU3M=",
+        "lastModified": 1718471300,
+        "narHash": "sha256-9BMVWt3WvYN2ro8M2Slt0lHHhDX8J3xaVR2M6YaIZUU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b31222ee9f1d93680514325f818f7adac4db5852",
+        "rev": "7154c01acab213910b80b4f788d1e35d8aa88769",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`7154c01a`](https://github.com/nix-community/emacs-overlay/commit/7154c01acab213910b80b4f788d1e35d8aa88769) | `` Updated emacs `` |