### PR TITLE
chore(flake/nur): `373d1731` -> `265f5dcb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719453392,
-        "narHash": "sha256-UCc1aWVUYeRDkxLi4i7yfouk3F6L3zcD2aRVAE/hUrk=",
+        "lastModified": 1719455694,
+        "narHash": "sha256-r0DP68GiAVa8qvqK9IKHLSbzYCV03tmQkjF486g2rnY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "373d17316a312499adfa1624a317b0bc0dce6724",
+        "rev": "265f5dcb75d079a996372f75297b8293c59df1f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`265f5dcb`](https://github.com/nix-community/NUR/commit/265f5dcb75d079a996372f75297b8293c59df1f8) | `` automatic update `` |