### PR TITLE
chore(flake/nur): `b40c1dcc` -> `18a48569`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720323965,
-        "narHash": "sha256-a4LgkEPxkubftebRcbRKgw0xXQZ1iADXVmmspEQb8oM=",
+        "lastModified": 1720352738,
+        "narHash": "sha256-S/FwaFfzUaGv81QxJJFWbrWhAAlR+L3S5i2MIujqmcE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b40c1dcc6ff1470b4df40f2994c2954def6e2bc5",
+        "rev": "18a4856920ac463d8ed386d9830a7742e2cf2c2c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`18a48569`](https://github.com/nix-community/NUR/commit/18a4856920ac463d8ed386d9830a7742e2cf2c2c) | `` automatic update `` |
| [`35485c6a`](https://github.com/nix-community/NUR/commit/35485c6a42e8f3ecb77d79fc6e3dea695e40c82d) | `` automatic update `` |
| [`64eb60af`](https://github.com/nix-community/NUR/commit/64eb60afcb54464e61d34fda417e7a5c7a935c21) | `` automatic update `` |
| [`25e98a0c`](https://github.com/nix-community/NUR/commit/25e98a0c8af990fdef4cd1aa951c6a7b93618bdd) | `` automatic update `` |
| [`8b420fd1`](https://github.com/nix-community/NUR/commit/8b420fd12e6189dcaea91b529b84997a8b6a4dfd) | `` automatic update `` |
| [`a1065290`](https://github.com/nix-community/NUR/commit/a10652901f05d44a0da241ec1d85e3a90ee3327a) | `` automatic update `` |