### PR TITLE
chore(flake/nur): `513292dc` -> `46158ae6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719886109,
-        "narHash": "sha256-KWySBr+8IF38cs1FfDff5F18jnaSdjYonFB8f1BpAO0=",
+        "lastModified": 1719892551,
+        "narHash": "sha256-E4q0X+z1zNgAJvQEcdbQ+xuQE2pr3QwCMGZE/aq3RDU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "513292dc2075f7b5445835c143777ed949a33539",
+        "rev": "46158ae602a77357f80f659277990e0ce3e6149f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`46158ae6`](https://github.com/nix-community/NUR/commit/46158ae602a77357f80f659277990e0ce3e6149f) | `` automatic update `` |
| [`403c95e6`](https://github.com/nix-community/NUR/commit/403c95e69f5a0ac32019f1415e1551e41913b9c8) | `` automatic update `` |
| [`f7f62617`](https://github.com/nix-community/NUR/commit/f7f6261789ad4ccfa8a51943ce4212a1569207ab) | `` automatic update `` |