### PR TITLE
chore(flake/nur): `e922d685` -> `e01fdcaa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718916325,
-        "narHash": "sha256-3q784G/aNpHIkir+9kZC3cKAUQxt59AbSD7RdDEi4xc=",
+        "lastModified": 1718922816,
+        "narHash": "sha256-mxLkqeIuGPi2G5uGYPaS3EFS7VgobRAGXrBSD10qyU8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e922d68587b1a8e13f6bee7f00dda87f54549e34",
+        "rev": "e01fdcaa77b0729f1ed08ed60e64d6a9ae33a4c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e01fdcaa`](https://github.com/nix-community/NUR/commit/e01fdcaa77b0729f1ed08ed60e64d6a9ae33a4c2) | `` automatic update `` |
| [`1577d28d`](https://github.com/nix-community/NUR/commit/1577d28d92a941a4da4cc4c6d8260c0c3c1697cc) | `` automatic update `` |