### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `81a7e702` -> `6eca8849`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718675614,
-        "narHash": "sha256-ALCQMCzcZuumVF/PaxW0xShwm72U5/2Zk/HHWwZrqlQ=",
+        "lastModified": 1718762034,
+        "narHash": "sha256-yZuwr3Cd7a5AwU6kRW5wO7Y7s71wQClOdA+e7zsX+iI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "27e6ef6f477ba42dc8682ed854a519cbea4bacaf",
+        "rev": "3d4fbfcca3379975205ff861c2055c014ba8b77e",
         "type": "github"
       },
       "original": {
@@ -519,11 +519,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1718699619,
-        "narHash": "sha256-J5g6bAi8EfdhpeWVhVJZh2q/m5EAQknA0KO7thE8sbI=",
+        "lastModified": 1718802677,
+        "narHash": "sha256-KjhaCHHSF+5fmjBrWdSENIwE5tFrqe9OOm2aRctq1As=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "81a7e702eb42874d4ea0ba3fbefa16d516596ba1",
+        "rev": "6eca8849f0c9aeb43326692486b82ea4120fba40",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                                                  |
| ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`6eca8849`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/6eca8849f0c9aeb43326692486b82ea4120fba40) | `` Drop "not all Doom module flags tested" disclaimer `` |
| [`ded25597`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/ded2559716190e08040b5f78cd770ed234678f89) | `` Build-test most previously untested packages ``       |
| [`9fd4990e`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/9fd4990ef67cc35d583fd33d58fde478dea3503d) | `` flake.lock: Update ``                                 |