### PR TITLE
chore(flake/nur): `14669bb1` -> `cfef8e13`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719729745,
-        "narHash": "sha256-CWWRBfRye0ncFmoUasEKBiFbY3kxofXp67lQUP8uCUk=",
+        "lastModified": 1719733143,
+        "narHash": "sha256-Q3gdHnH1HCLymN1OdvJqXhwX2xD0LCPL0G66hXK7O5o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "14669bb1ff2fe597106282114a0291e1b29eafb7",
+        "rev": "cfef8e13dde1c1679d6d1781d942b4ab0203e0d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cfef8e13`](https://github.com/nix-community/NUR/commit/cfef8e13dde1c1679d6d1781d942b4ab0203e0d2) | `` automatic update `` |
| [`421cc66f`](https://github.com/nix-community/NUR/commit/421cc66f8aa5d8a6be4535109ff5ae288fdd6966) | `` automatic update `` |