### PR TITLE
chore(flake/treefmt): `bdb63550` -> `6fc8bded`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1046,11 +1046,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719887753,
-        "narHash": "sha256-p0B2r98UtZzRDM5miGRafL4h7TwGRC4DII+XXHDHqek=",
+        "lastModified": 1720436211,
+        "narHash": "sha256-/cKXod0oGLl+vH4bKBZnTV3qxrw4jgOLnyQ8KXey5J8=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "bdb6355009562d8f9313d9460c0d3860f525bc6c",
+        "rev": "6fc8bded78715cdd43a3278a14ded226eb3a239e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                      |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`e1d7bd5e`](https://github.com/numtide/treefmt-nix/commit/e1d7bd5ec6fc389eb3a90e232c4150338bf6a508) | `` exclude some file types by default (#194) ``              |
| [`1675903b`](https://github.com/numtide/treefmt-nix/commit/1675903bb0dbb0f92723d96e2d42c62103e47a5e) | `` {shellcheck,shfmt}: also format .bash and .envrc files `` |