### PR TITLE
chore(flake/nur): `a9d5745c` -> `0fb65e07`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719639880,
-        "narHash": "sha256-ZU5u6yzSj6QvaDxjhVXJKnDB5Z1US9v++Z+KKp1Uo28=",
+        "lastModified": 1719645428,
+        "narHash": "sha256-DnSiED9cFDF+E2uekxXz5dSXOvb3IbVc0Kv8hixi9QE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a9d5745c0fc6375a7e06d45f436f35b9544c7b52",
+        "rev": "0fb65e070b581604c93d21b74c6cd2f7fcc25bac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0fb65e07`](https://github.com/nix-community/NUR/commit/0fb65e070b581604c93d21b74c6cd2f7fcc25bac) | `` automatic update `` |