### PR TITLE
chore(flake/nur): `0f80673b` -> `818a9b2b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719905307,
-        "narHash": "sha256-T6Iw3IadiRxPTV53EbrzK9tbTmlmgTzNKFh5epVE7Xo=",
+        "lastModified": 1719920694,
+        "narHash": "sha256-Gq87LHlMg/mXfwUAHNeJD8O4Mo72YLOrPTXS+FzUTbM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0f80673bc0e1c8fc8eda4e4a48e83e939a9ae415",
+        "rev": "818a9b2bc6d2d568b0426daf67e8f13a79fb19c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`818a9b2b`](https://github.com/nix-community/NUR/commit/818a9b2bc6d2d568b0426daf67e8f13a79fb19c8) | `` automatic update `` |
| [`6206fd68`](https://github.com/nix-community/NUR/commit/6206fd683edcb79c4a0592cf25e610449ed0d82d) | `` automatic update `` |