### PR TITLE
chore(flake/nur): `d31c65fe` -> `aa3a7837`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719650693,
-        "narHash": "sha256-tVpBKJulLhCSljt6ys6SLN7GgAyHstN4S+xlnuL8ioI=",
+        "lastModified": 1719657917,
+        "narHash": "sha256-jQSAVmM9MpQP7FGA0pwJZ36XvRokFEeVKfEiPcZ8uxc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d31c65feeea1e5312741db8e78f68e994fef63c1",
+        "rev": "aa3a783726ef51983a79f6bc4c6c61c615d59f61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`aa3a7837`](https://github.com/nix-community/NUR/commit/aa3a783726ef51983a79f6bc4c6c61c615d59f61) | `` automatic update `` |
| [`8675626c`](https://github.com/nix-community/NUR/commit/8675626c271624a04fbe5a5ab15856dc9294a5bf) | `` automatic update `` |