### PR TITLE
chore(flake/emacs-overlay): `c4f2a993` -> `190ca830`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720285729,
-        "narHash": "sha256-NLTftmyDPfLRYM7XSg6OUtU0rW0nBMKAISUyLiUuQXs=",
+        "lastModified": 1720314707,
+        "narHash": "sha256-2Jf95jXiihYPFpohUZIHNBefBbX/OZaWQwANAlueKgM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c4f2a9939e365b0c6ef8cbaed8781a9e144d5bdf",
+        "rev": "190ca830e9b11908d25a5baf69641e90518553c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message            |
| ------------------------------------------------------------------------------------------------------------ | ------------------ |
| [`190ca830`](https://github.com/nix-community/emacs-overlay/commit/190ca830e9b11908d25a5baf69641e90518553c9) | `` Updated elpa `` |