### PR TITLE
chore(flake/nur): `bdade428` -> `0bf7a548`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718541419,
-        "narHash": "sha256-pjBdBu9cWRYvgUO4pUG07uxMTJq2scRpjI9kpMLENH0=",
+        "lastModified": 1718549714,
+        "narHash": "sha256-DUKApfL6FHxudbNV15yWJiCQ8UUTvNThX7qLbYozWLk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bdade428001a69a002fb7e90acf7278879a9671a",
+        "rev": "0bf7a5480c9de6d038bd907b873c4248928e496b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0bf7a548`](https://github.com/nix-community/NUR/commit/0bf7a5480c9de6d038bd907b873c4248928e496b) | `` automatic update `` |
| [`74143b84`](https://github.com/nix-community/NUR/commit/74143b84ac70190a606dc8b0bb745e124cf12335) | `` automatic update `` |