### PR TITLE
chore(flake/nur): `e01fdcaa` -> `8df27cb3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718922816,
-        "narHash": "sha256-mxLkqeIuGPi2G5uGYPaS3EFS7VgobRAGXrBSD10qyU8=",
+        "lastModified": 1718938175,
+        "narHash": "sha256-uynLxMs7aqW87dYdc6i+o8ioxHzZhULvs3qIRcsnxxM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e01fdcaa77b0729f1ed08ed60e64d6a9ae33a4c2",
+        "rev": "8df27cb316ded8bfd12ba58d4ac7b6e7aee1ef3c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8df27cb3`](https://github.com/nix-community/NUR/commit/8df27cb316ded8bfd12ba58d4ac7b6e7aee1ef3c) | `` automatic update `` |
| [`9bd861ed`](https://github.com/nix-community/NUR/commit/9bd861edca129d54acabc39d945dad0a05d4dce7) | `` automatic update `` |