### PR TITLE
chore(flake/nur): `75e556db` -> `6a574b79`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720756005,
-        "narHash": "sha256-UwHfTj/uJBM0gaRa3z8k5KsQ/DcPbI8KuYgDSs4j0/Q=",
+        "lastModified": 1720757050,
+        "narHash": "sha256-huNwCkQELzJWoUbicOdcBquuqeRIjaupHCzFTTeGWXw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "75e556dbc2e2520ef2dc8901f5be95818f8e6274",
+        "rev": "6a574b79f865e8e50aa92a2270518559eacf37cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6a574b79`](https://github.com/nix-community/NUR/commit/6a574b79f865e8e50aa92a2270518559eacf37cb) | `` automatic update `` |