### PR TITLE
chore(flake/nixpkgs): `e9ee548d` -> `b60ebf54`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1718318537,
-        "narHash": "sha256-4Zu0RYRcAY/VWuu6awwq4opuiD//ahpc2aFHg2CWqFY=",
+        "lastModified": 1718530797,
+        "narHash": "sha256-pup6cYwtgvzDpvpSCFh1TEUjw2zkNpk8iolbKnyFmmU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e9ee548d90ff586a6471b4ae80ae9cfcbceb3420",
+        "rev": "b60ebf54c15553b393d144357375ea956f89e9a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                      |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`ee82ceab`](https://github.com/NixOS/nixpkgs/commit/ee82ceaba6b1229e9d99970a40f34338bf8967de) | `` wxc: init at 1.0.0.2 ``                                                                   |
| [`852c13ca`](https://github.com/NixOS/nixpkgs/commit/852c13ca9b6806ce54855f4c1b138662ed47b72d) | `` libbsd: fix version script with lld 17+ ``                                                |
| [`cb452d89`](https://github.com/NixOS/nixpkgs/commit/cb452d89b3abd70a9e21e8ebce2c6adb1e6afa94) | `` android-studio-full: move changelog; fix duplicate merged line ``                         |
| [`1cc16426`](https://github.com/NixOS/nixpkgs/commit/1cc164265d5ab03855f9dbcc24e6383455411e7f) | `` catamaran: init at 0-unstable-2024-03-02 ``                                               |
| [`150f609e`](https://github.com/NixOS/nixpkgs/commit/150f609e537b4a5a04ac1a71619bb529ad88e667) | `` xwayland: cherry-pick patch to fix segfault when linux-dmabuf device is not accessible `` |
| [`3d44176e`](https://github.com/NixOS/nixpkgs/commit/3d44176ec8df49433f1e8e0ee0e437319fe52dac) | `` iniparser: 4.1 -> 4.2.3 ``                                                                |
| [`c3a453e5`](https://github.com/NixOS/nixpkgs/commit/c3a453e548a0cd8ce3f5481f53774bd7abd15021) | `` bftpd: fix darwin build ``                                                                |
| [`d2eb2b4c`](https://github.com/NixOS/nixpkgs/commit/d2eb2b4cb09e36a66ff58bb1f6088370442b45f2) | `` vscode-extensions.discloud.discloud: update renamed astindev ``                           |
| [`9a2ff704`](https://github.com/NixOS/nixpkgs/commit/9a2ff70471b9b566c2912d4997dacd3206306ed7) | `` home-assistant-custom-components.adaptive_lighting: 1.19.1 -> 1.22.0 ``                   |
| [`17c2d298`](https://github.com/NixOS/nixpkgs/commit/17c2d29811ab7372e721a3ea47c49d17dcbbbb79) | `` maintainers: rename astindev to diogomdp ``                                               |
| [`8797a662`](https://github.com/NixOS/nixpkgs/commit/8797a662b34ad263ad666791246585357440c278) | `` home-assistant: 2024.6.2 -> 2024.6.3 ``                                                   |
| [`a48ca850`](https://github.com/NixOS/nixpkgs/commit/a48ca85062877e324ac82692568e54961eebbdd0) | `` python312Packages.buienradar: 1.0.5 -> 1.0.6 ``                                           |
| [`aefaf8f5`](https://github.com/NixOS/nixpkgs/commit/aefaf8f50bfb81a1a413a404dfcba84ee34ef50f) | `` tracy: move to wayland, add tracy-x11 ``                                                  |
| [`ed7c5230`](https://github.com/NixOS/nixpkgs/commit/ed7c5230a7654fba5cfe5dec9e75ae29a3087980) | `` local-ai: 2.15.0 -> 2.16.0 ``                                                             |
| [`49294995`](https://github.com/NixOS/nixpkgs/commit/4929499597ffc50407b0457237865353d1e790c6) | `` just: 1.28.0 -> 1.29.1 ``                                                                 |
| [`7f28d49b`](https://github.com/NixOS/nixpkgs/commit/7f28d49b484e533a449c1901e67ace29ca125e07) | `` nrf-udev: init at 1.0.1 ``                                                                |
| [`d5e03866`](https://github.com/NixOS/nixpkgs/commit/d5e038660c97bc2e96c7c0f8e47c2c165baadc48) | `` sssd: 2.9.4 -> 2.9.5 ``                                                                   |
| [`c31b747c`](https://github.com/NixOS/nixpkgs/commit/c31b747c327306699a6fb38f1c1cd61ddf8254dc) | `` pyright: 1.1.366 -> 1.1.367 ``                                                            |
| [`e3bcea2a`](https://github.com/NixOS/nixpkgs/commit/e3bcea2a6c451a62af9ad28beeb25af696cee43b) | `` python311Packages.blebox-uniapi: 2.3.0 -> 2.4.2 ``                                        |
| [`4ecb8ce1`](https://github.com/NixOS/nixpkgs/commit/4ecb8ce1c81fd9e2a826890ae60e9ce850b73d21) | `` python312Packages.aiolifx-themes: 0.4.17 -> 0.4.18 ``                                     |
| [`a7299edb`](https://github.com/NixOS/nixpkgs/commit/a7299edb1cdf125a78914721b64a697a36645033) | `` python311Packages.aiolifx: 1.0.2 -> 1.0.3 ``                                              |
| [`3b3d266d`](https://github.com/NixOS/nixpkgs/commit/3b3d266d077639e3d75380502f084c56e41a91b2) | `` python311Packages.exchangelib: 5.4.0 -> 5.4.1 ``                                          |
| [`b33daa31`](https://github.com/NixOS/nixpkgs/commit/b33daa31f2043794280f0301bd8d16593c96cd57) | `` uxn: 1.0-unstable-2024-06-05 -> 1.0-unstable-2024-06-14 ``                                |
| [`2e849dbb`](https://github.com/NixOS/nixpkgs/commit/2e849dbb7e898c6910eacaa71466bc876f640046) | `` chromium: 126.0.6478.55 -> 126.0.6478.61 ``                                               |
| [`21966db6`](https://github.com/NixOS/nixpkgs/commit/21966db6d5e0918452248fdb99461827b6b75d5a) | `` chromedriver: 126.0.6478.55 -> 126.0.6478.61 ``                                           |
| [`4b8fd789`](https://github.com/NixOS/nixpkgs/commit/4b8fd7890ef0d327496a1fff796dbb477d21512f) | `` thunderbird-unwrapped: 115.11.1 -> 115.12.0 ``                                            |
| [`95dc8075`](https://github.com/NixOS/nixpkgs/commit/95dc8075708a8f246fe0bbcb561608e3a36e6242) | `` discord: various updates (#319893) ``                                                     |
| [`7bd91fb6`](https://github.com/NixOS/nixpkgs/commit/7bd91fb6e8484d82f3151b00ef49da3190161c40) | `` home-assistant-custom-component-epex_spot: 2.3.5 -> 2.3.7 ``                              |
| [`b418b6c4`](https://github.com/NixOS/nixpkgs/commit/b418b6c469418e2cdb9fff4098cc3a9d3d5e21c8) | `` phpunit: 11.2.0 -> 11.2.2 ``                                                              |
| [`4b1d39d9`](https://github.com/NixOS/nixpkgs/commit/4b1d39d9359bb49f0d9abd72db2ae1f265e77aa4) | `` treewide: remove myself from packages I don’t use ``                                      |
| [`3da97e21`](https://github.com/NixOS/nixpkgs/commit/3da97e2163d090fbf03929971357a6757dc44037) | `` doc: Prevent unnecessary rebuilds ``                                                      |
| [`be6f553b`](https://github.com/NixOS/nixpkgs/commit/be6f553b7ddc2ca307ec8ef3395edf6010f13119) | `` doc: Remove unneeded functions/library dir ``                                             |
| [`b59560c3`](https://github.com/NixOS/nixpkgs/commit/b59560c3f8155ecf0a564f56f3e0ec26dc746202) | `` doc: Use build-time to insert dynamic python interpreter table ``                         |
| [`22362b36`](https://github.com/NixOS/nixpkgs/commit/22362b362743287cf6f31d7c42ee7f10344ddd05) | `` libeduvpn-common: 1.2.1 -> 2.0.1 ``                                                       |
| [`a0840027`](https://github.com/NixOS/nixpkgs/commit/a0840027a1a6bec2cb14094aa58b262ddba2a3a8) | `` eduvpn-client: 4.2.1 -> 4.3.1 ``                                                          |
| [`1d5371f9`](https://github.com/NixOS/nixpkgs/commit/1d5371f9acf021db201012900e3413aceebe4a5e) | `` symfony-cli: 5.8.19 -> 5.9.1 ``                                                           |
| [`b9e13e35`](https://github.com/NixOS/nixpkgs/commit/b9e13e352899150889d45fdb7a50ad89969d50ee) | `` nixos/tests/firefly-iii: Use postgres 16 ``                                               |
| [`3863fd9a`](https://github.com/NixOS/nixpkgs/commit/3863fd9a6a72d202d0956cd0edb74d6aab1e37e1) | `` firefly-iii: 6.1.16 -> 6.1.17 ``                                                          |
| [`176225ff`](https://github.com/NixOS/nixpkgs/commit/176225ff634be7732bea03d08ada22b1f539cb77) | `` python10Packages.hatch-vcs: fix broken hatch-vcs on pythons 39 and 310 (#320039) ``       |
| [`02da8741`](https://github.com/NixOS/nixpkgs/commit/02da874176afd50fd526639503354fdbb8eecaa8) | `` python311Packages.fastembed: 0.2.7 -> 0.3.0 ``                                            |
| [`ddb515d3`](https://github.com/NixOS/nixpkgs/commit/ddb515d3fd18a464bf0d860b866468d2d8b2f9f1) | `` sd-switch: 0.4.0 -> 0.5.0 ``                                                              |
| [`1c842131`](https://github.com/NixOS/nixpkgs/commit/1c842131a3960ba52fe54df99c553f5c4329791d) | `` koka: 3.1.0 -> 3.1.2 ``                                                                   |
| [`919226fb`](https://github.com/NixOS/nixpkgs/commit/919226fbc66d3c8b06437a735b1a39b4590a9b08) | `` arc-icon-theme: use upstream version number ``                                            |
| [`0317150a`](https://github.com/NixOS/nixpkgs/commit/0317150a7582718b42c929bb43f82bb6b23b4e0b) | `` komikku: 1.47.0 -> 1.48.1 ``                                                              |
| [`6a899b7b`](https://github.com/NixOS/nixpkgs/commit/6a899b7b15d0a3f96faaf7463983350bf5215112) | `` home-assistant: update component packages ``                                              |
| [`7a7060c5`](https://github.com/NixOS/nixpkgs/commit/7a7060c5bfae66ea06439f139ae8361f46e2bc35) | `` nixos/aria2: fix missing default ``                                                       |
| [`f6d31131`](https://github.com/NixOS/nixpkgs/commit/f6d3113164a7abcf5197bf9e70726177683d216f) | `` nixos/aria2: fix remove not needed code ``                                                |
| [`c27ac48c`](https://github.com/NixOS/nixpkgs/commit/c27ac48c739489b51d3fd89e7470632503235d91) | `` python311Packages.txtai: mark as broken on python 3.12 ``                                 |
| [`379f2e37`](https://github.com/NixOS/nixpkgs/commit/379f2e376eade87a02137a12823d228df2674b9e) | `` apt: 2.9.4 -> 2.9.5 ``                                                                    |
| [`00717923`](https://github.com/NixOS/nixpkgs/commit/007179238755938dcb56bd05a1972bb5a44e946a) | `` osinfo-db: 20240510 -> 20240523 ``                                                        |
| [`c79b8dff`](https://github.com/NixOS/nixpkgs/commit/c79b8dfff5f5daf6b906ee68bc11e9e9a31285fe) | `` python311Packages.bentoml: 1.2.5 -> 1.2.18 ``                                             |
| [`2be74bd8`](https://github.com/NixOS/nixpkgs/commit/2be74bd88f619929813674f1a6fca159e1f017b8) | `` libreoffice: add Slovak language ``                                                       |
| [`1141a5cd`](https://github.com/NixOS/nixpkgs/commit/1141a5cde5957eecb2d408f7eafbcedf7528dd76) | `` dtools: 2.108.0 -> 2.109.0 ``                                                             |
| [`4e5dda64`](https://github.com/NixOS/nixpkgs/commit/4e5dda64e96c6028ecb3d3a7534569d27764117a) | `` youtrack: use jdk21 ``                                                                    |
| [`1bd1b706`](https://github.com/NixOS/nixpkgs/commit/1bd1b7068bfb548d4cee09dad8072dc597486f75) | `` python311Packages.daphne: 4.0.0 -> 4.1.2 ``                                               |
| [`2d7d44af`](https://github.com/NixOS/nixpkgs/commit/2d7d44af2150a7e792d479f8515ffda034e553ca) | `` python311Packages.llama-index-vector-stores-qdrant: 0.2.9 -> 0.2.10 ``                    |
| [`ca82f0e9`](https://github.com/NixOS/nixpkgs/commit/ca82f0e954a79eaecaadef6258aeee40d6a24e16) | `` python311Packages.llama-index-vector-stores-postgres: 0.1.10 -> 0.1.11 ``                 |
| [`05577f3b`](https://github.com/NixOS/nixpkgs/commit/05577f3b1ff3c3f12aba0b524f71272ff1a7a142) | `` python311Packages.llama-index-readers-file: 0.1.23 -> 0.1.25 ``                           |
| [`12eac6ed`](https://github.com/NixOS/nixpkgs/commit/12eac6ed58928388c1c9b117eabd2cb8591f3a05) | `` python311Packages.llama-index-embeddings-gemini: 0.1.7 -> 0.1.8 ``                        |
| [`d130e581`](https://github.com/NixOS/nixpkgs/commit/d130e581ac71f1843eb86963dd8a6ded97cec6a7) | `` python311Packages.llama-index-core: 0.10.43 -> 0.10.45 ``                                 |
| [`e9a2d6b9`](https://github.com/NixOS/nixpkgs/commit/e9a2d6b9c829852cfe972c7520cf0b5d97cee3d0) | `` google-chrome: 125.0.6422.141 -> 126.0.6478.61 ``                                         |
| [`5258c17a`](https://github.com/NixOS/nixpkgs/commit/5258c17a489a2867debc3429831137149fad156a) | `` python312Packages.langchain-community: 0.2.4 -> 0.2.5 ``                                  |
| [`b4557063`](https://github.com/NixOS/nixpkgs/commit/b455706355e1cddfa44e95821baab249081c7bda) | `` python311Packages.langchain: 0.2.3 -> 0.2.5 ``                                            |
| [`4f68245f`](https://github.com/NixOS/nixpkgs/commit/4f68245ff83ac1b37043d8aeeffaa52661ff6338) | `` python311Packages.langchain-core: 0.2.5 -> 0.2.7 ``                                       |
| [`d8d74a2d`](https://github.com/NixOS/nixpkgs/commit/d8d74a2d5df6cccbd2a2411fe2218dce09373f76) | `` python312Packages.langsmith: 0.1.64 -> 0.1.77 ``                                          |
| [`3de644a0`](https://github.com/NixOS/nixpkgs/commit/3de644a0fbc0cd079a64abe29c20abd0beb82fd7) | `` python311Packages.pyinsteon: 1.6.1 -> 1.6.2 ``                                            |
| [`3e1c2e80`](https://github.com/NixOS/nixpkgs/commit/3e1c2e804fa8c1cf8ccac5b3276de6913cf35520) | `` python312Packages.pyhaversion: 23.1.0 -> 24.6.1 ``                                        |
| [`781d8796`](https://github.com/NixOS/nixpkgs/commit/781d87960213cf59f5e45952968f5a849e1ae100) | `` dissent: 0.0.24 -> 0.0.25 ``                                                              |
| [`0a71bbb6`](https://github.com/NixOS/nixpkgs/commit/0a71bbb64a89b311d9b5a715de2f1713368e799f) | `` gcc: fix building with gcc.cpu on some platforms ``                                       |
| [`22865319`](https://github.com/NixOS/nixpkgs/commit/228653194554cd413703449e149ace4b285e9f31) | `` tipidee: 0.0.4.0 -> 0.0.5.0 ``                                                            |
| [`b9eb2c67`](https://github.com/NixOS/nixpkgs/commit/b9eb2c67000081be60d93b23c88f1c1af152dd89) | `` mdevd: 0.1.6.3 -> 0.1.6.4 ``                                                              |
| [`08b133b1`](https://github.com/NixOS/nixpkgs/commit/08b133b1a0a26b7423b9e6dc07be819837ebc198) | `` s6-networking: 2.7.0.2 -> 2.7.0.3 ``                                                      |
| [`bff276e0`](https://github.com/NixOS/nixpkgs/commit/bff276e0d5eb8433652b7f9a6636aa4272d09210) | `` s6-dns: 2.3.7.1 -> 2.3.7.2 ``                                                             |
| [`196a8803`](https://github.com/NixOS/nixpkgs/commit/196a88033fa46c64f6cad4ca700ee03a56ee73b6) | `` s6-rc: 0.5.4.2 -> 0.5.4.3 ``                                                              |
| [`23cbbbe2`](https://github.com/NixOS/nixpkgs/commit/23cbbbe2fffc4efbbdf459e70a51828cc2cac08e) | `` s6: 2.12.0.4 -> 2.13.0.0 ``                                                               |
| [`e2fc145d`](https://github.com/NixOS/nixpkgs/commit/e2fc145de25e140f517415ddf3e8debddf133f05) | `` execline: 2.9.5.1 -> 2.9.6.0 ``                                                           |
| [`772eef19`](https://github.com/NixOS/nixpkgs/commit/772eef19a436511aec6e47005ec4fe044bae4dfd) | `` skalibs: 2.14.1.1 -> 2.14.2.0 ``                                                          |
| [`50524467`](https://github.com/NixOS/nixpkgs/commit/5052446710f8b12a2fe4f97acc050c7fd93386de) | `` exploitdb: 2024-06-08 -> 2024-06-15 ``                                                    |
| [`fdc5e35b`](https://github.com/NixOS/nixpkgs/commit/fdc5e35b3653480ac214af2b30e03b16cfff66e8) | `` decker: 1.43 -> 1.44 ``                                                                   |
| [`c77334a3`](https://github.com/NixOS/nixpkgs/commit/c77334a3ffa6396b5119f574966cb9ed35845813) | `` svtplay-dl: 4.79 -> 4.83 ``                                                               |
| [`8e358c05`](https://github.com/NixOS/nixpkgs/commit/8e358c05aab7f96e4ec8d1dab493fbab124894e6) | `` cimg: 3.3.6 -> 3.4.0 ``                                                                   |
| [`14d426f5`](https://github.com/NixOS/nixpkgs/commit/14d426f5d6150872bd1bfa23d890913236c6e121) | `` safety-cli: 3.2.2 -> 3.2.3 ``                                                             |
| [`1ad517b0`](https://github.com/NixOS/nixpkgs/commit/1ad517b090c39efc16152edd7d43cd960388b37c) | `` yaru-theme: 24.04.2 -> 24.04.3 ``                                                         |
| [`4a591293`](https://github.com/NixOS/nixpkgs/commit/4a59129384d0d0187c4f20f1a0a62b8da9bf5f43) | `` buildFlutterApplication: use the engine ``                                                |
| [`a54e49b3`](https://github.com/NixOS/nixpkgs/commit/a54e49b3604cc5cc3c2f74345db6d1a8fb4c9256) | `` flutter.engine: init ``                                                                   |
| [`d87cbe44`](https://github.com/NixOS/nixpkgs/commit/d87cbe4485ad79c4a2561b1a864e162a3afa2abb) | `` freecell-solver: 6.8.0 -> 6.10.0 ``                                                       |
| [`34282484`](https://github.com/NixOS/nixpkgs/commit/34282484192815af365751f98e904d21ebc134ce) | `` wxsqlite3: 4.9.10 -> 4.9.11 ``                                                            |
| [`78b5369f`](https://github.com/NixOS/nixpkgs/commit/78b5369fe471360f590e9791e2ed7f76478dd8ba) | `` topicctl: 1.17.0 -> 1.18.0 ``                                                             |
| [`a1fb5fa7`](https://github.com/NixOS/nixpkgs/commit/a1fb5fa71ad2f35f61d11efff492b9bec36f1a85) | `` sqlcmd: 1.6.0 -> 1.7.0 ``                                                                 |
| [`a994247f`](https://github.com/NixOS/nixpkgs/commit/a994247fa3593ee414c105be7dd32eac3fcd90de) | `` rclone: 1.66.0 -> 1.67.0 ``                                                               |
| [`40916ded`](https://github.com/NixOS/nixpkgs/commit/40916ded4ad5fe4bcc18963217c3a026db505c7f) | `` maintainers: rename nu-nu-ko to fsnkty ``                                                 |
| [`31687eaa`](https://github.com/NixOS/nixpkgs/commit/31687eaa6f4ace838f51b9eafb5a444a53f5d1ed) | `` oh-my-posh: 21.3.0 -> 21.9.1 ``                                                           |
| [`41d222f9`](https://github.com/NixOS/nixpkgs/commit/41d222f957e175e031520c4ff12c1d789e4423c2) | `` bitmagnet: 0.8.0 -> 0.9.2 ``                                                              |
| [`277e3536`](https://github.com/NixOS/nixpkgs/commit/277e3536ebd46d7ed277709cdd3a2dca58fe4ce3) | `` cloudsmith-cli: 1.2.3 -> 1.2.5 ``                                                         |
| [`ed316ede`](https://github.com/NixOS/nixpkgs/commit/ed316edef2277535c818d3017cd61c107953a074) | `` lunar-client: 3.2.9 -> 3.2.10 ``                                                          |
| [`e2940968`](https://github.com/NixOS/nixpkgs/commit/e2940968c846353a44d2784e021f6121f122bcde) | `` gitleaks: 8.18.3 -> 8.18.4 ``                                                             |
| [`7ee94320`](https://github.com/NixOS/nixpkgs/commit/7ee943203d36ad546f574e9436bede3619299fd8) | `` python311Packages.gpsoauth: 1.1.0 -> 1.1.1 ``                                             |
| [`b51cf6ec`](https://github.com/NixOS/nixpkgs/commit/b51cf6ec0e0bc9a192a6595d69e6817fec93c56c) | `` kexec-tools: fix compiling with llvm ``                                                   |
| [`3cd3b65f`](https://github.com/NixOS/nixpkgs/commit/3cd3b65fb9c098c00b6a40e9a213e6c534203376) | `` ananicy-rules-cachyos: 0-unstable-2024-06-07 -> 0-unstable-2024-06-14 ``                  |
| [`75345f51`](https://github.com/NixOS/nixpkgs/commit/75345f515b6cb6715131d826454e5e2f572bd40b) | `` emacsPackages.el-easydraw: 20240606.457 -> 20240612.1012 ``                               |