### PR TITLE
chore(flake/treefmt): `e75ba0a6` -> `68eb1dc3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1046,11 +1046,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718271476,
-        "narHash": "sha256-35hUMmFesmchb+u7heKHLG5B6c8fBOcSYo0jj0CHLes=",
+        "lastModified": 1718522839,
+        "narHash": "sha256-ULzoKzEaBOiLRtjeY3YoGFJMwWSKRYOic6VNw2UyTls=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "e75ba0a6bb562d2ce275db28f6a36a2e4fd81391",
+        "rev": "68eb1dc333ce82d0ab0c0357363ea17c31ea1f81",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                                     |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`21a992b1`](https://github.com/numtide/treefmt-nix/commit/21a992b1bfc56ab89ec135393501e43b0faee60b) | `` chore: Avoid accidental circular definition of `pkgs`; More descriptive `defaultText` `` |
| [`d81b6a54`](https://github.com/numtide/treefmt-nix/commit/d81b6a54e6ba3b272d29c089da69f8fecf4f04c5) | `` chore: fmt ``                                                                            |
| [`3123e376`](https://github.com/numtide/treefmt-nix/commit/3123e3763be68eee59dbc106a8b8c31bb73e06ec) | `` refactor: Create `submodule-modules` and import it in `flake-module` ``                  |
| [`84681ae1`](https://github.com/numtide/treefmt-nix/commit/84681ae164d00ade4ba184d009e7dc3055511a74) | `` feat(flake-parts): add `pkgs` module option ``                                           |