### PR TITLE
chore(flake/emacs-overlay): `ce9d4b14` -> `83b74938`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720400870,
-        "narHash": "sha256-YZnBPmZAGJ4o9T9tJ03Zd4naeB/2QVrP6pPXGOzv1l4=",
+        "lastModified": 1720403862,
+        "narHash": "sha256-+XOhfUQk5MFWuhJJ2zSg8/aCqUVGXqRgj5FJoMX/dYY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ce9d4b140f27816de62d6124019f0578edc2eeb7",
+        "rev": "83b749382e550dc9047f9c5f53a168878e560959",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`83b74938`](https://github.com/nix-community/emacs-overlay/commit/83b749382e550dc9047f9c5f53a168878e560959) | `` Updated emacs `` |
| [`5c173e5b`](https://github.com/nix-community/emacs-overlay/commit/5c173e5b9950e77cc008bc5a2c227556de0338cc) | `` Updated melpa `` |