### PR TITLE
chore(flake/nur): `85596df8` -> `06d455cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719344711,
-        "narHash": "sha256-k389PPp1HG9xk3yXn4Q/eAY/K+qm/+kbHLq9hfo+m14=",
+        "lastModified": 1719348041,
+        "narHash": "sha256-GHGzhSfXoH456YeseuMtoc1c2gXjyS+Y9yvyldlegmY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "85596df878b1b71a54e1de3835ac6135c1bb8744",
+        "rev": "06d455cff79e4721e30e9170e122f600898c2ffe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`06d455cf`](https://github.com/nix-community/NUR/commit/06d455cff79e4721e30e9170e122f600898c2ffe) | `` automatic update `` |
| [`befb9e51`](https://github.com/nix-community/NUR/commit/befb9e51bfa3d3ba6fc0b25dd5b0efecfae4097e) | `` automatic update `` |