### PR TITLE
chore(flake/emacs-overlay): `4d7d1626` -> `3fecf01c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1718557630,
-        "narHash": "sha256-74qMGGJVvIFL+/ursH7SB7Zr0FkSTt1Klh6g4lZs6Ug=",
+        "lastModified": 1718586432,
+        "narHash": "sha256-hOY0GN9y0ok8mLQnzg61EkXlwDkZYDutXrNCkPzpmjM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4d7d16266b8a9f7077c2514d487bf828caf121ca",
+        "rev": "3fecf01c3acd18b3b3c0069aa94c2e27ed0949ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message            |
| ------------------------------------------------------------------------------------------------------------ | ------------------ |
| [`3fecf01c`](https://github.com/nix-community/emacs-overlay/commit/3fecf01c3acd18b3b3c0069aa94c2e27ed0949ca) | `` Updated elpa `` |