### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `5bdfc4e1` -> `8c7b188a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -519,11 +519,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1719038590,
-        "narHash": "sha256-mxsPEmnqqjEgH4IGBbawzIIVBt4qPFQgdGzFOvCuRyc=",
+        "lastModified": 1719053283,
+        "narHash": "sha256-mAHC9HTxwEJL6VvIdLgJzgYAAEJjLLKPVrw1X+8luK4=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "5bdfc4e1a5e1085bfa950665d002e7c670410d39",
+        "rev": "8c7b188ae5a5e62b88f568c256242a2c2cafd704",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                                             |
| ---------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`8c7b188a`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/8c7b188ae5a5e62b88f568c256242a2c2cafd704) | `` CI: break up "CI" workflow ``                    |
| [`40a3228e`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/40a3228e647e730f15c3d920e8d6e5e8fb3981a4) | `` CI: make check/cachix callable with ref input `` |
| [`816827ff`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/816827ffed82d1b9ae943b86b89a553ab5bb206c) | `` CI: fix config error ``                          |
| [`8f0941c8`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/8f0941c8d7da4877f79dda51d764ee956c51fcc8) | `` CI: experimental flake-update workflow ``        |