### PR TITLE
chore(flake/nur): `2e052b90` -> `c2836da9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719239744,
-        "narHash": "sha256-SkhwOUu9whSM7n8/xOMjDhMJNdktO3SapYpAhwLCrFE=",
+        "lastModified": 1719258314,
+        "narHash": "sha256-9vk2lmLfq5eqQ/INOoGRp46fwpGUCvkboZr4x418XpA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2e052b90eea2313b1afd23e24c13007c7e6a5851",
+        "rev": "c2836da9bb8837dd2314da335746a16b0c1423f5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c2836da9`](https://github.com/nix-community/NUR/commit/c2836da9bb8837dd2314da335746a16b0c1423f5) | `` automatic update `` |
| [`ff75e6ab`](https://github.com/nix-community/NUR/commit/ff75e6abe4d0624cdee91b54f5a35e9302b7f2d2) | `` automatic update `` |
| [`fb5d2438`](https://github.com/nix-community/NUR/commit/fb5d243838c4994a7e3c48ac3a7b5a9c1cddaf21) | `` automatic update `` |
| [`5759f55f`](https://github.com/nix-community/NUR/commit/5759f55f61b31cca0bf3bf0c0aaf876bb06aee05) | `` automatic update `` |
| [`8313afa7`](https://github.com/nix-community/NUR/commit/8313afa775ebd7deea9f7695d871da22bd17a0f1) | `` automatic update `` |
| [`35dfb305`](https://github.com/nix-community/NUR/commit/35dfb305d71b61b9301054ddaead88a481f62e38) | `` automatic update `` |