### PR TITLE
chore(flake/emacs-overlay): `c4f4b5c2` -> `af082307`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720860892,
-        "narHash": "sha256-F4DAzCSJtMGX/17ZEvHmKZUvFb/Fq6HJwUjiE1ouIao=",
+        "lastModified": 1720889632,
+        "narHash": "sha256-bs+dbISrHQsklDpZkySjP/06WARgb3dQc9TF+AtPip4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c4f4b5c25406d98dcfc1992c6676405a1b19b8af",
+        "rev": "af08230704729e326317a14aa726b131f9ca8ca5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`af082307`](https://github.com/nix-community/emacs-overlay/commit/af08230704729e326317a14aa726b131f9ca8ca5) | `` Updated melpa `` |
| [`7d49a83b`](https://github.com/nix-community/emacs-overlay/commit/7d49a83b5da8301df021ef5c86ce37564ad062a6) | `` Updated elpa ``  |