### PR TITLE
chore(flake/nur): `91659221` -> `562a99e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -834,11 +834,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720843002,
-        "narHash": "sha256-RIOnpg6/JcHxE9qasDDWPKlYEbNS1+imvpgUlakAPLw=",
+        "lastModified": 1720857081,
+        "narHash": "sha256-9Uxy0EFrUoScUVwrpOkRvCL2q6/HRYhIKTrYKI8oWcQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9165922144ce8d58c99ee583872766d6a22b81cd",
+        "rev": "562a99e4477552a8b7ee6bf84b5289b413296503",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`562a99e4`](https://github.com/nix-community/NUR/commit/562a99e4477552a8b7ee6bf84b5289b413296503) | `` automatic update `` |
| [`d717531a`](https://github.com/nix-community/NUR/commit/d717531ab8f146c2bcd246bc53098fd057e41183) | `` automatic update `` |
| [`4b96b9dd`](https://github.com/nix-community/NUR/commit/4b96b9dd2651d0e6a848912cdbcbfbe6e2f3d4f6) | `` automatic update `` |
| [`3aa39365`](https://github.com/nix-community/NUR/commit/3aa39365e8468ecb3bad4494b37a784c325b986e) | `` automatic update `` |