### PR TITLE
chore(flake/nur): `08584a2e` -> `ef74ae1e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718974674,
-        "narHash": "sha256-fkAY5a0ydho/gIIa2gvDMpqYQk1K9xw0/ZDE9nGrgSc=",
+        "lastModified": 1718980488,
+        "narHash": "sha256-cULCoFNaBcyB9TUMmL6oDKu2FygaZbfn6I5mYwRC4G8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "08584a2e2c0f1f5e4d3ed65f2f158a190b3844dd",
+        "rev": "ef74ae1e19df0d2118a4f27d6127f1153469a25e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ef74ae1e`](https://github.com/nix-community/NUR/commit/ef74ae1e19df0d2118a4f27d6127f1153469a25e) | `` automatic update `` |