### PR TITLE
chore(flake/nur): `70f8cae4` -> `f64eea5e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720387701,
-        "narHash": "sha256-aFuRboLpWWRIi68Ee8AksLCOG94CB4LLc48eCd3TwcQ=",
+        "lastModified": 1720411045,
+        "narHash": "sha256-TpEdNtvpjwVjaj34JEX+CQT4AbL9idhO0311wWJSqnk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "70f8cae4d5d014a8e0394108b4ab57a524327de0",
+        "rev": "f64eea5ea86d4d0c64b41f9f1dcbef5ea741b1f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f64eea5e`](https://github.com/nix-community/NUR/commit/f64eea5ea86d4d0c64b41f9f1dcbef5ea741b1f1) | `` automatic update `` |
| [`8f434ba2`](https://github.com/nix-community/NUR/commit/8f434ba230d722620218a46d4306c460f9b655a7) | `` automatic update `` |
| [`e8680bef`](https://github.com/nix-community/NUR/commit/e8680befc408648935a694b7e296177fd88bd242) | `` automatic update `` |
| [`813dad69`](https://github.com/nix-community/NUR/commit/813dad69e6de057962406a0eb78fb53881ce4aea) | `` automatic update `` |
| [`99d5feef`](https://github.com/nix-community/NUR/commit/99d5feef337de3a85cd1dbcdb0927f9d1d9b6acc) | `` automatic update `` |
| [`de4677b0`](https://github.com/nix-community/NUR/commit/de4677b0689e7ec191fcb612fbf68cb5f87e3d4e) | `` automatic update `` |