### PR TITLE
chore(flake/nur): `18a48569` -> `0d106138`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720352738,
-        "narHash": "sha256-S/FwaFfzUaGv81QxJJFWbrWhAAlR+L3S5i2MIujqmcE=",
+        "lastModified": 1720356984,
+        "narHash": "sha256-/dqjqRAwEfVCiNe/FytpomRAbRnCLp/TPS5jciQVpg8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "18a4856920ac463d8ed386d9830a7742e2cf2c2c",
+        "rev": "0d106138cb9c2364c29e44427fb6d17da8057a44",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0d106138`](https://github.com/nix-community/NUR/commit/0d106138cb9c2364c29e44427fb6d17da8057a44) | `` automatic update `` |