### PR TITLE
chore(flake/emacs-overlay): `4ffecf56` -> `a2e483e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1719393085,
-        "narHash": "sha256-Ft0yuaMlo6aKHltFzfjgKSLiYOAri597YSDXgWvmZOI=",
+        "lastModified": 1719421936,
+        "narHash": "sha256-/EyKtewJTGMuloY03fR6dchO5WKh/ZswJa1QBKQwkTk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4ffecf56a5faa4cf163da6da9690752365376e99",
+        "rev": "a2e483e0969dcad460f7bed3ae359d526d772fa1",
         "type": "github"
       },
       "original": {
@@ -700,11 +700,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1719122173,
-        "narHash": "sha256-aEMsNUtqSPwn6l+LIZ/rX++nCgun3E9M3uSZs6Rwb7w=",
+        "lastModified": 1719234068,
+        "narHash": "sha256-1AjSIedDC/aERt24KsCUftLpVppW61S7awfjGe7bMio=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "906320ae02f769d13a646eb3605a9821df0d6ea2",
+        "rev": "90bd1b26e23760742fdcb6152369919098f05417",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`a2e483e0`](https://github.com/nix-community/emacs-overlay/commit/a2e483e0969dcad460f7bed3ae359d526d772fa1) | `` Updated emacs ``        |
| [`eeebb49e`](https://github.com/nix-community/emacs-overlay/commit/eeebb49e6f53c56612e0ac87154ad81f3d11a728) | `` Updated melpa ``        |
| [`a9911a9e`](https://github.com/nix-community/emacs-overlay/commit/a9911a9e50ad51d8acd402c60b0bcbce4291784e) | `` Updated elpa ``         |
| [`41ad3629`](https://github.com/nix-community/emacs-overlay/commit/41ad3629eaa64a587bd58f8bb9271cc5b17011e2) | `` Updated flake inputs `` |