### PR TITLE
chore(flake/nur): `f90f2ee5` -> `f094b615`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720446387,
-        "narHash": "sha256-PoDe53YQFLbuquplgz6M6L/ccQo1/QFE5JwddrekNKI=",
+        "lastModified": 1720447811,
+        "narHash": "sha256-3rHeN+lEeBwn1hQ272VkhYB9tagRkf9ozqCsD6VEbLo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f90f2ee5d203f9e6133130a41d160f05e44b8994",
+        "rev": "f094b615f438e148da6d069d85155637e1c3dd91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f094b615`](https://github.com/nix-community/NUR/commit/f094b615f438e148da6d069d85155637e1c3dd91) | `` automatic update `` |