### PR TITLE
chore(flake/nur): `6d841b41` -> `c8536751`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719381117,
-        "narHash": "sha256-/CAMYOC22ZQxrXVmN7UI5N+qtAQGLG1UB3rlQBRb+/c=",
+        "lastModified": 1719383903,
+        "narHash": "sha256-F0xie4qCdmYlG2R72nekEpLNVaLEPV7e8QeV0I4tVT4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6d841b41e480c27660928026a42a2b80690f7a7f",
+        "rev": "c85367517f0d61c87adec42e291049d57d9a3103",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c8536751`](https://github.com/nix-community/NUR/commit/c85367517f0d61c87adec42e291049d57d9a3103) | `` automatic update `` |