### PR TITLE
chore(flake/emacs-overlay): `728439cd` -> `b205ea48`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1718960968,
-        "narHash": "sha256-5DzqO4O3ZKPGx1dO5QhwCGBaI4bPTg2BSWSzasTYdmM=",
+        "lastModified": 1718988821,
+        "narHash": "sha256-Pofp09DoGNPikrYdp4iea+TLRsqYArj41ZQ0Xfd8Izw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "728439cd9e68339c306d6152b8950dcb87e604cf",
+        "rev": "b205ea48fe3b8cc70d86658a80d37ce157d65057",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`b205ea48`](https://github.com/nix-community/emacs-overlay/commit/b205ea48fe3b8cc70d86658a80d37ce157d65057) | `` Updated melpa ``        |
| [`bf2dbcf3`](https://github.com/nix-community/emacs-overlay/commit/bf2dbcf3cda2ff7ddbe42acd11ef764752f34284) | `` Updated elpa ``         |
| [`ee6a09cc`](https://github.com/nix-community/emacs-overlay/commit/ee6a09cc436d70f7e9e99e031033f037d29bd2ce) | `` Updated nongnu ``       |
| [`9786a3ab`](https://github.com/nix-community/emacs-overlay/commit/9786a3ab448958deab4257cc820c4cb496435b6f) | `` Updated flake inputs `` |