### PR TITLE
chore(flake/home-manager): `f749fabe` -> `c085b984`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -410,11 +410,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720616874,
-        "narHash": "sha256-yyGDjpHCoG3zSCpN7yLpItu56508quscOrYlRUxb3Mw=",
+        "lastModified": 1720646128,
+        "narHash": "sha256-BivO5yIQukDlJL+1875Sqf3GuOPxZDdA48dYDi3PkL8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f749fabeccb1587e4c1562e4f818cf33b8f77a51",
+        "rev": "c085b984ff2808bf322f375b10fea5a415a9c43d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`c085b984`](https://github.com/nix-community/home-manager/commit/c085b984ff2808bf322f375b10fea5a415a9c43d) | `` gnome-keyring: update package ``                    |
| [`57d85c6c`](https://github.com/nix-community/home-manager/commit/57d85c6c6d625c45bbf848ed77fbdb5794aa8414) | `` xdg-desktop-entries: allow `terminal` to be null `` |
| [`f79d950a`](https://github.com/nix-community/home-manager/commit/f79d950ac23a4c63e60bb71475d3321fbd9ace2d) | `` atuin: fix tests ``                                 |