### PR TITLE
chore(flake/nix-on-droid): `2d93311c` -> `45fcd2da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -612,11 +612,11 @@
         "nmd": "nmd_2"
       },
       "locked": {
-        "lastModified": 1710434231,
-        "narHash": "sha256-yrWnsG28518tbIapJWiluweHORuuIwAQrA8lga0Sqlw=",
+        "lastModified": 1719772177,
+        "narHash": "sha256-XJOxCLWQUn+3VQTQGRwMoz6nDjT+GoL0f4mVrUQdzfk=",
         "owner": "t184256",
         "repo": "nix-on-droid",
-        "rev": "2d93311c4f3f300154d2085e4b4b1d550237da92",
+        "rev": "45fcd2da39a70a96752e17f85d7a843b3c4f67f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`45fcd2da`](https://github.com/nix-community/nix-on-droid/commit/45fcd2da39a70a96752e17f85d7a843b3c4f67f4) | `` modules, ...: get rid of config.build.arch ``              |
| [`54a535b9`](https://github.com/nix-community/nix-on-droid/commit/54a535b91b866a661192a4b293aeed7561680760) | `` flake.nix: make users pass pkgs explicitly ``              |
| [`3d244418`](https://github.com/nix-community/nix-on-droid/commit/3d244418379c7f2c9a5d43e73d4135be93c9b451) | `` .github/workflows: revamp for extra parallelism ``         |
| [`291970c4`](https://github.com/nix-community/nix-on-droid/commit/291970c4c44500accc92c6e7cd853b501a6148ec) | `` tests/emulator, .github/workflows/emulator: add ``         |
| [`d72ab2a1`](https://github.com/nix-community/nix-on-droid/commit/d72ab2a167b9716878cd88f58ff9b7efad9917cc) | `` add x86_64 arch ``                                         |
| [`463e0f82`](https://github.com/nix-community/nix-on-droid/commit/463e0f82a65fd3a73f5c13deb375acc799637c3f) | `` tests/on-device: test vim, not vi (android can have vi) `` |
| [`da9596df`](https://github.com/nix-community/nix-on-droid/commit/da9596df884d63bec5f70fb9bb5a8c37116877bc) | `` scripts/deploy.sh: support file:/// urls ``                |
| [`5c87fc73`](https://github.com/nix-community/nix-on-droid/commit/5c87fc73572993da441bb7a288a84dd27a9d614f) | `` nix-on-droid, tests: use /data/local/tmp/n-o-d ``          |
| [`6ef3f8ff`](https://github.com/nix-community/nix-on-droid/commit/6ef3f8ff071a6ca843f87b430a2cc856c52313ad) | `` remove fakedroid ``                                        |
| [`d7c432ba`](https://github.com/nix-community/nix-on-droid/commit/d7c432bad3972a3848f2d964481f7c9eee29e097) | `` .github: drop fakedroid-odt workflow ``                    |