### PR TITLE
chore(flake/nur): `6d00ff1f` -> `cbe0c14a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720118156,
-        "narHash": "sha256-Be+e9oq4fMJIfMg+fhXWvNOs/0D1P08e4dmC83uiNPA=",
+        "lastModified": 1720122287,
+        "narHash": "sha256-yIG/3GoJ1iNAmeRbWCoziKS3ZwKnUA92PmwqWPxVb3s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6d00ff1fea7e85cb5977feaa972fd0fc084f8293",
+        "rev": "cbe0c14a99ad25bf7f4242830be11ede98f46617",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cbe0c14a`](https://github.com/nix-community/NUR/commit/cbe0c14a99ad25bf7f4242830be11ede98f46617) | `` automatic update `` |