### PR TITLE
chore(flake/srvos): `557ff94a` -> `4f314be1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -951,11 +951,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718844164,
-        "narHash": "sha256-QUXWv6llKIQ5To2N24d9dRI78Hqfm9iFyhvmvlOICNo=",
+        "lastModified": 1719189969,
+        "narHash": "sha256-6MSZrWvXSvUKIr0iC9eSbQ09NSm+j1Oh4o9Gentu1CU=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "557ff94aa1b48a723f8fa16eb9e7a2e6de991682",
+        "rev": "4f314be1307c8d5f1fb3d882a67e09dbdf285850",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`4f314be1`](https://github.com/nix-community/srvos/commit/4f314be1307c8d5f1fb3d882a67e09dbdf285850) | `` dev/private/flake.lock: Update `` |
| [`4d79f9c4`](https://github.com/nix-community/srvos/commit/4d79f9c4103a4daa42fb744cc7d46ee18cfddadc) | `` flake.lock: Update ``             |