### PR TITLE
chore(flake/nur): `d4bfad4c` -> `c8bd5900`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718649005,
-        "narHash": "sha256-1Aw+JgGQK6e9MZdV4cbO1d3GRvYRKbwOvmet5gSFwvE=",
+        "lastModified": 1718653574,
+        "narHash": "sha256-Eo/7TYdPdvOuBJuvIqmjsUtnCwmXO0N635bhYvIzT8k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d4bfad4cd8a5c44bb469f95f20e6eb4799145046",
+        "rev": "c8bd590025806bfaefbab9ee1f3a71614e4931af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c8bd5900`](https://github.com/nix-community/NUR/commit/c8bd590025806bfaefbab9ee1f3a71614e4931af) | `` automatic update `` |