### PR TITLE
chore(flake/emacs-overlay): `7c222bca` -> `9059feb4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1719766438,
-        "narHash": "sha256-WUCzjhblMl+4Vrnzseh3XOtSodlUwjBo5MSBb3x/OsI=",
+        "lastModified": 1719767646,
+        "narHash": "sha256-Y7Dqti8FpWEwb9PQRIfyEFp0GUff7HRAeKs1lYwBgrw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7c222bca07a021406d9a5386523c093ade7c8ebd",
+        "rev": "9059feb48648e980cdd797cd828377c08989ca8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`9059feb4`](https://github.com/nix-community/emacs-overlay/commit/9059feb48648e980cdd797cd828377c08989ca8f) | `` Updated emacs `` |