### PR TITLE
chore(flake/emacs-overlay): `6e7cd8e5` -> `3d4fbfcc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1718759147,
-        "narHash": "sha256-wKcxVUAo8UmjArsGFX7A8t8y0e/cily0W5BfOir8yzY=",
+        "lastModified": 1718762034,
+        "narHash": "sha256-yZuwr3Cd7a5AwU6kRW5wO7Y7s71wQClOdA+e7zsX+iI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6e7cd8e535254cdc023151b04f6d2344c9c74d4a",
+        "rev": "3d4fbfcca3379975205ff861c2055c014ba8b77e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`3d4fbfcc`](https://github.com/nix-community/emacs-overlay/commit/3d4fbfcca3379975205ff861c2055c014ba8b77e) | `` Updated emacs `` |
| [`9ad6e94c`](https://github.com/nix-community/emacs-overlay/commit/9ad6e94c659fdf303e34ec19af5f55f61a40ed94) | `` Updated melpa `` |