### PR TITLE
chore(flake/emacs-overlay): `6b14b134` -> `3b7942fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1719850620,
-        "narHash": "sha256-n/TlWcW3h7cC6zRjJLjLNk87LtXp4H6Nf0NghdnYlKY=",
+        "lastModified": 1719910489,
+        "narHash": "sha256-YXdiLpTp8HBcTxbeYj8eYHutRRKQUwKYgUUrtwWpBew=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6b14b1346a81aba358b2fe747e9f3de0e205945d",
+        "rev": "3b7942fc6a8f7b67e285b4ca38f4b8c311cd17b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`3b7942fc`](https://github.com/nix-community/emacs-overlay/commit/3b7942fc6a8f7b67e285b4ca38f4b8c311cd17b0) | `` Updated melpa ``  |
| [`4086d908`](https://github.com/nix-community/emacs-overlay/commit/4086d9080ff20be767bbf3b8ea8f8e144574d93d) | `` Updated elpa ``   |
| [`8f443b4c`](https://github.com/nix-community/emacs-overlay/commit/8f443b4c2ff53a91a391382e880cb013db6fcacc) | `` Updated nongnu `` |