### PR TITLE
chore(flake/nix-index-database): `33ff922c` -> `2917972e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -587,11 +587,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719716242,
-        "narHash": "sha256-5PbO2qcuFTVdUwqS6IrQ571qQE0Ss5lAgUUyh+lodxA=",
+        "lastModified": 1719832725,
+        "narHash": "sha256-dr8DkeS74KVNTgi8BE0BiUKALb+EKlMIV86G2xPYO64=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "33ff922c8f1d070a530cf6a7215d8673baeeb9ed",
+        "rev": "2917972ed34ce292309b3a4976286f8b5c08db27",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                           |
| ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`5f154bf6`](https://github.com/nix-community/nix-index-database/commit/5f154bf6c2b17d5751e45fbcf1bc520a92066089) | `` nixos-module: disable programs.command-not-found by default `` |
| [`838a910d`](https://github.com/nix-community/nix-index-database/commit/838a910df0f7e542de2327036b2867fd68ded3a2) | `` Add comma option to darwin module ``                           |
| [`2b0d5f3a`](https://github.com/nix-community/nix-index-database/commit/2b0d5f3a4229c581e2bb839ac0b992feb366eba5) | `` update generated.nix to release 2024-06-30-025731 ``           |