### PR TITLE
chore(flake/nur): `adf55d9b` -> `05c15148`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719294251,
-        "narHash": "sha256-bWFBdv7hR/prg6oJWHiWXjMPgBWFPpmQaz8DI+/P6To=",
+        "lastModified": 1719296800,
+        "narHash": "sha256-9KLPm13OOIsAp4aLyUMIZ5oAEBsBqyOFWdIrkN4Uvpg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "adf55d9b85d04db723b7128e9866a24113a6b149",
+        "rev": "05c15148223634c842ae20b576d786414488cf3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`05c15148`](https://github.com/nix-community/NUR/commit/05c15148223634c842ae20b576d786414488cf3b) | `` automatic update `` |