### PR TITLE
chore(flake/nur): `9f94fd46` -> `6f250a10`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719230278,
-        "narHash": "sha256-9XknpdjToV8swUSrqpIMO/EZ2/cib5US8QUtrRbrbT8=",
+        "lastModified": 1719232960,
+        "narHash": "sha256-fUSOM2nGfyKeTvUll7K1D9GTklQIFqMCp0cBbqPa8SE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9f94fd4605bf8a1e08c628a8abcab1ec3324899e",
+        "rev": "6f250a10f9412db2df79e517e7550ec0a8d1edfb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6f250a10`](https://github.com/nix-community/NUR/commit/6f250a10f9412db2df79e517e7550ec0a8d1edfb) | `` automatic update `` |
| [`aa6fd62a`](https://github.com/nix-community/NUR/commit/aa6fd62ad205b65f478d0534e83c521b203dcb72) | `` automatic update `` |