### PR TITLE
chore(flake/home-manager): `7e68e55d` -> `36317d4d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -410,11 +410,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719588253,
-        "narHash": "sha256-A03i8xiVgP14DCmV5P7VUv37eodCjY4e1iai0b2EuuM=",
+        "lastModified": 1719677234,
+        "narHash": "sha256-qO9WZsj/0E6zcK4Ht1y/iJ8XfwbBzq7xdqhBh44OP/M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7e68e55d2e16d3a1e92a679430728c35a30fd24e",
+        "rev": "36317d4d38887f7629876b0e43c8d9593c5cc48d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`36317d4d`](https://github.com/nix-community/home-manager/commit/36317d4d38887f7629876b0e43c8d9593c5cc48d) | `` direnv: add silent option ``         |
| [`c2f806e6`](https://github.com/nix-community/home-manager/commit/c2f806e60ac55c604708250ba0ebcf96bccbbafe) | `` pulseeffects: fix test evaluation `` |