### PR TITLE
chore(flake/nur): `0deceb3a` -> `f2cfe9a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719423995,
-        "narHash": "sha256-Lxj0iGJv68Gi3FGnPhVWDe4QHCd0tfRDwd2i2hOkv+0=",
+        "lastModified": 1719434685,
+        "narHash": "sha256-WA4FEvq+sQyltUcgSQJi+F0iBSJXT70QS//0Uv+iMv0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0deceb3ae1cd39201087acdbae2659daac2a11fc",
+        "rev": "f2cfe9a1a402f288ddd17d602f977e2d62fc250c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f2cfe9a1`](https://github.com/nix-community/NUR/commit/f2cfe9a1a402f288ddd17d602f977e2d62fc250c) | `` automatic update `` |
| [`70e9082d`](https://github.com/nix-community/NUR/commit/70e9082dde5e1053edc797048ba7689e6db494bb) | `` automatic update `` |
| [`83f5a464`](https://github.com/nix-community/NUR/commit/83f5a464c492c9188357096ccd47a2b10dc9f37a) | `` automatic update `` |
| [`9dfa9e74`](https://github.com/nix-community/NUR/commit/9dfa9e7493fea727c02b7b1e2a7f96cd13066022) | `` automatic update `` |