### PR TITLE
chore(flake/nur): `32418ba1` -> `d4bfad4c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718642297,
-        "narHash": "sha256-hun/M+XXadIjMOHansGAVssP/G+CJyGEOr/j0J6tFBI=",
+        "lastModified": 1718649005,
+        "narHash": "sha256-1Aw+JgGQK6e9MZdV4cbO1d3GRvYRKbwOvmet5gSFwvE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "32418ba10a3e009ab417c4bd7d66259815aceb2a",
+        "rev": "d4bfad4cd8a5c44bb469f95f20e6eb4799145046",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d4bfad4c`](https://github.com/nix-community/NUR/commit/d4bfad4cd8a5c44bb469f95f20e6eb4799145046) | `` automatic update `` |