### PR TITLE
chore(flake/home-manager): `bbe6e947` -> `e3582e51`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -410,11 +410,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720167120,
-        "narHash": "sha256-K9JYdlPiyaXp33JRg7CT8rMwH56e4ncXSsXW/YKnNXc=",
+        "lastModified": 1720188602,
+        "narHash": "sha256-lC3byBmhVZFzWl/dCic8+cKUEEAXAswWOYjq4paFmbo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bbe6e94737289c8cb92d4d8f9199fbfe4f11c0ba",
+        "rev": "e3582e5151498bc4d757e8361431ace8529e7bb7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`e3582e51`](https://github.com/nix-community/home-manager/commit/e3582e5151498bc4d757e8361431ace8529e7bb7) | `` sway: unfail units before starting session target `` |
| [`b7b55e28`](https://github.com/nix-community/home-manager/commit/b7b55e285cfc92e84f243012516bbc414691b747) | `` sway: stop sway-session.target on exit ``            |