### PR TITLE
chore(flake/nur): `c028e2c9` -> `642bcd7e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720560666,
-        "narHash": "sha256-FeK3EoOwxUJ1S8PwrkKdogSXbdXhFA6QzORVwbvChyE=",
+        "lastModified": 1720568009,
+        "narHash": "sha256-EC7HGMr4pIorA70QeHUMdqDQNuzlhzARuewZdByayyM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c028e2c910d28f6eb84b1e3a168575834d4ae114",
+        "rev": "642bcd7e694adb60641c8125baea542b3067ca5c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`642bcd7e`](https://github.com/nix-community/NUR/commit/642bcd7e694adb60641c8125baea542b3067ca5c) | `` automatic update `` |
| [`5646e822`](https://github.com/nix-community/NUR/commit/5646e82248c53755bc82b9eb1b0cc23103fe1b77) | `` automatic update `` |