### PR TITLE
chore(flake/nur): `60f0e231` -> `df5671c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720147755,
-        "narHash": "sha256-6WfyfYRQso1YkRfbIkzHQeMcnbiHHXdfpelRAcUyjTE=",
+        "lastModified": 1720159001,
+        "narHash": "sha256-odlNfxYg1cQXYqGdJMNb6NFJp0wGwxbRl/rXqwWyatE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "60f0e231d99150b56c60197aec3727219b451715",
+        "rev": "df5671c64b8c0978f6083e11f36b0d802d0c9aea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`df5671c6`](https://github.com/nix-community/NUR/commit/df5671c64b8c0978f6083e11f36b0d802d0c9aea) | `` automatic update `` |
| [`2f589da1`](https://github.com/nix-community/NUR/commit/2f589da1e9e2a59f6451c40a6b4ed502a53a565e) | `` automatic update `` |
| [`82e6d667`](https://github.com/nix-community/NUR/commit/82e6d6675eea1e4ba2af09c2bd48ba05e7b0d773) | `` automatic update `` |
| [`4f79e4e0`](https://github.com/nix-community/NUR/commit/4f79e4e0ef3548b992aba15cc8ac3f840dcb3e02) | `` automatic update `` |
| [`14dfc8d3`](https://github.com/nix-community/NUR/commit/14dfc8d3f0995dcad0e1564e0afd87e34565256c) | `` automatic update `` |
| [`61718df3`](https://github.com/nix-community/NUR/commit/61718df310924cd5236b99979b1150f251192b23) | `` automatic update `` |