### PR TITLE
chore(flake/treefmt): `a103c909` -> `bdb63550`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1046,11 +1046,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719846448,
-        "narHash": "sha256-UucUMHrTLSVryb8r2cqJFsYnKleK2586SmwD4uRdxmY=",
+        "lastModified": 1719887753,
+        "narHash": "sha256-p0B2r98UtZzRDM5miGRafL4h7TwGRC4DII+XXHDHqek=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "a103c909a918b95e25cde52fd08da2d012a64299",
+        "rev": "bdb6355009562d8f9313d9460c0d3860f525bc6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                             |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`8aa5b403`](https://github.com/numtide/treefmt-nix/commit/8aa5b4034b89b65fd3169505536ae0f82bec1784) | `` gdformat: use gdtoolkit_4 package ``             |
| [`6d63a367`](https://github.com/numtide/treefmt-nix/commit/6d63a367d0c6738bf714811bfb6b80a6ea8727db) | `` chore: remove lib.mdDoc, which is now default `` |
| [`9dfd0b09`](https://github.com/numtide/treefmt-nix/commit/9dfd0b09a6a710a5e3c3d6fa649ef0bedbe5f5a9) | `` nixfmt: use rfc-style by default ``              |
| [`d3cca0ad`](https://github.com/numtide/treefmt-nix/commit/d3cca0adad967f630ac4f8fbd86b580f7a075e2c) | `` flake.lock: Update ``                            |