### PR TITLE
chore(flake/nur): `489fedf3` -> `9f94fd46`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719226937,
-        "narHash": "sha256-PlRfQkDLiPhg1mAG99JDZC9uaY33qp05KLn/wOSgxGQ=",
+        "lastModified": 1719230278,
+        "narHash": "sha256-9XknpdjToV8swUSrqpIMO/EZ2/cib5US8QUtrRbrbT8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "489fedf3032de79f60fff5850492208f83a7bad3",
+        "rev": "9f94fd4605bf8a1e08c628a8abcab1ec3324899e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                     |
| -------------------------------------------------------------------------------------------------- | --------------------------- |
| [`9f94fd46`](https://github.com/nix-community/NUR/commit/9f94fd4605bf8a1e08c628a8abcab1ec3324899e) | `` automatic update ``      |
| [`9d74d7b6`](https://github.com/nix-community/NUR/commit/9d74d7b699fba006407a1ac93654fcec3dd909ed) | `` running format ``        |
| [`651e8010`](https://github.com/nix-community/NUR/commit/651e8010a51dc3be33661c4888fb5f1eb2d0be7b) | `` adding xonsh-xontribs `` |