### PR TITLE
chore(flake/nur): `d06168ff` -> `35e48702`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719584730,
-        "narHash": "sha256-O24Ms0iM0JE+duoXGlouxbzfaHRSXWUu0NKFKdveQ4c=",
+        "lastModified": 1719596768,
+        "narHash": "sha256-quSWztqqMxvSJIKddYp1D0GdR7Kg8JjEVCIzMbtBTQ4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d06168ffaa627c12e0d0ea2f993387b715934e1a",
+        "rev": "35e48702118124ec52a071e300f55c78a4b7b338",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`35e48702`](https://github.com/nix-community/NUR/commit/35e48702118124ec52a071e300f55c78a4b7b338) | `` automatic update `` |
| [`ee1f0944`](https://github.com/nix-community/NUR/commit/ee1f0944028ebd11098d45c8e13658cffcac3550) | `` automatic update `` |
| [`bba24f78`](https://github.com/nix-community/NUR/commit/bba24f78fa006c4be54d3be5ff0cbea4430a0d68) | `` automatic update `` |