### PR TITLE
chore(flake/nix-index-database): `963639a8` -> `6af2c5e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -587,11 +587,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718458449,
-        "narHash": "sha256-FcX3/lTbb+WIW783b18SPudPYhdmmNLQADf4S3SsZos=",
+        "lastModified": 1718507237,
+        "narHash": "sha256-xBEWCxWeRpWQggFFp8ugJCDa63cOJsVvx71R9F0Eowg=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "963639a87fb7f746d45f14b8ab429d2c52dbb396",
+        "rev": "6af2c5e58c20311276f59d247341cafeebfcb6f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`6af2c5e5`](https://github.com/nix-community/nix-index-database/commit/6af2c5e58c20311276f59d247341cafeebfcb6f4) | `` update generated.nix to release 2024-06-16-025740 `` |
| [`63e899d1`](https://github.com/nix-community/nix-index-database/commit/63e899d13904d9052d6dc6248be096d5e77b08ab) | `` flake.lock: Update ``                                |