### PR TITLE
chore(flake/nur): `7e2fd21d` -> `a2ab824a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718657117,
-        "narHash": "sha256-feD0akT2tYhVN6X2Oxv1SOM+mt7MuitAJZYrWEUwNc8=",
+        "lastModified": 1718660691,
+        "narHash": "sha256-BWXlmFDR6iYmLTj0DMYyWXtIKYE0+N2UY+P+TVNKJWE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7e2fd21daf021f7fef4d65d6bb3e77c90d15a631",
+        "rev": "a2ab824af78687765e29f9bbf2d80cfddaeca1c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a2ab824a`](https://github.com/nix-community/NUR/commit/a2ab824af78687765e29f9bbf2d80cfddaeca1c9) | `` automatic update `` |
| [`92a66e57`](https://github.com/nix-community/NUR/commit/92a66e57ace0bc2a7d3cbf6e7d65ba9dcdf00f16) | `` automatic update `` |