### PR TITLE
chore(flake/nur): `42f453fd` -> `1da2f959`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719114382,
-        "narHash": "sha256-peJPzlKalNobGnwwBGxk1F3tbndu0H3x1p5P+FNc0Z4=",
+        "lastModified": 1719126612,
+        "narHash": "sha256-DYDSykTYgVp+Ig8CqnDe20c1WJvyNSZCRUf2lLNUA6g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "42f453fd4339c76102251139189e1cd6971b2a04",
+        "rev": "1da2f959305c39b7c0fe6d39df88f9b2cbc73537",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1da2f959`](https://github.com/nix-community/NUR/commit/1da2f959305c39b7c0fe6d39df88f9b2cbc73537) | `` automatic update `` |
| [`4469ddcd`](https://github.com/nix-community/NUR/commit/4469ddcd8710a774a59f35f6463db2eb3e9ee5a1) | `` automatic update `` |
| [`b307173d`](https://github.com/nix-community/NUR/commit/b307173d88540ee47023631b4c7edca466b755b3) | `` automatic update `` |