### PR TITLE
chore(flake/nur): `5161f371` -> `b621db27`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720360661,
-        "narHash": "sha256-LmzfL+pA2mYLTf22oqgJKmkoxxE0Q7RxjYQDJtphNdQ=",
+        "lastModified": 1720377455,
+        "narHash": "sha256-crimUOMGDO2P+6CeuJZjz50yKyxFZ2ofQGPKjvOj3s4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5161f371baeb843454fd7aea918cb4354fa8ed08",
+        "rev": "b621db2713da7c77c40476ad0a622ef9e8e69f6a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b621db27`](https://github.com/nix-community/NUR/commit/b621db2713da7c77c40476ad0a622ef9e8e69f6a) | `` automatic update `` |
| [`ddceaa60`](https://github.com/nix-community/NUR/commit/ddceaa6035f27b4b80048d9a18965b72a22387d7) | `` automatic update `` |