### PR TITLE
chore(flake/nur): `673d935e` -> `b40c1dcc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720302358,
-        "narHash": "sha256-rTjqY94L6eQqQczKx2glCa8HlEQeoueCRCCB2gO3Vxc=",
+        "lastModified": 1720323965,
+        "narHash": "sha256-a4LgkEPxkubftebRcbRKgw0xXQZ1iADXVmmspEQb8oM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "673d935e914752452d4d87f37311be32ce5475c5",
+        "rev": "b40c1dcc6ff1470b4df40f2994c2954def6e2bc5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b40c1dcc`](https://github.com/nix-community/NUR/commit/b40c1dcc6ff1470b4df40f2994c2954def6e2bc5) | `` automatic update `` |
| [`7d63999c`](https://github.com/nix-community/NUR/commit/7d63999cf71795b0238a312a14f7965f171564cc) | `` automatic update `` |
| [`755cfc50`](https://github.com/nix-community/NUR/commit/755cfc508cdadba5d2f89b2707ef7ea1186b12fb) | `` automatic update `` |
| [`a16897d9`](https://github.com/nix-community/NUR/commit/a16897d918d84fe9ce72f6a9f829edd8771da564) | `` automatic update `` |
| [`e39adfd1`](https://github.com/nix-community/NUR/commit/e39adfd1946da3f1828b14ec0100bc199921be43) | `` automatic update `` |
| [`2bb1144a`](https://github.com/nix-community/NUR/commit/2bb1144a81bede7ec7b506fca176fbe7f0d06154) | `` automatic update `` |
| [`7de9f03a`](https://github.com/nix-community/NUR/commit/7de9f03ac9eb691d2dcbbe9fde677b30d1a61e9f) | `` automatic update `` |
| [`bc2df869`](https://github.com/nix-community/NUR/commit/bc2df8699a619bde9a928a6e316683fd490b1308) | `` automatic update `` |