### PR TITLE
chore(flake/nur): `4eb9a55a` -> `0f80673b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719903573,
-        "narHash": "sha256-/QMnlnLdavJqV6OSwtCj1zYzN33dCf6nrsMHdnQOWjw=",
+        "lastModified": 1719905307,
+        "narHash": "sha256-T6Iw3IadiRxPTV53EbrzK9tbTmlmgTzNKFh5epVE7Xo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4eb9a55ac59575f7cfbc58b11c043c61d2408e18",
+        "rev": "0f80673bc0e1c8fc8eda4e4a48e83e939a9ae415",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0f80673b`](https://github.com/nix-community/NUR/commit/0f80673bc0e1c8fc8eda4e4a48e83e939a9ae415) | `` automatic update `` |
| [`62508801`](https://github.com/nix-community/NUR/commit/6250880111ca334d3b19bce8c74459dfd76754fe) | `` automatic update `` |