### PR TITLE
chore(flake/emacs-overlay): `bbe883e6` -> `6090c122`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1719937143,
-        "narHash": "sha256-1E5AX/Si2p2yXuMX5yixQ+P1AeVcrV0+2gfuBrTRkgY=",
+        "lastModified": 1720023672,
+        "narHash": "sha256-Rdtg0WsPQj45jdxZvgM8mFxIF4hm7gdB8oQm8fiKTvs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bbe883e60c65dd9254d010e98a1a8a654a26f9d8",
+        "rev": "6090c122978df8fcd0cf94765e6792610a7b7f07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`6090c122`](https://github.com/nix-community/emacs-overlay/commit/6090c122978df8fcd0cf94765e6792610a7b7f07) | `` Updated elpa ``   |
| [`83a4223d`](https://github.com/nix-community/emacs-overlay/commit/83a4223d1df768ef50c683b688a71b8fe1636db6) | `` Updated nongnu `` |