### PR TITLE
chore(flake/nur): `ebd94cf2` -> `4f50a404`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718700344,
-        "narHash": "sha256-3KleIvt12hn1m+BnFamOoC329JkyqeImdrXr6XYaf8I=",
+        "lastModified": 1718703915,
+        "narHash": "sha256-PT4FT+JbQA2eRxKmrOhlTAGYctfCR1oGxSbCJ8521q8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ebd94cf2cd7ca8fc85601e2022bfcc339b1de8db",
+        "rev": "4f50a4040a3426e2257d35350e8f0fdc4eb2d9fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4f50a404`](https://github.com/nix-community/NUR/commit/4f50a4040a3426e2257d35350e8f0fdc4eb2d9fe) | `` automatic update `` |
| [`10068002`](https://github.com/nix-community/NUR/commit/10068002a87502e4e8ad4542babe510fcdac0e47) | `` automatic update `` |