### PR TITLE
chore(flake/emacs-overlay): `e2e8c730` -> `99ba4a77`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720170582,
-        "narHash": "sha256-L9MdoPyHWW31rFG172XjnXIIwvMB3nhjvWqQxacsCq0=",
+        "lastModified": 1720199372,
+        "narHash": "sha256-Qo/7GlKXULZwOArdt0jE6U9/9YYm/S8bvGYvyZFMKAg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e2e8c7303eafd8d3657e06c28be7b3b74c7024e6",
+        "rev": "99ba4a7778f783fdd054d090e08fb025b26f6ee0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`99ba4a77`](https://github.com/nix-community/emacs-overlay/commit/99ba4a7778f783fdd054d090e08fb025b26f6ee0) | `` Updated emacs `` |
| [`76ed4c02`](https://github.com/nix-community/emacs-overlay/commit/76ed4c021f3185ab80de6c22f584e80e8ebd14ff) | `` Updated melpa `` |
| [`abd7f6c6`](https://github.com/nix-community/emacs-overlay/commit/abd7f6c607b007baf5f53cbe25b84b678c533c72) | `` Updated elpa ``  |