### PR TITLE
chore(flake/nur): `6e617525` -> `4b0d9515`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718711189,
-        "narHash": "sha256-xky3e0zvQVCepj+p2UaUn0xFXj/c7WNsirI+XfXHh7I=",
+        "lastModified": 1718715610,
+        "narHash": "sha256-ZeBmuH1rHbsX5JTEoTCtXmSPZ0NlbkS3xET8U7smoYw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6e617525f9b8ad1b5721f805f40442e1afa2dbcb",
+        "rev": "4b0d95155fbffbfa3ad088a52fe38e3b52ae21ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4b0d9515`](https://github.com/nix-community/NUR/commit/4b0d95155fbffbfa3ad088a52fe38e3b52ae21ae) | `` automatic update `` |
| [`3987a77f`](https://github.com/nix-community/NUR/commit/3987a77f546268c612f0aaced6e33348e1b028a9) | `` automatic update `` |