### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `7ad53f4a` -> `f8012b87`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -519,11 +519,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1718526660,
-        "narHash": "sha256-BuxKu9ogXoTtnTJQHmXvW4qg5LZHYQP7Z6x8tGMBnlc=",
+        "lastModified": 1718543064,
+        "narHash": "sha256-cMldSR2Q/l5sKIVi9Kr7zQ2LS4QCPrYgX8sOOVR3HkM=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "7ad53f4a4f5a29d5e62afedb40cde243f5de990d",
+        "rev": "f8012b878529f707df037b1e7fdb1e8f476a296b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                                            |
| ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`f8012b87`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/f8012b878529f707df037b1e7fdb1e8f476a296b) | `` Tweak toInit input structure ``                 |
| [`c61cd622`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/c61cd622b7abb2de838c41d99cc9a0b1e4506917) | `` Add `extraBinPackages` for adding to `$PATH` `` |
| [`9b135676`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/9b1356765b6db2418c45fbfe0465f7851b51b20c) | `` Move extraPackages docs to the right section `` |