### PR TITLE
chore(flake/emacs-overlay): `190ca830` -> `b2eb2322`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720314707,
-        "narHash": "sha256-2Jf95jXiihYPFpohUZIHNBefBbX/OZaWQwANAlueKgM=",
+        "lastModified": 1720317610,
+        "narHash": "sha256-/qgzkNFHrD9nDjmBPvp1068N4UKtzboKp/tPlxBwhqM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "190ca830e9b11908d25a5baf69641e90518553c9",
+        "rev": "b2eb23229761144c87efe5cd481bf352ee853172",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`b2eb2322`](https://github.com/nix-community/emacs-overlay/commit/b2eb23229761144c87efe5cd481bf352ee853172) | `` Updated emacs `` |
| [`e277db6f`](https://github.com/nix-community/emacs-overlay/commit/e277db6fa25c262c27457e8628fa4c77c9e9471c) | `` Updated melpa `` |