### PR TITLE
chore(flake/nur): `2476e328` -> `8df07bc1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720042854,
-        "narHash": "sha256-QqwKjbTPzdBkr8V7W+lTXeUmcWD+s7OEv7W+U+65yNo=",
+        "lastModified": 1720051211,
+        "narHash": "sha256-xiGFqrKwu9aCwP/g8sRVHo+ZaXOZq0lPxceXW2btolQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2476e328d5e34bb40a62d91731d94a26e93f8078",
+        "rev": "8df07bc1ef697b27f2826cfadbb4897701bc5bdc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8df07bc1`](https://github.com/nix-community/NUR/commit/8df07bc1ef697b27f2826cfadbb4897701bc5bdc) | `` automatic update `` |
| [`1524e741`](https://github.com/nix-community/NUR/commit/1524e7416a973b2d27dfba858be69c3b8c04adb5) | `` automatic update `` |
| [`86c0a8a1`](https://github.com/nix-community/NUR/commit/86c0a8a10451d14fe11df97855ba2962bc61ae3c) | `` automatic update `` |