### PR TITLE
chore(flake/nur): `c8bafa42` -> `777efdae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718675359,
-        "narHash": "sha256-tgQ+hdqQ+dKclvBm03TIdxyYbOfSfdNBTVoY82hK81s=",
+        "lastModified": 1718682377,
+        "narHash": "sha256-+1Or+vVjFphxmenEEwnE37hHSPtI+fcnA0pCwB2g7iw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c8bafa42874ae92d2cf769c89d425e8af5313013",
+        "rev": "777efdaee0da7633fe95131985c6c9d72db59bed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`777efdae`](https://github.com/nix-community/NUR/commit/777efdaee0da7633fe95131985c6c9d72db59bed) | `` automatic update `` |
| [`661f4f9a`](https://github.com/nix-community/NUR/commit/661f4f9a639c3e1b43cd7bcd526bba191e6c7fba) | `` automatic update `` |