### PR TITLE
chore(flake/nixos-hardware): `23127426` -> `a59f00f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -627,11 +627,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1719647737,
-        "narHash": "sha256-OvX/qQQ33zyB5ReRzm+U5+9Hh6EeYxHdd21tXL3p/eY=",
+        "lastModified": 1719681865,
+        "narHash": "sha256-Lp+l1IsREVbz8WM35OJYZz8sAH0XOjrZWUXVB5bJ2qg=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "231274268ff2250d4730e274b808f66ef91b6381",
+        "rev": "a59f00f5ac65b19382617ba00f360f8bc07ed3ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`a59f00f5`](https://github.com/NixOS/nixos-hardware/commit/a59f00f5ac65b19382617ba00f360f8bc07ed3ac) | `` raspberry-pi/3: remove ttyAMA0 from console list `` |
| [`43ea86cc`](https://github.com/NixOS/nixos-hardware/commit/43ea86cc8c77dcb5f622766050f1c3315088c419) | `` remove probably not necessary library ``            |
| [`8d5e6d92`](https://github.com/NixOS/nixos-hardware/commit/8d5e6d9278a2214cf1ec7cb04a4016b1184edc73) | `` Raspberry Pi 3: try to fix tests ``                 |
| [`d11eeae7`](https://github.com/NixOS/nixos-hardware/commit/d11eeae7664006a07b0b9e8dbd6ea500c8b3dbdb) | `` Raspberry Pi 3: init ``                             |