### PR TITLE
chore(flake/nur): `8dea571e` -> `2d5e4d3c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720489821,
-        "narHash": "sha256-fJfqOK0oESRkg1vcwow4I7/BtI0Q8Cx9273HEil2DYs=",
+        "lastModified": 1720497847,
+        "narHash": "sha256-ypA+JH6nuUQSk30KUl//XRVjHLexMm7XamzpZTKaipc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8dea571e0a13c748fb098589877ed60ace268604",
+        "rev": "2d5e4d3c2bd532ae24b9794d7ef05bc50c546a1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2d5e4d3c`](https://github.com/nix-community/NUR/commit/2d5e4d3c2bd532ae24b9794d7ef05bc50c546a1e) | `` automatic update `` |
| [`d73c3406`](https://github.com/nix-community/NUR/commit/d73c340644ae330c0660b2a156a4c42cf4be4259) | `` automatic update `` |
| [`933b2a09`](https://github.com/nix-community/NUR/commit/933b2a090bd773126895cabce00962c39c23147a) | `` automatic update `` |
| [`1b920291`](https://github.com/nix-community/NUR/commit/1b920291f596c47c859e95c10100538837a747a3) | `` automatic update `` |
| [`9c17c3cb`](https://github.com/nix-community/NUR/commit/9c17c3cb1a7a44f5beeee916ca51d86e6e6516f6) | `` automatic update `` |
| [`c3bf9b94`](https://github.com/nix-community/NUR/commit/c3bf9b942fe3f0cdcf5738ce79cbc77e9a2d2eda) | `` automatic update `` |