### PR TITLE
chore(flake/nur): `315cf1f8` -> `c56d408f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719099906,
-        "narHash": "sha256-xo1cNkVBW7NxTU5zMu0B7ZkismtkHfTRWfhBXbNnp9g=",
+        "lastModified": 1719111160,
+        "narHash": "sha256-pmlJNbIzqTVvTjqXTpl+PQx+ggx/pRhijuBsOe7bk+A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "315cf1f8c5f5e92150d81ccafba7525c54327094",
+        "rev": "c56d408f5c53a9fac162e4cc28bc712f52779823",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c56d408f`](https://github.com/nix-community/NUR/commit/c56d408f5c53a9fac162e4cc28bc712f52779823) | `` automatic update `` |
| [`ee5ef25f`](https://github.com/nix-community/NUR/commit/ee5ef25f56354ce9e7183663fda826181ef27044) | `` automatic update `` |