### PR TITLE
chore(flake/nur): `374c21e3` -> `bdade428`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718531533,
-        "narHash": "sha256-4KPtYseQZ52Og8Ltu1Lgn6KjMyVDYjK0Dp2/p5EcPpE=",
+        "lastModified": 1718541419,
+        "narHash": "sha256-pjBdBu9cWRYvgUO4pUG07uxMTJq2scRpjI9kpMLENH0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "374c21e350ca7744623b40f37cc1da82788258cb",
+        "rev": "bdade428001a69a002fb7e90acf7278879a9671a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bdade428`](https://github.com/nix-community/NUR/commit/bdade428001a69a002fb7e90acf7278879a9671a) | `` automatic update `` |
| [`97a4e6d2`](https://github.com/nix-community/NUR/commit/97a4e6d29d313e0c25dde32e5833a27b750cc3d1) | `` automatic update `` |