### PR TITLE
chore(flake/home-manager): `cd886711` -> `6a9a1e51`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -410,11 +410,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719037157,
-        "narHash": "sha256-aOKd8+mhBsLQChCu1mn/W5ww79ta5cXVE59aJFrifM8=",
+        "lastModified": 1719177087,
+        "narHash": "sha256-3TqSVmZINDBQVo0AazepUYnDEGDOMYX4WwdKb5siZGA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cd886711998fe5d9ff7979fdd4b4cbd17b1f1511",
+        "rev": "6a9a1e51bbb8c301eae5aa63c9fc3c751ec5315b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`6a9a1e51`](https://github.com/nix-community/home-manager/commit/6a9a1e51bbb8c301eae5aa63c9fc3c751ec5315b) | `` flake.lock: Update ``                            |
| [`8be82697`](https://github.com/nix-community/home-manager/commit/8be82697f797ce2190b6e2d7b11cd384076caae7) | `` ssh-agent: fix evaluation of maintainer field `` |