### PR TITLE
chore(flake/nur): `acdcb9f4` -> `9606cead`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719020716,
-        "narHash": "sha256-TbVUyoSC+gYyL4WwnglhCl1yiza8BSUbxdk0ImDVx48=",
+        "lastModified": 1719024901,
+        "narHash": "sha256-uj2FGCWGpaVXTnAsq/2Msy1CE9ONElVTPjd91DS4xD0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "acdcb9f43efac6d2857ec3fe561b6980302d79b4",
+        "rev": "9606cead8c655b463525e7f8990b47dad973fcf6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9606cead`](https://github.com/nix-community/NUR/commit/9606cead8c655b463525e7f8990b47dad973fcf6) | `` automatic update `` |
| [`2b75f2d6`](https://github.com/nix-community/NUR/commit/2b75f2d6251df5b5d29b04beae3fb74a1ce8ec56) | `` automatic update `` |
| [`9e8f101b`](https://github.com/nix-community/NUR/commit/9e8f101b1bd431ea8394c78900b05aaba9dc2aee) | `` automatic update `` |