### PR TITLE
chore(flake/catppuccin): `73e06d5b` -> `fed3b63f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1718339789,
-        "narHash": "sha256-Q3fgY7huFE+uaw7BNsAl1x+FvjDAi3EDWPnlALJt5pM=",
+        "lastModified": 1719056731,
+        "narHash": "sha256-EVlDyB4DDxulGHTGHERzvfMOkoei4Dmu+mRp+SXRC60=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "73e06d5bd7ed34bdd0168030893ef8364fdc1d4a",
+        "rev": "fed3b63f1ecd286c148a2003e82e76530d2f58de",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                        |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`fed3b63f`](https://github.com/catppuccin/nix/commit/fed3b63f1ecd286c148a2003e82e76530d2f58de) | `` chore(modules): update ports (#233) ``                                      |
| [`8c44408b`](https://github.com/catppuccin/nix/commit/8c44408b01be356d1b1959140e7b02ea97cc4c24) | `` ci: update determinatesystems/magic-nix-cache-action action to v7 (#235) `` |
| [`047af948`](https://github.com/catppuccin/nix/commit/047af9481427500ec5622abae02ef4822a046e32) | `` ci: update determinatesystems/flakehub-push action to v4 (#234) ``          |