### PR TITLE
chore(flake/sops-nix): `c184aca4` -> `67035a35`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -931,11 +931,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1720321395,
-        "narHash": "sha256-kcI8q9Nh8/CSj0ygfWq1DLckHl8IHhFarL8ie6g7OEk=",
+        "lastModified": 1720479166,
+        "narHash": "sha256-jqvhLDXzTLTHq9ZviFOpcTmXXmnbLfz7mWhgMNipMN4=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c184aca4db5d71c3db0c8cbfcaaec337a5d065ea",
+        "rev": "67035a355b1d52d2d238501f8cc1a18706979760",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                           |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`67035a35`](https://github.com/Mic92/sops-nix/commit/67035a355b1d52d2d238501f8cc1a18706979760) | `` update vendorHash ``                                           |
| [`460f478a`](https://github.com/Mic92/sops-nix/commit/460f478a5a1ea459fef537b03d437dba1d4aed70) | `` build(deps): bump golang.org/x/crypto from 0.24.0 to 0.25.0 `` |