### PR TITLE
chore(flake/nur): `0bf7a548` -> `a901945b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718549714,
-        "narHash": "sha256-DUKApfL6FHxudbNV15yWJiCQ8UUTvNThX7qLbYozWLk=",
+        "lastModified": 1718552714,
+        "narHash": "sha256-PbbMUO6Teun4fqxco9b+YwoThh/OSenXTYWEvhiDGk0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0bf7a5480c9de6d038bd907b873c4248928e496b",
+        "rev": "a901945bee92ec63f1ed7f01913f8216bc8e94d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a901945b`](https://github.com/nix-community/NUR/commit/a901945bee92ec63f1ed7f01913f8216bc8e94d3) | `` automatic update `` |
| [`1a1a7893`](https://github.com/nix-community/NUR/commit/1a1a78932ae9ff8d1a1d44fca11f6b67841f0749) | `` automatic update `` |