### PR TITLE
chore(flake/nur): `77cf0476` -> `ec879287`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718988172,
-        "narHash": "sha256-8jSPDl0M9hRg79ZP+robOmempU1pQnnfkqPK/4WrCCY=",
+        "lastModified": 1718992251,
+        "narHash": "sha256-wHPXfpeleFtZZx4T/QJP4QDvVxjHE2sGmd+EDXBlWug=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "77cf047699e15d656cf2b852c19ae0872a9a0ef7",
+        "rev": "ec879287be7dbca645a82a9d9dfbd206835f3736",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ec879287`](https://github.com/nix-community/NUR/commit/ec879287be7dbca645a82a9d9dfbd206835f3736) | `` automatic update `` |
| [`ba345211`](https://github.com/nix-community/NUR/commit/ba345211bd48058745af1b427c9b87859cff14f1) | `` automatic update `` |