### PR TITLE
chore(flake/nur): `eb317e31` -> `4f69a017`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719815785,
-        "narHash": "sha256-QWEnb5xut6yQg6bg30bAu5gJNhOQkWF1yBvBHqNTu6w=",
+        "lastModified": 1719830755,
+        "narHash": "sha256-9VqRnwXjOgrs0joMYys+AEZ8DKJx7BOSf4UrMD0B754=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eb317e310f2c5e4dc6a670601af21a7bc0c323ef",
+        "rev": "4f69a017af9ccf0ac0aec02d72b53652bc78c93c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4f69a017`](https://github.com/nix-community/NUR/commit/4f69a017af9ccf0ac0aec02d72b53652bc78c93c) | `` automatic update `` |
| [`a8b6cf4d`](https://github.com/nix-community/NUR/commit/a8b6cf4d203414cd130e9a32487f9b4e3eba9e2d) | `` automatic update `` |
| [`e44c9acf`](https://github.com/nix-community/NUR/commit/e44c9acf4171b2cdcd88fcdc224282b13951e0e1) | `` automatic update `` |
| [`ffd2d707`](https://github.com/nix-community/NUR/commit/ffd2d707ce6aa5efca1cdb1869cad4f27dcca16d) | `` automatic update `` |
| [`24c39668`](https://github.com/nix-community/NUR/commit/24c396686b1ed7a1c3a794a34447a9cb9bc38c42) | `` automatic update `` |