### PR TITLE
chore(flake/nix-index-database): `ca551ae1` -> `685e40e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -587,11 +587,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720321665,
-        "narHash": "sha256-wdgi+obPl0Ama1uG2ulsylkU51zzZMjDMhrV5SADZnk=",
+        "lastModified": 1720334033,
+        "narHash": "sha256-X9pEvvHTVWJphhbUYqXvlLedOndNqGB7rvhSvL2CIgU=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "ca551ae1d2144db88b23b405758958dd4d6b2733",
+        "rev": "685e40e1348007d2cf76747a201bab43d86b38cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                       |
| ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`685e40e1`](https://github.com/nix-community/nix-index-database/commit/685e40e1348007d2cf76747a201bab43d86b38cb) | `` README: add warning to remove nix-index `` |