### PR TITLE
chore(flake/nur): `9ef2fa51` -> `3eba559a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719071113,
-        "narHash": "sha256-2eAVIu40LUEibcUyIoNta1cd0S3V3JmbOqyMpuHqqIw=",
+        "lastModified": 1719074268,
+        "narHash": "sha256-jI8xr3CiY6hAbflYMN4kUqOvsN0YrFiaFRPgwBL6pbk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ef2fa519d7e57532eda953f8364ede49ff34723",
+        "rev": "3eba559a8eaa33cfa8385f7b7e4210715e07eb7c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3eba559a`](https://github.com/nix-community/NUR/commit/3eba559a8eaa33cfa8385f7b7e4210715e07eb7c) | `` automatic update `` |