### PR TITLE
chore(flake/emacs-overlay): `496c42b1` -> `728439cd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1718903445,
-        "narHash": "sha256-0wQzcl2b1vyf3C/sQcSRS9aENDORAlE/aWvoPXyShvk=",
+        "lastModified": 1718960968,
+        "narHash": "sha256-5DzqO4O3ZKPGx1dO5QhwCGBaI4bPTg2BSWSzasTYdmM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "496c42b156668e2fa266019704ea4aafc9ce351d",
+        "rev": "728439cd9e68339c306d6152b8950dcb87e604cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`728439cd`](https://github.com/nix-community/emacs-overlay/commit/728439cd9e68339c306d6152b8950dcb87e604cf) | `` Updated emacs `` |
| [`04dc1d60`](https://github.com/nix-community/emacs-overlay/commit/04dc1d602efe32ab0be4e8a39f381f525691dba8) | `` Updated melpa `` |
| [`9dfcde97`](https://github.com/nix-community/emacs-overlay/commit/9dfcde97c51b6ac22c48dedd367040a9c915fc18) | `` Updated elpa ``  |