### PR TITLE
chore(flake/nur): `7526e7f1` -> `5208b89b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720619097,
-        "narHash": "sha256-DL4SSs6haSlm3NKGMABNmbQl7OjL5vuRCIVpiPFqQws=",
+        "lastModified": 1720626367,
+        "narHash": "sha256-y4mco097cQnSzPqSIGzG6NEmCPTNKb2FdVbDiGcSKCg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7526e7f1cafdf77e1053ee59ad19f054df1d5bfc",
+        "rev": "5208b89b86dfdee55b9a08896dc48f3e377f1776",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5208b89b`](https://github.com/nix-community/NUR/commit/5208b89b86dfdee55b9a08896dc48f3e377f1776) | `` automatic update `` |
| [`dcb8645b`](https://github.com/nix-community/NUR/commit/dcb8645b3f41f58b608845104def437b434997c7) | `` automatic update `` |