### PR TITLE
chore(flake/nixos-hardware): `a111ce6b` -> `c5013aa7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -627,11 +627,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1720515935,
-        "narHash": "sha256-8b+fzR4W2hI5axwB+4nBwoA15awPKkck4ghhCt8v39M=",
+        "lastModified": 1720737798,
+        "narHash": "sha256-G/OtEAts7ZUvW5lrGMXSb8HqRp2Jr9I7reBuvCOL54w=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "a111ce6b537df12a39874aa9672caa87f8677eda",
+        "rev": "c5013aa7ce2c7ec90acee5d965d950c8348db751",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`c5013aa7`](https://github.com/NixOS/nixos-hardware/commit/c5013aa7ce2c7ec90acee5d965d950c8348db751) | `` common/gpu/nvidia: use lib.mkDefault for hardware.nvidia.modesetting `` |
| [`6b745e23`](https://github.com/NixOS/nixos-hardware/commit/6b745e2331ba42e2f744434dcef1fe31ef9a4ced) | `` common-gpu-nvidia: enable modesetting by default ``                     |
| [`c5925d86`](https://github.com/NixOS/nixos-hardware/commit/c5925d86de15f5939c5f0de2945fdc736b28d4b1) | `` common-gpu-nvidia: drop libva-vdpau-driver ``                           |