### PR TITLE
chore(flake/nur): `2d2825fc` -> `3b54d7f3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -834,11 +834,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720806333,
-        "narHash": "sha256-iaPR+t0oyell/mfLf3gfdDkLEjCjjUwIHx+1hF0Zq6Q=",
+        "lastModified": 1720813500,
+        "narHash": "sha256-ZQqYC5H4AEBKrRgMDIQN26cJbUI1+331WRhS99ulNzE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2d2825fc1782cc80ebb446dc6bada37160363a32",
+        "rev": "3b54d7f31f0e3c097af56a6ad052ddb47a8effda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3b54d7f3`](https://github.com/nix-community/NUR/commit/3b54d7f31f0e3c097af56a6ad052ddb47a8effda) | `` automatic update `` |