### PR TITLE
chore(flake/emacs-overlay): `b96a1062` -> `e3e9ef4c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1719191206,
-        "narHash": "sha256-tXBGBYuOizMIlLknilXR/AiV9odvWz1/cFxghzrfZ4g=",
+        "lastModified": 1719193216,
+        "narHash": "sha256-4jggHHDsLt+i4/6lMNlZkHd3bzgV50feNpZGe4X3eMQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b96a106247cc8b5bce04299b905631040eaff816",
+        "rev": "e3e9ef4c9904fddbd8c00f3288e6a3be26a6bf0b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`e3e9ef4c`](https://github.com/nix-community/emacs-overlay/commit/e3e9ef4c9904fddbd8c00f3288e6a3be26a6bf0b) | `` Updated melpa `` |