### PR TITLE
chore(flake/nur): `5e825a70` -> `ffd44bb4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719978420,
-        "narHash": "sha256-S7xTFT6YYttXXdvseps/h/FguXxYBPvzwuAPmKDek3c=",
+        "lastModified": 1719981089,
+        "narHash": "sha256-2M5yTK6i/rzYLNilhr7wYzykhRVzaNs3frxqcpxBIwQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5e825a703f23fd8c2667a813a635e52021a8eb7e",
+        "rev": "ffd44bb409a81a84c2e9ea1236c1108ecff9dd90",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ffd44bb4`](https://github.com/nix-community/NUR/commit/ffd44bb409a81a84c2e9ea1236c1108ecff9dd90) | `` automatic update `` |
| [`0a11cc63`](https://github.com/nix-community/NUR/commit/0a11cc63b745c1fef844a5e2998c2cd2355a57d5) | `` automatic update `` |