### PR TITLE
chore(flake/nur): `2d5e4d3c` -> `812e04a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720497847,
-        "narHash": "sha256-ypA+JH6nuUQSk30KUl//XRVjHLexMm7XamzpZTKaipc=",
+        "lastModified": 1720501935,
+        "narHash": "sha256-Nky6PrNb6rBtxANZRSmUDR8WzSXZD9YEAR0bxryTDmk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2d5e4d3c2bd532ae24b9794d7ef05bc50c546a1e",
+        "rev": "812e04a62c0f7a749257bcd6cd06ac0390e79895",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`812e04a6`](https://github.com/nix-community/NUR/commit/812e04a62c0f7a749257bcd6cd06ac0390e79895) | `` automatic update `` |
| [`71b353d7`](https://github.com/nix-community/NUR/commit/71b353d7e4c222832bb377036b87647a48c9cf23) | `` automatic update `` |