### PR TITLE
chore(flake/catppuccin): `9eb0610d` -> `9345073d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1719758387,
-        "narHash": "sha256-bMaI1jJNzIZar4TP/hhoPQROqqcbD6zT6O+sqIJdp8c=",
+        "lastModified": 1719915848,
+        "narHash": "sha256-zq+CMkdT8A9z74HonwspXp8HsX4OvP4uaVdD98AO6as=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "9eb0610d48dd0e1fecf772bbdacf9050d7b82d7c",
+        "rev": "9345073d27d91ab66c1b6ab65df322906992aa59",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                               |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`9345073d`](https://github.com/catppuccin/nix/commit/9345073d27d91ab66c1b6ab65df322906992aa59) | `` chore(main): release 1.0.2 (#264) ``                               |
| [`7bfda77c`](https://github.com/catppuccin/nix/commit/7bfda77cd1c65a221edfc412051fab9c95102123) | `` revert(gtk): don't replace `normal` tweak with `default` (#271) `` |