### PR TITLE
chore(flake/nur): `9c4d6fc9` -> `4f03b7d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720706205,
-        "narHash": "sha256-WzQQxoF/pIpo5N8R8FLJFlsaGPxmqX754bHVWxFoRO0=",
+        "lastModified": 1720708501,
+        "narHash": "sha256-8yX7qUhLXApaSlHmdNJC7pNiZlmn8mNxbg6p38QT/kI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9c4d6fc949369069ef22d2ca194c2884557bde05",
+        "rev": "4f03b7d8f445176f0d139e38c8d3c40173eec42a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4f03b7d8`](https://github.com/nix-community/NUR/commit/4f03b7d8f445176f0d139e38c8d3c40173eec42a) | `` automatic update `` |