### PR TITLE
chore(flake/emacs-overlay): `a3bb4fef` -> `8ecf3957`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1718528845,
-        "narHash": "sha256-7j/JtNOEE/yJGNHyTJjpvrFDUQn9IcfonYOKau7su2E=",
+        "lastModified": 1718556753,
+        "narHash": "sha256-oYQMpZpv/4yUhu3MeseJaRAufCAHVEE0UOHfWsjWfco=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a3bb4fefef1ed47a18480ab14d65d409d1f9b9c0",
+        "rev": "8ecf395742cda40ca27ac7f3a0faaa69a3c67a35",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`8ecf3957`](https://github.com/nix-community/emacs-overlay/commit/8ecf395742cda40ca27ac7f3a0faaa69a3c67a35) | `` Updated melpa ``  |
| [`19f99d5e`](https://github.com/nix-community/emacs-overlay/commit/19f99d5e8e662bf228b388f12fa2f0e4d5928ec2) | `` Updated nongnu `` |