### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `ceaea0f0` -> `6ecd96ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -519,11 +519,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1720773183,
-        "narHash": "sha256-RMJLNV/mtq/R2Zuz3eE+4Bj8Kq4CyIsznvXmMVK5O/c=",
+        "lastModified": 1720844982,
+        "narHash": "sha256-g5dDP9RgDIgYKB0NNxx3cJgNP8vy1b+52b9H/Ppfahw=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "ceaea0f0a7c60b7352b44a0d614f827e712b5df7",
+        "rev": "6ecd96edc3a84d5ad70959828971ce699a5b3961",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                                               |
| ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`6ecd96ed`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/6ecd96edc3a84d5ad70959828971ce699a5b3961) | `` Improve error messages for unfetchable packages `` |