### PR TITLE
chore(flake/nur): `5208b89b` -> `1f6a7a6f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720626367,
-        "narHash": "sha256-y4mco097cQnSzPqSIGzG6NEmCPTNKb2FdVbDiGcSKCg=",
+        "lastModified": 1720629498,
+        "narHash": "sha256-mXoLqdBoE4YEOmo8ZZOD/d5ULhvJidCfJjgApujP7vU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5208b89b86dfdee55b9a08896dc48f3e377f1776",
+        "rev": "1f6a7a6f7ad7fffe86aca604aabb7ab06c4fbe90",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1f6a7a6f`](https://github.com/nix-community/NUR/commit/1f6a7a6f7ad7fffe86aca604aabb7ab06c4fbe90) | `` automatic update `` |