### PR TITLE
chore(flake/srvos): `4f314be1` -> `e938f07e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -951,11 +951,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719189969,
-        "narHash": "sha256-6MSZrWvXSvUKIr0iC9eSbQ09NSm+j1Oh4o9Gentu1CU=",
+        "lastModified": 1719449101,
+        "narHash": "sha256-rRrz763KKi6GnSZF4WF34kpJ9eMXR3AOPOWN/7hO1Zs=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "4f314be1307c8d5f1fb3d882a67e09dbdf285850",
+        "rev": "e938f07e5cd9d11576d3860b68c117932c161006",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`e938f07e`](https://github.com/nix-community/srvos/commit/e938f07e5cd9d11576d3860b68c117932c161006) | `` dev/private/flake.lock: Update `` |
| [`c4febeee`](https://github.com/nix-community/srvos/commit/c4febeee8db021e573bf16eba5a207a4b6975d32) | `` flake.lock: Update ``             |