### PR TITLE
chore(flake/nur): `fd3c2718` -> `8a23f349`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719028595,
-        "narHash": "sha256-DpgtnRouSCiYzYQTo1NIgB35pqEInRHc/GLKfpUjPQo=",
+        "lastModified": 1719034850,
+        "narHash": "sha256-MgoihdLPiecK/M7hu49a2THUmQL8ltWbOilJOLjNO9Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fd3c2718cd53e3b1682747e4129d5eef8596b603",
+        "rev": "8a23f349bc9e725ad47d294ff7ff7ea55edc1fe0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8a23f349`](https://github.com/nix-community/NUR/commit/8a23f349bc9e725ad47d294ff7ff7ea55edc1fe0) | `` automatic update `` |
| [`4e0d7399`](https://github.com/nix-community/NUR/commit/4e0d73990ac315fcd3dfbbc3bfb2279b98cdb9ce) | `` automatic update `` |
| [`5813214f`](https://github.com/nix-community/NUR/commit/5813214f0c32c18cec082e1ed655902fb3465deb) | `` automatic update `` |