### PR TITLE
chore(flake/emacs-overlay): `3a674072` -> `77ddb402`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720576699,
-        "narHash": "sha256-bY/K+mC2m11EP1TGQ8WkXFeDpZ4HEASnt9o2nZ7E0/c=",
+        "lastModified": 1720602715,
+        "narHash": "sha256-fjFdTtP0K94y6lsmUukyLh2VMqDme//+goDsTal+CrU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3a674072d755ea4c31fe37d5d4e1d98e90029203",
+        "rev": "77ddb4021ae40a3a6aac74d7730f36cdb3dde4ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`77ddb402`](https://github.com/nix-community/emacs-overlay/commit/77ddb4021ae40a3a6aac74d7730f36cdb3dde4ba) | `` Updated emacs `` |
| [`0c450f32`](https://github.com/nix-community/emacs-overlay/commit/0c450f32d6a19990f8fea1e0db2a786c67643011) | `` Updated melpa `` |