### PR TITLE
chore(flake/nur): `d6538b2a` -> `0da94b0b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719201853,
-        "narHash": "sha256-31+QBq8nwXJF+ex93dkDyWwjH/lUe+20u3P5WB2hmvo=",
+        "lastModified": 1719207736,
+        "narHash": "sha256-XNo4yWe5CF2CTuMazb0jU8AWcPXwCJdNBSCNH4U5d9k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d6538b2ac6e73890e37b763a9cded1b125aa086a",
+        "rev": "0da94b0b5561582fe4a4384298bea614bc2641c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0da94b0b`](https://github.com/nix-community/NUR/commit/0da94b0b5561582fe4a4384298bea614bc2641c1) | `` automatic update `` |