### PR TITLE
chore(flake/nur): `2b80ed2e` -> `23af1489`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718594884,
-        "narHash": "sha256-CdAu4oV/t/xKwyU3O9RNqnHr+fO+wBZGgPdjuMaJfN8=",
+        "lastModified": 1718602396,
+        "narHash": "sha256-TfBujkoAy+Oe0Ep/eKVJT6yvuh34JgfBQiqQICDN6Y0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2b80ed2e8c31a9da47a611eeb913d9d539133165",
+        "rev": "23af148935eeb5b5107bda6dcd9f5d63aa517cb4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`23af1489`](https://github.com/nix-community/NUR/commit/23af148935eeb5b5107bda6dcd9f5d63aa517cb4) | `` automatic update `` |
| [`d60d93a7`](https://github.com/nix-community/NUR/commit/d60d93a7f4c1070fdb5025d7e34285e87298f009) | `` automatic update `` |
| [`fe1f85ea`](https://github.com/nix-community/NUR/commit/fe1f85eae736c017ff6bf5849b5b2173000aa342) | `` automatic update `` |