### PR TITLE
chore(flake/nur): `1af8792e` -> `513292dc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719883469,
-        "narHash": "sha256-LWamZZ5PrMOsRe6VSgAPdcy9Pp9jLXZv4bvRHYUClYg=",
+        "lastModified": 1719886109,
+        "narHash": "sha256-KWySBr+8IF38cs1FfDff5F18jnaSdjYonFB8f1BpAO0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1af8792ecc691307b01f238f0be8e93173aeb356",
+        "rev": "513292dc2075f7b5445835c143777ed949a33539",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`513292dc`](https://github.com/nix-community/NUR/commit/513292dc2075f7b5445835c143777ed949a33539) | `` automatic update `` |
| [`f72d5706`](https://github.com/nix-community/NUR/commit/f72d57068f24fe565edbcd665a7e6ea3df67aed5) | `` automatic update `` |