### PR TITLE
chore(flake/nur): `46ab9f28` -> `72137385`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719153056,
-        "narHash": "sha256-nIp6HOIrPTMeIoaaj8MavebUI1HBeq1iz9P0nzWq1CI=",
+        "lastModified": 1719160963,
+        "narHash": "sha256-hm2XunlO5oD0xh9Z0r1kIQj8UEt1vYeyyFlieN8hkHI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "46ab9f286d5546781726537039455867a59c19a3",
+        "rev": "72137385988d41b40f749b9203f9ba831f4fbe04",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                    |
| -------------------------------------------------------------------------------------------------- | -------------------------- |
| [`72137385`](https://github.com/nix-community/NUR/commit/72137385988d41b40f749b9203f9ba831f4fbe04) | `` automatic update ``     |
| [`5efc6bc4`](https://github.com/nix-community/NUR/commit/5efc6bc42427b0b9bacffa246ee220d22c9b4470) | `` automatic update ``     |
| [`d9efd9a8`](https://github.com/nix-community/NUR/commit/d9efd9a80823ab2e87f5961daa83c614bd601392) | `` add qenya repository `` |