### PR TITLE
chore(flake/nur): `3eb7a42f` -> `0baa8dd2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720465822,
-        "narHash": "sha256-1np515zxubYoxmxPTzbX080UMLQU616bfRTbJDjjP0Q=",
+        "lastModified": 1720473786,
+        "narHash": "sha256-Oy3AjbFSOl1nYB9238GivzEVZW/0yXCWuIT1HyS6l6o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3eb7a42f3a643a47601949ba2c1e9e08ea09efce",
+        "rev": "0baa8dd29afaf63763d80c9d01d808cf8751a562",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0baa8dd2`](https://github.com/nix-community/NUR/commit/0baa8dd29afaf63763d80c9d01d808cf8751a562) | `` automatic update `` |
| [`dfcbbc1b`](https://github.com/nix-community/NUR/commit/dfcbbc1bc8a0ddd6554e5862e7d5a1469eaaf13b) | `` automatic update `` |
| [`c9afaf54`](https://github.com/nix-community/NUR/commit/c9afaf5401c2fd1502d9583b14e73c4e2fd495dc) | `` automatic update `` |