### PR TITLE
chore(flake/srvos): `6e6364a3` -> `14b3b0aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -951,11 +951,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719794994,
-        "narHash": "sha256-A76RzbJ2pOCnxqeQU7oEeNsmFmthDzpiDG4xoy2jfWs=",
+        "lastModified": 1719835186,
+        "narHash": "sha256-o0FB8SQVLOnbsYTk2Bt6gXwsfqEv4ZHsGP50/kM/gR0=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "6e6364a3d0de5549307a9f232febcb549df7b5e6",
+        "rev": "14b3b0aa48fa291f1be26ab8948d5b9eadaed0b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                          |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`2bad0e46`](https://github.com/nix-community/srvos/commit/2bad0e46a4cc0132c7606fb8a9ae70155cdf0ff3) | `` document mixins-mdns ``                                       |
| [`3207f2e6`](https://github.com/nix-community/srvos/commit/3207f2e66edb1b582cbcc767f0df648a1cd95896) | `` darwin/trusted-nix-caches: port over from NixOS ``            |
| [`c64a9722`](https://github.com/nix-community/srvos/commit/c64a972285f851f432ade0a75899d98a51fe6644) | `` darwin/nix-experimental: add based on nixos equivalent ``     |
| [`036ab1a0`](https://github.com/nix-community/srvos/commit/036ab1a01e2cdded94973906bd764c3d69f58f7c) | `` nixos/nix-experimental: drop stabilized discard-references `` |
| [`b742b865`](https://github.com/nix-community/srvos/commit/b742b86532b2fba82e42acd106419d0d7419ed4f) | `` common/openssh: apply workaround for CVE-2024-6387 ``         |