### PR TITLE
chore(flake/nur): `6f250a10` -> `2e052b90`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719232960,
-        "narHash": "sha256-fUSOM2nGfyKeTvUll7K1D9GTklQIFqMCp0cBbqPa8SE=",
+        "lastModified": 1719239744,
+        "narHash": "sha256-SkhwOUu9whSM7n8/xOMjDhMJNdktO3SapYpAhwLCrFE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6f250a10f9412db2df79e517e7550ec0a8d1edfb",
+        "rev": "2e052b90eea2313b1afd23e24c13007c7e6a5851",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2e052b90`](https://github.com/nix-community/NUR/commit/2e052b90eea2313b1afd23e24c13007c7e6a5851) | `` automatic update `` |