### PR TITLE
chore(flake/nur): `ca15da30` -> `87531078`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719534510,
-        "narHash": "sha256-hu9lqKegsPJueZIWdkpBIPIGeWXLFpYDcFutIS+Zqs8=",
+        "lastModified": 1719539335,
+        "narHash": "sha256-Pr22SusCrUbPMA/xjktwIgLirReqpqsmJqF1WECAQfc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ca15da302bd5c6308d51cf9b06f99da7d2d6f108",
+        "rev": "87531078c7f60794f874cda0378b3703b8616930",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`87531078`](https://github.com/nix-community/NUR/commit/87531078c7f60794f874cda0378b3703b8616930) | `` automatic update `` |