### PR TITLE
chore(flake/nur): `cf980180` -> `79d26b92`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719286781,
-        "narHash": "sha256-K9TtIyjvwtqZgS2KIzsSqzcZsDhprDuBI+8KF5Hljt0=",
+        "lastModified": 1719290395,
+        "narHash": "sha256-aHpjzyXypvUDR7PNBXy2oQELwtogL8MQTvpwBMNSkPw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cf980180f36d9d3312e268bae629edf75606cf1a",
+        "rev": "79d26b92485559cccf8e629403d033b40c8f330f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`79d26b92`](https://github.com/nix-community/NUR/commit/79d26b92485559cccf8e629403d033b40c8f330f) | `` automatic update `` |
| [`8c8cba99`](https://github.com/nix-community/NUR/commit/8c8cba99f1da04d7094d4ae9288fedf220431906) | `` automatic update `` |
| [`58d77499`](https://github.com/nix-community/NUR/commit/58d77499a608f70f5841fe8bca6c1c7c9b045d38) | `` automatic update `` |