### PR TITLE
chore(flake/emacs-overlay): `7154c01a` -> `182987af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1718471300,
-        "narHash": "sha256-9BMVWt3WvYN2ro8M2Slt0lHHhDX8J3xaVR2M6YaIZUU=",
+        "lastModified": 1718503032,
+        "narHash": "sha256-5Jmo8dUn9YrTm4IQsXbU1EvkftuXBnPwuaNdXN6g1LQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7154c01acab213910b80b4f788d1e35d8aa88769",
+        "rev": "182987afab0e1ef77703b46c16d7213de3d77f93",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`182987af`](https://github.com/nix-community/emacs-overlay/commit/182987afab0e1ef77703b46c16d7213de3d77f93) | `` Updated emacs ``  |
| [`892bbaae`](https://github.com/nix-community/emacs-overlay/commit/892bbaae6b7a22c64dc04c2c43282a27d1c53ab0) | `` Updated melpa ``  |
| [`8c7fac5e`](https://github.com/nix-community/emacs-overlay/commit/8c7fac5e8938572ec941f718892bb367a66913e7) | `` Updated elpa ``   |
| [`3395ed77`](https://github.com/nix-community/emacs-overlay/commit/3395ed77493ffdd75514f78e7dd098dcd6bfc3ed) | `` Updated nongnu `` |