### PR TITLE
chore(flake/nur): `b2272dd6` -> `a7db791f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719212025,
-        "narHash": "sha256-2bHo5MaNsJga0u7oikPGiooTA6S4UZTZFDfl+UiPif8=",
+        "lastModified": 1719218810,
+        "narHash": "sha256-PZWoNk7pAPFGOPNcnx0Zc5YcH0NMZR9cnIa7oSazDjc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b2272dd682bd49a6c70fc865d551d9b109811604",
+        "rev": "a7db791fd44e4d2e60b3891d08fa1aafd1ee37fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a7db791f`](https://github.com/nix-community/NUR/commit/a7db791fd44e4d2e60b3891d08fa1aafd1ee37fd) | `` automatic update `` |
| [`36ca5cba`](https://github.com/nix-community/NUR/commit/36ca5cbac25949ec20d9c86f9fa86269b0fbb1ad) | `` automatic update `` |
| [`e2069856`](https://github.com/nix-community/NUR/commit/e206985635efb6df38159c2c2075cffad7664135) | `` automatic update `` |