### PR TITLE
chore(flake/emacs-overlay): `9a699fa0` -> `5e8f95ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1719047351,
-        "narHash": "sha256-2BRqaxcs9c5SuM7PM6nzdeluNNGaox57nnDIMol3eGs=",
+        "lastModified": 1719076240,
+        "narHash": "sha256-yI1e5MZTqWyrbG9JnnOCFiFNJol5ZJ/LjWD7qjrn4Xs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9a699fa0f15ae69e7d12038640d34b8f5fb92e00",
+        "rev": "5e8f95ab8a282758813e3d8922fdaa0783ee5b41",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`5e8f95ab`](https://github.com/nix-community/emacs-overlay/commit/5e8f95ab8a282758813e3d8922fdaa0783ee5b41) | `` Updated emacs `` |
| [`614301b1`](https://github.com/nix-community/emacs-overlay/commit/614301b151f4d25fd7e73f57e6872fb875301bce) | `` Updated melpa `` |
| [`1cca3f01`](https://github.com/nix-community/emacs-overlay/commit/1cca3f01ffb976e03fd4b7879f99ec5b24cd22c3) | `` Updated elpa ``  |