### PR TITLE
chore(flake/emacs-overlay): `182987af` -> `a3bb4fef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1718503032,
-        "narHash": "sha256-5Jmo8dUn9YrTm4IQsXbU1EvkftuXBnPwuaNdXN6g1LQ=",
+        "lastModified": 1718528845,
+        "narHash": "sha256-7j/JtNOEE/yJGNHyTJjpvrFDUQn9IcfonYOKau7su2E=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "182987afab0e1ef77703b46c16d7213de3d77f93",
+        "rev": "a3bb4fefef1ed47a18480ab14d65d409d1f9b9c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`a3bb4fef`](https://github.com/nix-community/emacs-overlay/commit/a3bb4fefef1ed47a18480ab14d65d409d1f9b9c0) | `` Updated emacs `` |
| [`ea2aee03`](https://github.com/nix-community/emacs-overlay/commit/ea2aee03216671e9dd2f71c0c182bdb3fec90e5f) | `` Updated melpa `` |