### PR TITLE
chore(flake/nur): `6b85cb98` -> `d919f575`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718761769,
-        "narHash": "sha256-7x8PAIQwEor8G6MXGs3n8OgBvbSUQ5g3t/Zgp2rJgeI=",
+        "lastModified": 1718769430,
+        "narHash": "sha256-PL3J497rndIZxwjQAfImjYAede45elc6R/j7efybyn0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6b85cb98966c1009b7b0a86c91b501565460840d",
+        "rev": "d919f575c56ff23c20f5e26ae110e10d3b4d5bca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d919f575`](https://github.com/nix-community/NUR/commit/d919f575c56ff23c20f5e26ae110e10d3b4d5bca) | `` automatic update `` |
| [`2929149b`](https://github.com/nix-community/NUR/commit/2929149b922ac9a2d2f6c5612c298a9328844c36) | `` automatic update `` |
| [`3f57d483`](https://github.com/nix-community/NUR/commit/3f57d48308a10f2c3caed545488bbd16e310aafe) | `` automatic update `` |