### PR TITLE
chore(flake/nur): `2dc22d4f` -> `16241263`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719498894,
-        "narHash": "sha256-EAHZtVntBYKZkeyXT9GGEC7MZhLORKfimEfy+FLJ3Ds=",
+        "lastModified": 1719510997,
+        "narHash": "sha256-KxOrqnIyTFqubLMzz9GmWTWqp0kpaoxJKgYrNUz0kow=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2dc22d4fa3114be3048eb8e3994456f64a878f92",
+        "rev": "162412634e99dd353461e1b43085449c2c98d77f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`16241263`](https://github.com/nix-community/NUR/commit/162412634e99dd353461e1b43085449c2c98d77f) | `` automatic update `` |
| [`0713da57`](https://github.com/nix-community/NUR/commit/0713da5785faf081a4fa06500890f8726755f464) | `` automatic update `` |
| [`7f7a0662`](https://github.com/nix-community/NUR/commit/7f7a06623a13b72996776d2916e7ae7804ceb408) | `` automatic update `` |
| [`ecafd810`](https://github.com/nix-community/NUR/commit/ecafd810e1a5cf05218b75f20dbfc2ddab352979) | `` automatic update `` |