### PR TITLE
chore(flake/srvos): `e938f07e` -> `22155bc7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -951,11 +951,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719449101,
-        "narHash": "sha256-rRrz763KKi6GnSZF4WF34kpJ9eMXR3AOPOWN/7hO1Zs=",
+        "lastModified": 1719753014,
+        "narHash": "sha256-Lfv5qtltKuO5+HNqOKZPlEuEZo7WaLiZjAI+sTqpwws=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "e938f07e5cd9d11576d3860b68c117932c161006",
+        "rev": "22155bc76855f28a681b1d6987ea2420b899ad7e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                      |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`12697bf3`](https://github.com/nix-community/srvos/commit/12697bf38ab5f4dc7b62a2385efae09861b382f4) | `` docs/darwin: document current modules ``  |
| [`86591a39`](https://github.com/nix-community/srvos/commit/86591a3954f982252f27c705425e7b7bcbdb416d) | `` docs/nixos: document missing mixings ``   |
| [`a4749dab`](https://github.com/nix-community/srvos/commit/a4749dab68656ff391976badd2594d159bbfed9b) | `` add seperate server/desktop profiles ``   |
| [`6a1cd68c`](https://github.com/nix-community/srvos/commit/6a1cd68c792832ed740f35a66f7edb9995b3d122) | `` docs: add nix-darwin ``                   |
| [`3ec23504`](https://github.com/nix-community/srvos/commit/3ec2350421cc5cf585f8122e55297889a272fb49) | `` README: fix documentation preview ``      |
| [`14bf076b`](https://github.com/nix-community/srvos/commit/14bf076badd37b319e51a7b60101eb791d093b78) | `` darwin: add zsh integration by default `` |
| [`19dfb05f`](https://github.com/nix-community/srvos/commit/19dfb05f2bb6cfd1c842cd740f90b8b8aa7bca63) | `` add terminfo module ``                    |
| [`0c16f56a`](https://github.com/nix-community/srvos/commit/0c16f56ab889cb2a602deaae93536166718df001) | `` add basic darwinModules ``                |
| [`ea3d0822`](https://github.com/nix-community/srvos/commit/ea3d082265c8ce47f3552253378584e133acc049) | `` allow exposeModules to be shared ``       |