### PR TITLE
chore(flake/emacs-overlay): `a9c8464e` -> `907ffaed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720342476,
-        "narHash": "sha256-cXTzZqLinydLDr74ga92obsTsN4gdvXHRby21IsZsi4=",
+        "lastModified": 1720343386,
+        "narHash": "sha256-6OVidxIFSmlK7dWcU8UvTu5erv9yLXeCdRftaDR9wQk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a9c8464ed78de06dd5b7934499c20d4b724bead6",
+        "rev": "907ffaedc98068a23118e7d9d90ac7200095b3cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`907ffaed`](https://github.com/nix-community/emacs-overlay/commit/907ffaedc98068a23118e7d9d90ac7200095b3cd) | `` Updated emacs `` |