### PR TITLE
chore(flake/nur): `17503a38` -> `a3114a7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718867920,
-        "narHash": "sha256-tEQrb5MjDJczZ8rmfhjIec+DarPvQvamIf3k3X1URmk=",
+        "lastModified": 1718876532,
+        "narHash": "sha256-+xbEcG1jlWtnbHwg8Z7CQ7a24yIY06rVwwvtwRT10Eg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "17503a380c2f2f05ae457c908b819d9b94ce4269",
+        "rev": "a3114a7d0fcf2ca63f687f483b14060db7d375e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a3114a7d`](https://github.com/nix-community/NUR/commit/a3114a7d0fcf2ca63f687f483b14060db7d375e5) | `` automatic update `` |
| [`57f88b63`](https://github.com/nix-community/NUR/commit/57f88b637d41f8f1f7c4a6d827ead6d9c4347e50) | `` automatic update `` |
| [`c1f28d4b`](https://github.com/nix-community/NUR/commit/c1f28d4ba410603d97f9a05564937c7af13e3ace) | `` automatic update `` |