### PR TITLE
chore(flake/nur): `bdc5596e` -> `1910b7dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720056522,
-        "narHash": "sha256-vdnwRu3wovRA7FBglc3VM6PPeqwIwx8LlYKbpHZJYd8=",
+        "lastModified": 1720067478,
+        "narHash": "sha256-trBJvl0zUTS8zBX6Afa4A76iDH07lLNYUNushfl6b5k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bdc5596e26864c587e935f7f595b18dbba40287e",
+        "rev": "1910b7dd310dea06d00d7d1cfaf500152727c808",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1910b7dd`](https://github.com/nix-community/NUR/commit/1910b7dd310dea06d00d7d1cfaf500152727c808) | `` automatic update `` |
| [`94a52341`](https://github.com/nix-community/NUR/commit/94a52341fa5b0355cd5aa33b53632399a444d3c4) | `` automatic update `` |
| [`309f4e0e`](https://github.com/nix-community/NUR/commit/309f4e0e76e1162a853bdbc5c8322a90ba6f98cf) | `` automatic update `` |