### PR TITLE
chore(flake/nur): `af7f0b99` -> `50003cf6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720162013,
-        "narHash": "sha256-WcprtFdAb1M4mOYyIMBrkw3dQ3mxE5wKZTuvlqxwMio=",
+        "lastModified": 1720165490,
+        "narHash": "sha256-7dO9MVVMWOTqcYq0UD4e7LlBOnYMLkUlZup8wHF8omk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "af7f0b9941efb5f8fd0a805fa1d4e9dcd4cd4e8b",
+        "rev": "50003cf6e8afd3be5c84643a4e863239eec1b7ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`50003cf6`](https://github.com/nix-community/NUR/commit/50003cf6e8afd3be5c84643a4e863239eec1b7ee) | `` automatic update `` |