### PR TITLE
chore(flake/nur): `c35808fd` -> `f82d3038`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719180650,
-        "narHash": "sha256-KqAz2NpqjotMTi+54S27B36/P9576t6ol1OO91F7kpA=",
+        "lastModified": 1719200775,
+        "narHash": "sha256-eHlsa7dNXoFq2/we56XE/A9UZfZouu7XT2VpKXDfmJg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c35808fdf00eac21e675b7ec691f623fe0653553",
+        "rev": "f82d303843eb447e0d28639e371ec909d51b2252",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f82d3038`](https://github.com/nix-community/NUR/commit/f82d303843eb447e0d28639e371ec909d51b2252) | `` automatic update `` |
| [`d1704b5f`](https://github.com/nix-community/NUR/commit/d1704b5f877476fb4081e90c462fe7dc099814ed) | `` automatic update `` |
| [`bfb48eb3`](https://github.com/nix-community/NUR/commit/bfb48eb380fc28f797aacaee4cf1ca9145fe8e60) | `` automatic update `` |
| [`5ded2516`](https://github.com/nix-community/NUR/commit/5ded25168af6298a128881feca9b0f9dc441565a) | `` automatic update `` |