### PR TITLE
chore(flake/nur): `34c14e1e` -> `a9d5745c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719633844,
-        "narHash": "sha256-zOlrMnL96mNpP1GEJjMDLGmHjBXWbHthoOOmDlwGVs0=",
+        "lastModified": 1719639880,
+        "narHash": "sha256-ZU5u6yzSj6QvaDxjhVXJKnDB5Z1US9v++Z+KKp1Uo28=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "34c14e1efe32ee944f2fa6132399c3d836577a53",
+        "rev": "a9d5745c0fc6375a7e06d45f436f35b9544c7b52",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a9d5745c`](https://github.com/nix-community/NUR/commit/a9d5745c0fc6375a7e06d45f436f35b9544c7b52) | `` automatic update `` |