### PR TITLE
chore(flake/nur): `25345105` -> `dd04618a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718851736,
-        "narHash": "sha256-+z1DPipKu3+QkE5qAY0XkOTP9lLKAWQIp5LA9vFenBs=",
+        "lastModified": 1718859003,
+        "narHash": "sha256-zxJ3jCMflYhD65MrOTavfxa3W7FNi6dI+fgMTKuqVqQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "253451053701bbe7672c81e5a01407e5a30bb6fe",
+        "rev": "dd04618abb7619acc608bf3f98a7c295c153ff65",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                      |
| -------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`dd04618a`](https://github.com/nix-community/NUR/commit/dd04618abb7619acc608bf3f98a7c295c153ff65) | `` automatic update ``       |
| [`e6a3d15c`](https://github.com/nix-community/NUR/commit/e6a3d15c763743efcae1c3768f5bda5efe9f8371) | `` add dsuetin repository `` |