### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `6ecd96ed` -> `353a0125`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -519,11 +519,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1720844982,
-        "narHash": "sha256-g5dDP9RgDIgYKB0NNxx3cJgNP8vy1b+52b9H/Ppfahw=",
+        "lastModified": 1720847998,
+        "narHash": "sha256-CDJDkioumYmwuAQJS4Q04KmIy9Te3QK/AtA6g8dG3OE=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "6ecd96edc3a84d5ad70959828971ce699a5b3961",
+        "rev": "353a0125f421f850ce030f55dfceafe91ce2d759",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                                     |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`353a0125`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/353a0125f421f850ce030f55dfceafe91ce2d759) | `` Drop stale fetch override for ansible `` |