### PR TITLE
chore(flake/nur): `0fe48a8e` -> `56f8d13e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719467077,
-        "narHash": "sha256-npSarj7wdFkFJEP6Y/EaJHigXKMGSS3yHIb+VCwYyNs=",
+        "lastModified": 1719470785,
+        "narHash": "sha256-EUzEqB9dKH5J8s0VIqc54ycsI6zZ+yTLP2ePr21TCnU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0fe48a8e4ec6b220f529b8aa34a6c941400570a6",
+        "rev": "56f8d13e1b06406fb4654e9fc025f16037ba9bed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`56f8d13e`](https://github.com/nix-community/NUR/commit/56f8d13e1b06406fb4654e9fc025f16037ba9bed) | `` automatic update `` |