### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `96ae6b4a` -> `10dae5d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -519,11 +519,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1719653003,
-        "narHash": "sha256-cq/+A3wspcElRqockJAgks134/h742nChrgjrLXPDbM=",
+        "lastModified": 1719662086,
+        "narHash": "sha256-7pl5jPUeaw7BcnOGoVlYuxOxzPoOY6RLafduMbsKZfA=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "96ae6b4a0d0664056ed0d2c998fa2d5d33225643",
+        "rev": "10dae5d09150e6a607188f379465d80ccc460950",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                                                  |
| ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`10dae5d0`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/10dae5d09150e6a607188f379465d80ccc460950) | `` CI: build more for cachix ``                          |
| [`5f7f3b93`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/5f7f3b93868805e0a9be600807a2b3db2ef22c19) | `` Just build module flag combinations, omit run test `` |
| [`991d10dc`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/991d10dc557735a9015298e794e4f1dfb4061e5d) | `` Test with all flags except eglot and flymake ``       |
| [`0a5aa876`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/0a5aa8764ae6e9d3e7d8228fd8806c97dbd1d2fd) | `` Deduplicate flags ``                                  |
| [`cd94c45e`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/cd94c45e8d5a7a122967ccb45d0059d743c3b894) | `` Refactor doomdirs generation slightly ``              |