### PR TITLE
chore(flake/nur): `4ecd7170` -> `11210863`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719956777,
-        "narHash": "sha256-Vl8Tsb/XE1dcHvDiA50vJbVYEZBmdWnqaGWD3ONGTzE=",
+        "lastModified": 1719960285,
+        "narHash": "sha256-hyiQSqp9aDx9oXDSEkE6R4BdfoC6DDDY1qwu+Q9jrtc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ecd7170303a6e7eb0e34d44dfaf157b7b146adb",
+        "rev": "11210863bcccb0bd31e930f40826c9c20831bac2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`11210863`](https://github.com/nix-community/NUR/commit/11210863bcccb0bd31e930f40826c9c20831bac2) | `` automatic update `` |
| [`c1f0d07e`](https://github.com/nix-community/NUR/commit/c1f0d07eb67687ceb91f964d41a41e6f45ea11a8) | `` automatic update `` |