### PR TITLE
chore(flake/nur): `56f8d13e` -> `50191dd7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719470785,
-        "narHash": "sha256-EUzEqB9dKH5J8s0VIqc54ycsI6zZ+yTLP2ePr21TCnU=",
+        "lastModified": 1719478000,
+        "narHash": "sha256-b4FAQPUW69WBKwuwuJOcZaPaYsFVw54+UHNacgzUzvw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "56f8d13e1b06406fb4654e9fc025f16037ba9bed",
+        "rev": "50191dd71fb168860ad600af502f3382068ff724",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`50191dd7`](https://github.com/nix-community/NUR/commit/50191dd71fb168860ad600af502f3382068ff724) | `` automatic update `` |
| [`afd2321b`](https://github.com/nix-community/NUR/commit/afd2321b338c0b9d45445dbd510c355e0da45fe5) | `` automatic update `` |