### PR TITLE
chore(flake/srvos): `c607ffef` -> `557ff94a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -951,11 +951,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718585173,
-        "narHash": "sha256-G5DB6D3p8ucyGfmWt3JmiWcVW55DeuUoiT230wQ9Am4=",
+        "lastModified": 1718844164,
+        "narHash": "sha256-QUXWv6llKIQ5To2N24d9dRI78Hqfm9iFyhvmvlOICNo=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "c607ffef7c234d88f37ed12d75b2c48de3f4b3fe",
+        "rev": "557ff94aa1b48a723f8fa16eb9e7a2e6de991682",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`557ff94a`](https://github.com/nix-community/srvos/commit/557ff94aa1b48a723f8fa16eb9e7a2e6de991682) | `` dev/private/flake.lock: Update `` |
| [`47c63956`](https://github.com/nix-community/srvos/commit/47c6395608382ecb67fb200785dca07e623f11f6) | `` flake.lock: Update ``             |