### PR TITLE
chore(flake/nur): `4fb859ed` -> `df95aade`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719783977,
-        "narHash": "sha256-m+nRa562q1htqk2J5EC+wmPwOFo/T3WKaWFJ9XBOjm0=",
+        "lastModified": 1719786806,
+        "narHash": "sha256-JNuhV9wVbghDM4QMFe4Dtv7E0fv8XyikD6eTcf5jFsU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4fb859ed2f76f5bbd5a7637e664155e24bc70644",
+        "rev": "df95aadeb3663a9752e958559ba14f1ebc9477a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`df95aade`](https://github.com/nix-community/NUR/commit/df95aadeb3663a9752e958559ba14f1ebc9477a0) | `` automatic update `` |