### PR TITLE
chore(flake/nur): `c78ad7a1` -> `0fe48a8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719465282,
-        "narHash": "sha256-0kNnnD8jAz32L89cgGTcu1LnXgb3tplNtjd6HVS0NGQ=",
+        "lastModified": 1719467077,
+        "narHash": "sha256-npSarj7wdFkFJEP6Y/EaJHigXKMGSS3yHIb+VCwYyNs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c78ad7a172c61d79eedf2e3c366f1a8ace89cb65",
+        "rev": "0fe48a8e4ec6b220f529b8aa34a6c941400570a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0fe48a8e`](https://github.com/nix-community/NUR/commit/0fe48a8e4ec6b220f529b8aa34a6c941400570a6) | `` automatic update `` |
| [`eed642bb`](https://github.com/nix-community/NUR/commit/eed642bb9a9cd5475719a483f06c72e43e777730) | `` automatic update `` |