### PR TITLE
chore(flake/nur): `4cb066aa` -> `b1c40f20`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720521897,
-        "narHash": "sha256-k/lSErCNGvHj/vI+TXHLuQI9pmEnQBVcKbV3yB3I8NQ=",
+        "lastModified": 1720536396,
+        "narHash": "sha256-zQf0P5BxXIPoJ6YiPkQfoCdxEMlpZxRFhHqG2QuJg8o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4cb066aae41593df9901910e45f9dfd1af5aa743",
+        "rev": "b1c40f20d147dc1b0bd900b6a17ef603e708e403",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b1c40f20`](https://github.com/nix-community/NUR/commit/b1c40f20d147dc1b0bd900b6a17ef603e708e403) | `` automatic update `` |
| [`c91527ba`](https://github.com/nix-community/NUR/commit/c91527ba89310e7b1ddc1972eb0c9a3e182bedd0) | `` automatic update `` |
| [`b3920ca6`](https://github.com/nix-community/NUR/commit/b3920ca6b0e1ddedaa774168e5b3525c7c8df0ad) | `` automatic update `` |