### PR TITLE
chore(flake/srvos): `27dbc690` -> `21a32599`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -951,11 +951,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720190661,
-        "narHash": "sha256-51aPk6VqCSEuQeGvi/j5pdRyx8UxvqBeph+sXsj94EU=",
+        "lastModified": 1720400448,
+        "narHash": "sha256-v7JVJ8H1PyH7/8EU72mz7wzxJ1OLE/h3NCqQyZ6ONjs=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "27dbc690931cc30f2c4bb2ff39e46490c3b6421d",
+        "rev": "21a3259985e3cddc455f64ad66d4a825b39934ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`21a32599`](https://github.com/nix-community/srvos/commit/21a3259985e3cddc455f64ad66d4a825b39934ad) | `` dev/private/flake.lock: Update `` |
| [`7fa2dc46`](https://github.com/nix-community/srvos/commit/7fa2dc46e24fa833400caf34c550777129dd64d5) | `` flake.lock: Update ``             |