### PR TITLE
chore(flake/nur): `ff62716f` -> `06b35935`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720585878,
-        "narHash": "sha256-Ioa3bxQY2Ll7CuT7u0xDNYiCYgJ1OQxsC9AzE2sJXZ8=",
+        "lastModified": 1720590293,
+        "narHash": "sha256-GOQLFrlQXkI48hwZTsaAxwmG+5XjLikFYARNYRItmqc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ff62716f986058f217f411504e7a63bfb11f243b",
+        "rev": "06b3593559f298c5d3998be83153c4e41e53c800",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`06b35935`](https://github.com/nix-community/NUR/commit/06b3593559f298c5d3998be83153c4e41e53c800) | `` automatic update `` |