### PR TITLE
chore(flake/nur): `3f08753a` -> `c16c2571`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719721857,
-        "narHash": "sha256-/IXHp2JZbMuL3rloxqAe2VQBTB2m1o1c3gqEY6FUxeo=",
+        "lastModified": 1719726973,
+        "narHash": "sha256-hRgbo2qMhsKI/TA2772ZEOGnKJimW7g6eqdoB5ULvkA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3f08753a0bcfadcd95d4a2b9280b45a57fe1748d",
+        "rev": "c16c2571b358a5a3bcc77f7bc7ab741e3eb6eb11",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c16c2571`](https://github.com/nix-community/NUR/commit/c16c2571b358a5a3bcc77f7bc7ab741e3eb6eb11) | `` automatic update `` |
| [`597d6183`](https://github.com/nix-community/NUR/commit/597d6183194e0907ebd1045eec7d52cde9ecebb7) | `` automatic update `` |