### PR TITLE
chore(flake/nur): `b1c40f20` -> `c19b5409`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720536396,
-        "narHash": "sha256-zQf0P5BxXIPoJ6YiPkQfoCdxEMlpZxRFhHqG2QuJg8o=",
+        "lastModified": 1720551011,
+        "narHash": "sha256-LSudtrdA4qR8gezDmI1YIEe3+A0JUdMcWkx7FF8fK/w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b1c40f20d147dc1b0bd900b6a17ef603e708e403",
+        "rev": "c19b54097402ca61b5b1456967c48f7be59329d8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c19b5409`](https://github.com/nix-community/NUR/commit/c19b54097402ca61b5b1456967c48f7be59329d8) | `` automatic update `` |
| [`c7cc8060`](https://github.com/nix-community/NUR/commit/c7cc8060b718840cc8ca3d1d60dcb077c70f34eb) | `` automatic update `` |
| [`190e052f`](https://github.com/nix-community/NUR/commit/190e052f0ed47c4c80bf0064cdfae4370802feeb) | `` automatic update `` |
| [`08b26231`](https://github.com/nix-community/NUR/commit/08b2623160adbd791801b44cf83c48473dfe6acf) | `` automatic update `` |
| [`a9a67742`](https://github.com/nix-community/NUR/commit/a9a6774215cc62417ec27e4c3cdd3dd571aca554) | `` automatic update `` |