### PR TITLE
chore(flake/catppuccin): `65543d24` -> `9eb0610d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1719735467,
-        "narHash": "sha256-mlebc8Ni/fqnGgrTqmnFiX6qOayKMAFD2Hd4QVEUxJg=",
+        "lastModified": 1719758387,
+        "narHash": "sha256-bMaI1jJNzIZar4TP/hhoPQROqqcbD6zT6O+sqIJdp8c=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "65543d24023d9d5575c5c3e00a726291ad9358b7",
+        "rev": "9eb0610d48dd0e1fecf772bbdacf9050d7b82d7c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                   |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`9eb0610d`](https://github.com/catppuccin/nix/commit/9eb0610d48dd0e1fecf772bbdacf9050d7b82d7c) | `` fix(home-manager/cursors): exclude from `catppuccin.enable` (#263) ``  |
| [`ca2780d5`](https://github.com/catppuccin/nix/commit/ca2780d5ceccf349a226736c793531239aedb823) | `` chore(main): release 1.0.1 (#262) ``                                   |
| [`92e2d7ae`](https://github.com/catppuccin/nix/commit/92e2d7ae880cd77677be66af2e77b2bc6b74f4fa) | `` fix(home-manager/gtk): replace `normal` tweak with `default` (#261) `` |