### PR TITLE
chore(flake/emacs-overlay): `5e9c9736` -> `b5a840a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720890526,
-        "narHash": "sha256-wjw1UWQGxB0oNW20lEP45zY8zxdnW74Xa1ijLo+erYw=",
+        "lastModified": 1720919346,
+        "narHash": "sha256-gJeQHPhJorxjWisM65Xo1dyD9/CjSxhHb/kSrkM64Fo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5e9c97365e40a9a7f576dba8516eae5fd4f0fc62",
+        "rev": "b5a840a03acdb814fadfb3b7e5cbc2ea51a1f0c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`b5a840a0`](https://github.com/nix-community/emacs-overlay/commit/b5a840a03acdb814fadfb3b7e5cbc2ea51a1f0c5) | `` Updated flake inputs `` |