### PR TITLE
chore(flake/nur): `ef879b77` -> `ed61924f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719949581,
-        "narHash": "sha256-5oTHaCzhztZL0we4NxD9ZbHoRtxxS+psl+8VVVDNN+A=",
+        "lastModified": 1719952034,
+        "narHash": "sha256-wzYFrAtzAajNACRhHGUtqsWDQ7DieGtlwF2Gxnt/cP0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ef879b77a1fbbe7170ab555852e18fa531c23a60",
+        "rev": "ed61924f4ba9b4dab39c98f48839bf9c484352b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ed61924f`](https://github.com/nix-community/NUR/commit/ed61924f4ba9b4dab39c98f48839bf9c484352b3) | `` automatic update `` |