### PR TITLE
chore(flake/nur): `56764257` -> `74b25948`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718581505,
-        "narHash": "sha256-0ExPQuSrt6tRBOfB0HTc2vfjOZNP8dVzU1WSKaFs6qw=",
+        "lastModified": 1718589057,
+        "narHash": "sha256-fLnGmrQSUEDW6H3xgNrmMz/gGzucp8e3bIb1ZbQNk6w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5676425742af8c365cf01b3c56ef8608d0dadfb9",
+        "rev": "74b259485bb25ce3011425ea7449e61f853182f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`74b25948`](https://github.com/nix-community/NUR/commit/74b259485bb25ce3011425ea7449e61f853182f8) | `` automatic update `` |
| [`7b7d634b`](https://github.com/nix-community/NUR/commit/7b7d634b774221c3e339ff9a208dd5dd89660ad6) | `` automatic update `` |