### PR TITLE
chore(flake/nur): `1f6a7a6f` -> `84f76994`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720629498,
-        "narHash": "sha256-mXoLqdBoE4YEOmo8ZZOD/d5ULhvJidCfJjgApujP7vU=",
+        "lastModified": 1720634451,
+        "narHash": "sha256-MzNiVmY9QLWLlmCcA6nPl/nROoZSYRZk9dG5b4wXEEA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1f6a7a6f7ad7fffe86aca604aabb7ab06c4fbe90",
+        "rev": "84f76994f063f963de2ad7e1233c7c8a7c3aaf58",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`84f76994`](https://github.com/nix-community/NUR/commit/84f76994f063f963de2ad7e1233c7c8a7c3aaf58) | `` automatic update `` |