### PR TITLE
chore(flake/nur): `55a2e63c` -> `e7597af7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719615216,
-        "narHash": "sha256-gKtV5G/+6x85AajgziTnm4E/m0Wk/HN4AwFFyvAuk3A=",
+        "lastModified": 1719624082,
+        "narHash": "sha256-RpeJO2UN+XP1fiA6gPKwvW6+gw9m09lDuWdg67g+Zds=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "55a2e63c19bc19e04304fb975620c36d2ad355a6",
+        "rev": "e7597af73696a7217e6fa5cacf1da240a2a42165",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e7597af7`](https://github.com/nix-community/NUR/commit/e7597af73696a7217e6fa5cacf1da240a2a42165) | `` automatic update `` |
| [`1e2bca28`](https://github.com/nix-community/NUR/commit/1e2bca2802b67af186d161917e2f7a255d5ab094) | `` automatic update `` |
| [`233d0a34`](https://github.com/nix-community/NUR/commit/233d0a34e5a75575b716b958bdd97fc68dff09e8) | `` automatic update `` |