### PR TITLE
chore(flake/nur): `4f69a017` -> `0575d7fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719830755,
-        "narHash": "sha256-9VqRnwXjOgrs0joMYys+AEZ8DKJx7BOSf4UrMD0B754=",
+        "lastModified": 1719837916,
+        "narHash": "sha256-dV1URYa5SezYyz/1IDb1BHmIZ4tM0WtpPfVkFGH8xfY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4f69a017af9ccf0ac0aec02d72b53652bc78c93c",
+        "rev": "0575d7fb334ea662a0a03620780c87df0612eb9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0575d7fb`](https://github.com/nix-community/NUR/commit/0575d7fb334ea662a0a03620780c87df0612eb9a) | `` automatic update `` |
| [`1b663a6d`](https://github.com/nix-community/NUR/commit/1b663a6df25eafb99a69beda15f3479b9f71f91b) | `` automatic update `` |