### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `353a0125` -> `0ce818a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -162,11 +162,11 @@
     "doomemacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1720755125,
-        "narHash": "sha256-pEYm5SPa/S0iVCg0QvBM7P1+zZEndkJnnSulHfbhOuA=",
+        "lastModified": 1720813490,
+        "narHash": "sha256-qs6SjED0zK3gPY6P2QimXBBWpD51DYI6iLFvPR+qCfU=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "b0e1e68e78429659f6fd3b26e6691e921fa0d7e1",
+        "rev": "b9f1d5d2616751defd838266f6c8506faf642097",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720772320,
-        "narHash": "sha256-NtMifOeTwDEoc8PTPaSHX5mc2+G9JZE5W2au57KeFH4=",
+        "lastModified": 1720835887,
+        "narHash": "sha256-GV/bQouSP/1aWlFfjuVZR28tdySzpe55w1Ped9W7iyE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2bfc08cbf0c21fe50fd88ccfd05bbc979d823c79",
+        "rev": "b4d48b8ee6b73dd4b676cf87f61d09e417ea052b",
         "type": "github"
       },
       "original": {
@@ -519,11 +519,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1720847998,
-        "narHash": "sha256-CDJDkioumYmwuAQJS4Q04KmIy9Te3QK/AtA6g8dG3OE=",
+        "lastModified": 1720859430,
+        "narHash": "sha256-jZ0w8UUZNQCwAW71MjzmEEuk5oCddMIbscg3l+7DCN8=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "353a0125f421f850ce030f55dfceafe91ce2d759",
+        "rev": "0ce818a0a3c5ecb27b38ab8ea51e726d70e53c9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`0ce818a0`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/0ce818a0a3c5ecb27b38ab8ea51e726d70e53c9a) | `` flake.lock: Update `` |