### PR TITLE
chore(flake/nur): `b533e9ab` -> `3bf580b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719087874,
-        "narHash": "sha256-3y8HtNnOWS9Qm9QnBdRGCIMppnSCa4rMQ6h8LQhvTok=",
+        "lastModified": 1719091582,
+        "narHash": "sha256-KXV6Jko0y/7mSkxKdoMuxF40BgDSDixKrrjRMuL0vQA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b533e9ab9fb7e04e53c36d06baf917e6a22c86e1",
+        "rev": "3bf580b7c5b330ddd4ebc29a02b3923ee13ef9c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3bf580b7`](https://github.com/nix-community/NUR/commit/3bf580b7c5b330ddd4ebc29a02b3923ee13ef9c8) | `` automatic update `` |