### PR TITLE
chore(flake/home-manager): `2fb5c1e0` -> `f749fabe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -410,11 +410,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720470846,
-        "narHash": "sha256-7ftA4Bv5KfH4QdTRxqe8/Hz2YTKo+7IQ9n7vbNWgv28=",
+        "lastModified": 1720616874,
+        "narHash": "sha256-yyGDjpHCoG3zSCpN7yLpItu56508quscOrYlRUxb3Mw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2fb5c1e0a17bc6059fa09dc411a43d75f35bb192",
+        "rev": "f749fabeccb1587e4c1562e4f818cf33b8f77a51",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                       |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`f749fabe`](https://github.com/nix-community/home-manager/commit/f749fabeccb1587e4c1562e4f818cf33b8f77a51) | `` atuin: use 'lib.getExe' `` |