### PR TITLE
chore(flake/nur): `f82d3038` -> `d6538b2a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719200775,
-        "narHash": "sha256-eHlsa7dNXoFq2/we56XE/A9UZfZouu7XT2VpKXDfmJg=",
+        "lastModified": 1719201853,
+        "narHash": "sha256-31+QBq8nwXJF+ex93dkDyWwjH/lUe+20u3P5WB2hmvo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f82d303843eb447e0d28639e371ec909d51b2252",
+        "rev": "d6538b2ac6e73890e37b763a9cded1b125aa086a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d6538b2a`](https://github.com/nix-community/NUR/commit/d6538b2ac6e73890e37b763a9cded1b125aa086a) | `` automatic update `` |