### PR TITLE
chore(flake/nur): `1910b7dd` -> `4dda71c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720067478,
-        "narHash": "sha256-trBJvl0zUTS8zBX6Afa4A76iDH07lLNYUNushfl6b5k=",
+        "lastModified": 1720072332,
+        "narHash": "sha256-T7MzpqCKtH2C4OMLVD5DQeEbI+yM0YoosSt+khiR2/w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1910b7dd310dea06d00d7d1cfaf500152727c808",
+        "rev": "4dda71c2053a47a5371a35a5857467f8a21811f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4dda71c2`](https://github.com/nix-community/NUR/commit/4dda71c2053a47a5371a35a5857467f8a21811f8) | `` automatic update `` |
| [`9392bf4f`](https://github.com/nix-community/NUR/commit/9392bf4f4c8dcbc21aa3afdf43b1bf47c900133a) | `` automatic update `` |
| [`8d3f50ce`](https://github.com/nix-community/NUR/commit/8d3f50ce34adfdddbc92bfddb6e8177ca914f7ae) | `` automatic update `` |