### PR TITLE
chore(flake/emacs-overlay): `6944d9b0` -> `7e9e872a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1719021179,
-        "narHash": "sha256-nBeuck6QfcHw3C3MdJOeN8+53K3y04pD209cpg+uYuM=",
+        "lastModified": 1719046428,
+        "narHash": "sha256-zv0hC+rSFld2Wmo4WKc0OQhc5oXlZzQS2DPvPDNOVuQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6944d9b030689cf37cdf01e14fa828fff195d8f7",
+        "rev": "7e9e872a431d5de1f34bd8af3ba72644640eeccf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`7e9e872a`](https://github.com/nix-community/emacs-overlay/commit/7e9e872a431d5de1f34bd8af3ba72644640eeccf) | `` Updated melpa `` |