### PR TITLE
chore(flake/nur): `43be6a6d` -> `2476e328`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720039510,
-        "narHash": "sha256-IeqKkwx0frG/eszjaHTH4Tzt40RZee5pMvpdWnupU3c=",
+        "lastModified": 1720042854,
+        "narHash": "sha256-QqwKjbTPzdBkr8V7W+lTXeUmcWD+s7OEv7W+U+65yNo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "43be6a6d11467a5adceb05c38bd7c37f55d3ea50",
+        "rev": "2476e328d5e34bb40a62d91731d94a26e93f8078",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2476e328`](https://github.com/nix-community/NUR/commit/2476e328d5e34bb40a62d91731d94a26e93f8078) | `` automatic update `` |