### PR TITLE
chore(flake/nur): `801a327f` -> `d18bde0a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718782750,
-        "narHash": "sha256-6uYXrDzLMMgj7qnLPqbOyRHwXwKAzikpjxpxUhKGr3Y=",
+        "lastModified": 1718793921,
+        "narHash": "sha256-LLeeRcRTzqBJVnnuPe2+SogdNjqwua+p2ens84royGQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "801a327fae0e737a39655e816dce74628b589b40",
+        "rev": "d18bde0a76f1223112edb5dec3d387523df780e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d18bde0a`](https://github.com/nix-community/NUR/commit/d18bde0a76f1223112edb5dec3d387523df780e1) | `` automatic update `` |
| [`f3411df0`](https://github.com/nix-community/NUR/commit/f3411df07774dedfe08226e1d280f0109235e04d) | `` automatic update `` |
| [`e5a1d937`](https://github.com/nix-community/NUR/commit/e5a1d937b05b6bf600453b782136e5515b0c715c) | `` automatic update `` |
| [`0b21cf66`](https://github.com/nix-community/NUR/commit/0b21cf66670516802886950379a292a34a797cbd) | `` automatic update `` |