### PR TITLE
chore(flake/nur): `2c64e23d` -> `758d9248`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718826286,
-        "narHash": "sha256-naePB6wjRxBh1huo5xA3ekGDY9o4QXpQtBzvmH7dCU4=",
+        "lastModified": 1718833507,
+        "narHash": "sha256-hiW6lMYxgCrWXr1/huypj+F6xri/FlJ7Y+UGUwDOn4g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2c64e23d98dc7ec502ea9e70c640e40d44abedb8",
+        "rev": "758d924805f70485a125d0c9fd6e4000020b0f1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`758d9248`](https://github.com/nix-community/NUR/commit/758d924805f70485a125d0c9fd6e4000020b0f1e) | `` automatic update `` |