### PR TITLE
chore(flake/srvos): `b724a9ad` -> `c607ffef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -951,11 +951,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718459800,
-        "narHash": "sha256-oRkHJbp/jIljo+yXY6sSjMMTBqWNhIjd4qhs0pTjwbs=",
+        "lastModified": 1718585173,
+        "narHash": "sha256-G5DB6D3p8ucyGfmWt3JmiWcVW55DeuUoiT230wQ9Am4=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "b724a9ad24945a4d6fb11a42f1c2ce072fa3c4c2",
+        "rev": "c607ffef7c234d88f37ed12d75b2c48de3f4b3fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`c607ffef`](https://github.com/nix-community/srvos/commit/c607ffef7c234d88f37ed12d75b2c48de3f4b3fe) | `` dev/private/flake.lock: Update `` |
| [`23cdb41c`](https://github.com/nix-community/srvos/commit/23cdb41ca5ef2a78dbfefff71042dc32e318ae49) | `` flake.lock: Update ``             |