### PR TITLE
chore(flake/emacs-overlay): `99ba4a77` -> `c77f9bf3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720199372,
-        "narHash": "sha256-Qo/7GlKXULZwOArdt0jE6U9/9YYm/S8bvGYvyZFMKAg=",
+        "lastModified": 1720227849,
+        "narHash": "sha256-w9y0TIB9245t9TSkqXE7qB20sTHRhsgpruLulP+D+rI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "99ba4a7778f783fdd054d090e08fb025b26f6ee0",
+        "rev": "c77f9bf365589fa9506f1173fc9fdd8c99754f31",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`c77f9bf3`](https://github.com/nix-community/emacs-overlay/commit/c77f9bf365589fa9506f1173fc9fdd8c99754f31) | `` Updated elpa ``  |
| [`515e324e`](https://github.com/nix-community/emacs-overlay/commit/515e324ee073b95cbb1adfe0548a1198131a3f24) | `` Updated emacs `` |