### PR TITLE
chore(flake/nur): `fc076c6c` -> `59b2989e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -834,11 +834,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720908054,
-        "narHash": "sha256-nRmtu5zaYvzvonEZaQlORbIoZvctVy3P3YraH/ChzG0=",
+        "lastModified": 1720922221,
+        "narHash": "sha256-O4uvMQBS+kSSLAmmO486rxXw5kZDZG4vvoUPBAYtLZo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fc076c6c1c848d6f950303f937b26d202b23d4b0",
+        "rev": "59b2989ee0b973c772403e0b8a096b0a26dc869d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`59b2989e`](https://github.com/nix-community/NUR/commit/59b2989ee0b973c772403e0b8a096b0a26dc869d) | `` automatic update `` |
| [`f42702a6`](https://github.com/nix-community/NUR/commit/f42702a60ba54fc0d2d9a09deea3f83c446b581b) | `` automatic update `` |