### PR TITLE
chore(flake/nur): `53cf1c85` -> `4107ee27`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718483164,
-        "narHash": "sha256-Fm3v1sEndtHbsrAIoBzObz5NhbgWaXDluwEGlH+92s4=",
+        "lastModified": 1718503696,
+        "narHash": "sha256-qiGITbc96wIKxr8/cLMJZCbiOrnhVz/IHTXFrSg+CUY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "53cf1c854e66a5efa73b69eb3ab952d6bf2e2817",
+        "rev": "4107ee27c580259be448167a4f5744f5758c72ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4107ee27`](https://github.com/nix-community/NUR/commit/4107ee27c580259be448167a4f5744f5758c72ad) | `` automatic update `` |
| [`778b68e5`](https://github.com/nix-community/NUR/commit/778b68e51ab9e89659ea30cbe29b2d9b5f86e30c) | `` automatic update `` |