### PR TITLE
chore(flake/nur): `c12c080e` -> `9311f0f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -818,11 +818,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720763577,
-        "narHash": "sha256-wTjiFg3LXVsj49UUAtPOzpS8s8d5IPkIxaMiBR/RvoE=",
+        "lastModified": 1720781206,
+        "narHash": "sha256-hrDyh+DeumuXjxZ9PM1AenLE2MYywiO99rg4zblxo9A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c12c080efc15a921d949a16627a90c01130f55e0",
+        "rev": "9311f0f25bf3fd28bae8130a898ccd7ea53ea249",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9311f0f2`](https://github.com/nix-community/NUR/commit/9311f0f25bf3fd28bae8130a898ccd7ea53ea249) | `` automatic update `` |
| [`16f507d0`](https://github.com/nix-community/NUR/commit/16f507d01cbb072629ef948e5c18de23e6c9740a) | `` automatic update `` |
| [`3682749c`](https://github.com/nix-community/NUR/commit/3682749cfdeb771d2e6f014bd7e99e2f6b4d999c) | `` automatic update `` |
| [`8883466c`](https://github.com/nix-community/NUR/commit/8883466c65c186f7dfed1eaa10c5ff0444d6592c) | `` automatic update `` |
| [`372f69a0`](https://github.com/nix-community/NUR/commit/372f69a0cfbb55a145571621a96b898e1bf28f34) | `` automatic update `` |