### PR TITLE
chore(flake/treefmt): `6fc8bded` -> `8b63fe8c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1046,11 +1046,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720436211,
-        "narHash": "sha256-/cKXod0oGLl+vH4bKBZnTV3qxrw4jgOLnyQ8KXey5J8=",
+        "lastModified": 1720507012,
+        "narHash": "sha256-QIeZ43t9IVB4dLsFaWh2f4C7JSRfK7p+Y1U9dULsLXU=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "6fc8bded78715cdd43a3278a14ded226eb3a239e",
+        "rev": "8b63fe8cf7892c59b3df27cbcab4d5644035d72f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                     |
| ---------------------------------------------------------------------------------------------------- | --------------------------- |
| [`8b63fe8c`](https://github.com/numtide/treefmt-nix/commit/8b63fe8cf7892c59b3df27cbcab4d5644035d72f) | `` add actionlint (#146) `` |