### PR TITLE
chore(flake/emacs-overlay): `9059feb4` -> `9dd348fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1719767646,
-        "narHash": "sha256-Y7Dqti8FpWEwb9PQRIfyEFp0GUff7HRAeKs1lYwBgrw=",
+        "lastModified": 1719824159,
+        "narHash": "sha256-5AWx8t05lS6nlLca4OvWPY2HeFp2q6y5t2/H9jQShfc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9059feb48648e980cdd797cd828377c08989ca8f",
+        "rev": "9dd348fbc5c9708a607cda51b70958491bf925b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`9dd348fb`](https://github.com/nix-community/emacs-overlay/commit/9dd348fbc5c9708a607cda51b70958491bf925b3) | `` Updated melpa `` |
| [`4737a618`](https://github.com/nix-community/emacs-overlay/commit/4737a618f64a6e575347224d4b3b098ec4f60440) | `` Updated elpa ``  |