### PR TITLE
chore(flake/nur): `74b25948` -> `2b80ed2e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718589057,
-        "narHash": "sha256-fLnGmrQSUEDW6H3xgNrmMz/gGzucp8e3bIb1ZbQNk6w=",
+        "lastModified": 1718594884,
+        "narHash": "sha256-CdAu4oV/t/xKwyU3O9RNqnHr+fO+wBZGgPdjuMaJfN8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "74b259485bb25ce3011425ea7449e61f853182f8",
+        "rev": "2b80ed2e8c31a9da47a611eeb913d9d539133165",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2b80ed2e`](https://github.com/nix-community/NUR/commit/2b80ed2e8c31a9da47a611eeb913d9d539133165) | `` automatic update `` |