### PR TITLE
chore(flake/emacs-overlay): `7e9e872a` -> `9a699fa0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1719046428,
-        "narHash": "sha256-zv0hC+rSFld2Wmo4WKc0OQhc5oXlZzQS2DPvPDNOVuQ=",
+        "lastModified": 1719047351,
+        "narHash": "sha256-2BRqaxcs9c5SuM7PM6nzdeluNNGaox57nnDIMol3eGs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7e9e872a431d5de1f34bd8af3ba72644640eeccf",
+        "rev": "9a699fa0f15ae69e7d12038640d34b8f5fb92e00",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`9a699fa0`](https://github.com/nix-community/emacs-overlay/commit/9a699fa0f15ae69e7d12038640d34b8f5fb92e00) | `` Updated emacs `` |