### PR TITLE
chore(flake/nur): `733c1037` -> `4e11a4c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718903079,
-        "narHash": "sha256-88DWxDvExI5zWwmUfjSfVS3dCjme+SanWStVpAIxa8k=",
+        "lastModified": 1718913406,
+        "narHash": "sha256-nuRM54QTO24/CiuaRkFXrZt0JIPHiICBiiN9nTjeVYg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "733c103717ffbf4629b7418c650798bc4a3ad1df",
+        "rev": "4e11a4c664c94c9f1df6e407330232fd3c3a72b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4e11a4c6`](https://github.com/nix-community/NUR/commit/4e11a4c664c94c9f1df6e407330232fd3c3a72b5) | `` automatic update `` |