### PR TITLE
chore(flake/srvos): `b4f8e243` -> `27dbc690`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -951,11 +951,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720054509,
-        "narHash": "sha256-cVR1VTZRwxkECRK1TUjhrWn/HQJa62Chsgd5IUUcYiY=",
+        "lastModified": 1720190661,
+        "narHash": "sha256-51aPk6VqCSEuQeGvi/j5pdRyx8UxvqBeph+sXsj94EU=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "b4f8e243d8d72222b4e7468373bba6989c11b9ea",
+        "rev": "27dbc690931cc30f2c4bb2ff39e46490c3b6421d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                   |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`27dbc690`](https://github.com/nix-community/srvos/commit/27dbc690931cc30f2c4bb2ff39e46490c3b6421d) | `` disable auto-allocate-uids on macOS `` |