### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `2a436566` -> `0a4011fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718503032,
-        "narHash": "sha256-5Jmo8dUn9YrTm4IQsXbU1EvkftuXBnPwuaNdXN6g1LQ=",
+        "lastModified": 1718589318,
+        "narHash": "sha256-TAOe9upAJ8I9Yc5Z69M/w+bHlWq98ht+XBD2nlEyIDw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "182987afab0e1ef77703b46c16d7213de3d77f93",
+        "rev": "6439e136f3e93e21040f0e8483ed7744056b9d71",
         "type": "github"
       },
       "original": {
@@ -519,11 +519,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1718545258,
-        "narHash": "sha256-MqyXic4Wk5CubrBK0cPTvXy0Vb7O0mv7+A8lfY6ptz8=",
+        "lastModified": 1718613235,
+        "narHash": "sha256-EjBwbN0Pec8907o3HLl4FelBGUiRoJ9eMkPLfwF8tXY=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "2a436566e8bd515895d8572afd27328a42bccd85",
+        "rev": "0a4011fbface6bf5ba288ae1e5e4b5d17e8d32c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`0a4011fb`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/0a4011fbface6bf5ba288ae1e5e4b5d17e8d32c8) | `` flake.lock: Update `` |