### PR TITLE
chore(flake/catppuccin): `1adbfeb4` -> `51bd4ccf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1719311390,
-        "narHash": "sha256-eP+SydN7alV3ln7a1BrGhDoLVTBa6RaHxYZ9bTHAQIA=",
+        "lastModified": 1719426468,
+        "narHash": "sha256-HlEAH79OHAUl/ENo40j83Vb9Q8vEh+gi50TOMCgJqdA=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "1adbfeb44a54be0ae79eca751ba948a6faa3bb0f",
+        "rev": "51bd4ccfcfcc8e65a4fcb721a3e9c68afe009401",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                     |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`51bd4ccf`](https://github.com/catppuccin/nix/commit/51bd4ccfcfcc8e65a4fcb721a3e9c68afe009401) | `` chore(modules): update ports (#247) ``                                   |
| [`de0dec4c`](https://github.com/catppuccin/nix/commit/de0dec4cecc580c56127e5da2ced0f6d663cc510) | `` fix(home-manager): don't let swaylock cause infinite recursion (#243) `` |