### PR TITLE
chore(flake/nixpkgs): `d603719e` -> `a71e967e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1718895438,
-        "narHash": "sha256-k3JqJrkdoYwE3fHE6xGDY676AYmyh4U2Zw+0Bwe5DLU=",
+        "lastModified": 1719075281,
+        "narHash": "sha256-CyyxvOwFf12I91PBWz43iGT1kjsf5oi6ax7CrvaMyAo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d603719ec6e294f034936c0d0dc06f689d91b6c3",
+        "rev": "a71e967ef3694799d0c418c98332f7ff4cc5f6af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                    |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`9ad5d2de`](https://github.com/NixOS/nixpkgs/commit/9ad5d2dec8bc779d03a3c54b9f1e011e09bb8339) | `` local-ai: 2.16.0 -> 2.17.1 ``                                                           |
| [`4530b8f7`](https://github.com/NixOS/nixpkgs/commit/4530b8f72f4eb6a1811a82c7c4ff7f9a7c013a2f) | `` nixos/ipa: Lower default sssd debug_level (#310662) ``                                  |
| [`e93ccda8`](https://github.com/NixOS/nixpkgs/commit/e93ccda88728ca2269cd937cfeab127f0b69faee) | `` nixos/ipa: Make ipa_hostname configurable (#321588) ``                                  |
| [`9a065956`](https://github.com/NixOS/nixpkgs/commit/9a0659560e732c1795fde39b2cdbd8d822612aea) | `` home-assistant-custom-components.awtrix: init at unstable-2024-05-26 ``                 |
| [`d5bf1b6a`](https://github.com/NixOS/nixpkgs/commit/d5bf1b6a3b16fbaf4516e77dfec9a758a2d0637a) | `` luaPackages.lz-n: 1.3.0-1 -> 1.3.2-1 ``                                                 |
| [`205bd6f4`](https://github.com/NixOS/nixpkgs/commit/205bd6f42b72d3ecb67fb82d50a61f4bdd582929) | `` whatsapp: init at 2.24.11.85 (#321464) ``                                               |
| [`51096f2d`](https://github.com/NixOS/nixpkgs/commit/51096f2d7a8a230c51d005e18877f6c49a4b93a4) | `` gnome-podcasts: 0.6.1 -> 0.7.1 ``                                                       |
| [`343b3d4e`](https://github.com/NixOS/nixpkgs/commit/343b3d4e6dd5932dc717bad6412d27e7f2aca6d5) | `` liferea: 1.15.6 -> 1.15.7 ``                                                            |
| [`0360d42e`](https://github.com/NixOS/nixpkgs/commit/0360d42e20250ab6f0effccf9053e8a3d43ec74c) | `` nixos/keycloak: disable keycloak-metrics-spi in tests ``                                |
| [`d10d0fc4`](https://github.com/NixOS/nixpkgs/commit/d10d0fc42398b545367853f3a4747c7220810b17) | `` nixos/keycloak: update options for release 25.0.0 ``                                    |
| [`134a223f`](https://github.com/NixOS/nixpkgs/commit/134a223f3fda26847e51cbe92db9b06a8142e322) | `` keycloak: 24.0.5 -> 25.0.1 ``                                                           |
| [`53e7fbe0`](https://github.com/NixOS/nixpkgs/commit/53e7fbe0ec1da49366f69ec92f84a4491ea8746f) | `` kcachegrind: fix graphviz missing at runtime ``                                         |
| [`29d721b3`](https://github.com/NixOS/nixpkgs/commit/29d721b3b2e2043ffd1badd28a7f793349a23dec) | `` maintainers: remove wolfangaukang ``                                                    |
| [`7e1ff7bd`](https://github.com/NixOS/nixpkgs/commit/7e1ff7bd737691d877911fef537ccbf1713b6542) | `` treewide: remove wolfangaukang as maintainer ``                                         |
| [`8c86a467`](https://github.com/NixOS/nixpkgs/commit/8c86a4678076e22d8e83186545a604d74f221dd1) | `` python311Packages.correctionlib: 2.5.0 -> 2.6.0 (#321537) ``                            |
| [`216444a2`](https://github.com/NixOS/nixpkgs/commit/216444a2293461e75d08b58641525c012f59cf19) | `` hepmc3: 3.2.7 -> 3.3.0 ``                                                               |
| [`42509da2`](https://github.com/NixOS/nixpkgs/commit/42509da280ebc698a635ffa8659d5b8b7ae460e1) | `` cloud-hypervisor: 39.0 -> 40.0 ``                                                       |
| [`927af5c9`](https://github.com/NixOS/nixpkgs/commit/927af5c9aea94a52be46807a77097422413ef6c3) | `` home-assistant: update component-packages ``                                            |
| [`83b83dee`](https://github.com/NixOS/nixpkgs/commit/83b83dee939f03e4e9dda7c5d67d8d955b17eed4) | `` python312Packages.motionblindsble: init at 0.1.0 ``                                     |
| [`d6b36ce9`](https://github.com/NixOS/nixpkgs/commit/d6b36ce9581de53100078b2e032f7e85aa9af0b3) | `` charmcraft: 2.6.0 -> 2.7.0 ``                                                           |
| [`60d1d87d`](https://github.com/NixOS/nixpkgs/commit/60d1d87d756f111d01972af6dc6803ab49ab2450) | `` john: add cherrykitten as maintainer ``                                                 |
| [`e046d64d`](https://github.com/NixOS/nixpkgs/commit/e046d64d6a94c8a5215311c414c97614586b4e7c) | `` john: 1.9.0-Jumbo-1 -> rolling-2404 ``                                                  |
| [`c6a9be2a`](https://github.com/NixOS/nixpkgs/commit/c6a9be2a59a7a64fdea50e0d2091fe576d434974) | `` budgie.budgie-desktop: 10.9.1 -> 10.9.2 ``                                              |
| [`05b6d3fe`](https://github.com/NixOS/nixpkgs/commit/05b6d3fedb50a0b954ea4c1af7d08aacb09c1436) | `` gh-dash: 4.1.2 -> 4.2.0 ``                                                              |
| [`104590e7`](https://github.com/NixOS/nixpkgs/commit/104590e739f862283598bd44b399dd1057b9166e) | `` python312Packages.aiounifi: 78 -> 79 ``                                                 |
| [`77d4be77`](https://github.com/NixOS/nixpkgs/commit/77d4be773c8162df075781ac3bfac2b7f7f0388f) | `` python312Packages.aioairzone: 0.7.6 -> 0.7.7 ``                                         |
| [`0949980c`](https://github.com/NixOS/nixpkgs/commit/0949980cd29f2c242c3048f8297b2618e8121247) | `` flatpak: reorganize arguments ``                                                        |
| [`85338a04`](https://github.com/NixOS/nixpkgs/commit/85338a0427bb48b47d55e78874f10ee82cbe3e9f) | `` flatpak: use `nixos-icons` for validate-icon test ``                                    |
| [`619dd38e`](https://github.com/NixOS/nixpkgs/commit/619dd38e9fd269a13963ae5b650de70a1e640c15) | `` flatpak: add updateScript ``                                                            |
| [`ceb3b7ee`](https://github.com/NixOS/nixpkgs/commit/ceb3b7ee267279a3c73a14b29b08c6b03fbe4040) | `` flatpak: add version test ``                                                            |
| [`cda85c65`](https://github.com/NixOS/nixpkgs/commit/cda85c65be8c493e0bd37e5af9cd5c673a53a165) | `` flatpak: modernize ``                                                                   |
| [`feeae371`](https://github.com/NixOS/nixpkgs/commit/feeae371effa5d77b94814fd101b6d83ce32e7fc) | `` flatpak: adopt ``                                                                       |
| [`2ef5b8fb`](https://github.com/NixOS/nixpkgs/commit/2ef5b8fb851f99506f2c5b1539489c6584dacf88) | `` flatpak: format with nixfmt ``                                                          |
| [`b18e7b3e`](https://github.com/NixOS/nixpkgs/commit/b18e7b3e1c10b6c57b060fb52c164e9a05e571de) | `` flatpak: migrate to by-name ``                                                          |
| [`5625aa14`](https://github.com/NixOS/nixpkgs/commit/5625aa149cc64155bd1a01a85630530bda201f37) | `` sticky: 1.20 -> 1.21 ``                                                                 |
| [`2eb72094`](https://github.com/NixOS/nixpkgs/commit/2eb7209481b08fe200f32d89ba3977fa03e14dd1) | `` nixos/davfs2: Add deprecation notice ``                                                 |
| [`e81e68c0`](https://github.com/NixOS/nixpkgs/commit/e81e68c0aabc47005c53fbf6d43a3ed792112d0c) | `` dbgate: 5.3.0 -> 5.3.1 ``                                                               |
| [`8593ad0d`](https://github.com/NixOS/nixpkgs/commit/8593ad0d69206d76bb3392ab0039046ecd62de6c) | `` home-manager: 0-unstable-2024-06-13 -> 0-unstable-2024-06-22 ``                         |
| [`dbef1af4`](https://github.com/NixOS/nixpkgs/commit/dbef1af49e1f00227d5d1bb8fd087d14c53ec42f) | `` check-meta: rename local binding ``                                                     |
| [`5c0dc4c5`](https://github.com/NixOS/nixpkgs/commit/5c0dc4c55ed5dd23ae4eae94f555f42ac50dbc9f) | `` cinnamon.warpinator: 1.8.4 -> 1.8.5 ``                                                  |
| [`96a07867`](https://github.com/NixOS/nixpkgs/commit/96a078679dab302a03f505c5cfdb41501f63553c) | `` python312Packages.pysigma-backend-elasticsearch: 1.1.0 -> 1.1.1 ``                      |
| [`6a4f40eb`](https://github.com/NixOS/nixpkgs/commit/6a4f40eb8d6a51903021249477ccdce1964f1c62) | `` drawio: 24.4.8 -> 24.6.1 ``                                                             |
| [`7fd27561`](https://github.com/NixOS/nixpkgs/commit/7fd2756166d07adc6ddc607b7e38cf06759d2e0b) | `` python312Packages.zha: 0.0.13 -> 0.0.15 ``                                              |
| [`25ac633b`](https://github.com/NixOS/nixpkgs/commit/25ac633bdc62149e498125a34c7e09c19e79d4fd) | `` python312Packages.twilio: 9.2.0 -> 9.2.1 ``                                             |
| [`81b48a75`](https://github.com/NixOS/nixpkgs/commit/81b48a757421c5188952b860df3decda901117e0) | `` python312Packages.reconplogger: 4.16.0 -> 4.16.1 ``                                     |
| [`e5bfe4d3`](https://github.com/NixOS/nixpkgs/commit/e5bfe4d301b7bac2bf36077d2e6d9499fe6fc813) | `` python312Packages.peco: 0.0.30 -> 0.1.1 ``                                              |
| [`994a6508`](https://github.com/NixOS/nixpkgs/commit/994a6508a6609a4ffff359921e9a515f06c6349d) | `` python312Packages.peaqevcore: 19.10.12 -> 19.10.24 ``                                   |
| [`12b31dc8`](https://github.com/NixOS/nixpkgs/commit/12b31dc85bec8803a89be2762eba3480010a74f9) | `` python312Packages.messagebird: 2.1.0 -> 2.2.0 ``                                        |
| [`145201c2`](https://github.com/NixOS/nixpkgs/commit/145201c20c9c0c935dbf7aa6a2e696ebe0f8faa3) | `` python312Packages.hdate: 0.10.9 -> 0.10.11 ``                                           |
| [`c30febcb`](https://github.com/NixOS/nixpkgs/commit/c30febcb45530ac751a1ff18fd3f059f6672c0be) | `` python312Packages.cyclopts: 2.7.0 -> 2.7.1 ``                                           |
| [`e3dab459`](https://github.com/NixOS/nixpkgs/commit/e3dab459b5163471c3ffecab952b154285c0a13b) | `` python312Packages.fastcore: 1.5.46 -> 1.5.47 ``                                         |
| [`30013bd2`](https://github.com/NixOS/nixpkgs/commit/30013bd26cc1a920f046347ed8420214909e6f47) | `` python312Packages.aliyun-python-sdk-config: 2.2.12 -> 2.2.13 ``                         |
| [`858da48a`](https://github.com/NixOS/nixpkgs/commit/858da48acede3d228e457ebbdccbcea46c06e31c) | `` python312Packages.aioopenexchangerates: 0.4.12 -> 0.4.13 ``                             |
| [`44210d5c`](https://github.com/NixOS/nixpkgs/commit/44210d5c2366353b650150c4fe40d97679d82726) | `` fastly: 10.12.2 -> 10.12.3 ``                                                           |
| [`5f5f9109`](https://github.com/NixOS/nixpkgs/commit/5f5f9109ea990d74648e64efbd3ef1472d92e351) | `` warp-terminal: 0.2024.06.11.08.02.stable_03 -> 0.2024.06.18.08.02.stable_04 ``          |
| [`4a39a0e0`](https://github.com/NixOS/nixpkgs/commit/4a39a0e0a9d5b739aff64eeecd1b58743df80405) | `` melonDS: 0.9.5-unstable-2024-06-08 -> 0.9.5-unstable-2024-06-18 ``                      |
| [`0c5c39df`](https://github.com/NixOS/nixpkgs/commit/0c5c39dfdff4b8e7db979f6ff0bf4acbd9a545db) | `` automatic-timezoned: 2.0.16 -> 2.0.17 ``                                                |
| [`4e53a537`](https://github.com/NixOS/nixpkgs/commit/4e53a53767f558c5b1f260616d545371a77dd9a9) | `` linux/common-config: fix version conditionals ``                                        |
| [`b8877d07`](https://github.com/NixOS/nixpkgs/commit/b8877d07e8a2068b2f8718550b39ba2cc41eef1c) | `` discord-canary: 0.0.422 -> 0.0.431 ``                                                   |
| [`89f89134`](https://github.com/NixOS/nixpkgs/commit/89f89134b7be23d9304a1834b036605bf019fbfd) | `` gdu: 5.28.0 -> 5.29.0 ``                                                                |
| [`8601a83d`](https://github.com/NixOS/nixpkgs/commit/8601a83d6905e6d3c660ee9a48a45a902d36f0a6) | `` sbclPackages.vk: add vulkan-loader dependency ``                                        |
| [`e738c854`](https://github.com/NixOS/nixpkgs/commit/e738c854bcddbc4050e359c4a379bf980866db7a) | `` hatsu: 0.2.0 -> 0.2.1 ``                                                                |
| [`f6beec99`](https://github.com/NixOS/nixpkgs/commit/f6beec9909627ea8c7e56c2e029f9286236fae64) | `` gamescope: 3.14.18 -> 3.14.22 ``                                                        |
| [`ec594fe7`](https://github.com/NixOS/nixpkgs/commit/ec594fe72dd578310754fdf955198bb4c98ef54d) | `` python311Packages.clarifai: 10.3.3 -> 10.5.2 ``                                         |
| [`ba7ad835`](https://github.com/NixOS/nixpkgs/commit/ba7ad835656f5671f03e4c82334506d221143d30) | `` myks: 4.2.0 -> 4.2.1 ``                                                                 |
| [`1278d3b8`](https://github.com/NixOS/nixpkgs/commit/1278d3b8ba32e63d8587d1a7de36cdbc16ba2b23) | `` witness: 0.5.2 -> 0.6.0 ``                                                              |
| [`49674e5b`](https://github.com/NixOS/nixpkgs/commit/49674e5b272dccb6ae5bbcb5a914b5d17553ccab) | `` tparse: 0.13.3 -> 0.14.0 ``                                                             |
| [`5fea15e0`](https://github.com/NixOS/nixpkgs/commit/5fea15e09fa4beaf0bdbb4824fa737b868732275) | `` ddns-go: 6.6.2 -> 6.6.3 ``                                                              |
| [`c234886f`](https://github.com/NixOS/nixpkgs/commit/c234886f266584cf8e8e764e555ac39c91ce8b30) | `` qdrant-web-ui: 0.1.28 -> 0.1.29 ``                                                      |
| [`e502a164`](https://github.com/NixOS/nixpkgs/commit/e502a16439413c7f53be0bf78cd35b57207eb22e) | `` python311Packages.aioairzone-cloud: 0.5.2 -> 0.5.3 ``                                   |
| [`3bc62de6`](https://github.com/NixOS/nixpkgs/commit/3bc62de663872021b331933c0f97bea719d09e57) | `` jql: 7.1.11 -> 7.1.12 ``                                                                |
| [`a80e806f`](https://github.com/NixOS/nixpkgs/commit/a80e806f4cd6fb0b38b8b10ecaa9bf91fc6cb2f1) | `` narrowlink: 0.2.5 -> 0.2.6 ``                                                           |
| [`ba0c71b7`](https://github.com/NixOS/nixpkgs/commit/ba0c71b7dc5dddc6e55a58e0bc3b7d48b604786f) | `` caligula: add LIBCLANG_PATH to environment ``                                           |
| [`e8d7ce1b`](https://github.com/NixOS/nixpkgs/commit/e8d7ce1b47bffafd2f97a17eee8664fca704d94a) | `` treewide: move gobject-introspection from buildInputs to nativeBuildInputs (#321411) `` |
| [`5a39b02d`](https://github.com/NixOS/nixpkgs/commit/5a39b02dd273acfbacc9663a097a7fa9e2887d56) | `` php81Packages.phpstan: 1.11.4 -> 1.11.5 ``                                              |
| [`3653a2c5`](https://github.com/NixOS/nixpkgs/commit/3653a2c571d8b8a7d7508aa0c6723df6d7c4a82d) | `` cargo-generate: 0.21.0 -> 0.21.1 ``                                                     |
| [`66b060e0`](https://github.com/NixOS/nixpkgs/commit/66b060e0e70a20f883c240b96560b2d1afc77f60) | `` efibootmgr: adopt; modernize (#319159) ``                                               |
| [`e0e95c06`](https://github.com/NixOS/nixpkgs/commit/e0e95c06f127a16fb16f8ce8c97794fb8c72088b) | `` ardugotools: 0.5.1 -> 0.5.2 ``                                                          |
| [`d78c0a37`](https://github.com/NixOS/nixpkgs/commit/d78c0a37dfd7fba815245631b373fd2bc73450f5) | `` vscode-extensions.sdras.night-owl: init at 2.0.1 ``                                     |
| [`35dfce7a`](https://github.com/NixOS/nixpkgs/commit/35dfce7af5705460cf36c1170df81e5b17bdbc38) | `` maintainers: add pladypus ``                                                            |
| [`66f3c499`](https://github.com/NixOS/nixpkgs/commit/66f3c4997539a81a473f00d3061ea956cacf98d7) | `` gamescope: fix build ``                                                                 |
| [`d824a1bd`](https://github.com/NixOS/nixpkgs/commit/d824a1bd8f0c38d28c7f3821b3a4949c6af97a7b) | `` linuxKernel.kernels.linux_zen: 6.9.5-zen1 -> 6.9.6-zen1 ``                              |
| [`f9197f11`](https://github.com/NixOS/nixpkgs/commit/f9197f11f50b0394d6178088da82ac99e5645108) | `` checkip: 0.47.4 -> 0.47.5 ``                                                            |
| [`4a865f9f`](https://github.com/NixOS/nixpkgs/commit/4a865f9fee2ab5bb4bd8d28fa6a8a21b3d313558) | `` lensfun: 0.3.3 -> 0.3.4 ``                                                              |
| [`6215e2c7`](https://github.com/NixOS/nixpkgs/commit/6215e2c784d10c5bda60af356cb133ea96820323) | `` treesheets: 0-unstable-2024-06-09 -> 0-unstable-2024-06-20 ``                           |
| [`be80aaff`](https://github.com/NixOS/nixpkgs/commit/be80aaffb33cf9c64d6695da87c29de5f63606f1) | `` renode: use robotframework v6.1 as required by new versions ``                          |
| [`410fca5c`](https://github.com/NixOS/nixpkgs/commit/410fca5c11faa12f2ccd8ecb43562de263119a28) | `` organicmaps: 2024.06.02-12 -> 2024.06.19-3 ``                                           |
| [`e34c3f78`](https://github.com/NixOS/nixpkgs/commit/e34c3f785631eb4f613e344677c97de3e72d594d) | `` netbsd.libc: Create from constituent pkgs not hack ``                                   |
| [`569ea068`](https://github.com/NixOS/nixpkgs/commit/569ea068efa21c97d74b8f91bd1ec3bd97e31aea) | `` home-assistant: 2024.6.3 -> 2024.6.4 ``                                                 |
| [`8f2393b0`](https://github.com/NixOS/nixpkgs/commit/8f2393b07b7ac40ceecd6e0fa59935c5bda1e78a) | `` python312Packages.aiozoneinfo: 0.1.0 -> 0.2.0 ``                                        |
| [`8cc7430d`](https://github.com/NixOS/nixpkgs/commit/8cc7430d51e70a8aed0df60dd1590611e9c81262) | `` netbsd.libc: Use multiple outputs ``                                                    |
| [`94424da4`](https://github.com/NixOS/nixpkgs/commit/94424da4fcf5f9f1b7be9ca529c708c07e5f2161) | `` netbsd: Remove a bunch of unneeded `rsync` deps ``                                      |
| [`80d3b5db`](https://github.com/NixOS/nixpkgs/commit/80d3b5dbf95feb3a968b890886fd8f18b549dae8) | `` netbsd: No `_mainLibcExtraPaths` ``                                                     |
| [`9af283b0`](https://github.com/NixOS/nixpkgs/commit/9af283b03e98e32be5db38962c1b37f079fe4f76) | `` python312Packages.pydrawise: 2024.6.3 -> 2024.6.4 ``                                    |
| [`1190619f`](https://github.com/NixOS/nixpkgs/commit/1190619ffc22dd9ceef0fb5966d8badcf88fcf14) | `` python312Packages.plugwise: 0.38.3 -> 0.37.4.1 ``                                       |
| [`51e9c195`](https://github.com/NixOS/nixpkgs/commit/51e9c19584f6d257b9f5bb1b7963fa13b2a85b21) | `` home-assistant.intents: 2024.6.5 -> 2024.6.21 ``                                        |