### PR TITLE
chore(flake/nur): `11210863` -> `bf466293`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719960285,
-        "narHash": "sha256-hyiQSqp9aDx9oXDSEkE6R4BdfoC6DDDY1qwu+Q9jrtc=",
+        "lastModified": 1719988422,
+        "narHash": "sha256-CIaf8/BcZpWxeTPboW2yJK0MoAsliGeev42fL44PpEU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "11210863bcccb0bd31e930f40826c9c20831bac2",
+        "rev": "bf46629348af94058363c5b265431e548b4a81e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bf466293`](https://github.com/nix-community/NUR/commit/bf46629348af94058363c5b265431e548b4a81e6) | `` automatic update `` |
| [`dee7fe6e`](https://github.com/nix-community/NUR/commit/dee7fe6ed276de30af29275b77da6601e9c9768a) | `` automatic update `` |
| [`ffd44bb4`](https://github.com/nix-community/NUR/commit/ffd44bb409a81a84c2e9ea1236c1108ecff9dd90) | `` automatic update `` |
| [`0a11cc63`](https://github.com/nix-community/NUR/commit/0a11cc63b745c1fef844a5e2998c2cd2355a57d5) | `` automatic update `` |
| [`5e825a70`](https://github.com/nix-community/NUR/commit/5e825a703f23fd8c2667a813a635e52021a8eb7e) | `` automatic update `` |
| [`2f6188b4`](https://github.com/nix-community/NUR/commit/2f6188b417f9ae7634b3523a5c9c22235e2d50e8) | `` automatic update `` |
| [`2a69a83c`](https://github.com/nix-community/NUR/commit/2a69a83c9b3649e90cd836673d4b7804c7a0bf89) | `` automatic update `` |
| [`b349294a`](https://github.com/nix-community/NUR/commit/b349294a54ef16a289fe84d07892e1ef5a366979) | `` automatic update `` |
| [`79e53770`](https://github.com/nix-community/NUR/commit/79e53770f8f0b94ac65340b04dd5d666aa45f718) | `` automatic update `` |
| [`5c5cdf06`](https://github.com/nix-community/NUR/commit/5c5cdf064a81d04107c32dcc03f00007801f4b25) | `` automatic update `` |