### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `ceb72ac4` -> `0fb952b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -519,11 +519,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1719822810,
-        "narHash": "sha256-gDH1ovxs9GVguWctA3UjHzyev2u5U1eLN3x6q+nRi24=",
+        "lastModified": 1719839648,
+        "narHash": "sha256-qnSw+U7EMA/zopyY86shyv2rmGUwNNuze3/koC95znY=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "ceb72ac4582d6cc025544d45deeea6ba44b1f649",
+        "rev": "0fb952b3ce0567d4364325b761ec7cd1dca64fcb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                                            |
| ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`0fb952b3`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/0fb952b3ce0567d4364325b761ec7cd1dca64fcb) | `` Expose experimentalFetchTree in home-manager `` |