### PR TITLE
chore(flake/nur): `196f75d0` -> `673d935e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720295364,
-        "narHash": "sha256-clwkx3bqmlWPbAtywxJoqw0K7pEVUvQj5BArCqZxcUQ=",
+        "lastModified": 1720302358,
+        "narHash": "sha256-rTjqY94L6eQqQczKx2glCa8HlEQeoueCRCCB2gO3Vxc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "196f75d02c4a5662ac22763c1be690f91e21ef7b",
+        "rev": "673d935e914752452d4d87f37311be32ce5475c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`673d935e`](https://github.com/nix-community/NUR/commit/673d935e914752452d4d87f37311be32ce5475c5) | `` automatic update `` |