### PR TITLE
chore(flake/nur): `40472948` -> `1aee97b9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719412482,
-        "narHash": "sha256-Qea0ymnmTN/74pDUHye7nCJxywJ5q7c6te+S+9L1aM4=",
+        "lastModified": 1719416701,
+        "narHash": "sha256-YX99s0vmls0XNy3ltre0jAZDrObLzs+HdqBXi/wJbLo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "404729489a379ab0eb55ffefd7ec5bd8de4ab3fc",
+        "rev": "1aee97b978127ec34683944171f57f6a64291d1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1aee97b9`](https://github.com/nix-community/NUR/commit/1aee97b978127ec34683944171f57f6a64291d1f) | `` automatic update `` |