### PR TITLE
chore(flake/nur): `e357bc4c` -> `c2667e57`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719484852,
-        "narHash": "sha256-ZTSVIS5CungrINOCveZgKqypU0u2uYxGnYu1zHHN/wo=",
+        "lastModified": 1719488730,
+        "narHash": "sha256-4LTpvjM/S6DMxl9Kb35tQ5Y70XVTULMTM5UprsngFMg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e357bc4c25cf53c97fe0f4c1391705eb5eea6a04",
+        "rev": "c2667e57412f53b38d19386ebf7f6f564e28febe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c2667e57`](https://github.com/nix-community/NUR/commit/c2667e57412f53b38d19386ebf7f6f564e28febe) | `` automatic update `` |