### PR TITLE
chore(flake/nur): `bf466293` -> `61ac6dad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719988422,
-        "narHash": "sha256-CIaf8/BcZpWxeTPboW2yJK0MoAsliGeev42fL44PpEU=",
+        "lastModified": 1719999906,
+        "narHash": "sha256-3fucmTQRZDbTOX372EIQYhRHox3YSOX1mgkZJqhuYU4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bf46629348af94058363c5b265431e548b4a81e6",
+        "rev": "61ac6dad5efc8d6ffa408f9965a6706d83b6521d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`61ac6dad`](https://github.com/nix-community/NUR/commit/61ac6dad5efc8d6ffa408f9965a6706d83b6521d) | `` automatic update `` |
| [`a36b8ede`](https://github.com/nix-community/NUR/commit/a36b8ede9e85f64cf42120cd355d6831b4fb3b37) | `` automatic update `` |
| [`7e718ca8`](https://github.com/nix-community/NUR/commit/7e718ca82ebe6b8ac4084504381a40e433adb648) | `` automatic update `` |