### PR TITLE
chore(flake/nur): `c3b0c669` -> `1af8792e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719865591,
-        "narHash": "sha256-Fq9KxLJjrHGXtCX1rylzW5Ls65fo4Rgl8f2Kqv5Gpo8=",
+        "lastModified": 1719883469,
+        "narHash": "sha256-LWamZZ5PrMOsRe6VSgAPdcy9Pp9jLXZv4bvRHYUClYg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c3b0c669d39c3e03dbfba8c008487b5d2d62657d",
+        "rev": "1af8792ecc691307b01f238f0be8e93173aeb356",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1af8792e`](https://github.com/nix-community/NUR/commit/1af8792ecc691307b01f238f0be8e93173aeb356) | `` automatic update `` |
| [`5a8fded6`](https://github.com/nix-community/NUR/commit/5a8fded60408151c286730cffd7f5daff4b4e43b) | `` automatic update `` |
| [`ab4ddc22`](https://github.com/nix-community/NUR/commit/ab4ddc22be4fe8777219044416ac82d200f90ee4) | `` automatic update `` |
| [`17c9dd36`](https://github.com/nix-community/NUR/commit/17c9dd3696c2f112f8fa7fa7b882a640cb93b462) | `` automatic update `` |