### PR TITLE
chore(flake/nur): `c060d07e` -> `c3b0c669`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719863109,
-        "narHash": "sha256-eLzaowAhY7ioSCkxghxxZVICBJMFy2NCg1PEAHT6PA4=",
+        "lastModified": 1719865591,
+        "narHash": "sha256-Fq9KxLJjrHGXtCX1rylzW5Ls65fo4Rgl8f2Kqv5Gpo8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c060d07eaa7b532877141ce0ff110053125fdc5c",
+        "rev": "c3b0c669d39c3e03dbfba8c008487b5d2d62657d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c3b0c669`](https://github.com/nix-community/NUR/commit/c3b0c669d39c3e03dbfba8c008487b5d2d62657d) | `` automatic update `` |