### PR TITLE
chore(flake/nur): `b349294a` -> `5e825a70`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719971268,
-        "narHash": "sha256-TWBJNY0v2Ctcg//h3+svu+Vfx1OR1O7s1Em50Q87xNg=",
+        "lastModified": 1719978420,
+        "narHash": "sha256-S7xTFT6YYttXXdvseps/h/FguXxYBPvzwuAPmKDek3c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b349294a54ef16a289fe84d07892e1ef5a366979",
+        "rev": "5e825a703f23fd8c2667a813a635e52021a8eb7e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5e825a70`](https://github.com/nix-community/NUR/commit/5e825a703f23fd8c2667a813a635e52021a8eb7e) | `` automatic update `` |
| [`2f6188b4`](https://github.com/nix-community/NUR/commit/2f6188b417f9ae7634b3523a5c9c22235e2d50e8) | `` automatic update `` |
| [`2a69a83c`](https://github.com/nix-community/NUR/commit/2a69a83c9b3649e90cd836673d4b7804c7a0bf89) | `` automatic update `` |