### PR TITLE
chore(flake/emacs-overlay): `ebb1edb7` -> `7c222bca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1719709842,
-        "narHash": "sha256-25P52Ei7cA57wDKHhtag7MsfXFNprmdOGVWabJf+iKw=",
+        "lastModified": 1719766438,
+        "narHash": "sha256-WUCzjhblMl+4Vrnzseh3XOtSodlUwjBo5MSBb3x/OsI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ebb1edb7dfd8bfd176cfe931d8ebcb7c6ce88bca",
+        "rev": "7c222bca07a021406d9a5386523c093ade7c8ebd",
         "type": "github"
       },
       "original": {
@@ -700,11 +700,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1719234068,
-        "narHash": "sha256-1AjSIedDC/aERt24KsCUftLpVppW61S7awfjGe7bMio=",
+        "lastModified": 1719663039,
+        "narHash": "sha256-tXlrgAQygNIy49LDVFuPXlWD2zTQV9/F8pfoqwwPJyo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "90bd1b26e23760742fdcb6152369919098f05417",
+        "rev": "4a1e673523344f6ccc84b37f4413ad74ea19a119",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`7c222bca`](https://github.com/nix-community/emacs-overlay/commit/7c222bca07a021406d9a5386523c093ade7c8ebd) | `` Updated melpa ``        |
| [`a9a84712`](https://github.com/nix-community/emacs-overlay/commit/a9a8471214818720e26b9602495bac67ed9472cd) | `` Updated elpa ``         |
| [`a7dc10dc`](https://github.com/nix-community/emacs-overlay/commit/a7dc10dcdb880401734ce33b45dc6245cbf87808) | `` Updated flake inputs `` |