### PR TITLE
chore(flake/emacs-overlay): `bd468024` -> `f248e933`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720516213,
-        "narHash": "sha256-7rtoIV8IkqF5QLieMZkIiH+d/QTJnfoccxwFdH5ycek=",
+        "lastModified": 1720544194,
+        "narHash": "sha256-/Hr/u6c2Ma59Ue8X0vuqQP5crwknL2Q3LjheO1E0mIo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bd468024d6ec4fcbddb65f3184a5bb19c4ebef82",
+        "rev": "f248e933564ccaf8a61c2d81d095cf35820b426b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`f248e933`](https://github.com/nix-community/emacs-overlay/commit/f248e933564ccaf8a61c2d81d095cf35820b426b) | `` Updated melpa `` |
| [`179c0d4b`](https://github.com/nix-community/emacs-overlay/commit/179c0d4bdcb67096b770803a4463f9c9a4b7f387) | `` Updated elpa ``  |