### PR TITLE
chore(flake/nur): `e7597af7` -> `34c14e1e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719624082,
-        "narHash": "sha256-RpeJO2UN+XP1fiA6gPKwvW6+gw9m09lDuWdg67g+Zds=",
+        "lastModified": 1719633844,
+        "narHash": "sha256-zOlrMnL96mNpP1GEJjMDLGmHjBXWbHthoOOmDlwGVs0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e7597af73696a7217e6fa5cacf1da240a2a42165",
+        "rev": "34c14e1efe32ee944f2fa6132399c3d836577a53",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`34c14e1e`](https://github.com/nix-community/NUR/commit/34c14e1efe32ee944f2fa6132399c3d836577a53) | `` automatic update `` |