### PR TITLE
chore(flake/nixpkgs): `a71e967e` -> `2893f56d`

### DIFF
--- a/doomDir/init.el
+++ b/doomDir/init.el
@@ -75,7 +75,7 @@
        ;; lua
        (markdown +grip)
        (nix +lsp)
-       (org +pretty +roam2)
+       ;; (org +pretty +roam2)
        ;; (python +lsp +pyright +cython)
        ;; (ruby +rails)
        (rust +lsp)

--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1719075281,
-        "narHash": "sha256-CyyxvOwFf12I91PBWz43iGT1kjsf5oi6ax7CrvaMyAo=",
+        "lastModified": 1719254875,
+        "narHash": "sha256-ECni+IkwXjusHsm9Sexdtq8weAq/yUyt1TWIemXt3Ko=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a71e967ef3694799d0c418c98332f7ff4cc5f6af",
+        "rev": "2893f56de08021cffd9b6b6dfc70fd9ccd51eb60",
         "type": "github"
       },
       "original": {

--- a/users/bbigras/core/default.nix
+++ b/users/bbigras/core/default.nix
@@ -38,7 +38,7 @@
     ./btop.nix
     ./git.nix
     ./jujutsu.nix
-    ./emacs
+    # ./emacs
     ./ssh.nix
     ./tmux.nix
     ./xdg.nix


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                            |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`823f3a7a`](https://github.com/NixOS/nixpkgs/commit/823f3a7adee68b51091985cb3b8b153bddb2bd22) | `` CODEOWNERS: remove dasj from multiple locations (#322162) ``                    |
| [`c40c66f3`](https://github.com/NixOS/nixpkgs/commit/c40c66f3fbf04a65c302e7e1d13907cbf3078386) | `` vimPlugins.rocks-config-nvim: init at 1.5.0 ``                                  |
| [`dc044660`](https://github.com/NixOS/nixpkgs/commit/dc0446608cc85b2df1f1da68ef96f8fbc104012f) | `` rocks-nvim: stick to semantic release ``                                        |
| [`284be69a`](https://github.com/NixOS/nixpkgs/commit/284be69a1689765290045e80ba48e225809d7f86) | `` python311Packages.qdrant-client: 1.9.1 -> 1.9.2 ``                              |
| [`afd9d601`](https://github.com/NixOS/nixpkgs/commit/afd9d601202989cc1b7820dbcb4bf1b159be28cc) | `` vmctl: init at v0.99-unstable-2024-05-14 ``                                     |
| [`30436ac0`](https://github.com/NixOS/nixpkgs/commit/30436ac0d7d483631ac7d61c7c81e308bfe0d697) | `` path-of-building: add desktop item ``                                           |
| [`2a52a2de`](https://github.com/NixOS/nixpkgs/commit/2a52a2de74c803a48f51c21817977c0d7562fc00) | `` emacsPackages.lsp-bridge: 20240615.2321 -> 20240622.236 ``                      |
| [`e4fe6706`](https://github.com/NixOS/nixpkgs/commit/e4fe6706bcda17fcf23c2689e05bf5cc1a298c12) | `` rye: 0.34.0 -> 0.35.0 ``                                                        |
| [`36e8d8a5`](https://github.com/NixOS/nixpkgs/commit/36e8d8a53b253019a3b325015be47196c278afb7) | `` vimPlugins.nvim-treesitter: fix update.py and update documentation (#321535) `` |
| [`03f7e0ee`](https://github.com/NixOS/nixpkgs/commit/03f7e0ee26c4dd69587458d6fcdd81dfafa25f52) | `` ktailctl: 0.16.0 -> 0.16.1 ``                                                   |
| [`d213fa69`](https://github.com/NixOS/nixpkgs/commit/d213fa697f0af06f504e1ebd37a7bca78bc0e868) | `` pkgsMusl.crosvm: fix build ``                                                   |
| [`69f70080`](https://github.com/NixOS/nixpkgs/commit/69f70080a5c96fe0073314263acc059c613ba159) | `` protoc-gen-tonic: 0.3.0 -> 0.4.0 ``                                             |
| [`f7de4e29`](https://github.com/NixOS/nixpkgs/commit/f7de4e293f714a961186a18946d3c80a076023cd) | `` protoc-gen-prost-crate: 0.3.1 -> 0.4.0 ``                                       |
| [`c86d8aa1`](https://github.com/NixOS/nixpkgs/commit/c86d8aa179da46ee362a832e8c9933bbafcc4dac) | `` protoc-gen-prost-serde: 0.2.3 -> 0.3.0 ``                                       |
| [`fb4c3b79`](https://github.com/NixOS/nixpkgs/commit/fb4c3b791d208d05c30acb56394de8a85105f8ba) | `` protoc-gen-prost: 0.2.3 -> 0.3.1 ``                                             |
| [`207b8a23`](https://github.com/NixOS/nixpkgs/commit/207b8a238934d26c98c7aa08844de4214edd6b00) | `` python311Packages.coffea: 2024.6.0 -> 2024.6.1 (#322140) ``                     |
| [`0394bcf6`](https://github.com/NixOS/nixpkgs/commit/0394bcf6cb5d1a799ec5dde5bc7cf9d7b5243dc1) | `` nix-eval-jobs: 2.22.0 -> 2.22.1 ``                                              |
| [`b6815f85`](https://github.com/NixOS/nixpkgs/commit/b6815f85706b731569a8651232e75897a3168686) | `` monado: Use cmake flag instead of patch ``                                      |
| [`4a78856a`](https://github.com/NixOS/nixpkgs/commit/4a78856aad91bad2fbffa61d099c6ce5a93db75c) | `` python312Packages.rfc8785: init at 0.1.3 ``                                     |
| [`73cc1d09`](https://github.com/NixOS/nixpkgs/commit/73cc1d092b9eb9f6d2eefa6fc94c0a781bf074ba) | `` androidStudioPackages: iterate over update script ``                            |
| [`efb39c60`](https://github.com/NixOS/nixpkgs/commit/efb39c6052f3ce51587cf19733f5f4e5d515aa13) | `` vimPlugins.telescope-smart-history-nvim: init at 2022-12-15 ``                  |
| [`4cf0caf1`](https://github.com/NixOS/nixpkgs/commit/4cf0caf146ab1ddc0b3fca61b55c7deebbc79c46) | `` androidStudioPackages: add update script ``                                     |
| [`5a4d198b`](https://github.com/NixOS/nixpkgs/commit/5a4d198b55437cd7f9f976ddb7419ef93b3a7620) | `` sosreport: 4.7.1 -> 4.7.2 ``                                                    |
| [`50ca2228`](https://github.com/NixOS/nixpkgs/commit/50ca22287a1b88c6f6d0cff4e840f3aa712729ac) | `` wyrd: add darwin platform ``                                                    |
| [`e63cfefd`](https://github.com/NixOS/nixpkgs/commit/e63cfefd1e743ff65b11d8ed00a638062822f5f4) | `` sogo: 5.9.1 -> 5.10.0 (#320644) ``                                              |
| [`62db0a59`](https://github.com/NixOS/nixpkgs/commit/62db0a59de47a0d343bb7bedd4e65ebad135d66d) | `` webtorrent_desktop: update and use latest electron (#320293) ``                 |
| [`cfb5dcd6`](https://github.com/NixOS/nixpkgs/commit/cfb5dcd6374dd2ef1bd586e39babfa71f0b24fda) | `` bookstack: 24.05.1 -> 24.05.2 ``                                                |
| [`779bb1b5`](https://github.com/NixOS/nixpkgs/commit/779bb1b5b6257f3d4791775d2a12f659339988df) | `` lefthook: 1.6.16 -> 1.6.18 ``                                                   |
| [`6db066b2`](https://github.com/NixOS/nixpkgs/commit/6db066b2f96b8a7f896b596dade716e507913899) | `` vimPlugins.codesnap-nvim: add missing meta.homepage ``                          |
| [`11820671`](https://github.com/NixOS/nixpkgs/commit/1182067118cd83b780a625c7499e36401b46b92c) | `` devenv: remove `drupol` from maintainers ``                                     |
| [`2701015f`](https://github.com/NixOS/nixpkgs/commit/2701015ffb719bde689913bd99cc750f79206e67) | `` gpt4all: remove `drupol` from maintainers ``                                    |
| [`d88cebe7`](https://github.com/NixOS/nixpkgs/commit/d88cebe788a544055d4a489d31a26893848c764c) | `` jan: remove `drupol` from maintainers ``                                        |
| [`b4d41d3a`](https://github.com/NixOS/nixpkgs/commit/b4d41d3a4244457efcececbf7862529e31e5d13b) | `` python3Packages.private-gpt: remove `drupol` from maintainers ``                |
| [`f95c186e`](https://github.com/NixOS/nixpkgs/commit/f95c186eb933644012dffbb6035be0897c99dce4) | `` nixos/private-gpt: remove `drupol` from maintainers ``                          |
| [`b72135fd`](https://github.com/NixOS/nixpkgs/commit/b72135fdaa6a2607eb07dff513fc72115df2c628) | `` coder: 2.11.2 -> 2.11.3 ``                                                      |
| [`12af9eb0`](https://github.com/NixOS/nixpkgs/commit/12af9eb0d1f08942ef89d7aac985116975c1be2f) | `` boxbuddy: 2.2.5 -> 2.2.8 ``                                                     |
| [`d028fb66`](https://github.com/NixOS/nixpkgs/commit/d028fb66b08dd2f290ae5d03e8b51c4217645b13) | `` neocmakelsp: 0.7.4 -> 0.7.6 ``                                                  |
| [`06608e4b`](https://github.com/NixOS/nixpkgs/commit/06608e4bdb353b7f352940d7bacbb1bc646d5e5b) | `` netcat: add myself as maintainer ``                                             |
| [`7b8f8c84`](https://github.com/NixOS/nixpkgs/commit/7b8f8c84ee51e7c92d82e6374c4a39f5533b25d9) | `` unzip: add myself as maintainer ``                                              |
| [`cd915a95`](https://github.com/NixOS/nixpkgs/commit/cd915a951117b38ea88ada7e5102717343010896) | `` selinux-sandbox: add myself as maintainer ``                                    |
| [`e1ce7848`](https://github.com/NixOS/nixpkgs/commit/e1ce7848a930b2ef62e7655bb0e8e868b3dba2f7) | `` selinux-python: add myself as maintainer ``                                     |
| [`c00d8cb2`](https://github.com/NixOS/nixpkgs/commit/c00d8cb2a83e683437b0fa0f0f386597dc838031) | `` maintainers: add panky ``                                                       |
| [`aa38b880`](https://github.com/NixOS/nixpkgs/commit/aa38b880289b7ae835ba5dd6a8c0247db313499b) | `` imagemagick: 7.1.1-33 -> 7.1.1-34 ``                                            |
| [`0fda1046`](https://github.com/NixOS/nixpkgs/commit/0fda1046bb9c181df980b19571ded990e754390b) | `` gotify-server: 2.4.0 -> 2.5.0 ``                                                |
| [`b534b7e5`](https://github.com/NixOS/nixpkgs/commit/b534b7e5a5cd3774baca73337c4dbbe5963e4fae) | `` obs-studio-plugins.obs-teleport: 0.7.1 -> 0.7.2 ``                              |
| [`b0b4d2d0`](https://github.com/NixOS/nixpkgs/commit/b0b4d2d06d44c971dd744d19d1b4edf1baab3658) | `` pkgs/top-level: stop permitting openssl 1.1 ``                                  |
| [`9bb686f0`](https://github.com/NixOS/nixpkgs/commit/9bb686f064217ee326ada56ffe1f6c833c881f8d) | `` dwarfs: 0.7.5 → 0.9.10. ``                                                      |
| [`69074b67`](https://github.com/NixOS/nixpkgs/commit/69074b67a36d30a8eef6e76343246441c2c13730) | `` e16: fix e_gen_menu script for NixOS ``                                         |
| [`f756ee76`](https://github.com/NixOS/nixpkgs/commit/f756ee76674e2afb569c5159fee784eb4d1fa7a7) | `` lcov: 1.16 -> 2.1 ``                                                            |
| [`18cbc36a`](https://github.com/NixOS/nixpkgs/commit/18cbc36a603f486ef5473257ea1a56c7125cc377) | `` emacs28: backport a security fix from Emacs 29.4 ``                             |
| [`aa45c7e6`](https://github.com/NixOS/nixpkgs/commit/aa45c7e67ddb4fc1a8f033cbfe30bb8f1b5adfee) | `` emacs.pkgs.org: backport a security fix from 9.7.5 ``                           |
| [`6d551ad2`](https://github.com/NixOS/nixpkgs/commit/6d551ad2704bfac32723f0008e283790ed6c4128) | `` perl538Packages.MemoryProcess: init at 0.06 ``                                  |
| [`a5af8a01`](https://github.com/NixOS/nixpkgs/commit/a5af8a01299234b025a78f9a977bafdf5ec9543e) | `` perl538Packages.MemoryUsage: init at 0.201 ``                                   |
| [`6f9daa9d`](https://github.com/NixOS/nixpkgs/commit/6f9daa9d3deda181698a869d58f7bfdca717ac83) | `` perl538Packages.DevelCover: init at 1.44 ``                                     |
| [`38ca339c`](https://github.com/NixOS/nixpkgs/commit/38ca339cfb1ecc0b18fc4e4b2bc1a918cc8425ce) | `` ldtk: install desktop icon in correct directory ``                              |
| [`7983160a`](https://github.com/NixOS/nixpkgs/commit/7983160ab17e15d3e440ecb6b0dae382a3a59df3) | `` linkerd_edge: 24.6.2 -> 24.6.3 ``                                               |
| [`803a229f`](https://github.com/NixOS/nixpkgs/commit/803a229f08cd86630c3bf782412efe44c7cf109f) | `` gpsprune: 24.1 -> 24.2 ``                                                       |
| [`f0d126e4`](https://github.com/NixOS/nixpkgs/commit/f0d126e4753eae8a8a6e194f78c7f429200db21e) | `` python312Packages.pyloadapi: init at 1.2.0 ``                                   |
| [`69c67cf4`](https://github.com/NixOS/nixpkgs/commit/69c67cf44e7d9cd183e382790d0a38f395915c5a) | `` python312Packages.hatch-regex-commit: init at 0.0.3 ``                          |
| [`afe26983`](https://github.com/NixOS/nixpkgs/commit/afe26983233919e67bae94070ef67b7e6c713cef) | `` python312Packages.aioraven: 0.5.3 -> 0.6.0 ``                                   |
| [`8f217146`](https://github.com/NixOS/nixpkgs/commit/8f2171468e3fb90fadaab710d6f8e3a830a92a16) | `` python312Packages.yalexs: 6.4.0 -> 6.4.1 ``                                     |
| [`4154834b`](https://github.com/NixOS/nixpkgs/commit/4154834be5af054e54afdb225e10d4c7bc37a255) | `` bitwig-studio5: 5.18 -> 5.19 ``                                                 |
| [`2c40f69c`](https://github.com/NixOS/nixpkgs/commit/2c40f69cb3a4b6c7c57d5ec843f50ea42a8c1be7) | `` tenv: 2.0.7 -> 2.1.8 ``                                                         |
| [`f1b2ef46`](https://github.com/NixOS/nixpkgs/commit/f1b2ef46843c2b08306cc9b728e0c4d35efec52d) | `` lndhub-go: 1.0.0 -> 1.0.1 ``                                                    |
| [`0415c9c1`](https://github.com/NixOS/nixpkgs/commit/0415c9c1f48878426e078fd8a397c59c90b14ce0) | `` epson-escpr2: 1.2.10 -> 1.2.11 ``                                               |
| [`45cfa86f`](https://github.com/NixOS/nixpkgs/commit/45cfa86fd333c1fdc9c5d758703e9568009e5688) | `` miru: darwin support, add maintainer ``                                         |
| [`66adc9c5`](https://github.com/NixOS/nixpkgs/commit/66adc9c5d1f9eeec23fbd754ecc44c42de06a13f) | `` nixos/tests/home-assistant: test multi-component packages ``                    |
| [`7b81a213`](https://github.com/NixOS/nixpkgs/commit/7b81a213cfaf02cdc6c8196dbd8b00978a778d4f) | `` nixos/home-assistant: fix symlinking multi-manifest custom components ``        |
| [`ca39b726`](https://github.com/NixOS/nixpkgs/commit/ca39b726c75579507d3bec92226ec03bfa981067) | `` home-assistant-custom-components.spook: init at 3.0.1 ``                        |
| [`55e4d5af`](https://github.com/NixOS/nixpkgs/commit/55e4d5af1bbe3f303bde5131d39abe0cf05194a3) | `` python312Packages.drawsvg: 2.3.0 -> 2.4.0 ``                                    |
| [`053ad7bc`](https://github.com/NixOS/nixpkgs/commit/053ad7bcd4bc8c0f9262e6d1775fa0e9add0422d) | `` babashka-unwrapped: 1.3.190 -> 1.3.191 ``                                       |
| [`ac961ac4`](https://github.com/NixOS/nixpkgs/commit/ac961ac498c8e1d504dced8c612ca5600a28085c) | `` nixos/stalwart-mail: set pre-defined spam-filter rules ``                       |
| [`6eea6943`](https://github.com/NixOS/nixpkgs/commit/6eea6943bc2c0bce4fbb13d22817adfdcea12d5d) | `` stalwart-mail: include spam-filter config ``                                    |
| [`7a9fdd23`](https://github.com/NixOS/nixpkgs/commit/7a9fdd2390c74984c8507b03ca29837cd5710c37) | `` reindeer: 2024.06.10.00 -> 2024.06.17.00 ``                                     |
| [`9e08d3e1`](https://github.com/NixOS/nixpkgs/commit/9e08d3e197f410f1d05ffa3ade33451f6b002fc4) | `` victoriametrics: add shawn8901 as maintainer ``                                 |
| [`728715db`](https://github.com/NixOS/nixpkgs/commit/728715dbc1f96fba8fa7c76af916aa554b3cf1a0) | `` vmagent: build from victoriametrics package ``                                  |
| [`d68244cf`](https://github.com/NixOS/nixpkgs/commit/d68244cf1f038709fac2517c8bac803e3758c4ad) | `` victoriametrics: add support to enable/disable subpackages ``                   |
| [`f8d915b9`](https://github.com/NixOS/nixpkgs/commit/f8d915b942727faa00b3bb8ebdad1f19fc4bf830) | `` maintainers: add kkoniuszy ``                                                   |
| [`29709f87`](https://github.com/NixOS/nixpkgs/commit/29709f87d73517bdb3068c91cebf2ff363a43c7d) | `` monado: Enable FEATURE_TRACING ``                                               |
| [`22b34878`](https://github.com/NixOS/nixpkgs/commit/22b3487860c61629ce06e1e9e869037e4544a79b) | `` rclip: 1.10.0 -> 1.10.1 ``                                                      |
| [`e1bea835`](https://github.com/NixOS/nixpkgs/commit/e1bea835d6ea3e051c431b3dd99ca9fd6ff69498) | `` csharp-ls: 0.13.0 -> 0.14.0 ``                                                  |
| [`d681d912`](https://github.com/NixOS/nixpkgs/commit/d681d9126f2f59f45badb84bd4cf61e1e08df717) | `` substudy: init at 0.6.10 ``                                                     |
| [`948aaf3b`](https://github.com/NixOS/nixpkgs/commit/948aaf3bce26934892bb07275aac08b1dcecf23b) | `` gerbolyze: unbreak by downgrading resvg ``                                      |
| [`6c081949`](https://github.com/NixOS/nixpkgs/commit/6c0819491ac27bee7c6654a57c879cc4373f3045) | `` gtest: Allow specifying a newer C++ standard ``                                 |
| [`dbbaf02a`](https://github.com/NixOS/nixpkgs/commit/dbbaf02a9caa19e47e97c19e37091ec6a2630197) | `` release-notes: Mention `libe57format` upgrade ``                                |
| [`a8e7538f`](https://github.com/NixOS/nixpkgs/commit/a8e7538fcbd223f4e521796d680d6520f908d799) | `` libE57Format: 2.2.0 -> 3.1.1 ``                                                 |
| [`799243ce`](https://github.com/NixOS/nixpkgs/commit/799243cebf7342c6b27f3de29ffeac5f65755a9b) | `` planify: 4.8.2 -> 4.8.4 ``                                                      |
| [`5a4d1a86`](https://github.com/NixOS/nixpkgs/commit/5a4d1a86219eb691e5cee010f27e2238b89b6a0c) | `` jwx: 2.0.21 -> 2.1.0 ``                                                         |
| [`ef00c78e`](https://github.com/NixOS/nixpkgs/commit/ef00c78e0dfae6bfdcc873398c393363af1cf34d) | `` nixos/jenkins: add RuntimeDirectory ``                                          |
| [`1c25bad6`](https://github.com/NixOS/nixpkgs/commit/1c25bad679a0e2d6d75991f25b1c1413369f21ec) | `` kodiPackages.future: 0.18.3+matrix.1 -> 1.0.0+matrix.1 ``                       |
| [`e03bb988`](https://github.com/NixOS/nixpkgs/commit/e03bb988ac2d1e70d211c060d84c98633cb45692) | `` nezha-agent: 0.16.11 -> 0.17.0 ``                                               |
| [`491ab390`](https://github.com/NixOS/nixpkgs/commit/491ab390ad819f031fbd63f363a19e447d6b4312) | `` lscolors: 0.17.0 -> 0.18.0 ``                                                   |
| [`841e38e7`](https://github.com/NixOS/nixpkgs/commit/841e38e789f0eeee3867668a70a910bc1aaabb8d) | `` alacritty-theme: 0-unstable-2024-05-03 -> 0-unstable-2024-06-17 ``              |
| [`7abf7509`](https://github.com/NixOS/nixpkgs/commit/7abf750927b688cb834a53eb52ffe72a1cf71c0f) | `` pocketbase: 0.22.13 -> 0.22.14 ``                                               |
| [`442cd7de`](https://github.com/NixOS/nixpkgs/commit/442cd7dee5ddba627eb9aeecade5e78ab0febd85) | `` chezmoi: 2.49.0 -> 2.49.1 ``                                                    |
| [`a20d35f2`](https://github.com/NixOS/nixpkgs/commit/a20d35f291f75f1545b248900e51ebb4e0f94b38) | `` python311Packages.textual: 0.68.0 -> 0.70.0 ``                                  |
| [`9593fc49`](https://github.com/NixOS/nixpkgs/commit/9593fc49a20bc6a0d109302a1754d0926dcb6310) | `` codespell: 2.2.6 -> 2.3.0 ``                                                    |
| [`ff924bfb`](https://github.com/NixOS/nixpkgs/commit/ff924bfb4637c4958f00dfdc0440ebf7ed98fdcc) | `` pixinsight: 1.8.9-2-20230920 -> 1.8.9-3-20240619 ``                             |
| [`4858ce6b`](https://github.com/NixOS/nixpkgs/commit/4858ce6b753ac4d28a3e473662e258972bc771d4) | `` solo5: remove unsupported qemu flag in test ``                                  |
| [`da2e0f92`](https://github.com/NixOS/nixpkgs/commit/da2e0f92dc9a0d25394540d184630bce21fcf6a8) | `` revolt-desktop: migrate to pkgs/by-name ``                                      |
| [`fa346c84`](https://github.com/NixOS/nixpkgs/commit/fa346c841d677200c72f329e434f2e1a5b02368e) | `` technitium-dns-server: 12.1 -> 12.2.1 ``                                        |