### PR TITLE
chore(flake/nix-on-droid): `f3d3b829` -> `8bcadcef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -612,11 +612,11 @@
         "nmd": "nmd_2"
       },
       "locked": {
-        "lastModified": 1720396533,
-        "narHash": "sha256-UFzk/hZWO1VkciIO5UPaSpJN8s765wsngUSvtJM6d5Q=",
+        "lastModified": 1720612508,
+        "narHash": "sha256-WbjV0gmnh6jG1B292K4KIJwtBacn2sTWhiw1ZMeti9s=",
         "owner": "t184256",
         "repo": "nix-on-droid",
-        "rev": "f3d3b8294039f2f9a8fb7ea82c320f29c6b0fe25",
+        "rev": "8bcadcef69dcb5ca177bfb6ea3dc6b092cda2b06",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                      |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`8bcadcef`](https://github.com/nix-community/nix-on-droid/commit/8bcadcef69dcb5ca177bfb6ea3dc6b092cda2b06) | `` login: Do not dereference proot binds `/bin` and `/etc` ``                |
| [`25f49c76`](https://github.com/nix-community/nix-on-droid/commit/25f49c76c48ba439d3fe8719bb9115c31d64b111) | `` tests/emulator/test_channels_shell: set empty PATH to match device env `` |