### PR TITLE
chore(flake/nur): `2a5acaf6` -> `a7eeb42c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720727175,
-        "narHash": "sha256-Bw1yg6TKMFMhRAhCQK1c3Up+6iNlJwZClaZsD4DZBL0=",
+        "lastModified": 1720752659,
+        "narHash": "sha256-BGUlgnRnPyrkX6z5angbCg0fCvAit5JcpMYrYKoUlT8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2a5acaf6d3fc5f1a7add61a076f81b2d6f194a5c",
+        "rev": "a7eeb42c149c22a418ff5b6fdf6f329b35d0d1dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a7eeb42c`](https://github.com/nix-community/NUR/commit/a7eeb42c149c22a418ff5b6fdf6f329b35d0d1dd) | `` automatic update `` |
| [`3e5f8658`](https://github.com/nix-community/NUR/commit/3e5f86583f6defeb206a5aa81754b9954766b4a5) | `` automatic update `` |
| [`c261ae16`](https://github.com/nix-community/NUR/commit/c261ae16e1ddebbbd37181b27fa2f38f5044930c) | `` automatic update `` |
| [`6fe351ef`](https://github.com/nix-community/NUR/commit/6fe351ef9b3ff0e99fa0cb5e3d3be89f0a906ff7) | `` automatic update `` |