### PR TITLE
chore(flake/nur): `2cfe2568` -> `32f145d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720511807,
-        "narHash": "sha256-tpWofTlAsXYhmIWEUNEsyd7GbglCJCH99LkASVrJLi0=",
+        "lastModified": 1720514451,
+        "narHash": "sha256-Ch5HTquzvyN0bbyJgI4n8UBA/y0kLyGIhHjprJxYwDU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2cfe2568c3cc9088b8a4cb68084997f8a51f9fd7",
+        "rev": "32f145d81186996591f6d45fc4a32fb1b0a95935",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`32f145d8`](https://github.com/nix-community/NUR/commit/32f145d81186996591f6d45fc4a32fb1b0a95935) | `` automatic update `` |