### PR TITLE
chore(flake/nixos-hardware): `acb4f0e9` -> `0307a32b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -627,11 +627,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1718806950,
-        "narHash": "sha256-E+W/kbedZAiOuPtT+KQRposLaXGDLd7lyK7oL3IH/5U=",
+        "lastModified": 1718883385,
+        "narHash": "sha256-nLKMEZc6im82lfSdVPIBwff8OEYLlGVPpcZPvtpOFx4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "acb4f0e9bfa8ca2d6fca5e692307b5c994e7dbda",
+        "rev": "0307a32b553f81056edd6455168c635aeda6743b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                        |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`0307a32b`](https://github.com/NixOS/nixos-hardware/commit/0307a32b553f81056edd6455168c635aeda6743b) | `` system76/gaze18: add comment about implication of adding driSupport32Bit `` |
| [`4d6b7dfa`](https://github.com/NixOS/nixos-hardware/commit/4d6b7dfa61ccf39b90bb980d702de3130c940c50) | `` system76/gaze18: drop redundant driSupport ``                               |
| [`972f0149`](https://github.com/NixOS/nixos-hardware/commit/972f0149f26f44bd884e3140070f4e973ca043bd) | `` System76 Gaze18 nvidia not loaded fix and remove modesetting ``             |
| [`d23f980d`](https://github.com/NixOS/nixos-hardware/commit/d23f980d75df52ab675cddd1fe3e8038eda79016) | `` System76 Gaze18 cleanup ``                                                  |
| [`49705fd8`](https://github.com/NixOS/nixos-hardware/commit/49705fd8397d80c08f59ce67f37e9d32b376d3e3) | `` add system76 Gaze18 to README ``                                            |
| [`b34b2925`](https://github.com/NixOS/nixos-hardware/commit/b34b29254745a89d20e15c37a3a836ca11a9526e) | `` System76 Gaze18 cleanup ``                                                  |
| [`f5a5916b`](https://github.com/NixOS/nixos-hardware/commit/f5a5916b354e63e450d07bc06ea642752a1ea9d5) | `` System76 mkDefault ``                                                       |
| [`28684889`](https://github.com/NixOS/nixos-hardware/commit/28684889c8d4632309cf21ca3f41d570498f11b0) | `` System76 Gaze18 nvidia ``                                                   |
| [`56e370b3`](https://github.com/NixOS/nixos-hardware/commit/56e370b3425253395f7119b731b2c536bc2cda5a) | `` deprecate commons/hdd module ``                                             |