### PR TITLE
chore(flake/nix-on-droid): `45fcd2da` -> `e0216d3e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -612,11 +612,11 @@
         "nmd": "nmd_2"
       },
       "locked": {
-        "lastModified": 1719772177,
-        "narHash": "sha256-XJOxCLWQUn+3VQTQGRwMoz6nDjT+GoL0f4mVrUQdzfk=",
+        "lastModified": 1720381118,
+        "narHash": "sha256-0bKc3NZc5iy3TqTgDdhkGuWpWdjmQhlX1La7cu4YGFI=",
         "owner": "t184256",
         "repo": "nix-on-droid",
-        "rev": "45fcd2da39a70a96752e17f85d7a843b3c4f67f4",
+        "rev": "e0216d3e47d195aadf4ec3e7aa991a7b90504a08",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                    |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`e0216d3e`](https://github.com/nix-community/nix-on-droid/commit/e0216d3e47d195aadf4ec3e7aa991a7b90504a08) | `` modules/android-integration: termux-reload-settings ``                  |
| [`438cf8c6`](https://github.com/nix-community/nix-on-droid/commit/438cf8c62029a5bf451d16441c6c166120c1b367) | `` modules/android-integration: termux-wake-lock and termux-wake-unlock `` |
| [`b195fa0b`](https://github.com/nix-community/nix-on-droid/commit/b195fa0b15e6b5d1aa3a0512d7da841f2e688bea) | `` modules/android-integration: termux-open, termux-open-url, xdg-open ``  |
| [`733a9fe5`](https://github.com/nix-community/nix-on-droid/commit/733a9fe55c218ef0621f4f5eb8dcd4f7e31e8bee) | `` modules/android_integration: termux-setup-storage & unsupported ``      |
| [`c4c4f09e`](https://github.com/nix-community/nix-on-droid/commit/c4c4f09e3da4a9c8e499143698da2815268bf57d) | `` modules/android-integration: add am command ``                          |
| [`b7e7cd42`](https://github.com/nix-community/nix-on-droid/commit/b7e7cd423da855d2ad9a5e8cdbadf50b11bec192) | `` tests/emulator: better filenames ``                                     |
| [`faaacc18`](https://github.com/nix-community/nix-on-droid/commit/faaacc18a53f3f7a4162137f3f8f1443e7998cb1) | `` tests/emulator/bootstrap-*: work around ADD TO DICTIONARY ``            |
| [`3f744f24`](https://github.com/nix-community/nix-on-droid/commit/3f744f24753cdd0dc25975ab02148b74477a8452) | `` tests/emulator/on_device_tests: lower timeout ``                        |
| [`c84961e1`](https://github.com/nix-community/nix-on-droid/commit/c84961e1c25df74a631030a4cbb353a43b169e67) | `` pkgs/nix-directory: use stdenvNoCC.mkDerivation ``                      |