### PR TITLE
chore(flake/nur): `fa86e6ab` -> `25345105`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718846092,
-        "narHash": "sha256-6qoyrUWCevAfUzaWurvKcTBOdXT1jDkkpBNkCHt4QG8=",
+        "lastModified": 1718851736,
+        "narHash": "sha256-+z1DPipKu3+QkE5qAY0XkOTP9lLKAWQIp5LA9vFenBs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fa86e6ab80248868821f0075d68463c0d3495b75",
+        "rev": "253451053701bbe7672c81e5a01407e5a30bb6fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`25345105`](https://github.com/nix-community/NUR/commit/253451053701bbe7672c81e5a01407e5a30bb6fe) | `` automatic update `` |