### PR TITLE
chore(flake/nur): `0d106138` -> `5161f371`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720356984,
-        "narHash": "sha256-/dqjqRAwEfVCiNe/FytpomRAbRnCLp/TPS5jciQVpg8=",
+        "lastModified": 1720360661,
+        "narHash": "sha256-LmzfL+pA2mYLTf22oqgJKmkoxxE0Q7RxjYQDJtphNdQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0d106138cb9c2364c29e44427fb6d17da8057a44",
+        "rev": "5161f371baeb843454fd7aea918cb4354fa8ed08",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5161f371`](https://github.com/nix-community/NUR/commit/5161f371baeb843454fd7aea918cb4354fa8ed08) | `` automatic update `` |