### PR TITLE
chore(flake/nur): `8ba5290f` -> `801a327f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718779564,
-        "narHash": "sha256-9ZAgt0t4tu8nDDzRyVXmbUi+FGjlqnmbqzKYGsCTkwQ=",
+        "lastModified": 1718782750,
+        "narHash": "sha256-6uYXrDzLMMgj7qnLPqbOyRHwXwKAzikpjxpxUhKGr3Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8ba5290f5e5714fdacef25b2e6547c50309032ae",
+        "rev": "801a327fae0e737a39655e816dce74628b589b40",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`801a327f`](https://github.com/nix-community/NUR/commit/801a327fae0e737a39655e816dce74628b589b40) | `` automatic update `` |