### PR TITLE
chore(flake/nur): `4ba54c79` -> `57f0c7d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718506210,
-        "narHash": "sha256-C9/y4hIajGMFOhpHt9MkW4gOHSWFry0TO4QboWd64DU=",
+        "lastModified": 1718510652,
+        "narHash": "sha256-uOc+ka8lrTkX5RovBaPnYXeh/imxkRnZcb0AsaetGvw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ba54c796a0503dc82d8b2349cff2e5e3926506e",
+        "rev": "57f0c7d6504fa6f6e9fa5db44effa1b71c236e56",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`57f0c7d6`](https://github.com/nix-community/NUR/commit/57f0c7d6504fa6f6e9fa5db44effa1b71c236e56) | `` automatic update `` |
| [`80325772`](https://github.com/nix-community/NUR/commit/80325772fe1a5778cfbbf15fbbf043272c9d255a) | `` automatic update `` |
| [`6479d214`](https://github.com/nix-community/NUR/commit/6479d21486ebd225cf794c0773d74c398fbb5e50) | `` automatic update `` |