### PR TITLE
chore(flake/nur): `d0608ace` -> `08584a2e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718966732,
-        "narHash": "sha256-zFnbxZNG+49DRbkbQKfQfiUqbojwGbl5H4Gvlby2JPM=",
+        "lastModified": 1718974674,
+        "narHash": "sha256-fkAY5a0ydho/gIIa2gvDMpqYQk1K9xw0/ZDE9nGrgSc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d0608ace5dbf3c222e0804d5eaab2730876c0e40",
+        "rev": "08584a2e2c0f1f5e4d3ed65f2f158a190b3844dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`08584a2e`](https://github.com/nix-community/NUR/commit/08584a2e2c0f1f5e4d3ed65f2f158a190b3844dd) | `` automatic update `` |