### PR TITLE
chore(flake/nur): `5bb9dc57` -> `9f3d8cf1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719856081,
-        "narHash": "sha256-NaTjgcoYcSxmYH+KELBOEMXBcLWjNKLFUneHEzBSHXI=",
+        "lastModified": 1719858509,
+        "narHash": "sha256-jtm8ua6/+NxXr9lr9LuTKpWGida1jeOInda0MdXrS+k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5bb9dc57360e674b49e92d0cfc064c13d91f453c",
+        "rev": "9f3d8cf1bb4a91c5d757dc09198c85344e06ce1a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9f3d8cf1`](https://github.com/nix-community/NUR/commit/9f3d8cf1bb4a91c5d757dc09198c85344e06ce1a) | `` automatic update `` |