### PR TITLE
chore(flake/nur): `2401c31a` -> `8efb060c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719546364,
-        "narHash": "sha256-CZYqMz87Taewn7b2hEOzJouSrJu0embRf1q+Zpd+G5E=",
+        "lastModified": 1719549154,
+        "narHash": "sha256-tYYDCOkv6PBsKEyspUQM4N3Of3Ew9mQrHD6WOL5c2/s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2401c31a166107cb7d878ffd130ba9535d8cf2ae",
+        "rev": "8efb060c807ec580b985f5c7548f211c1d479706",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8efb060c`](https://github.com/nix-community/NUR/commit/8efb060c807ec580b985f5c7548f211c1d479706) | `` automatic update `` |
| [`598ed395`](https://github.com/nix-community/NUR/commit/598ed39548b3e3b757224e99c263d44cb19562b6) | `` automatic update `` |