### PR TITLE
chore(flake/nur): `5b463fae` -> `ea8e0d8a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719374239,
-        "narHash": "sha256-s8eTJ5QXle4vobYBtctl+3qtYFDen1H6ma1iuMcS/oc=",
+        "lastModified": 1719376326,
+        "narHash": "sha256-iHymNg91a+m+Td/iRfejWKGcC4Atztc19vTcOiT2tYA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5b463fae316a30dc75669168822247beba6a13b5",
+        "rev": "ea8e0d8a80b76401caaf789bc68de6c527139ef6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ea8e0d8a`](https://github.com/nix-community/NUR/commit/ea8e0d8a80b76401caaf789bc68de6c527139ef6) | `` automatic update `` |
| [`a19d506c`](https://github.com/nix-community/NUR/commit/a19d506cf1ababf52a8ea40934afab9168878397) | `` automatic update `` |