### PR TITLE
chore(flake/catppuccin): `53967ef2` -> `eaab21cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1719457243,
-        "narHash": "sha256-5rOWwMAp/suWVKGavhfdyLsF2mA7Fv2DQWXlt7S+QWA=",
+        "lastModified": 1719589849,
+        "narHash": "sha256-TNjpBp1ct065GnexxSdflKcYE4DmRyiy+CGQfw15mPU=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "53967ef237edd38a5b5cc5441e9b6a44b9554977",
+        "rev": "eaab21cb0b3e59e95a856b69013b70fdc1d99a7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                   |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`eaab21cb`](https://github.com/catppuccin/nix/commit/eaab21cb0b3e59e95a856b69013b70fdc1d99a7f) | `` chore(modules): update ports (#250) `` |