### PR TITLE
chore(flake/nur): `15e84bea` -> `bd5d6cc7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720439178,
-        "narHash": "sha256-ASwgeUB0kIZm4/zurVa3jez/ePDGlIa1j9KhFR3btkY=",
+        "lastModified": 1720443568,
+        "narHash": "sha256-6Lc3JTtjwnyEGLES5YxDRYm4UAZ/45Yvpg3StrVEA5M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "15e84beae2b0a7e4ab2e23403ef867b05d32d44b",
+        "rev": "bd5d6cc7367a5a2451e72e034b62dd91daaf5d0b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bd5d6cc7`](https://github.com/nix-community/NUR/commit/bd5d6cc7367a5a2451e72e034b62dd91daaf5d0b) | `` automatic update `` |