### PR TITLE
chore(flake/nur): `ffd44bb4` -> `dee7fe6e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719981089,
-        "narHash": "sha256-2M5yTK6i/rzYLNilhr7wYzykhRVzaNs3frxqcpxBIwQ=",
+        "lastModified": 1719985852,
+        "narHash": "sha256-xvlmAEcSG229u28tvrGFdCwYvz0gMRGzyjfqmjOSUAk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ffd44bb409a81a84c2e9ea1236c1108ecff9dd90",
+        "rev": "dee7fe6ed276de30af29275b77da6601e9c9768a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dee7fe6e`](https://github.com/nix-community/NUR/commit/dee7fe6ed276de30af29275b77da6601e9c9768a) | `` automatic update `` |