### PR TITLE
chore(flake/nur): `2a39f58d` -> `acdcb9f4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719006380,
-        "narHash": "sha256-87Yuu24pf0osnyyXOzlk1dufTCSMeZle/rD1NOvYCbY=",
+        "lastModified": 1719020716,
+        "narHash": "sha256-TbVUyoSC+gYyL4WwnglhCl1yiza8BSUbxdk0ImDVx48=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2a39f58d0ab57e6f77a187b08671250a7b893f68",
+        "rev": "acdcb9f43efac6d2857ec3fe561b6980302d79b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`acdcb9f4`](https://github.com/nix-community/NUR/commit/acdcb9f43efac6d2857ec3fe561b6980302d79b4) | `` automatic update `` |
| [`3b2c473f`](https://github.com/nix-community/NUR/commit/3b2c473f4564178e7c669ad8daeb20ec2da125f4) | `` automatic update `` |