### PR TITLE
chore(flake/nur): `fb7f9dce` -> `5e7535df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719693968,
-        "narHash": "sha256-c05u3DzjepVCuyMf5GcrcNYQG0qbBoyuxiSM3hGCH3c=",
+        "lastModified": 1719700445,
+        "narHash": "sha256-wakeJrXQNQd4mrqrlRt7QbJB896EiH6DaDqIwUNguXc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fb7f9dce9440801634d1c4161d37b636aed6c258",
+        "rev": "5e7535df8afc29acb6e409f4f79332af28359bb6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5e7535df`](https://github.com/nix-community/NUR/commit/5e7535df8afc29acb6e409f4f79332af28359bb6) | `` automatic update `` |
| [`9bf273a0`](https://github.com/nix-community/NUR/commit/9bf273a054250a990e3751cc7ae280c6ff5b4220) | `` automatic update `` |