### PR TITLE
chore(flake/flake-parts): `2a55567f` -> `c3c5ecc0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -259,11 +259,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1717285511,
-        "narHash": "sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw=",
+        "lastModified": 1719745305,
+        "narHash": "sha256-xwgjVUpqSviudEkpQnioeez1Uo2wzrsMaJKJClh+Bls=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8",
+        "rev": "c3c5ecc05edc7dafba779c6c1a61cd08ac6583e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                |
| -------------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`3c51d54b`](https://github.com/hercules-ci/flake-parts/commit/3c51d54b88f65036b66704c50a23b558376bb607) | `` flake.nix: Add templates.package `` |
| [`ec690b93`](https://github.com/hercules-ci/flake-parts/commit/ec690b93589463b81e2d6c91981d28905ee17eda) | `` template/package: Use fileset ``    |