### PR TITLE
chore(flake/nur): `06d455cf` -> `29717dba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719348041,
-        "narHash": "sha256-GHGzhSfXoH456YeseuMtoc1c2gXjyS+Y9yvyldlegmY=",
+        "lastModified": 1719352011,
+        "narHash": "sha256-b7TnVsG6oiwbqEqtRt9uI1Zz4tgIVzy5a6/jNE/WHXY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "06d455cff79e4721e30e9170e122f600898c2ffe",
+        "rev": "29717dba9879f6c7f69d5b2a92874c13fd6bdcc1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`29717dba`](https://github.com/nix-community/NUR/commit/29717dba9879f6c7f69d5b2a92874c13fd6bdcc1) | `` automatic update `` |