### PR TITLE
chore(flake/nur): `288f3844` -> `d76c0154`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719301380,
-        "narHash": "sha256-ohmQYGJDqnVbDnCt5bGF+mzJLD9LAQMBvxdeSbxSQfI=",
+        "lastModified": 1719308707,
+        "narHash": "sha256-NKS3AO5mTJvbzfnGwyEPeIFhHC6HK8Q2aLImNNBHYNM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "288f38441541b5550beb7b9f06ae70ec1518d52e",
+        "rev": "d76c0154e524f26a0e4a8e83db97e1844b5028b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d76c0154`](https://github.com/nix-community/NUR/commit/d76c0154e524f26a0e4a8e83db97e1844b5028b8) | `` automatic update `` |
| [`0eb612d2`](https://github.com/nix-community/NUR/commit/0eb612d23868e3618245bcd2a650730023eb6f0a) | `` automatic update `` |
| [`66a9c492`](https://github.com/nix-community/NUR/commit/66a9c492c01fe905f0c5429096985fb72c9c7386) | `` automatic update `` |