### PR TITLE
chore(flake/nur): `562a99e4` -> `34794b9e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -834,11 +834,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720857081,
-        "narHash": "sha256-9Uxy0EFrUoScUVwrpOkRvCL2q6/HRYhIKTrYKI8oWcQ=",
+        "lastModified": 1720860314,
+        "narHash": "sha256-0BhCADGI8zt5ifVHPRCqGf42V8lqXTc278mkMbbZOjw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "562a99e4477552a8b7ee6bf84b5289b413296503",
+        "rev": "34794b9e757b66c3166f204ec14ea07d034131dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`34794b9e`](https://github.com/nix-community/NUR/commit/34794b9e757b66c3166f204ec14ea07d034131dc) | `` automatic update `` |