### PR TITLE
chore(flake/emacs-overlay): `e8e95c71` -> `3a674072`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720573652,
-        "narHash": "sha256-z5CrcrDVQC0hvnmA3qsHtUcEo8HBYbfu94Kt1UOh7/k=",
+        "lastModified": 1720576699,
+        "narHash": "sha256-bY/K+mC2m11EP1TGQ8WkXFeDpZ4HEASnt9o2nZ7E0/c=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e8e95c711dad30522209090073cf30441ef72e5e",
+        "rev": "3a674072d755ea4c31fe37d5d4e1d98e90029203",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`3a674072`](https://github.com/nix-community/emacs-overlay/commit/3a674072d755ea4c31fe37d5d4e1d98e90029203) | `` Updated emacs `` |
| [`3f9f83b2`](https://github.com/nix-community/emacs-overlay/commit/3f9f83b24f4a9abf2bdeca8d014fa9e5ef219825) | `` Updated melpa `` |