### PR TITLE
chore(flake/emacs-overlay): `5e8f95ab` -> `f20b9cfd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1719076240,
-        "narHash": "sha256-yI1e5MZTqWyrbG9JnnOCFiFNJol5ZJ/LjWD7qjrn4Xs=",
+        "lastModified": 1719109212,
+        "narHash": "sha256-foFDVXTcOlbhpI1FYObKPWmSz4e4Al8nzMtPj9189ZI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5e8f95ab8a282758813e3d8922fdaa0783ee5b41",
+        "rev": "f20b9cfd2c52c2ea5351008d008fd8b2f1419c30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`f20b9cfd`](https://github.com/nix-community/emacs-overlay/commit/f20b9cfd2c52c2ea5351008d008fd8b2f1419c30) | `` Updated emacs `` |
| [`b5e4ae0a`](https://github.com/nix-community/emacs-overlay/commit/b5e4ae0a33bb011e9515181ff1634471a975539f) | `` Updated melpa `` |
| [`08ecd3e0`](https://github.com/nix-community/emacs-overlay/commit/08ecd3e099dce75a35d5096d6b049943353ac7dd) | `` Updated elpa ``  |