### PR TITLE
chore(flake/nur): `c6a371fa` -> `7a06db39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719388457,
-        "narHash": "sha256-rzwackjk5zFdY7VwgThgfyC3+28Bq6hSZSl5sOzLT5A=",
+        "lastModified": 1719401225,
+        "narHash": "sha256-8K6WAYoTzlTsBXxQhky8i0WO4j2ujwE5KfehurwXBbI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c6a371faf78277a88fc03f7f10998bd32dbf4684",
+        "rev": "7a06db3960032f4287f5478cc8330f5da04ccb68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7a06db39`](https://github.com/nix-community/NUR/commit/7a06db3960032f4287f5478cc8330f5da04ccb68) | `` automatic update `` |
| [`26636309`](https://github.com/nix-community/NUR/commit/26636309a9c370b71f22e9a3a8f4ef1520e2515d) | `` automatic update `` |