### PR TITLE
chore(flake/nur): `cfef8e13` -> `d10ef141`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719733143,
-        "narHash": "sha256-Q3gdHnH1HCLymN1OdvJqXhwX2xD0LCPL0G66hXK7O5o=",
+        "lastModified": 1719739294,
+        "narHash": "sha256-yxEGIy5JvRNOA129CkXcpHFlsQJA3akM/RdOQDZQvgY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cfef8e13dde1c1679d6d1781d942b4ab0203e0d2",
+        "rev": "d10ef14183603348e86cded6dc123337da095b01",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d10ef141`](https://github.com/nix-community/NUR/commit/d10ef14183603348e86cded6dc123337da095b01) | `` automatic update `` |
| [`5f66afdc`](https://github.com/nix-community/NUR/commit/5f66afdc03e6ea940b5eaaddb45c0614417daa4f) | `` automatic update `` |
| [`61e0f62e`](https://github.com/nix-community/NUR/commit/61e0f62e57cc8c70b99759a25249f5a49053dbd4) | `` automatic update `` |