### PR TITLE
chore(flake/nur): `9f35f4fc` -> `53cf1c85`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718476960,
-        "narHash": "sha256-pctNk0KcoMXLnbcBFBu3DzZ9qewVdo3rcHihYhd7EnA=",
+        "lastModified": 1718483164,
+        "narHash": "sha256-Fm3v1sEndtHbsrAIoBzObz5NhbgWaXDluwEGlH+92s4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9f35f4fc9cebc71803265c5bd7c6d330c152271b",
+        "rev": "53cf1c854e66a5efa73b69eb3ab952d6bf2e2817",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`53cf1c85`](https://github.com/nix-community/NUR/commit/53cf1c854e66a5efa73b69eb3ab952d6bf2e2817) | `` automatic update `` |
| [`5c66ef2e`](https://github.com/nix-community/NUR/commit/5c66ef2e7a19213ca1e17ecad013f6e3e5fb0129) | `` automatic update `` |
| [`fcc1d9fd`](https://github.com/nix-community/NUR/commit/fcc1d9fd6b47ff6364738679522b02a4b7991f00) | `` automatic update `` |
| [`e933e1a9`](https://github.com/nix-community/NUR/commit/e933e1a94c14d316c85f25860c3d61e5b598eece) | `` automatic update `` |