### PR TITLE
chore(flake/nur): `5806d846` -> `4b73db27`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719359202,
-        "narHash": "sha256-8r+joDOYsqyUE/IimhD6h71zk1w4eM0er4cP04ju6eY=",
+        "lastModified": 1719367539,
+        "narHash": "sha256-GZZPSKQIXzwaD8HDskhFJLFbmRV+61/VRrBb6rPqb78=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5806d846d7c73959fbf619be5fd71386dc1a9ac7",
+        "rev": "4b73db27e3c552c0423d6994ea9b1e90e1363c8e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4b73db27`](https://github.com/nix-community/NUR/commit/4b73db27e3c552c0423d6994ea9b1e90e1363c8e) | `` automatic update `` |
| [`7a28ded7`](https://github.com/nix-community/NUR/commit/7a28ded7c2ec2b178c52baff153d4901b9e50074) | `` automatic update `` |