### PR TITLE
chore(flake/nur): `4ee7be05` -> `77cf0476`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718984767,
-        "narHash": "sha256-M3UrNDDkKZFw57F+SMwDOhVOAIh59mKjdTs68qK5R5g=",
+        "lastModified": 1718988172,
+        "narHash": "sha256-8jSPDl0M9hRg79ZP+robOmempU1pQnnfkqPK/4WrCCY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ee7be0570090b1e5aac5a18e7b334fe61191a00",
+        "rev": "77cf047699e15d656cf2b852c19ae0872a9a0ef7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`77cf0476`](https://github.com/nix-community/NUR/commit/77cf047699e15d656cf2b852c19ae0872a9a0ef7) | `` automatic update `` |
| [`4c4feb61`](https://github.com/nix-community/NUR/commit/4c4feb61fa70d6b56b10bcc9eb0495f77a9c3112) | `` automatic update `` |