### PR TITLE
chore(flake/nur): `aa3a7837` -> `20c92ad4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719657917,
-        "narHash": "sha256-jQSAVmM9MpQP7FGA0pwJZ36XvRokFEeVKfEiPcZ8uxc=",
+        "lastModified": 1719661506,
+        "narHash": "sha256-Geo0wuQNVgAt2sd/IU2dfdOnbq1ymp2IIo5XFf6YViA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aa3a783726ef51983a79f6bc4c6c61c615d59f61",
+        "rev": "20c92ad45a6b911f61a79178b9659fb876d39046",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`20c92ad4`](https://github.com/nix-community/NUR/commit/20c92ad45a6b911f61a79178b9659fb876d39046) | `` automatic update `` |