### PR TITLE
chore(flake/catppuccin): `b6c85450` -> `2fb16f2d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1719059483,
-        "narHash": "sha256-JUGjp4P7Yi3ToxLW5iMSz7CI7mffprF8GsK1hkFdKzs=",
+        "lastModified": 1719104749,
+        "narHash": "sha256-ZYRhOs5Qm3KzTl0sZg3XVD9zAQf2yDM9E2NHyFMPv8I=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "b6c854508d8c03f3ff06bf658d12b0ae8052d7a5",
+        "rev": "2fb16f2d6ffb2759f14fbcbd1f1e242f5fb662c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                    |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`2fb16f2d`](https://github.com/catppuccin/nix/commit/2fb16f2d6ffb2759f14fbcbd1f1e242f5fb662c7) | `` fix(home-manager): use correct gtk theme name (#239) `` |