### PR TITLE
chore(flake/home-manager): `6b1f90a8` -> `92a26bf6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -410,11 +410,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719180626,
-        "narHash": "sha256-vZAzm5KQpR6RGple1dzmSJw5kPivES2heCFM+ZWkt0I=",
+        "lastModified": 1719385710,
+        "narHash": "sha256-0yb5D0wCEtXoTi4ssNZxwvLTrahTwlHYPtx252FZ1MU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6b1f90a8ff92e81638ae6eb48cd62349c3e387bb",
+        "rev": "92a26bf6df1f00cbbed16a99d2547531ff4b3a83",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`92a26bf6`](https://github.com/nix-community/home-manager/commit/92a26bf6df1f00cbbed16a99d2547531ff4b3a83) | `` yazi: add shellWrapperName & rename wrappers to yy `` |
| [`d3bf2a06`](https://github.com/nix-community/home-manager/commit/d3bf2a06129c2493ec55e217be2907b92279f30f) | `` yazi: add eljamm as maintainer ``                     |