### PR TITLE
chore(flake/emacs-overlay): `743e01cc` -> `793e6e4e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720429744,
-        "narHash": "sha256-DFDThlsRInZPkbReZgXOhDv3CqsOkf8KEs1RkGTb4R4=",
+        "lastModified": 1720455668,
+        "narHash": "sha256-c9lDwE07lkImyZo00i301d7w6xKWMImt3btpOroFdVk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "743e01cc6f5be48230b99178e3f14b34da84022e",
+        "rev": "793e6e4e1dee1d4d890ffee53d52e45ce1f0c790",
         "type": "github"
       },
       "original": {
@@ -700,11 +700,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1720244366,
-        "narHash": "sha256-WrDV0FPMVd2Sq9hkR5LNHudS3OSMmUrs90JUTN+MXpA=",
+        "lastModified": 1720386169,
+        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "49ee0e94463abada1de470c9c07bfc12b36dcf40",
+        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`793e6e4e`](https://github.com/nix-community/emacs-overlay/commit/793e6e4e1dee1d4d890ffee53d52e45ce1f0c790) | `` Updated elpa ``         |
| [`45f6b86b`](https://github.com/nix-community/emacs-overlay/commit/45f6b86b3816422c4d1d3f146e6f320823c62888) | `` Updated flake inputs `` |