### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `10dae5d0` -> `5a7b2282`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -162,11 +162,11 @@
     "doomemacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1719644146,
-        "narHash": "sha256-v9VxFfDzYOXI6hw8DS3louaPgxCK+LWUTjATJiutXHE=",
+        "lastModified": 1719689539,
+        "narHash": "sha256-snHiGk6T2wXRPUWf1ZXJtd/XWVE7x2vj6qSO7rqq6I4=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "d3d50474888195ab43db03c7607f356424b09d18",
+        "rev": "a0dadda2666886840e63f28d96a03a6f635a4fe6",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719625994,
-        "narHash": "sha256-DbB/SQVaF+B+I5KAU7+c/8tvlg86ZJ7X0IDSTPuIXec=",
+        "lastModified": 1719709842,
+        "narHash": "sha256-25P52Ei7cA57wDKHhtag7MsfXFNprmdOGVWabJf+iKw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "012409732a53433d75db7bb2e06dd0bdaf8ca7ea",
+        "rev": "ebb1edb7dfd8bfd176cfe931d8ebcb7c6ce88bca",
         "type": "github"
       },
       "original": {
@@ -519,11 +519,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1719662086,
-        "narHash": "sha256-7pl5jPUeaw7BcnOGoVlYuxOxzPoOY6RLafduMbsKZfA=",
+        "lastModified": 1719736234,
+        "narHash": "sha256-oPex11FDykoWipuFiysedup6eyfwYOt8qZjxGLcGrAU=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "10dae5d09150e6a607188f379465d80ccc460950",
+        "rev": "5a7b2282dd2fd18209e85128c0807252c9f80923",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`5a7b2282`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/5a7b2282dd2fd18209e85128c0807252c9f80923) | `` flake.lock: Update `` |