### PR TITLE
chore(flake/catppuccin): `ddeefd15` -> `e3d54d74`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1719671186,
-        "narHash": "sha256-PNbCz1bQEMOVF/AtNYRkSEHHWczlwJfZTPNXdWM3agk=",
+        "lastModified": 1719705674,
+        "narHash": "sha256-yq4twcOT5iBKi+rE17uB9fWUdhTPKKyeLde2m6fzVk8=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "ddeefd15d769000b54f90e11c017a0be83f31317",
+        "rev": "e3d54d7486445cb03f35408f412c00b49a4542b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                            |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`e3d54d74`](https://github.com/catppuccin/nix/commit/e3d54d7486445cb03f35408f412c00b49a4542b6) | `` docs: add v1.0.0 changelog to website (#257) `` |
| [`be57785b`](https://github.com/catppuccin/nix/commit/be57785b15076a10b6799aef76bb7eed9a73322b) | `` chore(main): release 1.0.0 (#65) ``             |