### PR TITLE
chore(flake/nur): `b978045b` -> `4eb9a55a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719894733,
-        "narHash": "sha256-T/zofRVToXkbvjBX+wnEOLCpaX3BbvMh9ZN6cKFydaA=",
+        "lastModified": 1719903573,
+        "narHash": "sha256-/QMnlnLdavJqV6OSwtCj1zYzN33dCf6nrsMHdnQOWjw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b978045baa040e6953fbe0a18c111749931673af",
+        "rev": "4eb9a55ac59575f7cfbc58b11c043c61d2408e18",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4eb9a55a`](https://github.com/nix-community/NUR/commit/4eb9a55ac59575f7cfbc58b11c043c61d2408e18) | `` automatic update `` |
| [`806d829e`](https://github.com/nix-community/NUR/commit/806d829e287cf50c65cf2073667e4a5d98f66a06) | `` automatic update `` |
| [`c5f343d1`](https://github.com/nix-community/NUR/commit/c5f343d1b90038dd4a7fb636580c08b2b0e59ef9) | `` automatic update `` |
| [`f788a7d0`](https://github.com/nix-community/NUR/commit/f788a7d07991a144eb3a5a9b1540cadb7d6da37c) | `` automatic update `` |