### PR TITLE
chore(flake/emacs-overlay): `24f168cf` -> `c8b1d61d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1718817009,
-        "narHash": "sha256-IqyKHR82Jp6+oB6L4mrPoQUVkxgQFNp8pJGFUWuJjgM=",
+        "lastModified": 1718845427,
+        "narHash": "sha256-t2rtbg4TaW4RCjze4mbo2gB8PxwyqchIXokuuXjh5m8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "24f168cf0db8c87ca16ac34066a586114ecaa182",
+        "rev": "c8b1d61d79f43d4a6bfbf6fcb40012d1a0089a7c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`c8b1d61d`](https://github.com/nix-community/emacs-overlay/commit/c8b1d61d79f43d4a6bfbf6fcb40012d1a0089a7c) | `` Updated elpa ``   |
| [`97df499f`](https://github.com/nix-community/emacs-overlay/commit/97df499fb0d81979ae0997d46039a81c455377ed) | `` Updated nongnu `` |