### PR TITLE
chore(flake/nur): `dffe7aa4` -> `50687bbf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718739965,
-        "narHash": "sha256-10P+xjmIaUMouA7sG4INXH0gChrClARAdQCnD+AXnAM=",
+        "lastModified": 1718746251,
+        "narHash": "sha256-wuNm++XFrZ4PRAJLD5edzIK/RjaqyWBcTYh0nV8ohd4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dffe7aa493c53257c63d1b91dc86fe066224dc30",
+        "rev": "50687bbf5ce6372f107bd2030a4ac290bb715533",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`50687bbf`](https://github.com/nix-community/NUR/commit/50687bbf5ce6372f107bd2030a4ac290bb715533) | `` automatic update `` |
| [`84f4f03d`](https://github.com/nix-community/NUR/commit/84f4f03db94a5de088cb53db6447cb6ee696dbfd) | `` automatic update `` |