### PR TITLE
chore(flake/nur): `43791e6f` -> `fb7f9dce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719690303,
-        "narHash": "sha256-VVN2D3W+F1N88YY3EgkS+04VnYay2+w9DMuDtLzuYj8=",
+        "lastModified": 1719693968,
+        "narHash": "sha256-c05u3DzjepVCuyMf5GcrcNYQG0qbBoyuxiSM3hGCH3c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "43791e6ff92d407af0f6cac6793f6d0246d7e515",
+        "rev": "fb7f9dce9440801634d1c4161d37b636aed6c258",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fb7f9dce`](https://github.com/nix-community/NUR/commit/fb7f9dce9440801634d1c4161d37b636aed6c258) | `` automatic update `` |