### PR TITLE
chore(flake/nur): `c2836da9` -> `a21a417c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719258314,
-        "narHash": "sha256-9vk2lmLfq5eqQ/INOoGRp46fwpGUCvkboZr4x418XpA=",
+        "lastModified": 1719261983,
+        "narHash": "sha256-J9/+U1U/WdVEBRyPD+FTwgs6TBHED9JTUen8QpkYObA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c2836da9bb8837dd2314da335746a16b0c1423f5",
+        "rev": "a21a417c111a1e8263cd0d9b9fe137df17004665",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a21a417c`](https://github.com/nix-community/NUR/commit/a21a417c111a1e8263cd0d9b9fe137df17004665) | `` automatic update `` |