### PR TITLE
chore(flake/nur): `935dfcaf` -> `f7c97149`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718800823,
-        "narHash": "sha256-sF1RFgtVbJv69q7ctLdJT1xWQM1+w5u7/7Dh/TzqoqU=",
+        "lastModified": 1718811866,
+        "narHash": "sha256-Jlm9c42Qk+eQbe2Wr3RHiN/MSc3MK7VE07qlmDqW2xU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "935dfcaf42846f1fbf1fdafbc0a633ebe5fb5100",
+        "rev": "f7c97149b8b5d0bf7943702577eabb530f7b5f4d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f7c97149`](https://github.com/nix-community/NUR/commit/f7c97149b8b5d0bf7943702577eabb530f7b5f4d) | `` automatic update `` |
| [`7ce69cdc`](https://github.com/nix-community/NUR/commit/7ce69cdcbc0f2e7315f0299e85952e5e02a83aed) | `` automatic update `` |
| [`34eeb00f`](https://github.com/nix-community/NUR/commit/34eeb00f9586136c2dbeaae40ab39d6917a5d6dd) | `` automatic update `` |