### PR TITLE
chore(flake/nur): `0f6e60b5` -> `8df0ba5b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -834,11 +834,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720936407,
-        "narHash": "sha256-oE5z1y9/qOlaxMyhZ4F/fuL+Utz6E2RcQ9NFSoyHgOE=",
+        "lastModified": 1720940415,
+        "narHash": "sha256-G7RqSP/imRCFEjr9MpcYOjBGiCdns4mw0J9XftfdQLA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0f6e60b5b53d8dd59ffe7f43e64fc6e7439ffa94",
+        "rev": "8df0ba5bc2dee58da09f28f7a9ccb71cb2fe12ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8df0ba5b`](https://github.com/nix-community/NUR/commit/8df0ba5bc2dee58da09f28f7a9ccb71cb2fe12ad) | `` automatic update `` |
| [`63d791ec`](https://github.com/nix-community/NUR/commit/63d791ec7ecc1f19f961e683eeaa35f26c1683e5) | `` automatic update `` |
| [`8a807f26`](https://github.com/nix-community/NUR/commit/8a807f26c199136a0f2ee81ecb431749aa99cbb3) | `` automatic update `` |
| [`93b67305`](https://github.com/nix-community/NUR/commit/93b6730560f15a557db9c0dd0227baa58cebbd30) | `` automatic update `` |
| [`a4935679`](https://github.com/nix-community/NUR/commit/a493567975bd6ead0139004fe29c273db6253824) | `` automatic update `` |