### PR TITLE
chore(flake/nur): `8df27cb3` -> `9c57686b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718938175,
-        "narHash": "sha256-uynLxMs7aqW87dYdc6i+o8ioxHzZhULvs3qIRcsnxxM=",
+        "lastModified": 1718941580,
+        "narHash": "sha256-1X7B85+v3RxvGyX8NKK1JqgHj46jnBMIWoXLWJ4VJt8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8df27cb316ded8bfd12ba58d4ac7b6e7aee1ef3c",
+        "rev": "9c57686ba55b4acd2577abb802b5c12872a6a34b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9c57686b`](https://github.com/nix-community/NUR/commit/9c57686ba55b4acd2577abb802b5c12872a6a34b) | `` automatic update `` |
| [`5cddfe9e`](https://github.com/nix-community/NUR/commit/5cddfe9e1f21b04e5e2230cca67bcc514c113aa9) | `` automatic update `` |