### PR TITLE
chore(flake/nur): `308734a6` -> `d82b8fd6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718837966,
-        "narHash": "sha256-K0O0W90Kf5odAHIEh55QdqT/QisFHo8un01iSS95Blw=",
+        "lastModified": 1718838769,
+        "narHash": "sha256-rIKa++VEoAscMAafCQla0WFp0hGD+y+/lGn19d0eh9U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "308734a6bb70edec820315229803464753ab6b7a",
+        "rev": "d82b8fd6c2b5e097bc16661369d8ef1d9f0951ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d82b8fd6`](https://github.com/nix-community/NUR/commit/d82b8fd6c2b5e097bc16661369d8ef1d9f0951ee) | `` automatic update `` |