### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `9f79e7ef` -> `de3f79ca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -519,11 +519,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1719563509,
-        "narHash": "sha256-QSjMEH9n4XSXwyJQj7SRcCn4IqXf4rehwsgQ+oj+WBw=",
+        "lastModified": 1719582153,
+        "narHash": "sha256-uIZAFPhCt8KrDqdt5LBR87VjwqMMSepXb3mHyinxMFk=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "9f79e7ef141a1a64bc3a3d2ccc8862c48e0a369f",
+        "rev": "de3f79cae7f8044cfc7472a41a7d47cbe9095622",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                                                 |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`de3f79ca`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/de3f79cae7f8044cfc7472a41a7d47cbe9095622) | `` newbie-friendly flake & home-manager instructions `` |