### PR TITLE
chore(flake/emacs-overlay): `8b44a1dc` -> `b399117d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720663048,
-        "narHash": "sha256-hUZ5llewpkJLDMQkarBDFY3i1v09S8wVhNGzvSETTFc=",
+        "lastModified": 1720688208,
+        "narHash": "sha256-pSr9Pr43rycDNaDEXbUqJ3W7llyFWSBCit26KaqxjvU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8b44a1dc99fed9e71d1a8d6880cd2827a1def65f",
+        "rev": "b399117d716c26fcfbe858988ca01ab0c132893b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`b399117d`](https://github.com/nix-community/emacs-overlay/commit/b399117d716c26fcfbe858988ca01ab0c132893b) | `` Updated melpa ``        |
| [`497bb499`](https://github.com/nix-community/emacs-overlay/commit/497bb499753986ce2ca3b7359532e7147cfb7f30) | `` Updated elpa ``         |
| [`b4330d68`](https://github.com/nix-community/emacs-overlay/commit/b4330d68fe8578e4eaa62b825ec34c571d0bf440) | `` Updated nongnu ``       |
| [`490ac846`](https://github.com/nix-community/emacs-overlay/commit/490ac8465d9c6677c9056e6911b02a8f346f058e) | `` Updated flake inputs `` |