### PR TITLE
chore(flake/nur): `6511d2fe` -> `ec00854d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720672822,
-        "narHash": "sha256-e9e5G3bkc4Ekwv5AuEiph4o8za7RcShr8QY7BN/Yxgg=",
+        "lastModified": 1720676141,
+        "narHash": "sha256-FQFpEs6lW8EZPcUwm8kUBCMEH7MgpBSr0Yz1WQMSmgA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6511d2fe5ba8b2853ae5bf27dda1444b57380c4e",
+        "rev": "ec00854d8d699d16e79c8f0c69260ec4d2c4e83f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ec00854d`](https://github.com/nix-community/NUR/commit/ec00854d8d699d16e79c8f0c69260ec4d2c4e83f) | `` automatic update `` |