### PR TITLE
chore(flake/emacs-overlay): `907ffaed` -> `01875064`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720343386,
-        "narHash": "sha256-6OVidxIFSmlK7dWcU8UvTu5erv9yLXeCdRftaDR9wQk=",
+        "lastModified": 1720371235,
+        "narHash": "sha256-L+H0OClGtCmRqK/6hyUkdmXzySf1eU6U28bQz+dqNZw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "907ffaedc98068a23118e7d9d90ac7200095b3cd",
+        "rev": "018750646b05c583aa3d4f1aa3bb14fcfa0b756d",
         "type": "github"
       },
       "original": {
@@ -700,11 +700,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1720110830,
-        "narHash": "sha256-E5dN9GDV4LwMEduhBLSkyEz51zM17XkWZ3/9luvNOPs=",
+        "lastModified": 1720244366,
+        "narHash": "sha256-WrDV0FPMVd2Sq9hkR5LNHudS3OSMmUrs90JUTN+MXpA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c0d0be00d4ecc4b51d2d6948e37466194c1e6c51",
+        "rev": "49ee0e94463abada1de470c9c07bfc12b36dcf40",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`01875064`](https://github.com/nix-community/emacs-overlay/commit/018750646b05c583aa3d4f1aa3bb14fcfa0b756d) | `` Updated melpa ``        |
| [`968b1efe`](https://github.com/nix-community/emacs-overlay/commit/968b1efefa2bd2a534c46090602e1ed4bcac87c9) | `` Updated elpa ``         |
| [`b84280a6`](https://github.com/nix-community/emacs-overlay/commit/b84280a674261ca24008a40959a306bd572d3f14) | `` Updated flake inputs `` |