### PR TITLE
chore(flake/catppuccin): `51bd4ccf` -> `53967ef2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1719426468,
-        "narHash": "sha256-HlEAH79OHAUl/ENo40j83Vb9Q8vEh+gi50TOMCgJqdA=",
+        "lastModified": 1719457243,
+        "narHash": "sha256-5rOWwMAp/suWVKGavhfdyLsF2mA7Fv2DQWXlt7S+QWA=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "51bd4ccfcfcc8e65a4fcb721a3e9c68afe009401",
+        "rev": "53967ef237edd38a5b5cc5441e9b6a44b9554977",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                    |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`53967ef2`](https://github.com/catppuccin/nix/commit/53967ef237edd38a5b5cc5441e9b6a44b9554977) | `` chore: remove unused argument in mk-site.nix (#245) ``                  |
| [`e02aca95`](https://github.com/catppuccin/nix/commit/e02aca950fba2843083264832473e5856541cb08) | `` fix(home-manager): assert `qt.platformTheme.name` for kvantum (#244) `` |