### PR TITLE
chore(flake/nur): `8039bbf5` -> `37ae4359`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719333593,
-        "narHash": "sha256-9ktfPXvz+0BNjZTnjqlgMRdCNkI+6jkmQWSNuNp14jM=",
+        "lastModified": 1719337524,
+        "narHash": "sha256-bYp4//+XM+J1Y23sW6VjXAiCHUdq3aqgXue/tVeCxLw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8039bbf50a73c2b192f4fdc1a8518ba44e3c6117",
+        "rev": "37ae43594731d4d801f53dffe465006421c7c292",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`37ae4359`](https://github.com/nix-community/NUR/commit/37ae43594731d4d801f53dffe465006421c7c292) | `` automatic update `` |
| [`c019a0ab`](https://github.com/nix-community/NUR/commit/c019a0ab8a21c5e84a440f34ef43947a0c9ebc34) | `` automatic update `` |