### PR TITLE
chore(flake/emacs-overlay): `cb0e2cbf` -> `7f48c7d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1719450324,
-        "narHash": "sha256-Sym1X1GARJSss3VUrNKwsb12S8qZlGlKxU6RpouSBvk=",
+        "lastModified": 1719507278,
+        "narHash": "sha256-2r4LOGbMn2vf6tPGj75lKCLG1AEdYPxWAlsGspeUqMo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cb0e2cbfad5eedcbe33cc2bff0e83e37e22afa12",
+        "rev": "7f48c7d3d44a5c6e8f3db67f2202759b8589f36a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`7f48c7d3`](https://github.com/nix-community/emacs-overlay/commit/7f48c7d3d44a5c6e8f3db67f2202759b8589f36a) | `` Updated melpa `` |
| [`aa2bfbde`](https://github.com/nix-community/emacs-overlay/commit/aa2bfbde35e9ed5edd64f037fc97a1515d40bfee) | `` Updated elpa ``  |