### PR TITLE
chore(flake/emacs-overlay): `2005d1e0` -> `4ffecf56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1719363732,
-        "narHash": "sha256-Hlnu6LkDJW5KiWNbcWGK4fpmipiZasd3a6KUPEzRg10=",
+        "lastModified": 1719393085,
+        "narHash": "sha256-Ft0yuaMlo6aKHltFzfjgKSLiYOAri597YSDXgWvmZOI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2005d1e0260e31e7775349c62eabbcd8ae5bd6e6",
+        "rev": "4ffecf56a5faa4cf163da6da9690752365376e99",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`4ffecf56`](https://github.com/nix-community/emacs-overlay/commit/4ffecf56a5faa4cf163da6da9690752365376e99) | `` Updated emacs `` |
| [`71aeeb45`](https://github.com/nix-community/emacs-overlay/commit/71aeeb45c76777bb24898d5a793999b402445fc7) | `` Updated melpa `` |
| [`f2541c14`](https://github.com/nix-community/emacs-overlay/commit/f2541c145a994837ba3fe732531197f65672ae65) | `` Updated elpa ``  |