### PR TITLE
chore(flake/nixos-hardware): `e8232c13` -> `c3e48cbd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -627,11 +627,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1719069430,
-        "narHash": "sha256-d9KzCJv3UG6nX9Aur5OSEf4Uj+ywuxojhiCiRKYVzXA=",
+        "lastModified": 1719145664,
+        "narHash": "sha256-+0bBlerLxsHUJcKPDWZM1wL3V9bzCFjz+VyRTG8fnUA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "e8232c132a95ddc62df9d404120ad4ff53862910",
+        "rev": "c3e48cbd88414f583ff08804eb57b0da4c194f9e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                     |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`c3e48cbd`](https://github.com/NixOS/nixos-hardware/commit/c3e48cbd88414f583ff08804eb57b0da4c194f9e) | `` update macbookpro14,1 to 24.01 (2024) ``                                 |
| [`0cf592f5`](https://github.com/NixOS/nixos-hardware/commit/0cf592f520a4cbb6e8b4e84e38988bee5e939cab) | `` add new tests to mergify configuration ``                                |
| [`7d87afd1`](https://github.com/NixOS/nixos-hardware/commit/7d87afd10b176dee02376c476cb916eb33e23d8b) | `` feat: spi thermal conf ``                                                |
| [`27487bcd`](https://github.com/NixOS/nixos-hardware/commit/27487bcd12139b8b20442252e1fc3895d4394ce1) | `` change iptsd and system-control to nixpkgs versions - fixes iptsd bug `` |