### PR TITLE
chore(flake/nur): `50191dd7` -> `e357bc4c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719478000,
-        "narHash": "sha256-b4FAQPUW69WBKwuwuJOcZaPaYsFVw54+UHNacgzUzvw=",
+        "lastModified": 1719484852,
+        "narHash": "sha256-ZTSVIS5CungrINOCveZgKqypU0u2uYxGnYu1zHHN/wo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "50191dd71fb168860ad600af502f3382068ff724",
+        "rev": "e357bc4c25cf53c97fe0f4c1391705eb5eea6a04",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e357bc4c`](https://github.com/nix-community/NUR/commit/e357bc4c25cf53c97fe0f4c1391705eb5eea6a04) | `` automatic update `` |
| [`78631f57`](https://github.com/nix-community/NUR/commit/78631f5730c773712edd9b44a52ab3c856e0de4f) | `` automatic update `` |