### PR TITLE
chore(flake/nur): `f7e2a6fd` -> `4fb859ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719779143,
-        "narHash": "sha256-ZkJ4U1TZKWALIMM3zDn0LcCXkmmsX/Xs4HU0pPZMfSE=",
+        "lastModified": 1719783977,
+        "narHash": "sha256-m+nRa562q1htqk2J5EC+wmPwOFo/T3WKaWFJ9XBOjm0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f7e2a6fd9ecaf72ad0bcce2ee10d1cfc9d74ade3",
+        "rev": "4fb859ed2f76f5bbd5a7637e664155e24bc70644",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4fb859ed`](https://github.com/nix-community/NUR/commit/4fb859ed2f76f5bbd5a7637e664155e24bc70644) | `` automatic update `` |