### PR TITLE
chore(flake/nur): `f6131b4d` -> `46ab9f28`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719150330,
-        "narHash": "sha256-ZnMlR5659iKdbGLHsmcu+YTv7KVNYf/K8aoSb7ZB8Po=",
+        "lastModified": 1719153056,
+        "narHash": "sha256-nIp6HOIrPTMeIoaaj8MavebUI1HBeq1iz9P0nzWq1CI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f6131b4da46a3d40d2f2631734b11a4dc63bb9e6",
+        "rev": "46ab9f286d5546781726537039455867a59c19a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`46ab9f28`](https://github.com/nix-community/NUR/commit/46ab9f286d5546781726537039455867a59c19a3) | `` automatic update `` |