### PR TITLE
chore(flake/nur): `333492b8` -> `9ef2fa51`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719066846,
-        "narHash": "sha256-9RVBjpYm2wFgml0fy2SE0kCgY04rb2SVgKxiv/yfIAc=",
+        "lastModified": 1719071113,
+        "narHash": "sha256-2eAVIu40LUEibcUyIoNta1cd0S3V3JmbOqyMpuHqqIw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "333492b857b7a10e8abd7224e75c12d3c2cfbd23",
+        "rev": "9ef2fa519d7e57532eda953f8364ede49ff34723",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9ef2fa51`](https://github.com/nix-community/NUR/commit/9ef2fa519d7e57532eda953f8364ede49ff34723) | `` automatic update `` |
| [`45eca515`](https://github.com/nix-community/NUR/commit/45eca51531f14fc14dc00ac7020bc698067a4767) | `` automatic update `` |
| [`029c96d3`](https://github.com/nix-community/NUR/commit/029c96d3b8e32efd5171cd096033c870a71d0e07) | `` automatic update `` |