### PR TITLE
chore(flake/nur): `50687bbf` -> `6b85cb98`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718746251,
-        "narHash": "sha256-wuNm++XFrZ4PRAJLD5edzIK/RjaqyWBcTYh0nV8ohd4=",
+        "lastModified": 1718761769,
+        "narHash": "sha256-7x8PAIQwEor8G6MXGs3n8OgBvbSUQ5g3t/Zgp2rJgeI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "50687bbf5ce6372f107bd2030a4ac290bb715533",
+        "rev": "6b85cb98966c1009b7b0a86c91b501565460840d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6b85cb98`](https://github.com/nix-community/NUR/commit/6b85cb98966c1009b7b0a86c91b501565460840d) | `` automatic update `` |
| [`5c630785`](https://github.com/nix-community/NUR/commit/5c630785d3d86f5cfb1f015ae8792a44e137aa34) | `` automatic update `` |