### PR TITLE
chore(flake/srvos): `1844f1a1` -> `b4f8e243`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -951,11 +951,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719965291,
-        "narHash": "sha256-IQiO6VNESSmgxQkpI1q86pqxRw0SZ45iSeM1jsmBpSw=",
+        "lastModified": 1720054509,
+        "narHash": "sha256-cVR1VTZRwxkECRK1TUjhrWn/HQJa62Chsgd5IUUcYiY=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "1844f1a15ef530c963bb07c3846172fccbfb9f74",
+        "rev": "b4f8e243d8d72222b4e7468373bba6989c11b9ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`b4f8e243`](https://github.com/nix-community/srvos/commit/b4f8e243d8d72222b4e7468373bba6989c11b9ea) | `` dev/private/flake.lock: Update `` |
| [`e2172c79`](https://github.com/nix-community/srvos/commit/e2172c79018b280d5cf030370a4462075f188fe1) | `` flake.lock: Update ``             |