### PR TITLE
chore(flake/nur): `8a43f70d` -> `6511d2fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720672470,
-        "narHash": "sha256-HHg0Hc7rVBUxNQvPBnwPmWwmPWEDE6FF6t91o8YLJQ4=",
+        "lastModified": 1720672822,
+        "narHash": "sha256-e9e5G3bkc4Ekwv5AuEiph4o8za7RcShr8QY7BN/Yxgg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8a43f70dba9725db55ca3972e6a0c6a34aafd997",
+        "rev": "6511d2fe5ba8b2853ae5bf27dda1444b57380c4e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6511d2fe`](https://github.com/nix-community/NUR/commit/6511d2fe5ba8b2853ae5bf27dda1444b57380c4e) | `` automatic update `` |