### PR TITLE
chore(flake/emacs-overlay): `b90ce397` -> `30b63b76`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1718788176,
-        "narHash": "sha256-5P/Y8QhKzl1LO65wIK5JKy8E7Fe2VDsDwT3yJFAxXkE=",
+        "lastModified": 1718816160,
+        "narHash": "sha256-24XheXNq4E1y8t3PJ2jBMMHnxWH2aaBkSCnKxQ27o6E=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b90ce397ca6331e20ffcb52d7434d1acd5ad6b22",
+        "rev": "30b63b76bc88190c81239f781303284f9166606d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`30b63b76`](https://github.com/nix-community/emacs-overlay/commit/30b63b76bc88190c81239f781303284f9166606d) | `` Updated melpa ``  |
| [`269fa8a1`](https://github.com/nix-community/emacs-overlay/commit/269fa8a1a1d458938c8a9b9c8c55e1be07ac760f) | `` Updated nongnu `` |
| [`6b277f41`](https://github.com/nix-community/emacs-overlay/commit/6b277f418652f9e869a2c839553c6355592a656c) | `` Updated elpa ``   |