### PR TITLE
chore(flake/nur): `5e7535df` -> `2610f917`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719700445,
-        "narHash": "sha256-wakeJrXQNQd4mrqrlRt7QbJB896EiH6DaDqIwUNguXc=",
+        "lastModified": 1719712510,
+        "narHash": "sha256-+TL48+Pgi6ArUARTLa+ZUskx0aNoaQXz9NapKEFHUmw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5e7535df8afc29acb6e409f4f79332af28359bb6",
+        "rev": "2610f917852c08dda329dd4039e7378043b7cbb1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2610f917`](https://github.com/nix-community/NUR/commit/2610f917852c08dda329dd4039e7378043b7cbb1) | `` automatic update `` |
| [`c64950a0`](https://github.com/nix-community/NUR/commit/c64950a01a4f2d115c06264842083db84d865bb9) | `` automatic update `` |