### PR TITLE
chore(flake/catppuccin): `9345073d` -> `0ec7ee23`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1719915848,
-        "narHash": "sha256-zq+CMkdT8A9z74HonwspXp8HsX4OvP4uaVdD98AO6as=",
+        "lastModified": 1720311994,
+        "narHash": "sha256-HsDHgJaozek5fExjwmN47QWbDtDnGLWJT4uOOtLEmvA=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "9345073d27d91ab66c1b6ab65df322906992aa59",
+        "rev": "0ec7ee23269bcbe3e5f23de743fbc8e1383a3315",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                    |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`0ec7ee23`](https://github.com/catppuccin/nix/commit/0ec7ee23269bcbe3e5f23de743fbc8e1383a3315) | `` chore(modules): update ports (#273) ``                                  |
| [`5d11815d`](https://github.com/catppuccin/nix/commit/5d11815d7664c190d0746d99dc576e4f678f5245) | `` ci: update korthout/backport-action action to v3 (#266) ``              |
| [`e57e033f`](https://github.com/catppuccin/nix/commit/e57e033f9f7e780d2b89dfe56f6b45f72f93cfcf) | `` ci: update determinatesystems/update-flake-lock action to v23 (#265) `` |