### PR TITLE
chore(flake/nur): `ec879287` -> `3304729c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1718992251,
-        "narHash": "sha256-wHPXfpeleFtZZx4T/QJP4QDvVxjHE2sGmd+EDXBlWug=",
+        "lastModified": 1718999178,
+        "narHash": "sha256-PPWMabnB+4iOCNZ0WGSpWp1ERqoRjROW3YRzAeOGPuc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ec879287be7dbca645a82a9d9dfbd206835f3736",
+        "rev": "3304729c6285043fc28e1e081b2285bf58506f20",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3304729c`](https://github.com/nix-community/NUR/commit/3304729c6285043fc28e1e081b2285bf58506f20) | `` automatic update `` |
| [`148db408`](https://github.com/nix-community/NUR/commit/148db40884d3ffb4be7f3c9ad99723eb31c52887) | `` automatic update `` |