### PR TITLE
chore(flake/nur): `ea8e0d8a` -> `6d841b41`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719376326,
-        "narHash": "sha256-iHymNg91a+m+Td/iRfejWKGcC4Atztc19vTcOiT2tYA=",
+        "lastModified": 1719381117,
+        "narHash": "sha256-/CAMYOC22ZQxrXVmN7UI5N+qtAQGLG1UB3rlQBRb+/c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ea8e0d8a80b76401caaf789bc68de6c527139ef6",
+        "rev": "6d841b41e480c27660928026a42a2b80690f7a7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6d841b41`](https://github.com/nix-community/NUR/commit/6d841b41e480c27660928026a42a2b80690f7a7f) | `` automatic update `` |