### PR TITLE
chore(flake/emacs-overlay): `fc91f5c6` -> `ebf448cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720716962,
-        "narHash": "sha256-LjLtItao26W5ZBjyaOzLqe7TeDzPY4FAszEND785BnU=",
+        "lastModified": 1720717880,
+        "narHash": "sha256-JW8kSDp8lc01djy+P+0PdpgTB5kBDyFHSq1o15kgccU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fc91f5c6f25426022edd3950fa6c5e2e1499c1b5",
+        "rev": "ebf448cc64c89dc77af3df7e269a32d03a8f143e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`ebf448cc`](https://github.com/nix-community/emacs-overlay/commit/ebf448cc64c89dc77af3df7e269a32d03a8f143e) | `` Updated emacs `` |