### PR TITLE
chore(flake/nur): `07c5cb4a` -> `d9fb647c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719799005,
-        "narHash": "sha256-3EeevUnGwIWGHUEKpLVfUvZ4/UssLOdXbZcp4o5uQIU=",
+        "lastModified": 1719806173,
+        "narHash": "sha256-b/dAsRSKKQzwdROViFNTx/oV3kGpCnR8SO8QwHuXc0s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "07c5cb4ac5db517553ab60d6914eb5b9f54a7ea1",
+        "rev": "d9fb647c8eb4e9b0b5e079b688afbe041fea8192",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d9fb647c`](https://github.com/nix-community/NUR/commit/d9fb647c8eb4e9b0b5e079b688afbe041fea8192) | `` automatic update `` |
| [`3c60508b`](https://github.com/nix-community/NUR/commit/3c60508b4382f53be8a7dc622bc8370117a0b491) | `` automatic update `` |
| [`7211a8d8`](https://github.com/nix-community/NUR/commit/7211a8d888d11d051e21cd3c33fa55a50671fd1c) | `` automatic update `` |