### PR TITLE
chore(flake/nur): `df5671c6` -> `af7f0b99`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720159001,
-        "narHash": "sha256-odlNfxYg1cQXYqGdJMNb6NFJp0wGwxbRl/rXqwWyatE=",
+        "lastModified": 1720162013,
+        "narHash": "sha256-WcprtFdAb1M4mOYyIMBrkw3dQ3mxE5wKZTuvlqxwMio=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "df5671c64b8c0978f6083e11f36b0d802d0c9aea",
+        "rev": "af7f0b9941efb5f8fd0a805fa1d4e9dcd4cd4e8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`af7f0b99`](https://github.com/nix-community/NUR/commit/af7f0b9941efb5f8fd0a805fa1d4e9dcd4cd4e8b) | `` automatic update `` |