### PR TITLE
chore(flake/nur): `50003cf6` -> `d133dd57`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720165490,
-        "narHash": "sha256-7dO9MVVMWOTqcYq0UD4e7LlBOnYMLkUlZup8wHF8omk=",
+        "lastModified": 1720179576,
+        "narHash": "sha256-4xPwUqy7DclUIgL7E2LpHLwXRWFZuIvZAIVZGmeOI64=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "50003cf6e8afd3be5c84643a4e863239eec1b7ee",
+        "rev": "d133dd578e4610c60dba865df97ba1f4da282de8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d133dd57`](https://github.com/nix-community/NUR/commit/d133dd578e4610c60dba865df97ba1f4da282de8) | `` automatic update `` |
| [`a7f3a4b3`](https://github.com/nix-community/NUR/commit/a7f3a4b394375acdd26a1a8c7aecacc71c824fbc) | `` automatic update `` |
| [`5939849e`](https://github.com/nix-community/NUR/commit/5939849e44f3f6f3d373db6d036e2f95ac31bbd3) | `` automatic update `` |
| [`8966131f`](https://github.com/nix-community/NUR/commit/8966131f6539d6dac01fe961702f3f948e77651e) | `` automatic update `` |
| [`56822463`](https://github.com/nix-community/NUR/commit/56822463b8bed8166c7c44ed7ae31beb48fe05af) | `` automatic update `` |