### PR TITLE
chore(flake/catppuccin): `6e77fdd9` -> `1adbfeb4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1719285238,
-        "narHash": "sha256-8TaJ6eVPytSZ44dsME7DUKCt5ZcU85EvTDSS7kuIpoM=",
+        "lastModified": 1719311390,
+        "narHash": "sha256-eP+SydN7alV3ln7a1BrGhDoLVTBa6RaHxYZ9bTHAQIA=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "6e77fdd91d4d92e3e984306458dd14502d91ca60",
+        "rev": "1adbfeb44a54be0ae79eca751ba948a6faa3bb0f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                  |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`1adbfeb4`](https://github.com/catppuccin/nix/commit/1adbfeb44a54be0ae79eca751ba948a6faa3bb0f) | `` fix(home-manager): assert `qt.style.name` for kvantum theme (#242) `` |