### PR TITLE
chore(flake/nur): `642b5070` -> `b9c5ba2e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720010855,
-        "narHash": "sha256-tF36DiquJP8Ow9QwphDYEjZtBfhkiZOKybUSMnM47wg=",
+        "lastModified": 1720032314,
+        "narHash": "sha256-QHQR/Gd/m483pCaeRMh/DwSHr+VQ5oHguxXBQBr3SRg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "642b5070e3fa9f0be118fd46c741a4313231be22",
+        "rev": "b9c5ba2e03480a9af2afb7ce4367f86465c20c39",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b9c5ba2e`](https://github.com/nix-community/NUR/commit/b9c5ba2e03480a9af2afb7ce4367f86465c20c39) | `` automatic update `` |
| [`f4aeaca4`](https://github.com/nix-community/NUR/commit/f4aeaca4642b8acbaf341219c9f16e94c4de9f7b) | `` automatic update `` |