### PR TITLE
chore(flake/nur): `a21a417c` -> `76c0a713`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719261983,
-        "narHash": "sha256-J9/+U1U/WdVEBRyPD+FTwgs6TBHED9JTUen8QpkYObA=",
+        "lastModified": 1719269074,
+        "narHash": "sha256-m8rtQO7yPNx0owXNZFOD1GDRIxCRJ+rVGwdP+mkjSAo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a21a417c111a1e8263cd0d9b9fe137df17004665",
+        "rev": "76c0a7136681b0dc81f83a64d86170c1c748f52e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`76c0a713`](https://github.com/nix-community/NUR/commit/76c0a7136681b0dc81f83a64d86170c1c748f52e) | `` automatic update `` |
| [`6c0aeebb`](https://github.com/nix-community/NUR/commit/6c0aeebbfdba7f51619129efe12e0748fc935ca7) | `` automatic update `` |