### PR TITLE
chore(flake/nur): `1ec5b968` -> `4c348abf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719938409,
-        "narHash": "sha256-GzmLs/YaKAzpTQr9u4VpU0ISGtBluAyx9qTZC/86wb4=",
+        "lastModified": 1719945053,
+        "narHash": "sha256-FfDhs1+0Tt741jqMHMucsUmC87P9ASXIyQviDWm0SdI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1ec5b968d5751a0c817b7e56974059d01b348bf2",
+        "rev": "4c348abf4023fe2684c45ef56d785d564d57a300",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4c348abf`](https://github.com/nix-community/NUR/commit/4c348abf4023fe2684c45ef56d785d564d57a300) | `` automatic update `` |
| [`8244f95a`](https://github.com/nix-community/NUR/commit/8244f95ad9fbbf3a8c508d859c6d9dcd7650b21a) | `` automatic update `` |