### PR TITLE
chore(flake/nur): `4b0d9515` -> `32d90e31`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718715610,
-        "narHash": "sha256-ZeBmuH1rHbsX5JTEoTCtXmSPZ0NlbkS3xET8U7smoYw=",
+        "lastModified": 1718718309,
+        "narHash": "sha256-3AcDagvybnFQcR3cvFPizbeo8aYTQfTQ8rRfRfc9RPg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4b0d95155fbffbfa3ad088a52fe38e3b52ae21ae",
+        "rev": "32d90e31879eaa37b83f1a6c12b1136007c79192",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`32d90e31`](https://github.com/nix-community/NUR/commit/32d90e31879eaa37b83f1a6c12b1136007c79192) | `` automatic update `` |