### PR TITLE
chore(flake/srvos): `22155bc7` -> `6e6364a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -951,11 +951,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719753014,
-        "narHash": "sha256-Lfv5qtltKuO5+HNqOKZPlEuEZo7WaLiZjAI+sTqpwws=",
+        "lastModified": 1719794994,
+        "narHash": "sha256-A76RzbJ2pOCnxqeQU7oEeNsmFmthDzpiDG4xoy2jfWs=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "22155bc76855f28a681b1d6987ea2420b899ad7e",
+        "rev": "6e6364a3d0de5549307a9f232febcb549df7b5e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`6e6364a3`](https://github.com/nix-community/srvos/commit/6e6364a3d0de5549307a9f232febcb549df7b5e6) | `` dev/private/flake.lock: Update `` |
| [`4f220604`](https://github.com/nix-community/srvos/commit/4f220604a396eff7e5694591849a525f384faa3c) | `` flake.lock: Update ``             |