### PR TITLE
chore(flake/nur): `784f0823` -> `40ec90c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718945871,
-        "narHash": "sha256-1xdka8gIPGtXon+z9daRToNkrwxsWuNPflzlVglbZ1U=",
+        "lastModified": 1718951848,
+        "narHash": "sha256-DEgPRkQkTl/DlYDzOtLx6O6Lawj0Xb92iKUam1wJuAU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "784f082316ef1d02af5b2db560ee9208b9363f4c",
+        "rev": "40ec90c0a00ec7cb07a727e4546dc618475175a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`40ec90c0`](https://github.com/nix-community/NUR/commit/40ec90c0a00ec7cb07a727e4546dc618475175a5) | `` automatic update `` |