### PR TITLE
chore(flake/nur): `f2cfe9a1` -> `ed22dbef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719434685,
-        "narHash": "sha256-WA4FEvq+sQyltUcgSQJi+F0iBSJXT70QS//0Uv+iMv0=",
+        "lastModified": 1719445514,
+        "narHash": "sha256-JN6pNagxC9G3XYeHG1IQqaZ1FdN+GLdbbyA9n9n5zx4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f2cfe9a1a402f288ddd17d602f977e2d62fc250c",
+        "rev": "ed22dbeff4743719cd5e8c1743233782595e6d99",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ed22dbef`](https://github.com/nix-community/NUR/commit/ed22dbeff4743719cd5e8c1743233782595e6d99) | `` automatic update `` |
| [`645d0067`](https://github.com/nix-community/NUR/commit/645d006748615a16d4f95a1c2386ffb2c5cb3956) | `` automatic update `` |