### PR TITLE
chore(flake/emacs-overlay): `b6082d10` -> `fd904f28`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1719245815,
-        "narHash": "sha256-BiDNkoh9a2dx2OTUFpzWhkGq5WfatG7sUX4Kw0Fdo7g=",
+        "lastModified": 1719303695,
+        "narHash": "sha256-SqJTGKtJEzkQdHEUWeMHwQ5vyAg4wE1kRbjTRjzfAUI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b6082d10feac69203dac419818daa47c5fe36464",
+        "rev": "fd904f28fb1d3d3a3d87db312fac97cb4a146db4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`fd904f28`](https://github.com/nix-community/emacs-overlay/commit/fd904f28fb1d3d3a3d87db312fac97cb4a146db4) | `` Updated elpa ``   |
| [`34b29b9d`](https://github.com/nix-community/emacs-overlay/commit/34b29b9d04e9eaabafdcf3d7dacdcd3f5bf3d29a) | `` Updated nongnu `` |