### PR TITLE
chore(flake/nur): `33262cda` -> `0f6e60b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -834,11 +834,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720931558,
-        "narHash": "sha256-YyAlrO0occOs4UkZLPQHeVTNcR+G5FZzkpx9M7vm0B0=",
+        "lastModified": 1720936407,
+        "narHash": "sha256-oE5z1y9/qOlaxMyhZ4F/fuL+Utz6E2RcQ9NFSoyHgOE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "33262cda24af36267d3cef00910eef4e30505f4c",
+        "rev": "0f6e60b5b53d8dd59ffe7f43e64fc6e7439ffa94",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0f6e60b5`](https://github.com/nix-community/NUR/commit/0f6e60b5b53d8dd59ffe7f43e64fc6e7439ffa94) | `` automatic update `` |
| [`42851361`](https://github.com/nix-community/NUR/commit/42851361fdfde870bfd7e3c71f2ac5d3113c63d6) | `` automatic update `` |