### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `9205f287` -> `0b124de2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -519,11 +519,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1719406097,
-        "narHash": "sha256-KF/L5JxagCdQwdYf0cmIZ3hUUYGHTkDWfAIM8UImCYI=",
+        "lastModified": 1719490230,
+        "narHash": "sha256-bumMyf9VYO30fNj6JAvRJt2RjO8TMJMV6u5ZD/xIifI=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "9205f2878ff2d173b91cf27f594d4f9a983b639f",
+        "rev": "0b124de235398119adfee99a5759fe317dfe995a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                                         |
| ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`0b124de2`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/0b124de235398119adfee99a5759fe317dfe995a) | `` Explicitly specify repo for emacs-ansible `` |