### PR TITLE
chore(flake/nixos-hardware): `cde8f7e1` -> `acb4f0e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -627,11 +627,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1718548414,
-        "narHash": "sha256-1obyIuQPR/Kq1j5/i/5EuAfQrDwjYnjCDG8iLtXmBhQ=",
+        "lastModified": 1718806950,
+        "narHash": "sha256-E+W/kbedZAiOuPtT+KQRposLaXGDLd7lyK7oL3IH/5U=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "cde8f7e11f036160b0fd6a9e07dc4c8e4061cf06",
+        "rev": "acb4f0e9bfa8ca2d6fca5e692307b5c994e7dbda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                   |
| ----------------------------------------------------------------------------------------------------- | ------------------------- |
| [`acb4f0e9`](https://github.com/NixOS/nixos-hardware/commit/acb4f0e9bfa8ca2d6fca5e692307b5c994e7dbda) | `` link to matrix room `` |