### PR TITLE
chore(flake/nur): `567a23db` -> `fc076c6c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -834,11 +834,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720899970,
-        "narHash": "sha256-aC6WheNDJKFPpq2gWTzxy8c68hhBdy5b1iLUhgbPgW0=",
+        "lastModified": 1720908054,
+        "narHash": "sha256-nRmtu5zaYvzvonEZaQlORbIoZvctVy3P3YraH/ChzG0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "567a23db21ba9798f52b9d7e900970525a0c7a85",
+        "rev": "fc076c6c1c848d6f950303f937b26d202b23d4b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fc076c6c`](https://github.com/nix-community/NUR/commit/fc076c6c1c848d6f950303f937b26d202b23d4b0) | `` automatic update `` |
| [`e00caa99`](https://github.com/nix-community/NUR/commit/e00caa9985bbea08c14e9c9e1e74695afb7fc819) | `` automatic update `` |