### PR TITLE
chore(flake/emacs-overlay): `b5a840a0` -> `1e722196`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720919346,
-        "narHash": "sha256-gJeQHPhJorxjWisM65Xo1dyD9/CjSxhHb/kSrkM64Fo=",
+        "lastModified": 1720947494,
+        "narHash": "sha256-Y1GCvS7s06vsCif9nkxzeuzXWxOEWcsayJftkQWuQRk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b5a840a03acdb814fadfb3b7e5cbc2ea51a1f0c5",
+        "rev": "1e722196c1a7cc5006d764540e04f52b83a9307a",
         "type": "github"
       },
       "original": {
@@ -700,11 +700,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1720691131,
-        "narHash": "sha256-CWT+KN8aTPyMIx8P303gsVxUnkinIz0a/Cmasz1jyIM=",
+        "lastModified": 1720823163,
+        "narHash": "sha256-FZ5dnrvKkln9ESdoTR8R7GKW9rNpXNZrxGsOXsbsTpE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a046c1202e11b62cbede5385ba64908feb7bfac4",
+        "rev": "f12ee5f64c6a09995e71c9626d88c4efa983b488",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`1e722196`](https://github.com/nix-community/emacs-overlay/commit/1e722196c1a7cc5006d764540e04f52b83a9307a) | `` Updated melpa ``        |
| [`de1df2f5`](https://github.com/nix-community/emacs-overlay/commit/de1df2f522cc5c248efc0df37bff5210350f4813) | `` Updated elpa ``         |
| [`a3000b09`](https://github.com/nix-community/emacs-overlay/commit/a3000b0964a202b16d7cd2a9ed2ac47b006ea6a7) | `` Updated flake inputs `` |