### PR TITLE
chore(flake/emacs-overlay): `098aab60` -> `ce9d4b14`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720393626,
-        "narHash": "sha256-r6nn/wuPJ7868hHE9FxK9wo0Is7w+xuGM3ImBC/bRLE=",
+        "lastModified": 1720400870,
+        "narHash": "sha256-YZnBPmZAGJ4o9T9tJ03Zd4naeB/2QVrP6pPXGOzv1l4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "098aab601d6eea8cecffb55536978ba081a82642",
+        "rev": "ce9d4b140f27816de62d6124019f0578edc2eeb7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message            |
| ------------------------------------------------------------------------------------------------------------ | ------------------ |
| [`ce9d4b14`](https://github.com/nix-community/emacs-overlay/commit/ce9d4b140f27816de62d6124019f0578edc2eeb7) | `` Updated elpa `` |