### PR TITLE
chore(flake/nur): `dd04618a` -> `501b1026`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718859003,
-        "narHash": "sha256-zxJ3jCMflYhD65MrOTavfxa3W7FNi6dI+fgMTKuqVqQ=",
+        "lastModified": 1718862149,
+        "narHash": "sha256-MQxbQF2p5lKBo50HQtqdYer8/yM7MxHzKSF0yTrw/PI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dd04618abb7619acc608bf3f98a7c295c153ff65",
+        "rev": "501b10268e84432ba6f39cf2fb354975361e8458",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`501b1026`](https://github.com/nix-community/NUR/commit/501b10268e84432ba6f39cf2fb354975361e8458) | `` automatic update `` |