### PR TITLE
chore(flake/org-tufte): `98bb659f` -> `a0673ce4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -833,11 +833,11 @@
     "org-tufte": {
       "flake": false,
       "locked": {
-        "lastModified": 1716629066,
-        "narHash": "sha256-mOoYPkovDcReSZKCYf9xnKfAoOITb5elXeCaKVR58ic=",
+        "lastModified": 1718918773,
+        "narHash": "sha256-6oGzp4qywKC8O/DKNW9ydBvimbe1BoRmZg5ykjmquyo=",
         "owner": "Zilong-Li",
         "repo": "org-tufte",
-        "rev": "98bb659f6a7199b9ee8b0de39c0e9450a82561dc",
+        "rev": "a0673ce4e81b3f7625230f61f693bf6c4a348ee4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                          |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`a0673ce4`](https://github.com/Zilong-Li/org-tufte/commit/a0673ce4e81b3f7625230f61f693bf6c4a348ee4) | `` supports caption of src as clickable block `` |