### PR TITLE
chore(flake/nur): `3f937d15` -> `f0a48214`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720208481,
-        "narHash": "sha256-RtLovYSWt6p8ustpxjm0dNwAqxGwFVGeCWeIidw1i0U=",
+        "lastModified": 1720231591,
+        "narHash": "sha256-4oC66tf+A0mUz8MUm+Y99bcAkog1rz1O15LJjTv0OJ4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3f937d15f3218fa58e1c0683e839cd72fcad641a",
+        "rev": "f0a482140c20307e4b584001b08316f10a9ae0dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f0a48214`](https://github.com/nix-community/NUR/commit/f0a482140c20307e4b584001b08316f10a9ae0dd) | `` automatic update `` |
| [`1b8e689c`](https://github.com/nix-community/NUR/commit/1b8e689c52bbc9ad32aac245e9481e6d45d5a576) | `` automatic update `` |