### PR TITLE
chore(flake/nur): `46158ae6` -> `b978045b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719892551,
-        "narHash": "sha256-E4q0X+z1zNgAJvQEcdbQ+xuQE2pr3QwCMGZE/aq3RDU=",
+        "lastModified": 1719894733,
+        "narHash": "sha256-T/zofRVToXkbvjBX+wnEOLCpaX3BbvMh9ZN6cKFydaA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "46158ae602a77357f80f659277990e0ce3e6149f",
+        "rev": "b978045baa040e6953fbe0a18c111749931673af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b978045b`](https://github.com/nix-community/NUR/commit/b978045baa040e6953fbe0a18c111749931673af) | `` automatic update `` |