### PR TITLE
chore(flake/nur): `265f5dcb` -> `104069e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719455694,
-        "narHash": "sha256-r0DP68GiAVa8qvqK9IKHLSbzYCV03tmQkjF486g2rnY=",
+        "lastModified": 1719460561,
+        "narHash": "sha256-gPAVwyAABMijzqWzf+52DtKXs+Xilowd/8tuIeSy2Js=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "265f5dcb75d079a996372f75297b8293c59df1f8",
+        "rev": "104069e5f902b77ef2c30cded69ffaaaa4f8c029",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`104069e5`](https://github.com/nix-community/NUR/commit/104069e5f902b77ef2c30cded69ffaaaa4f8c029) | `` automatic update `` |
| [`ca630a69`](https://github.com/nix-community/NUR/commit/ca630a697b69dc4098df04ca803f22e48115da6c) | `` automatic update `` |
| [`8b643244`](https://github.com/nix-community/NUR/commit/8b643244512f0e42cca051c919e52d915aab0776) | `` automatic update `` |
| [`248f19ec`](https://github.com/nix-community/NUR/commit/248f19ec7e8740d78d58f32e65a62063a5e37af8) | `` automatic update `` |