### PR TITLE
chore(flake/nur): `f8cde393` -> `f33520c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719315635,
-        "narHash": "sha256-EyB/u00b7/8rur1voDGA0vJ1BhiZ8JuNRSXc8Oo1igU=",
+        "lastModified": 1719320296,
+        "narHash": "sha256-sOdJpSoPxpg9yFMGxgGMVPRwysFRyyxCsRgCmkvxLRQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f8cde39311fb10213775654187c067d7b115c590",
+        "rev": "f33520c2a2d2429f4ab5342be952549dca934a56",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f33520c2`](https://github.com/nix-community/NUR/commit/f33520c2a2d2429f4ab5342be952549dca934a56) | `` automatic update `` |