### PR TITLE
chore(flake/emacs-overlay): `83b74938` -> `7c19b4d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720403862,
-        "narHash": "sha256-+XOhfUQk5MFWuhJJ2zSg8/aCqUVGXqRgj5FJoMX/dYY=",
+        "lastModified": 1720428947,
+        "narHash": "sha256-6Br0Q0xN5YQM4LJaXSfYXcjNI9zGxD789/1/rZ5Ijy8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "83b749382e550dc9047f9c5f53a168878e560959",
+        "rev": "7c19b4d8b7896819ce9624728d1c323f5d00beff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`7c19b4d8`](https://github.com/nix-community/emacs-overlay/commit/7c19b4d8b7896819ce9624728d1c323f5d00beff) | `` Updated melpa `` |