### PR TITLE
chore(flake/nur): `0da94b0b` -> `b2272dd6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719207736,
-        "narHash": "sha256-XNo4yWe5CF2CTuMazb0jU8AWcPXwCJdNBSCNH4U5d9k=",
+        "lastModified": 1719212025,
+        "narHash": "sha256-2bHo5MaNsJga0u7oikPGiooTA6S4UZTZFDfl+UiPif8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0da94b0b5561582fe4a4384298bea614bc2641c1",
+        "rev": "b2272dd682bd49a6c70fc865d551d9b109811604",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b2272dd6`](https://github.com/nix-community/NUR/commit/b2272dd682bd49a6c70fc865d551d9b109811604) | `` automatic update `` |
| [`6df3826f`](https://github.com/nix-community/NUR/commit/6df3826f9f7c7c6f82b880da772b2f2e97255601) | `` automatic update `` |
| [`4db188c3`](https://github.com/nix-community/NUR/commit/4db188c3dc892f256acaafd662f3fefa7dbd3e6c) | `` automatic update `` |