### PR TITLE
chore(flake/home-manager): `36e2f9da` -> `0a30138c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -410,11 +410,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719992360,
-        "narHash": "sha256-SRq0ZRkqagqpMGVf4z9q9CIWRbPYjO7FTqSJyWh7nes=",
+        "lastModified": 1720045378,
+        "narHash": "sha256-lmE7B+QXw7lWdBu5GQlUABSpzPk3YBb9VbV+IYK5djk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "36e2f9da91ce8b63a549a47688ae60d47c50de4b",
+        "rev": "0a30138c694ab3b048ac300794c2eb599dc40266",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                            |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`0a30138c`](https://github.com/nix-community/home-manager/commit/0a30138c694ab3b048ac300794c2eb599dc40266) | `` mpd: specify dependency of service on socket `` |
| [`58268b4d`](https://github.com/nix-community/home-manager/commit/58268b4d7745f6747be18033e6f10011466ce8d4) | `` flake.lock: Update ``                           |
| [`e9158314`](https://github.com/nix-community/home-manager/commit/e9158314725af06854009b829d2249d0d6c23c79) | `` yazi: allow literal string for `initLua` ``     |
| [`269cc18d`](https://github.com/nix-community/home-manager/commit/269cc18d945dd44bcbc22d58df3876a5d0dbac0b) | `` sway: fix systemd variables example ``          |