### PR TITLE
chore(flake/nur): `ed22dbef` -> `373d1731`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719445514,
-        "narHash": "sha256-JN6pNagxC9G3XYeHG1IQqaZ1FdN+GLdbbyA9n9n5zx4=",
+        "lastModified": 1719453392,
+        "narHash": "sha256-UCc1aWVUYeRDkxLi4i7yfouk3F6L3zcD2aRVAE/hUrk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ed22dbeff4743719cd5e8c1743233782595e6d99",
+        "rev": "373d17316a312499adfa1624a317b0bc0dce6724",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`373d1731`](https://github.com/nix-community/NUR/commit/373d17316a312499adfa1624a317b0bc0dce6724) | `` automatic update `` |
| [`b6fe3fe1`](https://github.com/nix-community/NUR/commit/b6fe3fe1931c9eb0ba39ac1ee972eba9221664af) | `` automatic update `` |
| [`d1d95536`](https://github.com/nix-community/NUR/commit/d1d955366ba8d3624b8bed760d522211f8b1201a) | `` automatic update `` |
| [`0c4d473a`](https://github.com/nix-community/NUR/commit/0c4d473a60a9f676cb115a671328e89ec4547fec) | `` automatic update `` |
| [`471b60c0`](https://github.com/nix-community/NUR/commit/471b60c0844ea152845d1717be606ca738779e52) | `` automatic update `` |