### PR TITLE
chore(flake/nixos-hardware): `0307a32b` -> `083823b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -627,11 +627,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1718883385,
-        "narHash": "sha256-nLKMEZc6im82lfSdVPIBwff8OEYLlGVPpcZPvtpOFx4=",
+        "lastModified": 1718894893,
+        "narHash": "sha256-hxQBUtDbFOCCW1CsFZTS9Q5Ov1ZKdJgbBZHSez1M6iA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "0307a32b553f81056edd6455168c635aeda6743b",
+        "rev": "083823b7904e43a4fc1c7229781417e875359a42",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`083823b7`](https://github.com/NixOS/nixos-hardware/commit/083823b7904e43a4fc1c7229781417e875359a42) | `` gpu/amd: drop hardware.amdgpu.opencl option `` |
| [`144f53f5`](https://github.com/NixOS/nixos-hardware/commit/144f53f534c553dadbf80388e930d0bb494f7b58) | `` common: remove deprecated modules ``           |