### PR TITLE
chore(flake/nur): `57f0c7d6` -> `374c21e3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718510652,
-        "narHash": "sha256-uOc+ka8lrTkX5RovBaPnYXeh/imxkRnZcb0AsaetGvw=",
+        "lastModified": 1718531533,
+        "narHash": "sha256-4KPtYseQZ52Og8Ltu1Lgn6KjMyVDYjK0Dp2/p5EcPpE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "57f0c7d6504fa6f6e9fa5db44effa1b71c236e56",
+        "rev": "374c21e350ca7744623b40f37cc1da82788258cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                               |
| -------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`374c21e3`](https://github.com/nix-community/NUR/commit/374c21e350ca7744623b40f37cc1da82788258cb) | `` automatic update ``                |
| [`b597d4a1`](https://github.com/nix-community/NUR/commit/b597d4a11404a81f5e548ac3cfc5895b8abfa4fc) | `` automatic update ``                |
| [`9d2a1f5c`](https://github.com/nix-community/NUR/commit/9d2a1f5ce9af494fd7d413a4fe0c485e1c5682b4) | `` automatic update ``                |
| [`1a35ccf4`](https://github.com/nix-community/NUR/commit/1a35ccf47645e8dcaf93d6aa94dddf4db6ea8a27) | `` automatic update ``                |
| [`f72c4e01`](https://github.com/nix-community/NUR/commit/f72c4e012d72ffc9ea0add09a7ed107f4ab13008) | `` manifest-format ``                 |
| [`6821218b`](https://github.com/nix-community/NUR/commit/6821218be5bb7122133ff12e403122910ff0234a) | `` Add Redrield/nurpkgs repository `` |
| [`f165da2b`](https://github.com/nix-community/NUR/commit/f165da2bae9a9ecba9baee0125f33c4d0f28750b) | `` automatic update ``                |
| [`08e6ae0b`](https://github.com/nix-community/NUR/commit/08e6ae0b7b0ac953491c6e2396f1db113eaaf1c6) | `` automatic update ``                |
| [`14d28790`](https://github.com/nix-community/NUR/commit/14d2879054f9411da2f421b6ff034983947c14dc) | `` automatic update ``                |
| [`579d53dc`](https://github.com/nix-community/NUR/commit/579d53dce1ce7a7adaeb339c671502471e2a846d) | `` automatic update ``                |
| [`a6a63011`](https://github.com/nix-community/NUR/commit/a6a630117abef43fcdff35e39e2c06de0302ee9c) | `` automatic update ``                |