### PR TITLE
chore(flake/nur): `ed61924f` -> `4ecd7170`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719952034,
-        "narHash": "sha256-wzYFrAtzAajNACRhHGUtqsWDQ7DieGtlwF2Gxnt/cP0=",
+        "lastModified": 1719956777,
+        "narHash": "sha256-Vl8Tsb/XE1dcHvDiA50vJbVYEZBmdWnqaGWD3ONGTzE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ed61924f4ba9b4dab39c98f48839bf9c484352b3",
+        "rev": "4ecd7170303a6e7eb0e34d44dfaf157b7b146adb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4ecd7170`](https://github.com/nix-community/NUR/commit/4ecd7170303a6e7eb0e34d44dfaf157b7b146adb) | `` automatic update `` |