### PR TITLE
chore(flake/nur): `4b73db27` -> `5b463fae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719367539,
-        "narHash": "sha256-GZZPSKQIXzwaD8HDskhFJLFbmRV+61/VRrBb6rPqb78=",
+        "lastModified": 1719374239,
+        "narHash": "sha256-s8eTJ5QXle4vobYBtctl+3qtYFDen1H6ma1iuMcS/oc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4b73db27e3c552c0423d6994ea9b1e90e1363c8e",
+        "rev": "5b463fae316a30dc75669168822247beba6a13b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5b463fae`](https://github.com/nix-community/NUR/commit/5b463fae316a30dc75669168822247beba6a13b5) | `` automatic update `` |
| [`af9b240f`](https://github.com/nix-community/NUR/commit/af9b240f22e87fe8b8627d66155b43341e8748c4) | `` automatic update `` |
| [`006695e9`](https://github.com/nix-community/NUR/commit/006695e960e4d38af730c50af779c82d7fab6527) | `` automatic update `` |
| [`3bf57d4c`](https://github.com/nix-community/NUR/commit/3bf57d4cbf6dda397a62cc1bd7f86f9946f9695a) | `` automatic update `` |