### PR TITLE
chore(flake/nur): `23b9b6e7` -> `60a4dffb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718769867,
-        "narHash": "sha256-0y4bMOkeja1fmG7eLanqrzoaIAIKfcqevZrLUCWyCaQ=",
+        "lastModified": 1718775829,
+        "narHash": "sha256-N+JSs4KjhOn6+ugmGxgUDLphDfKiCjdur3Ok5m/LYMk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "23b9b6e71ce6b4feaaf0bc20c79bbf55fc88e63c",
+        "rev": "60a4dffb65dadcc1c4fc79c0ae8c3cdee7a96461",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`60a4dffb`](https://github.com/nix-community/NUR/commit/60a4dffb65dadcc1c4fc79c0ae8c3cdee7a96461) | `` automatic update `` |