### PR TITLE
chore(flake/nix-on-droid): `e0216d3e` -> `f3d3b829`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -612,11 +612,11 @@
         "nmd": "nmd_2"
       },
       "locked": {
-        "lastModified": 1720381118,
-        "narHash": "sha256-0bKc3NZc5iy3TqTgDdhkGuWpWdjmQhlX1La7cu4YGFI=",
+        "lastModified": 1720396533,
+        "narHash": "sha256-UFzk/hZWO1VkciIO5UPaSpJN8s765wsngUSvtJM6d5Q=",
         "owner": "t184256",
         "repo": "nix-on-droid",
-        "rev": "e0216d3e47d195aadf4ec3e7aa991a7b90504a08",
+        "rev": "f3d3b8294039f2f9a8fb7ea82c320f29c6b0fe25",
         "type": "github"
       },
       "original": {
@@ -672,17 +672,17 @@
     },
     "nixpkgs-for-bootstrap": {
       "locked": {
-        "lastModified": 1708105575,
-        "narHash": "sha256-sS4AItZeUnAei6v8FqxNlm+/27MPlfoGym/TZP0rmH0=",
+        "lastModified": 1720244366,
+        "narHash": "sha256-WrDV0FPMVd2Sq9hkR5LNHudS3OSMmUrs90JUTN+MXpA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1d1817869c47682a6bee85b5b0a6537b6c0fba26",
+        "rev": "49ee0e94463abada1de470c9c07bfc12b36dcf40",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1d1817869c47682a6bee85b5b0a6537b6c0fba26",
+        "rev": "49ee0e94463abada1de470c9c07bfc12b36dcf40",
         "type": "github"
       }
     },


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                          |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`f3d3b829`](https://github.com/nix-community/nix-on-droid/commit/f3d3b8294039f2f9a8fb7ea82c320f29c6b0fe25) | `` CHANGELOG.md: mark 24.05 as released ``                       |
| [`fdcdea8a`](https://github.com/nix-community/nix-on-droid/commit/fdcdea8a45569b773f02f585672c286d4354f8f3) | `` WIP: tests/emulator: avoid "ADD TO DICTIONARY" by sleeping `` |
| [`bab7c453`](https://github.com/nix-community/nix-on-droid/commit/bab7c453f4303dbcd40378fd9a98cabfb2c0bb16) | `` login-inner: get rid of gnused in flake bootstrap ``          |
| [`35076ea3`](https://github.com/nix-community/nix-on-droid/commit/35076ea33fa9c73fb7c5110adbd512a81c9f4309) | `` pkgs/proot-termux: update ``                                  |
| [`4d20bfc8`](https://github.com/nix-community/nix-on-droid/commit/4d20bfc8462f356433510721ff1ab2fc704c7083) | `` update inputs and copyrights to 24.05 ``                      |