### PR TITLE
chore(flake/nur): `0f996e26` -> `333492b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719038236,
-        "narHash": "sha256-OanMZyoEz5MNiZ/FRjLydB8cOLsGdto3VYwf0a1u8ck=",
+        "lastModified": 1719066846,
+        "narHash": "sha256-9RVBjpYm2wFgml0fy2SE0kCgY04rb2SVgKxiv/yfIAc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0f996e26d69f5ec221838bb8bbc84e0a0b58e5eb",
+        "rev": "333492b857b7a10e8abd7224e75c12d3c2cfbd23",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`333492b8`](https://github.com/nix-community/NUR/commit/333492b857b7a10e8abd7224e75c12d3c2cfbd23) | `` automatic update `` |
| [`880c22ac`](https://github.com/nix-community/NUR/commit/880c22ac49ac208c1ee3e75d67238da4abdaff6f) | `` automatic update `` |
| [`57c6e744`](https://github.com/nix-community/NUR/commit/57c6e74466573b2999bd60d40fd4df381e56ca0b) | `` automatic update `` |
| [`f1b52ba4`](https://github.com/nix-community/NUR/commit/f1b52ba4df9226117b0f33b5226ccea7aad08068) | `` automatic update `` |
| [`04a7f7a1`](https://github.com/nix-community/NUR/commit/04a7f7a16373c03f9a874683f6b6692c5cc792f6) | `` automatic update `` |
| [`8c0265fb`](https://github.com/nix-community/NUR/commit/8c0265fb87a59efd0831b8645c8a2db9f8a06941) | `` automatic update `` |