### PR TITLE
chore(flake/emacs-overlay): `77ddb402` -> `9cb438ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720602715,
-        "narHash": "sha256-fjFdTtP0K94y6lsmUukyLh2VMqDme//+goDsTal+CrU=",
+        "lastModified": 1720631485,
+        "narHash": "sha256-l/xKm4WtVw8zbVHTqeedFjNk52O943XxzVEGS+1Libs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "77ddb4021ae40a3a6aac74d7730f36cdb3dde4ba",
+        "rev": "9cb438ce0f2ac37fe8a9935a250e9b85581cd69d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`9cb438ce`](https://github.com/nix-community/emacs-overlay/commit/9cb438ce0f2ac37fe8a9935a250e9b85581cd69d) | `` Updated emacs `` |
| [`b1b64aa1`](https://github.com/nix-community/emacs-overlay/commit/b1b64aa130fb9c5293da895064b1902f692a92fe) | `` Updated melpa `` |
| [`5ac5fde1`](https://github.com/nix-community/emacs-overlay/commit/5ac5fde10e34da0a67ebcdf2797586869f69e26b) | `` Updated elpa ``  |