### PR TITLE
chore(flake/nixpkgs): `c00d587b` -> `d603719e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1718714799,
-        "narHash": "sha256-FUZpz9rg3gL8NVPKbqU8ei1VkPLsTIfAJ2fdAf5qjak=",
+        "lastModified": 1718895438,
+        "narHash": "sha256-k3JqJrkdoYwE3fHE6xGDY676AYmyh4U2Zw+0Bwe5DLU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c00d587b1a1afbf200b1d8f0b0e4ba9deb1c7f0e",
+        "rev": "d603719ec6e294f034936c0d0dc06f689d91b6c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`e4c66a8a`](https://github.com/NixOS/nixpkgs/commit/e4c66a8a2aa64707a5cda7aac673dab5a1e3b306) | `` kdePackages.kdenlive: backport bug fix ``                                   |
| [`9043e861`](https://github.com/NixOS/nixpkgs/commit/9043e8619ffac8c476898f49d24b37dbff18592d) | `` kdePackages.ksvg: backport bug fix ``                                       |
| [`10e9deb7`](https://github.com/NixOS/nixpkgs/commit/10e9deb7982f659c05bb0304ec09ee862e6395b1) | `` python39Packages.bsddb3: disable on Python 3.10+, remove distutils usage `` |
| [`92fd43bd`](https://github.com/NixOS/nixpkgs/commit/92fd43bd759a6f5a504bf5e90e6fd5e9dbde25ed) | `` gramps: replace bsddb3 with berkeleydb ``                                   |
| [`729f34a0`](https://github.com/NixOS/nixpkgs/commit/729f34a0c8df601db5090f0d9f134433bfe9d3f8) | `` exaile: replace bsddb3 with berkeleydb ``                                   |
| [`8b7d6f8b`](https://github.com/NixOS/nixpkgs/commit/8b7d6f8b0a09f7db74cbce56cf6f1b4bad58d93a) | `` logseq: fix build, move to by-name ``                                       |
| [`fb927d50`](https://github.com/NixOS/nixpkgs/commit/fb927d5019d1c5111efcad5008ba10f53481f1d5) | `` BuildRustCrate: proc macros must be built for build's platform ``           |
| [`b839fa3b`](https://github.com/NixOS/nixpkgs/commit/b839fa3b0a270f4c79a9cebe272beb1a1e36da47) | `` lint-staged: 15.2.6 -> 15.2.7 ``                                            |
| [`c37af90b`](https://github.com/NixOS/nixpkgs/commit/c37af90bfca168646310553f2a057663b8fe4459) | `` buildkit: 0.14.0 -> 0.14.1 ``                                               |
| [`db1b636f`](https://github.com/NixOS/nixpkgs/commit/db1b636f240717f09c88451ad7828643c85d8d09) | `` papermc: 1.20.6-137 -> 1.21-15 ``                                           |
| [`78e5e62b`](https://github.com/NixOS/nixpkgs/commit/78e5e62b97b0079a674ad289cbcb60f588f40e1b) | `` ice-bar: init at 0.9.0 (#317971) ``                                         |
| [`0f915671`](https://github.com/NixOS/nixpkgs/commit/0f915671e8733dd0e8e255146ea7eed7b26083b9) | `` lix: 2.90-beta.1 -> 2.90.0-rc1 ``                                           |
| [`b5d723ae`](https://github.com/NixOS/nixpkgs/commit/b5d723ae3aa5b41fd46043b4c5cf685019a8dac5) | `` vimPlugins.rocks-nvim: added rocks.nvim ``                                  |
| [`9971bbfc`](https://github.com/NixOS/nixpkgs/commit/9971bbfc87e26adf51cc818508e8033d9facd49b) | `` violet: 0.4.6 -> 0.5.0 ``                                                   |
| [`80f48521`](https://github.com/NixOS/nixpkgs/commit/80f48521c91c12d51ac42b8a6c935fae917bb14d) | `` pluginupdate.py: print script duration ``                                   |
| [`74cf25b5`](https://github.com/NixOS/nixpkgs/commit/74cf25b5ce30b91c6b21ff24e264d76bf1d10dc3) | `` signal-desktop: 7.11.1 -> 7.12.0 ``                                         |
| [`41d88dfb`](https://github.com/NixOS/nixpkgs/commit/41d88dfb9b34f6da5b40a80179628b7bfd490a66) | `` waylyrics: 0.3.11 -> 0.3.12 ``                                              |
| [`e6b0f860`](https://github.com/NixOS/nixpkgs/commit/e6b0f860eb7214a41c84e59b24066751894d1e26) | `` keepassxc: 2.7.8 -> 2.7.9 ``                                                |
| [`a686680c`](https://github.com/NixOS/nixpkgs/commit/a686680c88e8f6f63d517e2f9a039e6875d9d472) | `` rain: 1.10.0 -> 1.11.0 ``                                                   |
| [`ba7e7693`](https://github.com/NixOS/nixpkgs/commit/ba7e7693dc1a052a233cd5cbbf9cbc020f672c3b) | `` nixos/matrix-synapse: fix typo ``                                           |
| [`0ecdd056`](https://github.com/NixOS/nixpkgs/commit/0ecdd056a86945c1b5cbe0fe217eab2647c7f5ab) | `` gosmee: 0.22.0 -> 0.22.1 ``                                                 |
| [`0d51c25d`](https://github.com/NixOS/nixpkgs/commit/0d51c25d62156e3021b2420f09d35bc991c43897) | `` wl-clipboard-rs: 0.8.1 -> 0.9.0 ``                                          |
| [`965018f4`](https://github.com/NixOS/nixpkgs/commit/965018f4b7238470ba66f6350035fb09696e8b70) | `` vcard: Avoid recursive evaluation ``                                        |
| [`07b3d60b`](https://github.com/NixOS/nixpkgs/commit/07b3d60bb43f75c8f538dcb96a11361900589104) | `` vcard: enable auto-update ``                                                |
| [`a4507a89`](https://github.com/NixOS/nixpkgs/commit/a4507a898f7433590a818837497239ffb37d082d) | `` picom-pijulius: 8.2-unstable-2024-04-30 -> 8.2-unstable-2024-06-13 ``       |
| [`d94a39f8`](https://github.com/NixOS/nixpkgs/commit/d94a39f87de439090cdc23663d082396d3ce468d) | `` mealie: 1.7.0 -> 1.9.0 ``                                                   |
| [`7876d878`](https://github.com/NixOS/nixpkgs/commit/7876d878cffc97dddb3078cffa3cd728f32d298f) | `` hypnotix: 4.4 -> 4.5 ``                                                     |
| [`330d634b`](https://github.com/NixOS/nixpkgs/commit/330d634b541138ad644d5ce719e2cb525f3849b1) | `` k9s: 0.32.4 -> 0.32.5 ``                                                    |
| [`9e716b10`](https://github.com/NixOS/nixpkgs/commit/9e716b10358e8a7637ceae0507742133ac197e5f) | `` cargo-i18n: 0.2.12 -> 0.2.13 ``                                             |
| [`a82d3ce1`](https://github.com/NixOS/nixpkgs/commit/a82d3ce1bb75eef8bc12fcd047f01b5412d71245) | `` gitlab-ci-local: 4.50.1 -> 4.51.0 ``                                        |
| [`0b581b16`](https://github.com/NixOS/nixpkgs/commit/0b581b1626693f428d3d78118e1a7260e6c8a5e1) | `` kvmtool: cleanup make flags ``                                              |
| [`abc1350d`](https://github.com/NixOS/nixpkgs/commit/abc1350df4dbd5d43dbe728da9952a5907a2dd45) | `` vscode-extensions.ms-vscode-remote.remote-wsl: init at 0.88.2 ``            |
| [`5b981cf6`](https://github.com/NixOS/nixpkgs/commit/5b981cf68afee6f21cbf06b539704a99334df916) | `` python311Packages.pycrdt-websocket: 0.13.4 -> 0.13.5 ``                     |
| [`c0d2cfe8`](https://github.com/NixOS/nixpkgs/commit/c0d2cfe8f61f87ee5d23c648b47d75a04067e052) | `` pid1: 0.1.2 -> 0.1.3 ``                                                     |
| [`3911231c`](https://github.com/NixOS/nixpkgs/commit/3911231cc4aee4e139a21d13ec181448e86c50ce) | `` radicale: 3.2.1 -> 3.2.2 ``                                                 |
| [`5fa4d405`](https://github.com/NixOS/nixpkgs/commit/5fa4d405272ea98dab145f0c9f7ea1dbb9c87c31) | `` ocamlPackages.uri: set correct src hash ``                                  |
| [`282a8256`](https://github.com/NixOS/nixpkgs/commit/282a8256970deb911b35a51f4ad1fa817a538cc5) | `` hclfmt: 2.20.1 -> 2.21.0 (#321035) ``                                       |
| [`79df5368`](https://github.com/NixOS/nixpkgs/commit/79df5368f862204e46498870963493b226f6ab32) | `` jetbrains: prevent download of unpatched jetbrains jdk ``                   |
| [`74988451`](https://github.com/NixOS/nixpkgs/commit/74988451f1329d12f09541f341859b18467f7a27) | `` raycast: 1.76.1 -> 1.77.0 ``                                                |
| [`a4776f9f`](https://github.com/NixOS/nixpkgs/commit/a4776f9fc96ef7d8cea2513ff58a3c34c9bfc09f) | `` nixos/docuum: add missing options ``                                        |
| [`354a1725`](https://github.com/NixOS/nixpkgs/commit/354a1725b6618ff6487bf5bea30865ce20c70bef) | `` docuum: 0.24.0 -> 0.25.0 ``                                                 |
| [`cc7c307b`](https://github.com/NixOS/nixpkgs/commit/cc7c307b2b871ece38719e2602002987f334f93c) | `` google-chrome: 126.0.6478.61 -> 126.0.6478.114 ``                           |
| [`d62d2c6b`](https://github.com/NixOS/nixpkgs/commit/d62d2c6b491b8d59c43949eb02b8d44f657ff17d) | `` mariadb: 10.5.25, 10.6.18, 10.11.8, 11.0.6 (#315099) ``                     |
| [`bbe67d46`](https://github.com/NixOS/nixpkgs/commit/bbe67d46fd4c3237ad41acfa5787970b1b355d27) | `` zpaqfranz: 59.7 -> 59.8 ``                                                  |
| [`4fba5afa`](https://github.com/NixOS/nixpkgs/commit/4fba5afaf6f46018b9d1e45808b1dab2a3a363ad) | `` vsce: 2.27.0 -> 2.28.0 ``                                                   |
| [`48f99be6`](https://github.com/NixOS/nixpkgs/commit/48f99be66ae06ed9d12682c4f62e22716856e457) | `` tbls: 1.76.0 -> 1.76.1 ``                                                   |
| [`dda39b70`](https://github.com/NixOS/nixpkgs/commit/dda39b703d8760ddf05a10031ea3d246d406127b) | `` hyprutils: 0.1.2 -> 0.1.4 ``                                                |
| [`da694466`](https://github.com/NixOS/nixpkgs/commit/da694466aab6da413c1edd3d2f41c8cd921b5e4a) | `` system_stats: init at 3.0 ``                                                |
| [`5bfb8d7d`](https://github.com/NixOS/nixpkgs/commit/5bfb8d7d7d71411cb9e62f8e2bce002aeeb1eddd) | `` chromium: 126.0.6478.61 -> 126.0.6478.114 ``                                |
| [`df90591e`](https://github.com/NixOS/nixpkgs/commit/df90591e548884a607898d92426975bbed234593) | `` chromedriver: 126.0.6478.61 -> 126.0.6478.62 ``                             |
| [`c217dc97`](https://github.com/NixOS/nixpkgs/commit/c217dc9717e9250e5cd05139e2dee3c8fa150e49) | `` python3Packages.clustershell: remove blocking test ``                       |
| [`e924ef52`](https://github.com/NixOS/nixpkgs/commit/e924ef5224c33919f4b46a5e8d8572328506bec1) | `` deltachat-cursed: 0.8.0 -> 0.9.0 ``                                         |
| [`935eb154`](https://github.com/NixOS/nixpkgs/commit/935eb15442967e297e439f022af091c2b9fbdb61) | `` python311Packages.deltachat2: init at 0.6.2 ``                              |
| [`1b5c2460`](https://github.com/NixOS/nixpkgs/commit/1b5c2460cb3f4872fc96953a2ff59ced3132d523) | `` furmark: add an icon ``                                                     |
| [`4ee62639`](https://github.com/NixOS/nixpkgs/commit/4ee62639cdfa344a02c90108fc8a106bcd76f757) | `` deltachat-desktop: 1.44.1 -> 1.46.1 ``                                      |
| [`96a701f1`](https://github.com/NixOS/nixpkgs/commit/96a701f146fdec0cc344d7ccb854860f1810c210) | `` haskellPackages: add mpscholten as maintainer ``                            |
| [`43f4cead`](https://github.com/NixOS/nixpkgs/commit/43f4cead14a3a367c9f57bcc37abbad755340ccd) | `` vimPlugins.nvim-treesitter: update grammars ``                              |
| [`39630864`](https://github.com/NixOS/nixpkgs/commit/396308649ae151302de0c3dc10c0b7cb4d8a1826) | `` vimPlugins: resolve github repository redirects ``                          |
| [`d8b8a7b6`](https://github.com/NixOS/nixpkgs/commit/d8b8a7b62369a2386773b7a539cdac461bf39ffc) | `` lightdm-slick-greeter: 2.0.4 -> 2.0.5 ``                                    |
| [`b5b4eec6`](https://github.com/NixOS/nixpkgs/commit/b5b4eec6d1daf67f596f972da7811785a7383a31) | `` libdeltachat: 1.136.3 -> 1.140.2 ``                                         |
| [`ab1f52a0`](https://github.com/NixOS/nixpkgs/commit/ab1f52a010e1046e84b5d74c53b5b912b42a42f0) | `` vimPlugins: update on 2024-06-19 ``                                         |
| [`c0fcdd95`](https://github.com/NixOS/nixpkgs/commit/c0fcdd95a73f55d3e6c4e2962b99efb3589ef5e6) | `` easytag: tied ogg patch to commit ``                                        |
| [`5a2f8d17`](https://github.com/NixOS/nixpkgs/commit/5a2f8d17cf517722b9bc9a691cf069a24838fdc5) | `` sysmenu: init at unstable-2024-06-13 ``                                     |
| [`1eb68050`](https://github.com/NixOS/nixpkgs/commit/1eb680508ca99cf84934c438996feb881936d5b2) | `` mate.mate-panel: 1.28.1 -> 1.28.2 ``                                        |
| [`6952b7e9`](https://github.com/NixOS/nixpkgs/commit/6952b7e948f49f2af6dfc82a7125cd63bc35951c) | `` cinnamon.xviewer: 3.4.4 -> 3.4.5 ``                                         |
| [`ba19c96d`](https://github.com/NixOS/nixpkgs/commit/ba19c96d14ec81f6090c4f143bf10b975fcdeb70) | `` cinnamon.pix: 3.4.0 -> 3.4.1 ``                                             |
| [`23363112`](https://github.com/NixOS/nixpkgs/commit/23363112caff2fd9ec4808776c3eee25f724e4a1) | `` gnome-online-accounts-gtk: 3.50.2 -> 3.50.3 ``                              |
| [`6c10cfba`](https://github.com/NixOS/nixpkgs/commit/6c10cfba34a151fceed537b4b8642ad033301d7d) | `` tests/odoo: fix broken test ``                                              |
| [`934bfb6c`](https://github.com/NixOS/nixpkgs/commit/934bfb6c36d141e2035d2c08472dd70936f0249a) | `` odoo: 17.0.20240507 -> 17.0.20240616 ``                                     |
| [`8306ac3d`](https://github.com/NixOS/nixpkgs/commit/8306ac3d7e617a40e61438e1fa8b99a321bc7952) | `` odoo: migrate to pkgs/by-name ``                                            |
| [`a972071a`](https://github.com/NixOS/nixpkgs/commit/a972071a311abb6576560c32fb586f852a7aaffd) | `` odoo: 16.0.20231024 -> 17.0.20240507 ``                                     |
| [`b906b688`](https://github.com/NixOS/nixpkgs/commit/b906b68826db45fa67630ea6db53692d769d449c) | `` odoo: fix build ``                                                          |
| [`e74b624e`](https://github.com/NixOS/nixpkgs/commit/e74b624e0bf413f2aedd9a9ebfbe60ffef888a69) | `` rPackages.nearfar: fixed build ``                                           |
| [`271ba430`](https://github.com/NixOS/nixpkgs/commit/271ba4304ea3226d258e5564e728ba7f6b2ba31a) | `` cinnamon.bulky: 3.2 -> 3.3 ``                                               |
| [`cfcf1f0b`](https://github.com/NixOS/nixpkgs/commit/cfcf1f0b87a872ac32db7e5e54fe0c662961533f) | `` rPackages.diveR: fixed build ``                                             |
| [`4da5ce01`](https://github.com/NixOS/nixpkgs/commit/4da5ce0176e68a99101dfa3629e6f15bbc6472a5) | `` rPackages.PROJ: fixed build ``                                              |
| [`f7227f35`](https://github.com/NixOS/nixpkgs/commit/f7227f35973556a4445f3baef030b91bfaa8c75f) | `` haskellPackages.hledger-iadd: Remove broken flag ``                         |
| [`34fd38d2`](https://github.com/NixOS/nixpkgs/commit/34fd38d269fd0206617dff4aa563a9a88e5dc839) | `` rPackages.avotrex: fixed build ``                                           |
| [`75cb8246`](https://github.com/NixOS/nixpkgs/commit/75cb82461787c7a439f762b218801fb82c2d43a9) | `` cnspec: 11.8.0 -> 11.9.0 ``                                                 |
| [`e9a349ae`](https://github.com/NixOS/nixpkgs/commit/e9a349aea9bf98bd8929575034c231cc08cff584) | `` haskellPackages.ghcjs-prim: Clarify comment ``                              |
| [`3f13871d`](https://github.com/NixOS/nixpkgs/commit/3f13871d641acf55d28691f0ac303f7eadc67057) | `` python311Packages.llama-index-embeddings-huggingface: 0.2.1 -> 0.2.2 ``     |
| [`be91973b`](https://github.com/NixOS/nixpkgs/commit/be91973b10d3c9082d9e272b9be20e2372da7936) | `` bun: add diogomdp as a maintainer ``                                        |
| [`cf779236`](https://github.com/NixOS/nixpkgs/commit/cf779236cdbdf4873706003c41fbec7ce20efca1) | `` bun: 1.1.13 -> 1.1.14 ``                                                    |
| [`d5bf9a65`](https://github.com/NixOS/nixpkgs/commit/d5bf9a656a73a6aec95d8f5127547fe5e75a2f08) | `` vale: 3.5.0 -> 3.6.0 ``                                                     |
| [`6c446d90`](https://github.com/NixOS/nixpkgs/commit/6c446d9095e8d7f4289dad5d0bfd461fdd53eb2a) | `` qownnotes: 24.6.1 -> 24.6.3 ``                                              |
| [`26231650`](https://github.com/NixOS/nixpkgs/commit/262316508d46c89c0db6ff1f82eb98647a98f633) | `` uv: 0.2.11 -> 0.2.13 ``                                                     |
| [`82f84b39`](https://github.com/NixOS/nixpkgs/commit/82f84b39180f904e8265b4bf610c6ba6b3c84ef3) | `` firefox-bin-unwrapped: 127.0 -> 127.0.1 ``                                  |
| [`d31442b8`](https://github.com/NixOS/nixpkgs/commit/d31442b8d6cb0c14a13f659c4d4e10f457801bd2) | `` firefox-unwrapped: 127.0 -> 127.0.1 ``                                      |