### PR TITLE
chore(flake/nixos-hardware): `da0aa7b5` -> `72d3c007`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -627,11 +627,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1720372297,
-        "narHash": "sha256-bwy1rPQSQSCj/TNf1yswHW88nBQYvJQkeScGvOA8pd4=",
+        "lastModified": 1720429258,
+        "narHash": "sha256-d6JI5IgJ1xdrk7DvYVx7y8ijcYz5I1nhCwOiDP6cq00=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "da0aa7b533d49e6319c603e07b46a5690082f65f",
+        "rev": "72d3c007024ce47d838bb38693c8773812f54bf2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                         |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`72d3c007`](https://github.com/NixOS/nixos-hardware/commit/72d3c007024ce47d838bb38693c8773812f54bf2) | `` Added new model to flake.nix and README ``   |
| [`00f9c4bb`](https://github.com/NixOS/nixos-hardware/commit/00f9c4bb0628983bc017d7644f67d49ae66bdbfa) | `` Fix Lenovo Thinkpad T14s not powering off `` |