### PR TITLE
chore(flake/catppuccin): `eaab21cb` -> `63e08597`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1719589849,
-        "narHash": "sha256-TNjpBp1ct065GnexxSdflKcYE4DmRyiy+CGQfw15mPU=",
+        "lastModified": 1719592953,
+        "narHash": "sha256-pvWudX7LM7nFkutIxi5KCjv8RITAuiA547MtRZJ25LE=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "eaab21cb0b3e59e95a856b69013b70fdc1d99a7f",
+        "rev": "63e0859743908a53e58b3ceeca06a145a45c4435",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                       |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`63e08597`](https://github.com/catppuccin/nix/commit/63e0859743908a53e58b3ceeca06a145a45c4435) | `` fix(home-manager): only enable pointerCursor by default on linux (#248) `` |
| [`3f460748`](https://github.com/catppuccin/nix/commit/3f4607481bf3aa5cbb0bc67da456f8224391beba) | `` chore(modules): use attrset as argument to `mkCatppuccinOpt` (#252) ``     |