### PR TITLE
chore(flake/nur): `501b1026` -> `17503a38`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718862149,
-        "narHash": "sha256-MQxbQF2p5lKBo50HQtqdYer8/yM7MxHzKSF0yTrw/PI=",
+        "lastModified": 1718867920,
+        "narHash": "sha256-tEQrb5MjDJczZ8rmfhjIec+DarPvQvamIf3k3X1URmk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "501b10268e84432ba6f39cf2fb354975361e8458",
+        "rev": "17503a380c2f2f05ae457c908b819d9b94ce4269",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`17503a38`](https://github.com/nix-community/NUR/commit/17503a380c2f2f05ae457c908b819d9b94ce4269) | `` automatic update `` |
| [`8985fe5d`](https://github.com/nix-community/NUR/commit/8985fe5d21e1a74582d32620bf11412305d0c9ae) | `` automatic update `` |