### PR TITLE
chore(flake/emacs-overlay): `edb6d7b4` -> `19212150`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720141546,
-        "narHash": "sha256-hQlzMdf358+H4y03p/C/NV4RUHSfJQNBNHpCdLFyqXg=",
+        "lastModified": 1720144502,
+        "narHash": "sha256-nSHggVRuqtFsAyvG6+nXE7O1wQvtqclUNQTqXUEnsFY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "edb6d7b4d9c1cae8ec2906bf8bd1a2b25f8ddb49",
+        "rev": "19212150460a6e07993b58e20b215a71a50fd04b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`19212150`](https://github.com/nix-community/emacs-overlay/commit/19212150460a6e07993b58e20b215a71a50fd04b) | `` Updated emacs `` |
| [`90d89e8c`](https://github.com/nix-community/emacs-overlay/commit/90d89e8cffc7f41e3d9a063dd6d0c0984728cf2d) | `` Updated melpa `` |