### PR TITLE
chore(flake/nur): `a901945b` -> `8a85dd30`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718552714,
-        "narHash": "sha256-PbbMUO6Teun4fqxco9b+YwoThh/OSenXTYWEvhiDGk0=",
+        "lastModified": 1718567081,
+        "narHash": "sha256-IPqZSLbNkBidOM8YYnugdwr0GneHoiPZyRXKac5ydIM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a901945bee92ec63f1ed7f01913f8216bc8e94d3",
+        "rev": "8a85dd301eda27f8ca394be91a706512f10fe897",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8a85dd30`](https://github.com/nix-community/NUR/commit/8a85dd301eda27f8ca394be91a706512f10fe897) | `` automatic update `` |
| [`92d4e146`](https://github.com/nix-community/NUR/commit/92d4e146d9db87b515fc9d0e4f5f1ffd0a0b47cd) | `` automatic update `` |
| [`d88b007f`](https://github.com/nix-community/NUR/commit/d88b007f1213f2c704c4c56b99df3e67cb6036fa) | `` automatic update `` |