### PR TITLE
chore(flake/nur): `dba3b78e` -> `ff62716f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720583758,
-        "narHash": "sha256-7ZFHPCQA7sYU7Z/4tHJv6MFFAXCv1hmy8lGMsCxsD+c=",
+        "lastModified": 1720585878,
+        "narHash": "sha256-Ioa3bxQY2Ll7CuT7u0xDNYiCYgJ1OQxsC9AzE2sJXZ8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dba3b78e7c752cb7487f4ae15d33c0c4561229f9",
+        "rev": "ff62716f986058f217f411504e7a63bfb11f243b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ff62716f`](https://github.com/nix-community/NUR/commit/ff62716f986058f217f411504e7a63bfb11f243b) | `` automatic update `` |
| [`9b3573fb`](https://github.com/nix-community/NUR/commit/9b3573fb55bf29627db5485644a8380f08bd24c5) | `` automatic update `` |