### PR TITLE
chore(flake/nur): `81c02fae` -> `07c5cb4a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719794401,
-        "narHash": "sha256-zo4gc7QWd5ufnmfnCkc2u5MBqiu+1FCQDin50e9d2lg=",
+        "lastModified": 1719799005,
+        "narHash": "sha256-3EeevUnGwIWGHUEKpLVfUvZ4/UssLOdXbZcp4o5uQIU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "81c02fae273ea034ae2c53bf5c132f38e2287f85",
+        "rev": "07c5cb4ac5db517553ab60d6914eb5b9f54a7ea1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`07c5cb4a`](https://github.com/nix-community/NUR/commit/07c5cb4ac5db517553ab60d6914eb5b9f54a7ea1) | `` automatic update `` |