### PR TITLE
chore(flake/emacs-overlay): `186361c0` -> `b4d48b8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720832844,
-        "narHash": "sha256-nGDSJTTMqomiaVyANMXmu58K2ZnbDKuJ2cawq6ey/Uc=",
+        "lastModified": 1720835887,
+        "narHash": "sha256-GV/bQouSP/1aWlFfjuVZR28tdySzpe55w1Ped9W7iyE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "186361c0684b9eed32261d395708821a8a8d02fb",
+        "rev": "b4d48b8ee6b73dd4b676cf87f61d09e417ea052b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`b4d48b8e`](https://github.com/nix-community/emacs-overlay/commit/b4d48b8ee6b73dd4b676cf87f61d09e417ea052b) | `` Updated emacs `` |
| [`942a1ea9`](https://github.com/nix-community/emacs-overlay/commit/942a1ea9dc400bb01dcfb7d3a0304fc47de12747) | `` Updated melpa `` |