### PR TITLE
chore(flake/treefmt): `065a23ed` -> `8df5ff62`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1046,11 +1046,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719243788,
-        "narHash": "sha256-9T9mSY35EZSM1KAwb7K9zwQ78qTlLjosZgtUGnw4rn4=",
+        "lastModified": 1719749022,
+        "narHash": "sha256-ddPKHcqaKCIFSFc/cvxS14goUhCOAwsM1PbMr0ZtHMg=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "065a23edceff48f948816b795ea8cc6c0dee7cdf",
+        "rev": "8df5ff62195d4e67e2264df0b7f5e8c9995fd0bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                   |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`05635b03`](https://github.com/numtide/treefmt-nix/commit/05635b039ab9c20d7047464d4ccd2281ad3f2a04) | `` doc: fix treefmt configuration link `` |