### PR TITLE
chore(flake/nur): `d5601152` -> `ef5fd0c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720643206,
-        "narHash": "sha256-1Har2X6Vw1TCv71/CojvUW8phGMafHMra0nU1XlNyFI=",
+        "lastModified": 1720648854,
+        "narHash": "sha256-ZuocgUbiI2nuurUDD0ii3WhAiy3XUXo+FvT0rDf1ROc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d5601152782e0f1ff387288fc83bdc76bc35d949",
+        "rev": "ef5fd0c56733ef0fee66d7c0e66bc83b8f23b94f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ef5fd0c5`](https://github.com/nix-community/NUR/commit/ef5fd0c56733ef0fee66d7c0e66bc83b8f23b94f) | `` automatic update `` |
| [`8e93a900`](https://github.com/nix-community/NUR/commit/8e93a9000d44494d90f6902a8f721ea818ace0dc) | `` automatic update `` |
| [`5859b1ba`](https://github.com/nix-community/NUR/commit/5859b1ba5122cb1bcb4848088c09d6c52f6e864d) | `` automatic update `` |