### PR TITLE
chore(flake/nur): `7a4b90f4` -> `60f0e231`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720145252,
-        "narHash": "sha256-aQpWHnXNOBr8h9ctwvDDSJCTZHrFOIy3mu9awAQGfsM=",
+        "lastModified": 1720147755,
+        "narHash": "sha256-6WfyfYRQso1YkRfbIkzHQeMcnbiHHXdfpelRAcUyjTE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7a4b90f4bf5e6312dc423ce7d0286b603cc76d3d",
+        "rev": "60f0e231d99150b56c60197aec3727219b451715",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`60f0e231`](https://github.com/nix-community/NUR/commit/60f0e231d99150b56c60197aec3727219b451715) | `` automatic update `` |