### PR TITLE
chore(flake/catppuccin): `59d05792` -> `d75d5803`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1720391255,
-        "narHash": "sha256-XRP6eTFF5SqzBErR0T1iD/WFjb+VoFY4MXKm7UUfuTM=",
+        "lastModified": 1720472194,
+        "narHash": "sha256-CYscFEts6tyvosc1T29nxhzIYJAj/1CCEkV3ZMzSN/c=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "59d0579264239b3b6a15decf6ec762d92dfd0323",
+        "rev": "d75d5803852fb0833767dc969a4581ac13204e22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                      |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`d75d5803`](https://github.com/catppuccin/nix/commit/d75d5803852fb0833767dc969a4581ac13204e22) | `` ci: merge and cleanup workflows (#282) `` |
| [`e323548e`](https://github.com/catppuccin/nix/commit/e323548efcfccd297831c7bff8ea5b46cf273ae8) | `` chore(modules): update ports (#280) ``    |