### PR TITLE
chore(flake/nix-index-database): `2917972e` -> `ca551ae1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -587,11 +587,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719832725,
-        "narHash": "sha256-dr8DkeS74KVNTgi8BE0BiUKALb+EKlMIV86G2xPYO64=",
+        "lastModified": 1720321665,
+        "narHash": "sha256-wdgi+obPl0Ama1uG2ulsylkU51zzZMjDMhrV5SADZnk=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "2917972ed34ce292309b3a4976286f8b5c08db27",
+        "rev": "ca551ae1d2144db88b23b405758958dd4d6b2733",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`ca551ae1`](https://github.com/nix-community/nix-index-database/commit/ca551ae1d2144db88b23b405758958dd4d6b2733) | `` update generated.nix to release 2024-07-07-025737 `` |
| [`6d61f720`](https://github.com/nix-community/nix-index-database/commit/6d61f72020aa748ed1cec87b21e6739be71b13c5) | `` flake.lock: Update ``                                |