### PR TITLE
chore(flake/emacs-overlay): `292ec202` -> `1f57a659`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1718615420,
-        "narHash": "sha256-hW9fRiFp/sMlX9PXj5az9tozcq5CYAYhWDWXrrnrmM4=",
+        "lastModified": 1718644238,
+        "narHash": "sha256-Kjqe0v2n0+ZU74edGZJADysx+n4Ny5QVuqk4xVEblHE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "292ec2022a1d758d0a91232e524eab5e4a36a219",
+        "rev": "1f57a6596440c15e6135dfbde5f93c2851f01ac9",
         "type": "github"
       },
       "original": {
@@ -700,11 +700,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1718229064,
-        "narHash": "sha256-ZFav8A9zPNfjZg/wrxh1uZeMJHELRfRgFP+meq01XYk=",
+        "lastModified": 1718447546,
+        "narHash": "sha256-JHuXsrC9pr4kA4n7LuuPfWFJUVlDBVJ1TXDVpHEuUgM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5c2ec3a5c2ee9909904f860dadc19bc12cd9cc44",
+        "rev": "842253bf992c3a7157b67600c2857193f126563a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`1f57a659`](https://github.com/nix-community/emacs-overlay/commit/1f57a6596440c15e6135dfbde5f93c2851f01ac9) | `` Updated emacs ``        |
| [`5e079b99`](https://github.com/nix-community/emacs-overlay/commit/5e079b9904fcac005ccd60adbe39d04b3a4eee23) | `` Updated melpa ``        |
| [`41dcf6b0`](https://github.com/nix-community/emacs-overlay/commit/41dcf6b00a196a4d806a804ada2d36a9d670ea6c) | `` Updated elpa ``         |
| [`3cfce01b`](https://github.com/nix-community/emacs-overlay/commit/3cfce01be3211cac316b2e07929849e52992a543) | `` Updated flake inputs `` |