### PR TITLE
chore(flake/nur): `c16c2571` -> `14669bb1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719726973,
-        "narHash": "sha256-hRgbo2qMhsKI/TA2772ZEOGnKJimW7g6eqdoB5ULvkA=",
+        "lastModified": 1719729745,
+        "narHash": "sha256-CWWRBfRye0ncFmoUasEKBiFbY3kxofXp67lQUP8uCUk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c16c2571b358a5a3bcc77f7bc7ab741e3eb6eb11",
+        "rev": "14669bb1ff2fe597106282114a0291e1b29eafb7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`14669bb1`](https://github.com/nix-community/NUR/commit/14669bb1ff2fe597106282114a0291e1b29eafb7) | `` automatic update `` |