### PR TITLE
chore(flake/emacs-overlay): `2fd2345c` -> `c4f2a993`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720284817,
-        "narHash": "sha256-yv/PC1rQZlxOn7HYKBxCjSnXJVnejZevfuHw5oLgKMU=",
+        "lastModified": 1720285729,
+        "narHash": "sha256-NLTftmyDPfLRYM7XSg6OUtU0rW0nBMKAISUyLiUuQXs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2fd2345c7fae391aa8ed4e30e44d236e5f639f5e",
+        "rev": "c4f2a9939e365b0c6ef8cbaed8781a9e144d5bdf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`c4f2a993`](https://github.com/nix-community/emacs-overlay/commit/c4f2a9939e365b0c6ef8cbaed8781a9e144d5bdf) | `` Updated emacs `` |