### PR TITLE
chore(flake/nur): `9b79429a` -> `40472948`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719406847,
-        "narHash": "sha256-rlYrWEm7dbrFVDnzOD+0aQMe+gaX2xlozjDi5pkkEvo=",
+        "lastModified": 1719412482,
+        "narHash": "sha256-Qea0ymnmTN/74pDUHye7nCJxywJ5q7c6te+S+9L1aM4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9b79429aa832546c496c4798e9336495d93e9323",
+        "rev": "404729489a379ab0eb55ffefd7ec5bd8de4ab3fc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`40472948`](https://github.com/nix-community/NUR/commit/404729489a379ab0eb55ffefd7ec5bd8de4ab3fc) | `` automatic update `` |