### PR TITLE
chore(flake/nur): `b9c5ba2e` -> `0c95cf8d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720032314,
-        "narHash": "sha256-QHQR/Gd/m483pCaeRMh/DwSHr+VQ5oHguxXBQBr3SRg=",
+        "lastModified": 1720035920,
+        "narHash": "sha256-htNiIHtfg/ss8oPLB/5ACY9s0yEWYVPg2qqPJAoq8lE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b9c5ba2e03480a9af2afb7ce4367f86465c20c39",
+        "rev": "0c95cf8dfaf56dcd02edd2a22c209e16c9b7782e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0c95cf8d`](https://github.com/nix-community/NUR/commit/0c95cf8dfaf56dcd02edd2a22c209e16c9b7782e) | `` automatic update `` |