### PR TITLE
chore(flake/nur): `db025ae0` -> `15e84bea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720422264,
-        "narHash": "sha256-oPd3E1XD2sjOsi32hTpklOZevwg2DjhYWYY14IbSC/s=",
+        "lastModified": 1720439178,
+        "narHash": "sha256-ASwgeUB0kIZm4/zurVa3jez/ePDGlIa1j9KhFR3btkY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "db025ae0e02678497a77cff0a174062d913fbc39",
+        "rev": "15e84beae2b0a7e4ab2e23403ef867b05d32d44b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`15e84bea`](https://github.com/nix-community/NUR/commit/15e84beae2b0a7e4ab2e23403ef867b05d32d44b) | `` automatic update `` |
| [`eb329f8f`](https://github.com/nix-community/NUR/commit/eb329f8fd6cdd9790d6e2fb50d9f466cd687ee76) | `` automatic update `` |
| [`83235d87`](https://github.com/nix-community/NUR/commit/83235d87345b03b1e31d71174a26f7f2e2906ce5) | `` automatic update `` |
| [`701f1dad`](https://github.com/nix-community/NUR/commit/701f1dad56ca72e8ac16f845992861fab680d770) | `` automatic update `` |