### PR TITLE
chore(flake/catppuccin): `fed3b63f` -> `b6c85450`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1719056731,
-        "narHash": "sha256-EVlDyB4DDxulGHTGHERzvfMOkoei4Dmu+mRp+SXRC60=",
+        "lastModified": 1719059483,
+        "narHash": "sha256-JUGjp4P7Yi3ToxLW5iMSz7CI7mffprF8GsK1hkFdKzs=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "fed3b63f1ecd286c148a2003e82e76530d2f58de",
+        "rev": "b6c854508d8c03f3ff06bf658d12b0ae8052d7a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                               |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`b6c85450`](https://github.com/catppuccin/nix/commit/b6c854508d8c03f3ff06bf658d12b0ae8052d7a5) | `` fix(nixos): use the qt 6 version of sddm (#230) `` |
| [`cc8d3b17`](https://github.com/catppuccin/nix/commit/cc8d3b17d2164c41e73a5b7f983430f4f000f126) | `` chore: update dev flake inputs (#238) ``           |