### PR TITLE
chore(flake/nur): `9f3d8cf1` -> `c060d07e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719858509,
-        "narHash": "sha256-jtm8ua6/+NxXr9lr9LuTKpWGida1jeOInda0MdXrS+k=",
+        "lastModified": 1719863109,
+        "narHash": "sha256-eLzaowAhY7ioSCkxghxxZVICBJMFy2NCg1PEAHT6PA4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9f3d8cf1bb4a91c5d757dc09198c85344e06ce1a",
+        "rev": "c060d07eaa7b532877141ce0ff110053125fdc5c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c060d07e`](https://github.com/nix-community/NUR/commit/c060d07eaa7b532877141ce0ff110053125fdc5c) | `` automatic update `` |