### PR TITLE
chore(flake/nur): `79d26b92` -> `adf55d9b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719290395,
-        "narHash": "sha256-aHpjzyXypvUDR7PNBXy2oQELwtogL8MQTvpwBMNSkPw=",
+        "lastModified": 1719294251,
+        "narHash": "sha256-bWFBdv7hR/prg6oJWHiWXjMPgBWFPpmQaz8DI+/P6To=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "79d26b92485559cccf8e629403d033b40c8f330f",
+        "rev": "adf55d9b85d04db723b7128e9866a24113a6b149",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`adf55d9b`](https://github.com/nix-community/NUR/commit/adf55d9b85d04db723b7128e9866a24113a6b149) | `` automatic update `` |
| [`13c23bf1`](https://github.com/nix-community/NUR/commit/13c23bf110043d83d2042673ae117a042368940d) | `` automatic update `` |
| [`79e2c775`](https://github.com/nix-community/NUR/commit/79e2c77541270b2712a1d755513bbc898ee36e1d) | `` automatic update `` |