### PR TITLE
chore(flake/nixos-hardware): `6e253f12` -> `da0aa7b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -627,11 +627,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1719895800,
-        "narHash": "sha256-xNbjISJTFailxass4LmdWeV4jNhAlmJPwj46a/GxE6M=",
+        "lastModified": 1720372297,
+        "narHash": "sha256-bwy1rPQSQSCj/TNf1yswHW88nBQYvJQkeScGvOA8pd4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "6e253f12b1009053eff5344be5e835f604bb64cd",
+        "rev": "da0aa7b533d49e6319c603e07b46a5690082f65f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                               |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`da0aa7b5`](https://github.com/NixOS/nixos-hardware/commit/da0aa7b533d49e6319c603e07b46a5690082f65f) | `` apple/t2: bump kernel to 6.9.8 ``                                  |
| [`c1cdb2f8`](https://github.com/NixOS/nixos-hardware/commit/c1cdb2f8282818808fd6e0726620c7cd54c8a260) | `` apple/t2: update patches repo ref ``                               |
| [`f75ab8b2`](https://github.com/NixOS/nixos-hardware/commit/f75ab8b22cf73522330cd23c8312ead6fbca8093) | `` apple/t2: factor out kernel definition for improved readability `` |