### PR TITLE
chore(flake/nur): `d76c0154` -> `f8cde393`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719308707,
-        "narHash": "sha256-NKS3AO5mTJvbzfnGwyEPeIFhHC6HK8Q2aLImNNBHYNM=",
+        "lastModified": 1719315635,
+        "narHash": "sha256-EyB/u00b7/8rur1voDGA0vJ1BhiZ8JuNRSXc8Oo1igU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d76c0154e524f26a0e4a8e83db97e1844b5028b8",
+        "rev": "f8cde39311fb10213775654187c067d7b115c590",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f8cde393`](https://github.com/nix-community/NUR/commit/f8cde39311fb10213775654187c067d7b115c590) | `` automatic update `` |
| [`21338571`](https://github.com/nix-community/NUR/commit/21338571f78604fb7d7aa6dfa25687abc1f171f4) | `` automatic update `` |
| [`059e5aa2`](https://github.com/nix-community/NUR/commit/059e5aa2d5d6e5e0fdf77daafe93f97e80f33a0b) | `` automatic update `` |