### PR TITLE
chore(flake/emacs-overlay): `01875064` -> `91c8f114`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720371235,
-        "narHash": "sha256-L+H0OClGtCmRqK/6hyUkdmXzySf1eU6U28bQz+dqNZw=",
+        "lastModified": 1720372100,
+        "narHash": "sha256-wkx4alF+UaiFeL/WSxe12eODuhA23G9KRWno5vzkcyc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "018750646b05c583aa3d4f1aa3bb14fcfa0b756d",
+        "rev": "91c8f1140e9286f71f1fd38f7dc608d774798f64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`91c8f114`](https://github.com/nix-community/emacs-overlay/commit/91c8f1140e9286f71f1fd38f7dc608d774798f64) | `` Updated emacs `` |