### PR TITLE
chore(flake/nur): `40ec90c0` -> `ad577284`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718951848,
-        "narHash": "sha256-DEgPRkQkTl/DlYDzOtLx6O6Lawj0Xb92iKUam1wJuAU=",
+        "lastModified": 1718959592,
+        "narHash": "sha256-1LCpPrZN5C8NDG/U2lVNULRkbJVovXpMixD2t+bopkY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "40ec90c0a00ec7cb07a727e4546dc618475175a5",
+        "rev": "ad57728446a1c57c18e14c51752f0ceb7e166a37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ad577284`](https://github.com/nix-community/NUR/commit/ad57728446a1c57c18e14c51752f0ceb7e166a37) | `` automatic update `` |
| [`349c49cf`](https://github.com/nix-community/NUR/commit/349c49cff7c033df7c7025cb641fdab58f4379fe) | `` automatic update `` |