### PR TITLE
chore(flake/nur): `b278b41e` -> `b5d57ed0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720089983,
-        "narHash": "sha256-myMQWXP39p0c7saIADxTzcSugO2kymmGWQ1p/lGaZ7Y=",
+        "lastModified": 1720104947,
+        "narHash": "sha256-rSFzvd7/tfs/7/cvjJrBmsxcV5VRXq6xMDA9jTVpQ1A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b278b41e760f20c537edb57284ee4bbc5a674bf0",
+        "rev": "b5d57ed0159780f55ac6df4cd041fb07b057d49b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b5d57ed0`](https://github.com/nix-community/NUR/commit/b5d57ed0159780f55ac6df4cd041fb07b057d49b) | `` automatic update `` |
| [`3bea142e`](https://github.com/nix-community/NUR/commit/3bea142e43206126968fdae8a262e18be760c998) | `` automatic update `` |