### PR TITLE
chore(flake/emacs-overlay): `27e6ef6f` -> `d98b82fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1718675614,
-        "narHash": "sha256-ALCQMCzcZuumVF/PaxW0xShwm72U5/2Zk/HHWwZrqlQ=",
+        "lastModified": 1718730505,
+        "narHash": "sha256-xpO6/68SFj+hCXmTcB8PBltuVZJoOU0BTZSyax9dRw4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "27e6ef6f477ba42dc8682ed854a519cbea4bacaf",
+        "rev": "d98b82faa313f3a3ac1c3f00f98819eb75bfc00d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`d98b82fa`](https://github.com/nix-community/emacs-overlay/commit/d98b82faa313f3a3ac1c3f00f98819eb75bfc00d) | `` Updated emacs `` |
| [`ecfedc0d`](https://github.com/nix-community/emacs-overlay/commit/ecfedc0d607abf7df2b077f421872fdfcc457ce7) | `` Updated melpa `` |
| [`40400234`](https://github.com/nix-community/emacs-overlay/commit/40400234c06e01b61d8fe33aa512cc8b0d0fb7a9) | `` Updated elpa ``  |