### PR TITLE
chore(flake/catppuccin): `e3d54d74` -> `6459b5a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1719705674,
-        "narHash": "sha256-yq4twcOT5iBKi+rE17uB9fWUdhTPKKyeLde2m6fzVk8=",
+        "lastModified": 1719709086,
+        "narHash": "sha256-AOSqDyzQV8I6+LpIoXdNh/DaH2qR3MCX4pGqDOhusL8=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "e3d54d7486445cb03f35408f412c00b49a4542b6",
+        "rev": "6459b5a4a7fb5dd7b2ce1f86bc025da7e5c0aa4b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                   |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`6459b5a4`](https://github.com/catppuccin/nix/commit/6459b5a4a7fb5dd7b2ce1f86bc025da7e5c0aa4b) | `` docs: symlink site changelog (#258) `` |