### PR TITLE
chore(flake/nur): `34794b9e` -> `4cf61634`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -834,11 +834,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720860314,
-        "narHash": "sha256-0BhCADGI8zt5ifVHPRCqGf42V8lqXTc278mkMbbZOjw=",
+        "lastModified": 1720867608,
+        "narHash": "sha256-/7rvbpsRpfN9977Z15N+uY5Qh1nFnPn1mQOt5rbstXA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "34794b9e757b66c3166f204ec14ea07d034131dc",
+        "rev": "4cf61634b7b92c0330e0e2acba931d67e3110a53",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4cf61634`](https://github.com/nix-community/NUR/commit/4cf61634b7b92c0330e0e2acba931d67e3110a53) | `` automatic update `` |