### PR TITLE
chore(flake/emacs-overlay): `d98b82fa` -> `6e7cd8e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1718730505,
-        "narHash": "sha256-xpO6/68SFj+hCXmTcB8PBltuVZJoOU0BTZSyax9dRw4=",
+        "lastModified": 1718759147,
+        "narHash": "sha256-wKcxVUAo8UmjArsGFX7A8t8y0e/cily0W5BfOir8yzY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d98b82faa313f3a3ac1c3f00f98819eb75bfc00d",
+        "rev": "6e7cd8e535254cdc023151b04f6d2344c9c74d4a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`6e7cd8e5`](https://github.com/nix-community/emacs-overlay/commit/6e7cd8e535254cdc023151b04f6d2344c9c74d4a) | `` Updated elpa ``   |
| [`9d798ee1`](https://github.com/nix-community/emacs-overlay/commit/9d798ee197f5464f79afe05e64518b553dfe23ef) | `` Updated nongnu `` |