### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `b28f009e` -> `5bdfc4e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -519,11 +519,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1718958737,
-        "narHash": "sha256-cm4pw3lV1MKFgDll+MJzAqTrmGeXyQSfTnmvbBRu2G8=",
+        "lastModified": 1719038590,
+        "narHash": "sha256-mxsPEmnqqjEgH4IGBbawzIIVBt4qPFQgdGzFOvCuRyc=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "b28f009ef7e7681e24ebcafa7e0c7a2e46b96433",
+        "rev": "5bdfc4e1a5e1085bfa950665d002e7c670410d39",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                                               |
| ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`5bdfc4e1`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/5bdfc4e1a5e1085bfa950665d002e7c670410d39) | `` CI: run just the new "check" workflow on push ``   |
| [`7e62ee35`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/7e62ee35b0354f20887b73e90dfe52ff0f485543) | `` CI: Add dedicated check and cachix workflows ``    |
| [`8ceb9a74`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/8ceb9a7431193cb3f7ef3e877598fa004bc92ff2) | `` CI: move download caching to a composite action `` |
| [`6899c075`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/6899c075ca340a0d132f6be8a9d5bb03424efa4c) | `` Experiment: run tests without nativecomp ``        |
| [`fa6fe4cf`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/fa6fe4cf937e25dfcf1a44bd4d69ecbca280a85f) | `` Load non-packages.el autoloads ``                  |