### PR TITLE
chore(flake/nur): `a2ab824a` -> `8eb5c47b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718660691,
-        "narHash": "sha256-BWXlmFDR6iYmLTj0DMYyWXtIKYE0+N2UY+P+TVNKJWE=",
+        "lastModified": 1718663606,
+        "narHash": "sha256-pKSwptYQ7lNAzjyfg8OcpM2Absr8W0b0O0Pi5obcslU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a2ab824af78687765e29f9bbf2d80cfddaeca1c9",
+        "rev": "8eb5c47baa5cd794f62b72e8083fcc56ce703d90",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8eb5c47b`](https://github.com/nix-community/NUR/commit/8eb5c47baa5cd794f62b72e8083fcc56ce703d90) | `` automatic update `` |