### PR TITLE
chore(flake/nur): `d919f575` -> `23b9b6e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718769430,
-        "narHash": "sha256-PL3J497rndIZxwjQAfImjYAede45elc6R/j7efybyn0=",
+        "lastModified": 1718769867,
+        "narHash": "sha256-0y4bMOkeja1fmG7eLanqrzoaIAIKfcqevZrLUCWyCaQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d919f575c56ff23c20f5e26ae110e10d3b4d5bca",
+        "rev": "23b9b6e71ce6b4feaaf0bc20c79bbf55fc88e63c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`23b9b6e7`](https://github.com/nix-community/NUR/commit/23b9b6e71ce6b4feaaf0bc20c79bbf55fc88e63c) | `` automatic update `` |