### PR TITLE
chore(flake/nur): `60a4dffb` -> `8ba5290f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718775829,
-        "narHash": "sha256-N+JSs4KjhOn6+ugmGxgUDLphDfKiCjdur3Ok5m/LYMk=",
+        "lastModified": 1718779564,
+        "narHash": "sha256-9ZAgt0t4tu8nDDzRyVXmbUi+FGjlqnmbqzKYGsCTkwQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "60a4dffb65dadcc1c4fc79c0ae8c3cdee7a96461",
+        "rev": "8ba5290f5e5714fdacef25b2e6547c50309032ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8ba5290f`](https://github.com/nix-community/NUR/commit/8ba5290f5e5714fdacef25b2e6547c50309032ae) | `` automatic update `` |
| [`3e554a35`](https://github.com/nix-community/NUR/commit/3e554a35d267119857504f11cbaa3734eb7b1acb) | `` automatic update `` |