### PR TITLE
chore(flake/emacs-overlay): `66b7bfa0` -> `292ec202`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1718614529,
-        "narHash": "sha256-05g+B38IRQmLo/2XbO9G+qG/pi5X7syoY68Ddc1Nbr4=",
+        "lastModified": 1718615420,
+        "narHash": "sha256-hW9fRiFp/sMlX9PXj5az9tozcq5CYAYhWDWXrrnrmM4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "66b7bfa068e2bf81a4096c8196512075ceb39ec2",
+        "rev": "292ec2022a1d758d0a91232e524eab5e4a36a219",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`292ec202`](https://github.com/nix-community/emacs-overlay/commit/292ec2022a1d758d0a91232e524eab5e4a36a219) | `` Updated emacs `` |