### PR TITLE
chore(flake/nur): `fdd0e004` -> `8a43f70d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720651109,
-        "narHash": "sha256-A32KUU4jOgPk0VHVGEs8jU9OPt0YpV0vLydwUgsLXxs=",
+        "lastModified": 1720672470,
+        "narHash": "sha256-HHg0Hc7rVBUxNQvPBnwPmWwmPWEDE6FF6t91o8YLJQ4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fdd0e004142167fd71e5718dbf07586d885fb594",
+        "rev": "8a43f70dba9725db55ca3972e6a0c6a34aafd997",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8a43f70d`](https://github.com/nix-community/NUR/commit/8a43f70dba9725db55ca3972e6a0c6a34aafd997) | `` automatic update `` |
| [`b96aec06`](https://github.com/nix-community/NUR/commit/b96aec06ddf0fed4494316f41db8f703213c1a01) | `` automatic update `` |
| [`248efba8`](https://github.com/nix-community/NUR/commit/248efba89bd1db378c93016e252f0fc3644ab842) | `` automatic update `` |
| [`5a8e6007`](https://github.com/nix-community/NUR/commit/5a8e60074d7d2f24c2d773fd0ff36b84a6fc9ecd) | `` automatic update `` |
| [`a9f27ed1`](https://github.com/nix-community/NUR/commit/a9f27ed1e86f05b340da0adaa9339a676b3817fe) | `` automatic update `` |
| [`3b780183`](https://github.com/nix-community/NUR/commit/3b78018346d14c3157a6427f1d4a1c99ed865924) | `` automatic update `` |
| [`47c4216b`](https://github.com/nix-community/NUR/commit/47c4216be26846fe421d36ffee37808cad33d272) | `` automatic update `` |
| [`143296e1`](https://github.com/nix-community/NUR/commit/143296e16c6e62976013eba2c24820be141808f6) | `` automatic update `` |
| [`1e68ed61`](https://github.com/nix-community/NUR/commit/1e68ed61b081ec83d65fed5b9664d92dee241c2b) | `` automatic update `` |
| [`477b0d6a`](https://github.com/nix-community/NUR/commit/477b0d6ac43b0dbb332ad5ea3cfeb82221925d20) | `` automatic update `` |