### PR TITLE
chore(flake/nur): `4f03b7d8` -> `71328095`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720708501,
-        "narHash": "sha256-8yX7qUhLXApaSlHmdNJC7pNiZlmn8mNxbg6p38QT/kI=",
+        "lastModified": 1720719914,
+        "narHash": "sha256-ArchYVk3s2loMYobkkatuUczwUIRqpa+BtBZBQJWHzU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4f03b7d8f445176f0d139e38c8d3c40173eec42a",
+        "rev": "713280951c81b831d0ab95fcc7629fc0cdae490e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`71328095`](https://github.com/nix-community/NUR/commit/713280951c81b831d0ab95fcc7629fc0cdae490e) | `` automatic update `` |
| [`9c557f5b`](https://github.com/nix-community/NUR/commit/9c557f5bf6bac834f74afa376212556e9a194006) | `` automatic update `` |