### PR TITLE
chore(flake/emacs-overlay): `76e9df7e` -> `1facfd15`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720775597,
-        "narHash": "sha256-qivvOeTDRpsELqHB2zGSoaTwz5Z9UoHIuK5b+9wic58=",
+        "lastModified": 1720803380,
+        "narHash": "sha256-rObLDU8IgOpA+jnOr4M9G2QywYbSLEXrGk6dv+oMr/g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "76e9df7e3f701466fb91591a985f2e3ef73cf65b",
+        "rev": "1facfd15b6498f435fb5843b8d94bb4fa7f80a39",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`1facfd15`](https://github.com/nix-community/emacs-overlay/commit/1facfd15b6498f435fb5843b8d94bb4fa7f80a39) | `` Updated melpa `` |
| [`d867960e`](https://github.com/nix-community/emacs-overlay/commit/d867960eab795fefa48a9b2cdc204d4c82e51b56) | `` Updated elpa ``  |