### PR TITLE
chore(flake/nur): `b621db27` -> `8ed74a8d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720377455,
-        "narHash": "sha256-crimUOMGDO2P+6CeuJZjz50yKyxFZ2ofQGPKjvOj3s4=",
+        "lastModified": 1720381169,
+        "narHash": "sha256-ADHrjselnrl7Qsl6dFyGNFIGpCLB6CqHjemL82R2N/s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b621db2713da7c77c40476ad0a622ef9e8e69f6a",
+        "rev": "8ed74a8d7bbd29e942b3fc7816d59cab2c99da1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8ed74a8d`](https://github.com/nix-community/NUR/commit/8ed74a8d7bbd29e942b3fc7816d59cab2c99da1e) | `` automatic update `` |