### PR TITLE
chore(flake/nur): `d82b8fd6` -> `fa86e6ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718838769,
-        "narHash": "sha256-rIKa++VEoAscMAafCQla0WFp0hGD+y+/lGn19d0eh9U=",
+        "lastModified": 1718846092,
+        "narHash": "sha256-6qoyrUWCevAfUzaWurvKcTBOdXT1jDkkpBNkCHt4QG8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d82b8fd6c2b5e097bc16661369d8ef1d9f0951ee",
+        "rev": "fa86e6ab80248868821f0075d68463c0d3495b75",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fa86e6ab`](https://github.com/nix-community/NUR/commit/fa86e6ab80248868821f0075d68463c0d3495b75) | `` automatic update `` |
| [`01ef6060`](https://github.com/nix-community/NUR/commit/01ef606063821d9cc80e41bf4f66f3af232bed8e) | `` automatic update `` |