### PR TITLE
chore(flake/nur): `5c5cdf06` -> `b349294a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719963896,
-        "narHash": "sha256-bwg3jYFB9dGfcmaxqqC5IXFWm2uQyJb/et/BPZRujTY=",
+        "lastModified": 1719971268,
+        "narHash": "sha256-TWBJNY0v2Ctcg//h3+svu+Vfx1OR1O7s1Em50Q87xNg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5c5cdf064a81d04107c32dcc03f00007801f4b25",
+        "rev": "b349294a54ef16a289fe84d07892e1ef5a366979",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b349294a`](https://github.com/nix-community/NUR/commit/b349294a54ef16a289fe84d07892e1ef5a366979) | `` automatic update `` |
| [`79e53770`](https://github.com/nix-community/NUR/commit/79e53770f8f0b94ac65340b04dd5d666aa45f718) | `` automatic update `` |