### PR TITLE
chore(flake/nur): `f64eea5e` -> `43a81030`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720411045,
-        "narHash": "sha256-TpEdNtvpjwVjaj34JEX+CQT4AbL9idhO0311wWJSqnk=",
+        "lastModified": 1720421529,
+        "narHash": "sha256-Y2cWRcNwVdWVNzdeiukoMCsGZj3nEjQGBeV002LcZ3s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f64eea5ea86d4d0c64b41f9f1dcbef5ea741b1f1",
+        "rev": "43a81030d26fc3d177cfff616057e58bc543be7b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`43a81030`](https://github.com/nix-community/NUR/commit/43a81030d26fc3d177cfff616057e58bc543be7b) | `` automatic update `` |
| [`d57b5661`](https://github.com/nix-community/NUR/commit/d57b56614a2ab6338728319990c8f8d890f7c9c9) | `` automatic update `` |
| [`664e4689`](https://github.com/nix-community/NUR/commit/664e4689fd64153ee71553f2c67df9f83a3480a1) | `` automatic update `` |
| [`fb403448`](https://github.com/nix-community/NUR/commit/fb403448962e44e016e6274df1f9a78ff3fbb874) | `` automatic update `` |