### PR TITLE
chore(flake/nur): `9606cead` -> `fd3c2718`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719024901,
-        "narHash": "sha256-uj2FGCWGpaVXTnAsq/2Msy1CE9ONElVTPjd91DS4xD0=",
+        "lastModified": 1719028595,
+        "narHash": "sha256-DpgtnRouSCiYzYQTo1NIgB35pqEInRHc/GLKfpUjPQo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9606cead8c655b463525e7f8990b47dad973fcf6",
+        "rev": "fd3c2718cd53e3b1682747e4129d5eef8596b603",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fd3c2718`](https://github.com/nix-community/NUR/commit/fd3c2718cd53e3b1682747e4129d5eef8596b603) | `` automatic update `` |
| [`7d3f736a`](https://github.com/nix-community/NUR/commit/7d3f736aa26e17b3ffc76c3884b77084eb19e3f9) | `` automatic update `` |
| [`f30fa241`](https://github.com/nix-community/NUR/commit/f30fa241f7723222f5457e6f1243e4e89ba697f3) | `` automatic update `` |