### PR TITLE
chore(flake/nixos-hardware): `14aadcba` -> `3980e781`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -627,11 +627,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1719487696,
-        "narHash": "sha256-pCsl9qFCuIuhIfGH03CiBOsy1LNwITC6VMb6/5tz+Qc=",
+        "lastModified": 1719552654,
+        "narHash": "sha256-PX3msbC5KdwCDnucGtir3qzlzv+1fuiU4tk17nljFIE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "14aadcba1a26c8c142453839f888afd0db8b2041",
+        "rev": "3980e7816c99d9e4da7a7b762e5b294055b73b2f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                   |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`3980e781`](https://github.com/NixOS/nixos-hardware/commit/3980e7816c99d9e4da7a7b762e5b294055b73b2f) | `` enable bluetooth support for Yoga 6 13ALC6. (#1013) `` |