### PR TITLE
chore(flake/emacs-overlay): `1f57a659` -> `b63132f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1718644238,
-        "narHash": "sha256-Kjqe0v2n0+ZU74edGZJADysx+n4Ny5QVuqk4xVEblHE=",
+        "lastModified": 1718672729,
+        "narHash": "sha256-E+HzIw+TXXzHaK/6ZZexZDmVOw2xeIBEp3vy4ci0L+0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1f57a6596440c15e6135dfbde5f93c2851f01ac9",
+        "rev": "b63132f970a0f0f4a11ddde5f6b109b3a555922e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`b63132f9`](https://github.com/nix-community/emacs-overlay/commit/b63132f970a0f0f4a11ddde5f6b109b3a555922e) | `` Updated elpa ``         |
| [`2957aa6c`](https://github.com/nix-community/emacs-overlay/commit/2957aa6cfd14a46cadad9d07d64f110bece1978d) | `` Updated nongnu ``       |
| [`f9906ea2`](https://github.com/nix-community/emacs-overlay/commit/f9906ea2849fb8d54d2cc4d7089736d743b62dba) | `` Updated flake inputs `` |