### PR TITLE
chore(flake/nur): `8a23f349` -> `0f996e26`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719034850,
-        "narHash": "sha256-MgoihdLPiecK/M7hu49a2THUmQL8ltWbOilJOLjNO9Y=",
+        "lastModified": 1719038236,
+        "narHash": "sha256-OanMZyoEz5MNiZ/FRjLydB8cOLsGdto3VYwf0a1u8ck=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8a23f349bc9e725ad47d294ff7ff7ea55edc1fe0",
+        "rev": "0f996e26d69f5ec221838bb8bbc84e0a0b58e5eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0f996e26`](https://github.com/nix-community/NUR/commit/0f996e26d69f5ec221838bb8bbc84e0a0b58e5eb) | `` automatic update `` |
| [`a28610c1`](https://github.com/nix-community/NUR/commit/a28610c1f5ec46812978be8e342ec5927d8c8443) | `` automatic update `` |