### PR TITLE
chore(flake/nur): `d18bde0a` -> `935dfcaf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718793921,
-        "narHash": "sha256-LLeeRcRTzqBJVnnuPe2+SogdNjqwua+p2ens84royGQ=",
+        "lastModified": 1718800823,
+        "narHash": "sha256-sF1RFgtVbJv69q7ctLdJT1xWQM1+w5u7/7Dh/TzqoqU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d18bde0a76f1223112edb5dec3d387523df780e1",
+        "rev": "935dfcaf42846f1fbf1fdafbc0a633ebe5fb5100",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`935dfcaf`](https://github.com/nix-community/NUR/commit/935dfcaf42846f1fbf1fdafbc0a633ebe5fb5100) | `` automatic update `` |
| [`92fe5c4d`](https://github.com/nix-community/NUR/commit/92fe5c4d685a6a3cd11f41787043bf24aa0aa091) | `` automatic update `` |
| [`9d0a0cb6`](https://github.com/nix-community/NUR/commit/9d0a0cb65bcd2b67aa105f43044c627424b8a540) | `` automatic update `` |