### PR TITLE
chore(flake/catppuccin): `63e08597` -> `ddeefd15`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1719592953,
-        "narHash": "sha256-pvWudX7LM7nFkutIxi5KCjv8RITAuiA547MtRZJ25LE=",
+        "lastModified": 1719671186,
+        "narHash": "sha256-PNbCz1bQEMOVF/AtNYRkSEHHWczlwJfZTPNXdWM3agk=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "63e0859743908a53e58b3ceeca06a145a45c4435",
+        "rev": "ddeefd15d769000b54f90e11c017a0be83f31317",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                           |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`ddeefd15`](https://github.com/catppuccin/nix/commit/ddeefd15d769000b54f90e11c017a0be83f31317) | `` docs: update link to `catppuccin.enable` (#256) ``             |
| [`bd1e5a5c`](https://github.com/catppuccin/nix/commit/bd1e5a5cd53bad4b034969b3aba3581c38224d6f) | `` chore: update dev flake inputs (#249) ``                       |
| [`0ea2427c`](https://github.com/catppuccin/nix/commit/0ea2427cd0422758c458aa4e2d1860be84ca396e) | `` ci: add backport action (#253) ``                              |
| [`3fdc0112`](https://github.com/catppuccin/nix/commit/3fdc011242c684c48ed96d91e77c74e760aedc3e) | `` chore(modules): add tests for home-manager on darwin (#251) `` |