### PR TITLE
chore(flake/nur): `e45d6997` -> `733c1037`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718898304,
-        "narHash": "sha256-0bYagVoLe12JbB/JCTrSb0to41Y/odrqMIbKcszApNM=",
+        "lastModified": 1718903079,
+        "narHash": "sha256-88DWxDvExI5zWwmUfjSfVS3dCjme+SanWStVpAIxa8k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e45d69976a66cdee301f3145063033e540f0621e",
+        "rev": "733c103717ffbf4629b7418c650798bc4a3ad1df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`733c1037`](https://github.com/nix-community/NUR/commit/733c103717ffbf4629b7418c650798bc4a3ad1df) | `` automatic update `` |
| [`0cb52445`](https://github.com/nix-community/NUR/commit/0cb52445db59bb7b9fee653026be15a945d3be8b) | `` automatic update `` |