### PR TITLE
chore(flake/darwin): `fabc6535` -> `cf297a8d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -104,11 +104,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720469887,
-        "narHash": "sha256-BwPsGQ/EMqCreUc5j9Efj+wx13AjREtuHhbyHZygcE4=",
+        "lastModified": 1720599442,
+        "narHash": "sha256-jdm+sKVbBXoyrxcHbVaV0htlpq2iFR+eJw3Xe/DPcDo=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "fabc653517106127e2ed435fb52e7e8854354428",
+        "rev": "cf297a8d248db6a455b60133f6c0029c04ebe50e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                              |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
| [`36a15e8c`](https://github.com/LnL7/nix-darwin/commit/36a15e8c6c4686be29ccbf0ae0ac1d6133074615) | `` write-text: remove support for `copy` ``          |
| [`b833d4a3`](https://github.com/LnL7/nix-darwin/commit/b833d4a32d965e6393a63b2c91b46eca2a5030d8) | `` ssh: use symlinks for `authorizedKeys` options `` |