### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `f8012b87` -> `2a436566`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -519,11 +519,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1718543064,
-        "narHash": "sha256-cMldSR2Q/l5sKIVi9Kr7zQ2LS4QCPrYgX8sOOVR3HkM=",
+        "lastModified": 1718545258,
+        "narHash": "sha256-MqyXic4Wk5CubrBK0cPTvXy0Vb7O0mv7+A8lfY6ptz8=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "f8012b878529f707df037b1e7fdb1e8f476a296b",
+        "rev": "2a436566e8bd515895d8572afd27328a42bccd85",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                                                 |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`2a436566`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/2a436566e8bd515895d8572afd27328a42bccd85) | `` Force a dependency on generated dependencies json `` |