### PR TITLE
chore(flake/nur): `939e1b88` -> `91659221`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -834,11 +834,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720835355,
-        "narHash": "sha256-/hMedYEbsIMLttx3kBXCskw9MZIhn1Mb+fB4lDA8SW0=",
+        "lastModified": 1720843002,
+        "narHash": "sha256-RIOnpg6/JcHxE9qasDDWPKlYEbNS1+imvpgUlakAPLw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "939e1b88e5e86c177714efc75992c8dcba1ce1cd",
+        "rev": "9165922144ce8d58c99ee583872766d6a22b81cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`91659221`](https://github.com/nix-community/NUR/commit/9165922144ce8d58c99ee583872766d6a22b81cd) | `` automatic update `` |
| [`811ad743`](https://github.com/nix-community/NUR/commit/811ad74399ef5567d5cd1a9a3d03185f96f60369) | `` automatic update `` |