### PR TITLE
chore(flake/nur): `5abdb09c` -> `9f35f4fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718473585,
-        "narHash": "sha256-ywJIP4GaQa//RDvH/cYJ+uOxyZkRunl4YTwRf9lhv3U=",
+        "lastModified": 1718476960,
+        "narHash": "sha256-pctNk0KcoMXLnbcBFBu3DzZ9qewVdo3rcHihYhd7EnA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5abdb09c77d9f713504f4cbaac2bb83eb42245e7",
+        "rev": "9f35f4fc9cebc71803265c5bd7c6d330c152271b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9f35f4fc`](https://github.com/nix-community/NUR/commit/9f35f4fc9cebc71803265c5bd7c6d330c152271b) | `` automatic update `` |