### PR TITLE
chore(flake/treefmt): `750dfb55` -> `5b002f8a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1063,11 +1063,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720645794,
-        "narHash": "sha256-vAeYp+WH7i/DlBM5xNt9QeWiOiqzzf5abO8DYGkbUxg=",
+        "lastModified": 1720818892,
+        "narHash": "sha256-f52x9srIcqQm1Df3T+xYR5P6VfdnDFa2vkkcLhlTp6U=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "750dfb555b5abdab4d3266b3f9a05dec6d205c04",
+        "rev": "5b002f8a53ed04c1a4177e7b00809d57bd2c696f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                         |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`5b002f8a`](https://github.com/numtide/treefmt-nix/commit/5b002f8a53ed04c1a4177e7b00809d57bd2c696f) | `` actionlint: also lint action files (#197) `` |