### PR TITLE
chore(flake/sops-nix): `5e2e9421` -> `c2ea1186`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -931,11 +931,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1719111739,
-        "narHash": "sha256-kr2QzRrplzlCP87ddayCZQS+dhGW98kw2zy7+jUXtF4=",
+        "lastModified": 1719268571,
+        "narHash": "sha256-pcUk2Fg5vPXLUEnFI97qaB8hto/IToRfqskFqsjvjb8=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "5e2e9421e9ed2b918be0a441c4535cfa45e04811",
+        "rev": "c2ea1186c0cbfa4d06d406ae50f3e4b085ddc9b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                       |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`c2ea1186`](https://github.com/Mic92/sops-nix/commit/c2ea1186c0cbfa4d06d406ae50f3e4b085ddc9b3) | `` update vendorHash ``                                       |
| [`9ab26ff4`](https://github.com/Mic92/sops-nix/commit/9ab26ff4c64e8c9131ff6aed6e5d0652a34cb375) | `` build(deps): bump github.com/ProtonMail/go-crypto ``       |
| [`417c1193`](https://github.com/Mic92/sops-nix/commit/417c1193abfc13f2d80129d151d852d72f6762e8) | `` update vendorHash ``                                       |
| [`b5f0a8af`](https://github.com/Mic92/sops-nix/commit/b5f0a8af5cb7f1e0f032d51eeaea0bacffca7c11) | `` build(deps): bump github.com/hashicorp/go-retryablehttp `` |