### PR TITLE
chore(flake/nur): `b5d57ed0` -> `6d00ff1f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720104947,
-        "narHash": "sha256-rSFzvd7/tfs/7/cvjJrBmsxcV5VRXq6xMDA9jTVpQ1A=",
+        "lastModified": 1720118156,
+        "narHash": "sha256-Be+e9oq4fMJIfMg+fhXWvNOs/0D1P08e4dmC83uiNPA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b5d57ed0159780f55ac6df4cd041fb07b057d49b",
+        "rev": "6d00ff1fea7e85cb5977feaa972fd0fc084f8293",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6d00ff1f`](https://github.com/nix-community/NUR/commit/6d00ff1fea7e85cb5977feaa972fd0fc084f8293) | `` automatic update `` |
| [`51e238d1`](https://github.com/nix-community/NUR/commit/51e238d1713b58ce589b3f0696750222c1aa58ed) | `` automatic update `` |