### PR TITLE
chore(flake/emacs-overlay): `44398152` -> `b96a1062`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1719162455,
-        "narHash": "sha256-4rnZGmNB8sncEZyDRNfAM9UrR1eU+4En+psO+1L8cA8=",
+        "lastModified": 1719191206,
+        "narHash": "sha256-tXBGBYuOizMIlLknilXR/AiV9odvWz1/cFxghzrfZ4g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "443981528ce117ec3055d0fd182793d6cacbe778",
+        "rev": "b96a106247cc8b5bce04299b905631040eaff816",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`b96a1062`](https://github.com/nix-community/emacs-overlay/commit/b96a106247cc8b5bce04299b905631040eaff816) | `` Updated elpa ``   |
| [`3532a16b`](https://github.com/nix-community/emacs-overlay/commit/3532a16bb3dc791b6a1ac45c656bb010462e4665) | `` Updated nongnu `` |