### PR TITLE
chore(flake/nur): `3c6f9c7e` -> `f6131b4d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719139566,
-        "narHash": "sha256-9BdusbaiDmwZaHQGrnGjaw1psHZ09fCxjXFlAnUBKkI=",
+        "lastModified": 1719150330,
+        "narHash": "sha256-ZnMlR5659iKdbGLHsmcu+YTv7KVNYf/K8aoSb7ZB8Po=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3c6f9c7e3c707015d550fd9210b15143d13965a9",
+        "rev": "f6131b4da46a3d40d2f2631734b11a4dc63bb9e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f6131b4d`](https://github.com/nix-community/NUR/commit/f6131b4da46a3d40d2f2631734b11a4dc63bb9e6) | `` automatic update `` |
| [`df3679b2`](https://github.com/nix-community/NUR/commit/df3679b280597ef85c72c1ecdf1ba04668be1554) | `` automatic update `` |