### PR TITLE
chore(flake/nur): `32f145d8` -> `4cb066aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720514451,
-        "narHash": "sha256-Ch5HTquzvyN0bbyJgI4n8UBA/y0kLyGIhHjprJxYwDU=",
+        "lastModified": 1720521897,
+        "narHash": "sha256-k/lSErCNGvHj/vI+TXHLuQI9pmEnQBVcKbV3yB3I8NQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "32f145d81186996591f6d45fc4a32fb1b0a95935",
+        "rev": "4cb066aae41593df9901910e45f9dfd1af5aa743",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                |
| -------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`4cb066aa`](https://github.com/nix-community/NUR/commit/4cb066aae41593df9901910e45f9dfd1af5aa743) | `` automatic update ``                 |
| [`726ecadb`](https://github.com/nix-community/NUR/commit/726ecadba5ce1258bff9574f61abe4576be2b66b) | `` automatic update ``                 |
| [`db5682ef`](https://github.com/nix-community/NUR/commit/db5682efb150f8f18e497fff17a11fb69b5b37ff) | `` add gigamonster256 repository ``    |
| [`46fc1064`](https://github.com/nix-community/NUR/commit/46fc1064601848ce547ab7b7e2cc6f77c7c5cf29) | `` automatic update ``                 |
| [`ad56b332`](https://github.com/nix-community/NUR/commit/ad56b3326801963a13e6c636aee4c69e82ef0e30) | `` add Sittymin repository ``          |
| [`e50b1b35`](https://github.com/nix-community/NUR/commit/e50b1b35edca3422ac676bd676cf94e5f3a32b42) | `` automatic update ``                 |
| [`0d51cfb7`](https://github.com/nix-community/NUR/commit/0d51cfb7480e79a67df66f5221b82f3acbb802c4) | `` automatic update ``                 |
| [`9656b7df`](https://github.com/nix-community/NUR/commit/9656b7dfbd673545f4d2923000004e91b5e20182) | `` automatic update ``                 |
| [`1f391b54`](https://github.com/nix-community/NUR/commit/1f391b5474e2372979345a8bfddce093e3e88ebe) | `` fix ci ``                           |
| [`7f18ce66`](https://github.com/nix-community/NUR/commit/7f18ce667cc5f57fa3239c64c314af80f7b853ed) | `` add michaelglass repo ``            |
| [`03e6e5fc`](https://github.com/nix-community/NUR/commit/03e6e5fc99c162dfb53abf145c0f480a0702ce36) | `` add federicoschonborn repository `` |