### PR TITLE
chore(flake/emacs-overlay): `c77f9bf3` -> `fceeefa2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720227849,
-        "narHash": "sha256-w9y0TIB9245t9TSkqXE7qB20sTHRhsgpruLulP+D+rI=",
+        "lastModified": 1720229911,
+        "narHash": "sha256-+CFbfmCBPMoP2pUYO9RHoPKmmWWJ+JUncku/Uw850+o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c77f9bf365589fa9506f1173fc9fdd8c99754f31",
+        "rev": "fceeefa2383706a2839adbcdbe83b2aab1ae0d24",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`fceeefa2`](https://github.com/nix-community/emacs-overlay/commit/fceeefa2383706a2839adbcdbe83b2aab1ae0d24) | `` Updated melpa `` |