### PR TITLE
chore(flake/nur): `69ba17a0` -> `fa8fa01d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -834,11 +834,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720875805,
-        "narHash": "sha256-uGfemlSNjcYVKbr/YDjVx6bYwA1h5RzByw/BF8mPkOg=",
+        "lastModified": 1720893074,
+        "narHash": "sha256-ljbIJUmihqfXfs/Ve72B0HEDFy2M3R7zn81ostsmPD0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "69ba17a06e86bd5f67db774aa2bc2e5942ed88d6",
+        "rev": "fa8fa01dd3fa39da9152b849075bb29c30675987",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fa8fa01d`](https://github.com/nix-community/NUR/commit/fa8fa01dd3fa39da9152b849075bb29c30675987) | `` automatic update `` |
| [`ecde873d`](https://github.com/nix-community/NUR/commit/ecde873d238284ccb47675c15436b55f6d6ec285) | `` automatic update `` |
| [`60faa999`](https://github.com/nix-community/NUR/commit/60faa99986395bf17751a551cef1f1aa5bc314da) | `` automatic update `` |
| [`c4678c14`](https://github.com/nix-community/NUR/commit/c4678c147815302fa70235315bcfb70b9c56f5e7) | `` automatic update `` |
| [`9049f257`](https://github.com/nix-community/NUR/commit/9049f257021e2cbc1c69910a928abb616e295938) | `` automatic update `` |