### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `c8f52ddc` -> `445cab34`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -519,11 +519,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1720341070,
-        "narHash": "sha256-+DE2jNutY1IVIyeTCLjfsE5eg1XGujOmVOuTgp39Axc=",
+        "lastModified": 1720358785,
+        "narHash": "sha256-LOrmGWEPPXq9wZ2UEcU03TCimQTXfi3g4SBBGYVI7lU=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "c8f52ddca5426367a2e83a6c9315c725d88559eb",
+        "rev": "445cab3486923701e718cb9b5f1103886a072e64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                                           |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`445cab34`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/445cab3486923701e718cb9b5f1103886a072e64) | `` Drop lsp-python-ms check (removed upstream) `` |