### PR TITLE
chore(flake/nur): `c615b431` -> `8e89b613`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -834,11 +834,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720894421,
-        "narHash": "sha256-lnWh1zUaTvalG+yNxUzGd9bqK4+5YAFyXPhs9Fza5MM=",
+        "lastModified": 1720896303,
+        "narHash": "sha256-gnno8DtwPKp88y7C3Ds1Ydp4qPBNPsNHTVV6fh1lAAg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c615b431e36931b3e57e8bf912443b532f05e6dc",
+        "rev": "8e89b6134111ef77b7577b8a2e2472e50ce41ddd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8e89b613`](https://github.com/nix-community/NUR/commit/8e89b6134111ef77b7577b8a2e2472e50ce41ddd) | `` automatic update `` |