### PR TITLE
chore(flake/nur): `8f9ee1cd` -> `7526e7f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720611912,
-        "narHash": "sha256-J62XIgUzzYjEPdPv9pha8Le6K6T9ZNknNCQv65I5Pa8=",
+        "lastModified": 1720619097,
+        "narHash": "sha256-DL4SSs6haSlm3NKGMABNmbQl7OjL5vuRCIVpiPFqQws=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8f9ee1cd48223d2985b85c8ba9432aec51dd0d1b",
+        "rev": "7526e7f1cafdf77e1053ee59ad19f054df1d5bfc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7526e7f1`](https://github.com/nix-community/NUR/commit/7526e7f1cafdf77e1053ee59ad19f054df1d5bfc) | `` automatic update `` |
| [`183e79e8`](https://github.com/nix-community/NUR/commit/183e79e8cf3da32f9e54b81b2c81086ef169fa01) | `` automatic update `` |