### PR TITLE
chore(flake/emacs-overlay): `1da0807e` -> `160e167f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720083334,
-        "narHash": "sha256-+Xo3ZO28ULu5S3tu5gz6yBVEBqJXOz2z5PGGAwMbQFk=",
+        "lastModified": 1720112930,
+        "narHash": "sha256-pdiJ6QGnBYo8L1ePd32u2DH5/jDijE3YGf1TMebaIcU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1da0807e2f2dca14c7595c306018d98ccbdf0913",
+        "rev": "160e167fee1bb84587aa7ba26005e974903490cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`160e167f`](https://github.com/nix-community/emacs-overlay/commit/160e167fee1bb84587aa7ba26005e974903490cc) | `` Updated emacs ``        |
| [`8988d02a`](https://github.com/nix-community/emacs-overlay/commit/8988d02ae03a4a6ffaa7f56078daa0930b3f49c5) | `` Updated melpa ``        |
| [`dd2fd545`](https://github.com/nix-community/emacs-overlay/commit/dd2fd5453376f5f99be0a3e05f288ba249d3fb0a) | `` Updated elpa ``         |
| [`b397731f`](https://github.com/nix-community/emacs-overlay/commit/b397731fab95687acb28789f261192e5e8a102be) | `` Updated flake inputs `` |