### PR TITLE
chore(flake/nur): `ef74ae1e` -> `4ee7be05`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718980488,
-        "narHash": "sha256-cULCoFNaBcyB9TUMmL6oDKu2FygaZbfn6I5mYwRC4G8=",
+        "lastModified": 1718984767,
+        "narHash": "sha256-M3UrNDDkKZFw57F+SMwDOhVOAIh59mKjdTs68qK5R5g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ef74ae1e19df0d2118a4f27d6127f1153469a25e",
+        "rev": "4ee7be0570090b1e5aac5a18e7b334fe61191a00",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4ee7be05`](https://github.com/nix-community/NUR/commit/4ee7be0570090b1e5aac5a18e7b334fe61191a00) | `` automatic update `` |