### PR TITLE
chore(flake/darwin): `cf297a8d` -> `5ce8503c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -104,11 +104,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720599442,
-        "narHash": "sha256-jdm+sKVbBXoyrxcHbVaV0htlpq2iFR+eJw3Xe/DPcDo=",
+        "lastModified": 1720845312,
+        "narHash": "sha256-yPhAsJTpyoIPQZJGC8Fw8W2lAXyhLoTn+HP20bmfkfk=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "cf297a8d248db6a455b60133f6c0029c04ebe50e",
+        "rev": "5ce8503cf402cf76b203eba4b7e402bea8e44abc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------ |
| [`902d6b65`](https://github.com/LnL7/nix-darwin/commit/902d6b65d3c18ff6528fbfe3349e4d3ed890fbae) | `` Set default flake directory as `/etc/nix-darwin` `` |