### PR TITLE
chore(flake/catppuccin): `2fb16f2d` -> `6e77fdd9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1719104749,
-        "narHash": "sha256-ZYRhOs5Qm3KzTl0sZg3XVD9zAQf2yDM9E2NHyFMPv8I=",
+        "lastModified": 1719285238,
+        "narHash": "sha256-8TaJ6eVPytSZ44dsME7DUKCt5ZcU85EvTDSS7kuIpoM=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "2fb16f2d6ffb2759f14fbcbd1f1e242f5fb662c7",
+        "rev": "6e77fdd91d4d92e3e984306458dd14502d91ca60",
         "type": "github"
       },
       "original": {

--- a/users/bbigras/graphical/sway/default.nix
+++ b/users/bbigras/graphical/sway/default.nix
@@ -18,13 +18,6 @@
     ];
   };
 
-  # https://github.com/catppuccin/nix/issues/176
-  home.pointerCursor = {
-    package = pkgs.bibata-cursors;
-    name = "Bibata-Modern-Ice";
-    size = 22;
-  };
-
   programs = {
     swaylock = {
       enable = true;


### PR DESCRIPTION
| Commit                                                                                          | Message                                                          |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`6e77fdd9`](https://github.com/catppuccin/nix/commit/6e77fdd91d4d92e3e984306458dd14502d91ca60) | `` feat(home-manager)!: add support for global cursors (#195) `` |