### PR TITLE
chore(flake/emacs-overlay): `dc376600` -> `44398152`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1719133657,
-        "narHash": "sha256-dO0SCFW/Odcbsdr17sk61USNokcpQGoKjP+88HbiYZU=",
+        "lastModified": 1719162455,
+        "narHash": "sha256-4rnZGmNB8sncEZyDRNfAM9UrR1eU+4En+psO+1L8cA8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "dc376600483aae0272de58ea9b2d06c9f4e132eb",
+        "rev": "443981528ce117ec3055d0fd182793d6cacbe778",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`44398152`](https://github.com/nix-community/emacs-overlay/commit/443981528ce117ec3055d0fd182793d6cacbe778) | `` Updated emacs `` |
| [`bdf81ad8`](https://github.com/nix-community/emacs-overlay/commit/bdf81ad80a4319ffd0a10ed176451ac5a1fa0b24) | `` Updated melpa `` |
| [`3dddf556`](https://github.com/nix-community/emacs-overlay/commit/3dddf55641599cb16f6e95ae3398761fdf6d7311) | `` Updated elpa ``  |