### PR TITLE
chore(flake/nur): `124969f6` -> `8f9ee1cd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720594917,
-        "narHash": "sha256-FVcJs/zDc1antZs/dMwbpq3LSU8kvcDJ9GXl/ygV/U4=",
+        "lastModified": 1720611912,
+        "narHash": "sha256-J62XIgUzzYjEPdPv9pha8Le6K6T9ZNknNCQv65I5Pa8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "124969f6bd7dc8578a0139745eb26537af2549c8",
+        "rev": "8f9ee1cd48223d2985b85c8ba9432aec51dd0d1b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8f9ee1cd`](https://github.com/nix-community/NUR/commit/8f9ee1cd48223d2985b85c8ba9432aec51dd0d1b) | `` automatic update `` |
| [`eedd8e8c`](https://github.com/nix-community/NUR/commit/eedd8e8c8e9cbfc00e5a973a2fe581c599d8518c) | `` automatic update `` |
| [`2b1c51b1`](https://github.com/nix-community/NUR/commit/2b1c51b160c4514bae6d4e57dafbce695ada9d38) | `` automatic update `` |
| [`6b178461`](https://github.com/nix-community/NUR/commit/6b17846197e6b32104b050b86aa0f47566c93a43) | `` automatic update `` |
| [`63a462f3`](https://github.com/nix-community/NUR/commit/63a462f34bac52d178fc719e1955426d04e943b6) | `` automatic update `` |