### PR TITLE
chore(flake/nur): `5d507526` -> `1aca73dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719806679,
-        "narHash": "sha256-3h4H6T09N/h/EWPiZPnpzkgENE149gaKsm+0bVu9Zmg=",
+        "lastModified": 1719812425,
+        "narHash": "sha256-TwdXDNT+5xUdK9sYDJQJ6weBP5fDHdxzpleu+5s4G5w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5d5075269f046fcb971260590c9a595334b1b8d6",
+        "rev": "1aca73dd6ab4f99dc580ad99bc325e00a3b92590",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1aca73dd`](https://github.com/nix-community/NUR/commit/1aca73dd6ab4f99dc580ad99bc325e00a3b92590) | `` automatic update `` |