### PR TITLE
chore(flake/home-manager): `8d5e27b4` -> `0a7ffb28`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -410,11 +410,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718243258,
-        "narHash": "sha256-abBpj2VU8p6qlRzTU8o22q68MmOaZ4v8zZ4UlYl5YRU=",
+        "lastModified": 1718526747,
+        "narHash": "sha256-sKrD/utGvmtQALvuDj4j0CT3AJXP1idOAq2p+27TpeE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8d5e27b4807d25308dfe369d5a923d87e7dbfda3",
+        "rev": "0a7ffb28e5df5844d0e8039c9833d7075cdee792",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`0a7ffb28`](https://github.com/nix-community/home-manager/commit/0a7ffb28e5df5844d0e8039c9833d7075cdee792) | `` Translate using Weblate (Hungarian) ``       |
| [`6396c032`](https://github.com/nix-community/home-manager/commit/6396c03229a8efa21a7550375de26620e07020b6) | `` Add translation using Weblate (Hungarian) `` |
| [`f2f25464`](https://github.com/nix-community/home-manager/commit/f2f254640ef74ee99cc4d6e76a7a13ec56ed5205) | `` Add translation using Weblate (Arabic) ``    |
| [`03c45b98`](https://github.com/nix-community/home-manager/commit/03c45b982c4e1ec683dbcbb587cddb41691bf52a) | `` flake.lock: Update ``                        |