### PR TITLE
chore(flake/nur): `777efdae` -> `03dbb137`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718682377,
-        "narHash": "sha256-+1Or+vVjFphxmenEEwnE37hHSPtI+fcnA0pCwB2g7iw=",
+        "lastModified": 1718685219,
+        "narHash": "sha256-RYVPWU8akb4Kham9bo7G03zXtVYNjZvabthN3C0S0Cc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "777efdaee0da7633fe95131985c6c9d72db59bed",
+        "rev": "03dbb1378bf45c5ff79c2260f5d46236ac09c875",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`03dbb137`](https://github.com/nix-community/NUR/commit/03dbb1378bf45c5ff79c2260f5d46236ac09c875) | `` automatic update `` |
| [`6446fc7e`](https://github.com/nix-community/NUR/commit/6446fc7e2f37276f6875411c86ec7f30dcd98ba8) | `` automatic update `` |