### PR TITLE
chore(flake/nur): `0c95cf8d` -> `43be6a6d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720035920,
-        "narHash": "sha256-htNiIHtfg/ss8oPLB/5ACY9s0yEWYVPg2qqPJAoq8lE=",
+        "lastModified": 1720039510,
+        "narHash": "sha256-IeqKkwx0frG/eszjaHTH4Tzt40RZee5pMvpdWnupU3c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0c95cf8dfaf56dcd02edd2a22c209e16c9b7782e",
+        "rev": "43be6a6d11467a5adceb05c38bd7c37f55d3ea50",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`43be6a6d`](https://github.com/nix-community/NUR/commit/43be6a6d11467a5adceb05c38bd7c37f55d3ea50) | `` automatic update `` |
| [`b28f0aa9`](https://github.com/nix-community/NUR/commit/b28f0aa9611f743d03e846181db789f12360e3de) | `` automatic update `` |