### PR TITLE
chore(flake/nur): `3b54d7f3` -> `f9b13b99`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -834,11 +834,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720813500,
-        "narHash": "sha256-ZQqYC5H4AEBKrRgMDIQN26cJbUI1+331WRhS99ulNzE=",
+        "lastModified": 1720816448,
+        "narHash": "sha256-3z+nguQc3/HxFoJ6l1lyirewwoLRG5nPYlv775DHImo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3b54d7f31f0e3c097af56a6ad052ddb47a8effda",
+        "rev": "f9b13b99b4e7d7f462a5291969bedbcba0b5b7c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f9b13b99`](https://github.com/nix-community/NUR/commit/f9b13b99b4e7d7f462a5291969bedbcba0b5b7c9) | `` automatic update `` |