### PR TITLE
chore(flake/emacs-overlay): `862212a4` -> `fc91f5c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720689099,
-        "narHash": "sha256-sTZbsq2IYa2EQu7Gel8HLlPI4xVdufonNOJxmFGhigw=",
+        "lastModified": 1720716962,
+        "narHash": "sha256-LjLtItao26W5ZBjyaOzLqe7TeDzPY4FAszEND785BnU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "862212a4e798845254e4ae2ad97f69b7b4d85a72",
+        "rev": "fc91f5c6f25426022edd3950fa6c5e2e1499c1b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`fc91f5c6`](https://github.com/nix-community/emacs-overlay/commit/fc91f5c6f25426022edd3950fa6c5e2e1499c1b5) | `` Updated melpa `` |
| [`472d957f`](https://github.com/nix-community/emacs-overlay/commit/472d957ff40e23b1048b092d8f48fe856dd06edf) | `` Updated elpa ``  |