### PR TITLE
chore(flake/nur): `61ac6dad` -> `642b5070`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1719999906,
-        "narHash": "sha256-3fucmTQRZDbTOX372EIQYhRHox3YSOX1mgkZJqhuYU4=",
+        "lastModified": 1720010855,
+        "narHash": "sha256-tF36DiquJP8Ow9QwphDYEjZtBfhkiZOKybUSMnM47wg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "61ac6dad5efc8d6ffa408f9965a6706d83b6521d",
+        "rev": "642b5070e3fa9f0be118fd46c741a4313231be22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`642b5070`](https://github.com/nix-community/NUR/commit/642b5070e3fa9f0be118fd46c741a4313231be22) | `` automatic update `` |
| [`c385bbfd`](https://github.com/nix-community/NUR/commit/c385bbfd12d4b59b918e8840af518a78d91d6fe1) | `` automatic update `` |