### PR TITLE
chore(flake/flake-parts): `4e358342` -> `9227223f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -259,11 +259,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1719877454,
-        "narHash": "sha256-g5N1yyOSsPNiOlFfkuI/wcUjmtah+nxdImJqrSATjOU=",
+        "lastModified": 1719994518,
+        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "4e3583423212f9303aa1a6337f8dffb415920e4f",
+        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                        |
| -------------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`6f8516c8`](https://github.com/hercules-ci/flake-parts/commit/6f8516c8741c68195f369a4a8538fbeb2904b7db) | `` Test mkFlake specialArgs `` |