### PR TITLE
chore(flake/nur): `4cf61634` -> `69ba17a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -834,11 +834,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720867608,
-        "narHash": "sha256-/7rvbpsRpfN9977Z15N+uY5Qh1nFnPn1mQOt5rbstXA=",
+        "lastModified": 1720875805,
+        "narHash": "sha256-uGfemlSNjcYVKbr/YDjVx6bYwA1h5RzByw/BF8mPkOg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4cf61634b7b92c0330e0e2acba931d67e3110a53",
+        "rev": "69ba17a06e86bd5f67db774aa2bc2e5942ed88d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`69ba17a0`](https://github.com/nix-community/NUR/commit/69ba17a06e86bd5f67db774aa2bc2e5942ed88d6) | `` automatic update `` |