### PR TITLE
chore(flake/nixos-hardware): `72d3c007` -> `a111ce6b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -627,11 +627,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1720429258,
-        "narHash": "sha256-d6JI5IgJ1xdrk7DvYVx7y8ijcYz5I1nhCwOiDP6cq00=",
+        "lastModified": 1720515935,
+        "narHash": "sha256-8b+fzR4W2hI5axwB+4nBwoA15awPKkck4ghhCt8v39M=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "72d3c007024ce47d838bb38693c8773812f54bf2",
+        "rev": "a111ce6b537df12a39874aa9672caa87f8677eda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                             |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`a111ce6b`](https://github.com/NixOS/nixos-hardware/commit/a111ce6b537df12a39874aa9672caa87f8677eda) | `` flake: Deprecate Intel generation-specific outputs ``            |
| [`ba8294c0`](https://github.com/NixOS/nixos-hardware/commit/ba8294c0a1fc318ed4869bb63fd122c63881fff0) | `` common: Move Intel generation-specific config from cpu to gpu `` |