### PR TITLE
chore(flake/nur): `f33520c2` -> `1e03b52a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719320296,
-        "narHash": "sha256-sOdJpSoPxpg9yFMGxgGMVPRwysFRyyxCsRgCmkvxLRQ=",
+        "lastModified": 1719323109,
+        "narHash": "sha256-8bz4EMBq2oxebuGycB7MeN/O54bDR1hFX8QNwFWX024=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f33520c2a2d2429f4ab5342be952549dca934a56",
+        "rev": "1e03b52a077e864f638ddb1b58798c5ebc7cc9e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1e03b52a`](https://github.com/nix-community/NUR/commit/1e03b52a077e864f638ddb1b58798c5ebc7cc9e5) | `` automatic update `` |