### PR TITLE
chore(flake/nur): `d9fb647c` -> `5d507526`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719806173,
-        "narHash": "sha256-b/dAsRSKKQzwdROViFNTx/oV3kGpCnR8SO8QwHuXc0s=",
+        "lastModified": 1719806679,
+        "narHash": "sha256-3h4H6T09N/h/EWPiZPnpzkgENE149gaKsm+0bVu9Zmg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d9fb647c8eb4e9b0b5e079b688afbe041fea8192",
+        "rev": "5d5075269f046fcb971260590c9a595334b1b8d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5d507526`](https://github.com/nix-community/NUR/commit/5d5075269f046fcb971260590c9a595334b1b8d6) | `` automatic update `` |