### PR TITLE
chore(flake/nur): `c8bd5900` -> `7e2fd21d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718653574,
-        "narHash": "sha256-Eo/7TYdPdvOuBJuvIqmjsUtnCwmXO0N635bhYvIzT8k=",
+        "lastModified": 1718657117,
+        "narHash": "sha256-feD0akT2tYhVN6X2Oxv1SOM+mt7MuitAJZYrWEUwNc8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c8bd590025806bfaefbab9ee1f3a71614e4931af",
+        "rev": "7e2fd21daf021f7fef4d65d6bb3e77c90d15a631",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7e2fd21d`](https://github.com/nix-community/NUR/commit/7e2fd21daf021f7fef4d65d6bb3e77c90d15a631) | `` automatic update `` |
| [`4d3b1da2`](https://github.com/nix-community/NUR/commit/4d3b1da2c3b6559fc403622c7daf36539580ed5b) | `` automatic update `` |