### PR TITLE
chore(flake/nur): `03dbb137` -> `6ccc9308`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718685219,
-        "narHash": "sha256-RYVPWU8akb4Kham9bo7G03zXtVYNjZvabthN3C0S0Cc=",
+        "lastModified": 1718690133,
+        "narHash": "sha256-WW/3sFg/fKF/ThspcV55SvqC9tLBGn+7qIrAAbBWtUk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "03dbb1378bf45c5ff79c2260f5d46236ac09c875",
+        "rev": "6ccc930853f8ceaff6a1825e5d9fe239a9b1bc4c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6ccc9308`](https://github.com/nix-community/NUR/commit/6ccc930853f8ceaff6a1825e5d9fe239a9b1bc4c) | `` automatic update `` |
| [`617102d0`](https://github.com/nix-community/NUR/commit/617102d01564127e00d8a6c7db3e02fcfdaa9824) | `` automatic update `` |