### PR TITLE
chore(flake/nur): `2ef1c731` -> `f7e2a6fd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719771190,
-        "narHash": "sha256-W2EApTej3kQYP+nn8BbCoSOQs+5Kvn+0LJzlT+GkB2E=",
+        "lastModified": 1719779143,
+        "narHash": "sha256-ZkJ4U1TZKWALIMM3zDn0LcCXkmmsX/Xs4HU0pPZMfSE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2ef1c7312fd083f118fee1bfeef40f4de36b14ca",
+        "rev": "f7e2a6fd9ecaf72ad0bcce2ee10d1cfc9d74ade3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f7e2a6fd`](https://github.com/nix-community/NUR/commit/f7e2a6fd9ecaf72ad0bcce2ee10d1cfc9d74ade3) | `` automatic update `` |
| [`55e1eb98`](https://github.com/nix-community/NUR/commit/55e1eb9856a765abed740305e1bf84910f97758b) | `` automatic update `` |