### PR TITLE
chore(flake/srvos): `21a32599` -> `3ba7dcad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -951,11 +951,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720400448,
-        "narHash": "sha256-v7JVJ8H1PyH7/8EU72mz7wzxJ1OLE/h3NCqQyZ6ONjs=",
+        "lastModified": 1720658737,
+        "narHash": "sha256-4KpDp16Spz4iz+WBPSLUz3Fi8FHfmIExAjsw2p5OSoA=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "21a3259985e3cddc455f64ad66d4a825b39934ad",
+        "rev": "3ba7dcad7b480a50da07b6361edeef2c9b9c37ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`3ba7dcad`](https://github.com/nix-community/srvos/commit/3ba7dcad7b480a50da07b6361edeef2c9b9c37ec) | `` dev/private/flake.lock: Update `` |
| [`2e1bb853`](https://github.com/nix-community/srvos/commit/2e1bb853089d67ff37d5a402e9d25af6601b86c5) | `` flake.lock: Update ``             |