### PR TITLE
chore(flake/nur): `2610f917` -> `3f08753a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719712510,
-        "narHash": "sha256-+TL48+Pgi6ArUARTLa+ZUskx0aNoaQXz9NapKEFHUmw=",
+        "lastModified": 1719721857,
+        "narHash": "sha256-/IXHp2JZbMuL3rloxqAe2VQBTB2m1o1c3gqEY6FUxeo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2610f917852c08dda329dd4039e7378043b7cbb1",
+        "rev": "3f08753a0bcfadcd95d4a2b9280b45a57fe1748d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3f08753a`](https://github.com/nix-community/NUR/commit/3f08753a0bcfadcd95d4a2b9280b45a57fe1748d) | `` automatic update `` |
| [`07462a3c`](https://github.com/nix-community/NUR/commit/07462a3c498e64a3d3e0de381a09052edcd5f7d5) | `` automatic update `` |
| [`4460c2b5`](https://github.com/nix-community/NUR/commit/4460c2b501e9a5b9be9a9e0c9b5b810c1cfe0632) | `` automatic update `` |