### PR TITLE
chore(flake/srvos): `3ba7dcad` -> `e3e8ff54`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -951,11 +951,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720658737,
-        "narHash": "sha256-4KpDp16Spz4iz+WBPSLUz3Fi8FHfmIExAjsw2p5OSoA=",
+        "lastModified": 1720691926,
+        "narHash": "sha256-VE9ZfWRbyBjps5GV8KXiF8XodAykmwRpcJtPiVWCu8M=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "3ba7dcad7b480a50da07b6361edeef2c9b9c37ec",
+        "rev": "e3e8ff545ef14f13c69a0f743078637fde952018",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                           |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`2888a228`](https://github.com/nix-community/srvos/commit/2888a2286c0d69954b66aede3c12191755f58685) | `` hetzner-cloud: enable qemu-agent for password resets (#455) `` |
| [`b6889c9f`](https://github.com/nix-community/srvos/commit/b6889c9fc17aa89a718cb37c7a8f8f060b2a388d) | `` serial: change defaults to bring back kernel logs ``           |