### PR TITLE
chore(flake/nur): `c8536751` -> `c6a371fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719383903,
-        "narHash": "sha256-F0xie4qCdmYlG2R72nekEpLNVaLEPV7e8QeV0I4tVT4=",
+        "lastModified": 1719388457,
+        "narHash": "sha256-rzwackjk5zFdY7VwgThgfyC3+28Bq6hSZSl5sOzLT5A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c85367517f0d61c87adec42e291049d57d9a3103",
+        "rev": "c6a371faf78277a88fc03f7f10998bd32dbf4684",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c6a371fa`](https://github.com/nix-community/NUR/commit/c6a371faf78277a88fc03f7f10998bd32dbf4684) | `` automatic update `` |