### PR TITLE
chore(flake/nur): `f094b615` -> `3eb7a42f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720447811,
-        "narHash": "sha256-3rHeN+lEeBwn1hQ272VkhYB9tagRkf9ozqCsD6VEbLo=",
+        "lastModified": 1720465822,
+        "narHash": "sha256-1np515zxubYoxmxPTzbX080UMLQU616bfRTbJDjjP0Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f094b615f438e148da6d069d85155637e1c3dd91",
+        "rev": "3eb7a42f3a643a47601949ba2c1e9e08ea09efce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3eb7a42f`](https://github.com/nix-community/NUR/commit/3eb7a42f3a643a47601949ba2c1e9e08ea09efce) | `` automatic update `` |
| [`8b01b07e`](https://github.com/nix-community/NUR/commit/8b01b07ec0ee608dbd233a112c32a8ee3e21fd66) | `` automatic update `` |
| [`e833883b`](https://github.com/nix-community/NUR/commit/e833883bd0f137e536ef87c04b7b36dd2d1c9fe7) | `` automatic update `` |