### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `8c7b188a` -> `4ff67c9a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -162,11 +162,11 @@
     "doomemacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1718922555,
-        "narHash": "sha256-nRscxmB2CaS/sAEP0h6gllgr2rZof5i7Y9qDjmkTNss=",
+        "lastModified": 1719011490,
+        "narHash": "sha256-qVb5Ab6XCkRZQVwhnNc4AK2Pby6GjWwr/E7a8FY2s5s=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "9116ec2ec729bc30732dfd15a3fcac9ae4988025",
+        "rev": "62248f836674dcae71c36036276193ad103d070f",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718958056,
-        "narHash": "sha256-d1HKeHO6kB0jK5crI+ChtY9z0BHh9idvY7+YAupjePo=",
+        "lastModified": 1719047351,
+        "narHash": "sha256-2BRqaxcs9c5SuM7PM6nzdeluNNGaox57nnDIMol3eGs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9dfcde97c51b6ac22c48dedd367040a9c915fc18",
+        "rev": "9a699fa0f15ae69e7d12038640d34b8f5fb92e00",
         "type": "github"
       },
       "original": {
@@ -519,11 +519,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1719053283,
-        "narHash": "sha256-mAHC9HTxwEJL6VvIdLgJzgYAAEJjLLKPVrw1X+8luK4=",
+        "lastModified": 1719059769,
+        "narHash": "sha256-Cq026FtkvOEwVS2SloE0XHVm6MjGo1vet44vTtXW2jk=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "8c7b188ae5a5e62b88f568c256242a2c2cafd704",
+        "rev": "4ff67c9abb8219df0e7c39aa17216a12c91bca8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                                                 |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`4ff67c9a`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/4ff67c9abb8219df0e7c39aa17216a12c91bca8d) | `` flake.lock: Update ``                                |
| [`0c55f606`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/0c55f6064f3d23788fc26c49092d259a3c789e0c) | `` CI: try to make push of flake-update to main work `` |
| [`5e2835bf`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/5e2835bffebf3d82882a564b72c18319e9219f6e) | `` Make extraPins override Doom pins ``                 |
| [`5d98aba1`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/5d98aba1a24458eb02d9b63f8b5d1ca3d4ef85ca) | `` flake.lock: Update ``                                |
| [`5533ae9a`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/5533ae9a36dc23c3c8ebfcdf6538a86ec14779d7) | `` Fix conflicting pins of magit and git-commit ``      |
| [`13e64824`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/13e64824f48c85673613232f159a353705fb7780) | `` CI: fix permissions ``                               |