### PR TITLE
chore(flake/emacs-overlay): `f20b9cfd` -> `dc376600`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1719109212,
-        "narHash": "sha256-foFDVXTcOlbhpI1FYObKPWmSz4e4Al8nzMtPj9189ZI=",
+        "lastModified": 1719133657,
+        "narHash": "sha256-dO0SCFW/Odcbsdr17sk61USNokcpQGoKjP+88HbiYZU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f20b9cfd2c52c2ea5351008d008fd8b2f1419c30",
+        "rev": "dc376600483aae0272de58ea9b2d06c9f4e132eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`dc376600`](https://github.com/nix-community/emacs-overlay/commit/dc376600483aae0272de58ea9b2d06c9f4e132eb) | `` Updated emacs ``        |
| [`afdfe84c`](https://github.com/nix-community/emacs-overlay/commit/afdfe84c77aef4664773b11d84b4b3c2d36d5d72) | `` Updated melpa ``        |
| [`ce81f683`](https://github.com/nix-community/emacs-overlay/commit/ce81f683a7f0806cecf57012a295ec7e1fa467d5) | `` Updated flake inputs `` |