### PR TITLE
chore(flake/emacs-overlay): `3cf2f10f` -> `6d983712`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720256097,
-        "narHash": "sha256-SRitZz+nK0UuTAdKXT1IBWrNLZhbLx/U5FrCmYeMW4s=",
+        "lastModified": 1720256942,
+        "narHash": "sha256-ohfS5d4yR+zdLTICE78rNJmqL/en0BNPGm5zCK6N0QA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3cf2f10ff9ea5ecbd67351440b4302da4c0f8493",
+        "rev": "6d9837126e1be779c8f34ed9fdd609e676a1b891",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`6d983712`](https://github.com/nix-community/emacs-overlay/commit/6d9837126e1be779c8f34ed9fdd609e676a1b891) | `` Updated emacs `` |