### PR TITLE
chore(flake/emacs-overlay): `2cd3970a` -> `696c6597`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720458569,
-        "narHash": "sha256-0k58JAJwpu+Uv93BW77WusIodLLZhfbXsOOlBw11NNw=",
+        "lastModified": 1720487216,
+        "narHash": "sha256-JZhoqAP7ra6IllqcM99xoJrR6DRyYB3tQRcTNkuE+xc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2cd3970ae5d7b1bd8e1781736e8857b365788db8",
+        "rev": "696c65979377b32a9a64d9851bc37f974927dd2e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`696c6597`](https://github.com/nix-community/emacs-overlay/commit/696c65979377b32a9a64d9851bc37f974927dd2e) | `` Updated elpa ``         |
| [`69a0cd04`](https://github.com/nix-community/emacs-overlay/commit/69a0cd04fc52ecea9d545eacfb1035a013102cf8) | `` Updated flake inputs `` |