### PR TITLE
chore(flake/emacs-overlay): `7f48c7d3` -> `950ed590`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1719507278,
-        "narHash": "sha256-2r4LOGbMn2vf6tPGj75lKCLG1AEdYPxWAlsGspeUqMo=",
+        "lastModified": 1719508394,
+        "narHash": "sha256-zpBYMUsJAVjR9mAxSNbzOGJqYIWu1HDECAMyag6D8cg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7f48c7d3d44a5c6e8f3db67f2202759b8589f36a",
+        "rev": "950ed5909d7b4f3941c68a6119eaeb1a3665e239",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`950ed590`](https://github.com/nix-community/emacs-overlay/commit/950ed5909d7b4f3941c68a6119eaeb1a3665e239) | `` Updated emacs `` |