### PR TITLE
chore(flake/nur): `0dee89a3` -> `43791e6f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719679086,
-        "narHash": "sha256-4s1Tn2T9EY9WE94bu9dGZXvl2L1BaerQSzoUfkpSINY=",
+        "lastModified": 1719690303,
+        "narHash": "sha256-VVN2D3W+F1N88YY3EgkS+04VnYay2+w9DMuDtLzuYj8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0dee89a38d574f3fd8a1ebe1dc43bfe8fb3448ec",
+        "rev": "43791e6ff92d407af0f6cac6793f6d0246d7e515",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`43791e6f`](https://github.com/nix-community/NUR/commit/43791e6ff92d407af0f6cac6793f6d0246d7e515) | `` automatic update `` |