### PR TITLE
chore(flake/nur): `7e568a22` -> `315cf1f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719093877,
-        "narHash": "sha256-DvChoFVCT5JEX6aGQ2JEKq1r/rXyC/r4div65BXqAho=",
+        "lastModified": 1719099906,
+        "narHash": "sha256-xo1cNkVBW7NxTU5zMu0B7ZkismtkHfTRWfhBXbNnp9g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7e568a22346bc4efb0160ff7382f5f6d4ce7bc8b",
+        "rev": "315cf1f8c5f5e92150d81ccafba7525c54327094",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`315cf1f8`](https://github.com/nix-community/NUR/commit/315cf1f8c5f5e92150d81ccafba7525c54327094) | `` automatic update `` |
| [`d104be57`](https://github.com/nix-community/NUR/commit/d104be57e78b09589cae6685a49fbb914522b29d) | `` automatic update `` |