### PR TITLE
chore(flake/emacs-overlay): `c8b1d61d` -> `496c42b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1718845427,
-        "narHash": "sha256-t2rtbg4TaW4RCjze4mbo2gB8PxwyqchIXokuuXjh5m8=",
+        "lastModified": 1718903445,
+        "narHash": "sha256-0wQzcl2b1vyf3C/sQcSRS9aENDORAlE/aWvoPXyShvk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c8b1d61d79f43d4a6bfbf6fcb40012d1a0089a7c",
+        "rev": "496c42b156668e2fa266019704ea4aafc9ce351d",
         "type": "github"
       },
       "original": {
@@ -700,11 +700,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1718447546,
-        "narHash": "sha256-JHuXsrC9pr4kA4n7LuuPfWFJUVlDBVJ1TXDVpHEuUgM=",
+        "lastModified": 1718811006,
+        "narHash": "sha256-0Y8IrGhRmBmT7HHXlxxepg2t8j1X90++qRN3lukGaIk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "842253bf992c3a7157b67600c2857193f126563a",
+        "rev": "03d771e513ce90147b65fe922d87d3a0356fc125",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`496c42b1`](https://github.com/nix-community/emacs-overlay/commit/496c42b156668e2fa266019704ea4aafc9ce351d) | `` Updated emacs ``        |
| [`c7d105f6`](https://github.com/nix-community/emacs-overlay/commit/c7d105f68c47ff9b6114b5473eeb9a3f7ea9ac06) | `` Updated melpa ``        |
| [`90d92953`](https://github.com/nix-community/emacs-overlay/commit/90d92953fd3d438943f65a2bf094f5627af11819) | `` Updated elpa ``         |
| [`4afd31ad`](https://github.com/nix-community/emacs-overlay/commit/4afd31ada85dc547f07651c1ce1e108564ed16dc) | `` Updated nongnu ``       |
| [`a438495f`](https://github.com/nix-community/emacs-overlay/commit/a438495f2375b3067998c971718b3619f4ff07a8) | `` Updated flake inputs `` |
| [`ddb45572`](https://github.com/nix-community/emacs-overlay/commit/ddb455723166a611e0399169197b7454313f1ffc) | `` Updated melpa ``        |
| [`c287c23f`](https://github.com/nix-community/emacs-overlay/commit/c287c23f43187bfe829e07e667a2dc36f9427fbc) | `` Updated emacs ``        |
| [`41c0d4a1`](https://github.com/nix-community/emacs-overlay/commit/41c0d4a18d609381a3e961873b3f69cdfbfef87a) | `` Updated melpa ``        |
| [`0fef1e1e`](https://github.com/nix-community/emacs-overlay/commit/0fef1e1e08554183d9e2502f7184cb2dc08bf94d) | `` Update README.org ``    |