### PR TITLE
chore(flake/emacs-overlay): `950ed590` -> `3d38ddfb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1719508394,
-        "narHash": "sha256-zpBYMUsJAVjR9mAxSNbzOGJqYIWu1HDECAMyag6D8cg=",
+        "lastModified": 1719594572,
+        "narHash": "sha256-lKf2QyQ3CxJ6jcEQxiIMKA8rhRRDqJZzoV287rAsv60=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "950ed5909d7b4f3941c68a6119eaeb1a3665e239",
+        "rev": "3d38ddfb5229e78c66a3896de47f7ee9edfb4bc3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`3d38ddfb`](https://github.com/nix-community/emacs-overlay/commit/3d38ddfb5229e78c66a3896de47f7ee9edfb4bc3) | `` Updated emacs `` |
| [`afe79087`](https://github.com/nix-community/emacs-overlay/commit/afe79087f7f5727e87b80bfdc118767974e64969) | `` Updated melpa `` |
| [`d44d81ab`](https://github.com/nix-community/emacs-overlay/commit/d44d81ab57dc102db479400e958355b7e8e67660) | `` Updated elpa ``  |
| [`e3a4b715`](https://github.com/nix-community/emacs-overlay/commit/e3a4b715f2a60efafa9cbe6bfa6b8bb5b659a381) | `` Updated elpa ``  |