### PR TITLE
chore(flake/nur): `05c15148` -> `288f3844`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719296800,
-        "narHash": "sha256-9KLPm13OOIsAp4aLyUMIZ5oAEBsBqyOFWdIrkN4Uvpg=",
+        "lastModified": 1719301380,
+        "narHash": "sha256-ohmQYGJDqnVbDnCt5bGF+mzJLD9LAQMBvxdeSbxSQfI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "05c15148223634c842ae20b576d786414488cf3b",
+        "rev": "288f38441541b5550beb7b9f06ae70ec1518d52e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                    |
| -------------------------------------------------------------------------------------------------- | -------------------------- |
| [`288f3844`](https://github.com/nix-community/NUR/commit/288f38441541b5550beb7b9f06ae70ec1518d52e) | `` Fix macos evaluation `` |