### PR TITLE
chore(flake/home-manager): `1a4f12ae` -> `7e68e55d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -410,11 +410,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719438532,
-        "narHash": "sha256-/Vmso2ZMoFE3M7d1MRsQ2K5sR8CVKnrM6t1ys9Xjpz4=",
+        "lastModified": 1719588253,
+        "narHash": "sha256-A03i8xiVgP14DCmV5P7VUv37eodCjY4e1iai0b2EuuM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1a4f12ae0bda877ec4099b429cf439aad897d7e9",
+        "rev": "7e68e55d2e16d3a1e92a679430728c35a30fd24e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                            |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`7e68e55d`](https://github.com/nix-community/home-manager/commit/7e68e55d2e16d3a1e92a679430728c35a30fd24e) | `` glance: add module ``           |
| [`f50e2779`](https://github.com/nix-community/home-manager/commit/f50e2779edbc905ab131ce7ce36b14a09ab44f3c) | `` flake.lock: Update ``           |
| [`19e2f43e`](https://github.com/nix-community/home-manager/commit/19e2f43e0b0aec2067e5101f7d1ec75a43f64778) | `` rbw: fix url option examples `` |