### PR TITLE
chore(flake/nur): `8e89b613` -> `567a23db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -834,11 +834,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720896303,
-        "narHash": "sha256-gnno8DtwPKp88y7C3Ds1Ydp4qPBNPsNHTVV6fh1lAAg=",
+        "lastModified": 1720899970,
+        "narHash": "sha256-aC6WheNDJKFPpq2gWTzxy8c68hhBdy5b1iLUhgbPgW0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8e89b6134111ef77b7577b8a2e2472e50ce41ddd",
+        "rev": "567a23db21ba9798f52b9d7e900970525a0c7a85",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`567a23db`](https://github.com/nix-community/NUR/commit/567a23db21ba9798f52b9d7e900970525a0c7a85) | `` automatic update `` |
| [`7f34d06b`](https://github.com/nix-community/NUR/commit/7f34d06ba108a36478931976805421570419f594) | `` automatic update `` |