### PR TITLE
chore(flake/nur): `a331f411` -> `8039bbf5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719326701,
-        "narHash": "sha256-IDEPbakCvjk61uX19cnmSB8fsdFTmMe5Wt4bCyIUGdA=",
+        "lastModified": 1719333593,
+        "narHash": "sha256-9ktfPXvz+0BNjZTnjqlgMRdCNkI+6jkmQWSNuNp14jM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a331f41142ed524ce58ed0df1c72a7d0b13ec867",
+        "rev": "8039bbf50a73c2b192f4fdc1a8518ba44e3c6117",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8039bbf5`](https://github.com/nix-community/NUR/commit/8039bbf50a73c2b192f4fdc1a8518ba44e3c6117) | `` automatic update `` |