### PR TITLE
chore(flake/nur): `4e11a4c6` -> `e922d685`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718913406,
-        "narHash": "sha256-nuRM54QTO24/CiuaRkFXrZt0JIPHiICBiiN9nTjeVYg=",
+        "lastModified": 1718916325,
+        "narHash": "sha256-3q784G/aNpHIkir+9kZC3cKAUQxt59AbSD7RdDEi4xc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4e11a4c664c94c9f1df6e407330232fd3c3a72b5",
+        "rev": "e922d68587b1a8e13f6bee7f00dda87f54549e34",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e922d685`](https://github.com/nix-community/NUR/commit/e922d68587b1a8e13f6bee7f00dda87f54549e34) | `` automatic update `` |
| [`a4cf3446`](https://github.com/nix-community/NUR/commit/a4cf34469a6f2592521b4b609bcf2393694891fb) | `` automatic update `` |