### PR TITLE
chore(flake/catppuccin): `6459b5a4` -> `65543d24`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1719709086,
-        "narHash": "sha256-AOSqDyzQV8I6+LpIoXdNh/DaH2qR3MCX4pGqDOhusL8=",
+        "lastModified": 1719735467,
+        "narHash": "sha256-mlebc8Ni/fqnGgrTqmnFiX6qOayKMAFD2Hd4QVEUxJg=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "6459b5a4a7fb5dd7b2ce1f86bc025da7e5c0aa4b",
+        "rev": "65543d24023d9d5575c5c3e00a726291ad9358b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                |
| ----------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`65543d24`](https://github.com/catppuccin/nix/commit/65543d24023d9d5575c5c3e00a726291ad9358b7) | `` chore: simplify dev flake (#260) `` |