### PR TITLE
chore(flake/nur): `0ea09e11` -> `7369862c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719557585,
-        "narHash": "sha256-83ZCA00GZ7h9474I/GEcHK3JqXjeVqZnek11xW8ZkVw=",
+        "lastModified": 1719564461,
+        "narHash": "sha256-wCFs1sf1tPoV3nCG5N5KaakAKm88FyzN6pRdOsOqNZg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0ea09e11ae7981afc825007482fcab50621d8317",
+        "rev": "7369862c4a8f293f6fde79044369dad7dfc04798",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7369862c`](https://github.com/nix-community/NUR/commit/7369862c4a8f293f6fde79044369dad7dfc04798) | `` automatic update `` |
| [`ff35ff6a`](https://github.com/nix-community/NUR/commit/ff35ff6a15802e375b09ec548d44ba2526214f9d) | `` automatic update `` |