### PR TITLE
chore(flake/nur): `ec00854d` -> `1643074b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720676141,
-        "narHash": "sha256-FQFpEs6lW8EZPcUwm8kUBCMEH7MgpBSr0Yz1WQMSmgA=",
+        "lastModified": 1720689012,
+        "narHash": "sha256-igRAAL1qJvYA3H+SZGY3MgZvs2GdzjBy9OKLukN0qz0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ec00854d8d699d16e79c8f0c69260ec4d2c4e83f",
+        "rev": "1643074be5f5a9d2e362080048df235cb2473e80",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1643074b`](https://github.com/nix-community/NUR/commit/1643074be5f5a9d2e362080048df235cb2473e80) | `` automatic update `` |
| [`ffe8f85a`](https://github.com/nix-community/NUR/commit/ffe8f85a680f0fc8f2494db2a7147f7e6d1dd770) | `` automatic update `` |