### PR TITLE
chore(flake/nur): `9c57686b` -> `784f0823`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718941580,
-        "narHash": "sha256-1X7B85+v3RxvGyX8NKK1JqgHj46jnBMIWoXLWJ4VJt8=",
+        "lastModified": 1718945871,
+        "narHash": "sha256-1xdka8gIPGtXon+z9daRToNkrwxsWuNPflzlVglbZ1U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9c57686ba55b4acd2577abb802b5c12872a6a34b",
+        "rev": "784f082316ef1d02af5b2db560ee9208b9363f4c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`784f0823`](https://github.com/nix-community/NUR/commit/784f082316ef1d02af5b2db560ee9208b9363f4c) | `` automatic update `` |
| [`26e0c572`](https://github.com/nix-community/NUR/commit/26e0c572967db20926c6e849841f47af9d1f8c62) | `` automatic update `` |
| [`f5b0df75`](https://github.com/nix-community/NUR/commit/f5b0df7523ccdbfa7b9f90d10f7a85694ac95d10) | `` automatic update `` |