### PR TITLE
chore(flake/nur): `76c0a713` -> `37476ffd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719269074,
-        "narHash": "sha256-m8rtQO7yPNx0owXNZFOD1GDRIxCRJ+rVGwdP+mkjSAo=",
+        "lastModified": 1719271960,
+        "narHash": "sha256-DjGdPmj6asbFXgbFOIlAYlRTHrXmBIYgR+GppA863Ck=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "76c0a7136681b0dc81f83a64d86170c1c748f52e",
+        "rev": "37476ffd9bad58898cfd35fe8c6b342a7cc5d614",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`37476ffd`](https://github.com/nix-community/NUR/commit/37476ffd9bad58898cfd35fe8c6b342a7cc5d614) | `` automatic update `` |