### PR TITLE
chore(flake/nur): `bd5d6cc7` -> `f90f2ee5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720443568,
-        "narHash": "sha256-6Lc3JTtjwnyEGLES5YxDRYm4UAZ/45Yvpg3StrVEA5M=",
+        "lastModified": 1720446387,
+        "narHash": "sha256-PoDe53YQFLbuquplgz6M6L/ccQo1/QFE5JwddrekNKI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bd5d6cc7367a5a2451e72e034b62dd91daaf5d0b",
+        "rev": "f90f2ee5d203f9e6133130a41d160f05e44b8994",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f90f2ee5`](https://github.com/nix-community/NUR/commit/f90f2ee5d203f9e6133130a41d160f05e44b8994) | `` automatic update `` |