### PR TITLE
chore(flake/nur): `a217160b` -> `2ef1c731`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719754571,
-        "narHash": "sha256-O1I7g4vyivTfhTaNXRYxeMHce5NiNgIZ0v72sEuUVZQ=",
+        "lastModified": 1719771190,
+        "narHash": "sha256-W2EApTej3kQYP+nn8BbCoSOQs+5Kvn+0LJzlT+GkB2E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a217160b2183f4f0be1adec6b44c85a2ed618770",
+        "rev": "2ef1c7312fd083f118fee1bfeef40f4de36b14ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2ef1c731`](https://github.com/nix-community/NUR/commit/2ef1c7312fd083f118fee1bfeef40f4de36b14ca) | `` automatic update `` |
| [`80b917d8`](https://github.com/nix-community/NUR/commit/80b917d886c6554264f71e1fc68e6b17cd5fdfa1) | `` automatic update `` |
| [`a0486ef9`](https://github.com/nix-community/NUR/commit/a0486ef95a970eacd4f0016c0b1976eec5fb126b) | `` automatic update `` |
| [`72eb052d`](https://github.com/nix-community/NUR/commit/72eb052d6fb3bbe98c85d8987e5a75c78cbffe49) | `` automatic update `` |