### PR TITLE
chore(flake/nur): `59b2989e` -> `33262cda`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -834,11 +834,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720922221,
-        "narHash": "sha256-O4uvMQBS+kSSLAmmO486rxXw5kZDZG4vvoUPBAYtLZo=",
+        "lastModified": 1720931558,
+        "narHash": "sha256-YyAlrO0occOs4UkZLPQHeVTNcR+G5FZzkpx9M7vm0B0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "59b2989ee0b973c772403e0b8a096b0a26dc869d",
+        "rev": "33262cda24af36267d3cef00910eef4e30505f4c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`33262cda`](https://github.com/nix-community/NUR/commit/33262cda24af36267d3cef00910eef4e30505f4c) | `` automatic update `` |
| [`6eb7270d`](https://github.com/nix-community/NUR/commit/6eb7270d6ea5d059005b6ec0a4fcf94d539cd9c3) | `` automatic update `` |
| [`9387d7ec`](https://github.com/nix-community/NUR/commit/9387d7eceac3cd1bd023beeddb9345648353f375) | `` automatic update `` |
| [`1cd7fff2`](https://github.com/nix-community/NUR/commit/1cd7fff2ba7b18502e4c81ed83b7b38879918a15) | `` automatic update `` |
| [`2bd7624a`](https://github.com/nix-community/NUR/commit/2bd7624a4fdd9745640bf2f1a781bf37478c226a) | `` automatic update `` |
| [`5dd3a6b5`](https://github.com/nix-community/NUR/commit/5dd3a6b5f50365989322431fc03aedc963ae5cf3) | `` automatic update `` |
| [`9829e32e`](https://github.com/nix-community/NUR/commit/9829e32e4c5ed025da181a10fb6fbd4cea5e5d43) | `` automatic update `` |
| [`d0c841f7`](https://github.com/nix-community/NUR/commit/d0c841f7600475cdec175a1a7fdd93533d83c2d3) | `` automatic update `` |