### PR TITLE
chore(flake/nur): `4f50a404` -> `6e617525`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718703915,
-        "narHash": "sha256-PT4FT+JbQA2eRxKmrOhlTAGYctfCR1oGxSbCJ8521q8=",
+        "lastModified": 1718711189,
+        "narHash": "sha256-xky3e0zvQVCepj+p2UaUn0xFXj/c7WNsirI+XfXHh7I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4f50a4040a3426e2257d35350e8f0fdc4eb2d9fe",
+        "rev": "6e617525f9b8ad1b5721f805f40442e1afa2dbcb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6e617525`](https://github.com/nix-community/NUR/commit/6e617525f9b8ad1b5721f805f40442e1afa2dbcb) | `` automatic update `` |