### PR TITLE
chore(flake/nur): `aad0a952` -> `dffe7aa4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718728700,
-        "narHash": "sha256-awXrZIDyA22ArEiecVTI04mNlZXShhjTusynq86YYW0=",
+        "lastModified": 1718739965,
+        "narHash": "sha256-10P+xjmIaUMouA7sG4INXH0gChrClARAdQCnD+AXnAM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aad0a9529ebd80fd909720a26db47ad2fe991790",
+        "rev": "dffe7aa493c53257c63d1b91dc86fe066224dc30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dffe7aa4`](https://github.com/nix-community/NUR/commit/dffe7aa493c53257c63d1b91dc86fe066224dc30) | `` automatic update `` |