### PR TITLE
chore(flake/nur): `f9b13b99` -> `aabf6d1e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -834,11 +834,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720816448,
-        "narHash": "sha256-3z+nguQc3/HxFoJ6l1lyirewwoLRG5nPYlv775DHImo=",
+        "lastModified": 1720823789,
+        "narHash": "sha256-IWrwFVc12e6646X31k8PmZd+6rGeWk/3dJmzw53FM5M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f9b13b99b4e7d7f462a5291969bedbcba0b5b7c9",
+        "rev": "aabf6d1edce7b1bd0883259506c632528c94a5d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`aabf6d1e`](https://github.com/nix-community/NUR/commit/aabf6d1edce7b1bd0883259506c632528c94a5d2) | `` automatic update `` |
| [`88df334e`](https://github.com/nix-community/NUR/commit/88df334ed35f799f95889181930f366962422f92) | `` automatic update `` |
| [`d0cfeff1`](https://github.com/nix-community/NUR/commit/d0cfeff1d79b6fe8397007384672bc745021c7dc) | `` automatic update `` |