### PR TITLE
chore(flake/nur): `1da2f959` -> `88407857`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719126612,
-        "narHash": "sha256-DYDSykTYgVp+Ig8CqnDe20c1WJvyNSZCRUf2lLNUA6g=",
+        "lastModified": 1719130969,
+        "narHash": "sha256-U+a/N3m0tg36KD/SjGyveV5hx8VYSnFHiKRjlt+iyL4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1da2f959305c39b7c0fe6d39df88f9b2cbc73537",
+        "rev": "88407857c90e39f2654a0ef347c2c920c25f453c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`88407857`](https://github.com/nix-community/NUR/commit/88407857c90e39f2654a0ef347c2c920c25f453c) | `` automatic update `` |