### PR TITLE
chore(flake/nur): `3bf580b7` -> `7e568a22`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719091582,
-        "narHash": "sha256-KXV6Jko0y/7mSkxKdoMuxF40BgDSDixKrrjRMuL0vQA=",
+        "lastModified": 1719093877,
+        "narHash": "sha256-DvChoFVCT5JEX6aGQ2JEKq1r/rXyC/r4div65BXqAho=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3bf580b7c5b330ddd4ebc29a02b3923ee13ef9c8",
+        "rev": "7e568a22346bc4efb0160ff7382f5f6d4ce7bc8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7e568a22`](https://github.com/nix-community/NUR/commit/7e568a22346bc4efb0160ff7382f5f6d4ce7bc8b) | `` automatic update `` |