### PR TITLE
chore(flake/nur): `06b35935` -> `124969f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720590293,
-        "narHash": "sha256-GOQLFrlQXkI48hwZTsaAxwmG+5XjLikFYARNYRItmqc=",
+        "lastModified": 1720594917,
+        "narHash": "sha256-FVcJs/zDc1antZs/dMwbpq3LSU8kvcDJ9GXl/ygV/U4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "06b3593559f298c5d3998be83153c4e41e53c800",
+        "rev": "124969f6bd7dc8578a0139745eb26537af2549c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`124969f6`](https://github.com/nix-community/NUR/commit/124969f6bd7dc8578a0139745eb26537af2549c8) | `` automatic update `` |