### PR TITLE
chore(flake/nur): `8efb060c` -> `0ea09e11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719549154,
-        "narHash": "sha256-tYYDCOkv6PBsKEyspUQM4N3Of3Ew9mQrHD6WOL5c2/s=",
+        "lastModified": 1719557585,
+        "narHash": "sha256-83ZCA00GZ7h9474I/GEcHK3JqXjeVqZnek11xW8ZkVw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8efb060c807ec580b985f5c7548f211c1d479706",
+        "rev": "0ea09e11ae7981afc825007482fcab50621d8317",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0ea09e11`](https://github.com/nix-community/NUR/commit/0ea09e11ae7981afc825007482fcab50621d8317) | `` automatic update `` |
| [`7c4abedf`](https://github.com/nix-community/NUR/commit/7c4abedf3993f6e2b9862144c2c6311ab035c6ed) | `` automatic update `` |
| [`162caa25`](https://github.com/nix-community/NUR/commit/162caa250f703e0d29399e7002b7c9f4b6fb0ce4) | `` automatic update `` |
| [`4eff50b9`](https://github.com/nix-community/NUR/commit/4eff50b91356f83230ff2efa7585ffa40e2f8643) | `` automatic update `` |