### PR TITLE
chore(flake/nur): `c3334201` -> `0d585f95`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720240924,
-        "narHash": "sha256-XO61O4liEecHHB85c0K4Iy8iit5WK8OWh9QMgS9CtZA=",
+        "lastModified": 1720246927,
+        "narHash": "sha256-eiorA41XDKK+fbMxK2ZmHG1FP7tSWpiifA5uL6Tx0Ug=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c33342012b6ef239d05729c8b473c2a83575a9ca",
+        "rev": "0d585f9538f47c1b574831a35b2097aa1a707707",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0d585f95`](https://github.com/nix-community/NUR/commit/0d585f9538f47c1b574831a35b2097aa1a707707) | `` automatic update `` |
| [`024869c9`](https://github.com/nix-community/NUR/commit/024869c9b63a7641ff5431de390a4d3a4383aefe) | `` automatic update `` |