### PR TITLE
chore(flake/srvos): `14b3b0aa` -> `1844f1a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -951,11 +951,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719835186,
-        "narHash": "sha256-o0FB8SQVLOnbsYTk2Bt6gXwsfqEv4ZHsGP50/kM/gR0=",
+        "lastModified": 1719965291,
+        "narHash": "sha256-IQiO6VNESSmgxQkpI1q86pqxRw0SZ45iSeM1jsmBpSw=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "14b3b0aa48fa291f1be26ab8948d5b9eadaed0b8",
+        "rev": "1844f1a15ef530c963bb07c3846172fccbfb9f74",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                           |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`1844f1a1`](https://github.com/nix-community/srvos/commit/1844f1a15ef530c963bb07c3846172fccbfb9f74) | `` Revert "common/openssh: apply workaround for CVE-2024-6387" `` |
| [`83146a09`](https://github.com/nix-community/srvos/commit/83146a094e5b1d90500750cf240ac59f4d71139f) | `` dev/private/flake.lock: Update ``                              |
| [`83e98214`](https://github.com/nix-community/srvos/commit/83e98214921f3bccafc398cc39dac9d33e94e096) | `` flake.lock: Update ``                                          |