### PR TITLE
chore(flake/sops-nix): `b5974d43` -> `a11224af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -931,11 +931,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1719716556,
-        "narHash": "sha256-KA9gy2Wkv76s4A8eLnOcdKVTygewbw3xsB8+awNMyqs=",
+        "lastModified": 1719873517,
+        "narHash": "sha256-D1dxZmXf6M2h5lNE1m6orojuUawVPjogbGRsqSBX+1g=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "b5974d4331fb6c893e808977a2e1a6d34b3162d6",
+        "rev": "a11224af8d824935f363928074b4717ca2e280db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                    |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`a11224af`](https://github.com/Mic92/sops-nix/commit/a11224af8d824935f363928074b4717ca2e280db) | `` update vendorHash ``                                                    |
| [`33098439`](https://github.com/Mic92/sops-nix/commit/33098439f70bac6bacbc8cd3a973799a8584ebfb) | `` build(deps): bump github.com/ProtonMail/go-crypto ``                    |
| [`84f8c460`](https://github.com/Mic92/sops-nix/commit/84f8c4600ea61f375acb6830955dfbafe62feaaf) | `` build(deps): bump DeterminateSystems/update-flake-lock from 22 to 23 `` |