### PR TITLE
chore(flake/nur): `8ed74a8d` -> `70f8cae4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720381169,
-        "narHash": "sha256-ADHrjselnrl7Qsl6dFyGNFIGpCLB6CqHjemL82R2N/s=",
+        "lastModified": 1720387701,
+        "narHash": "sha256-aFuRboLpWWRIi68Ee8AksLCOG94CB4LLc48eCd3TwcQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8ed74a8d7bbd29e942b3fc7816d59cab2c99da1e",
+        "rev": "70f8cae4d5d014a8e0394108b4ab57a524327de0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`70f8cae4`](https://github.com/nix-community/NUR/commit/70f8cae4d5d014a8e0394108b4ab57a524327de0) | `` automatic update `` |