### PR TITLE
chore(flake/srvos): `e3e8ff54` -> `111d0cf0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -968,11 +968,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720691926,
-        "narHash": "sha256-VE9ZfWRbyBjps5GV8KXiF8XodAykmwRpcJtPiVWCu8M=",
+        "lastModified": 1720947127,
+        "narHash": "sha256-xvFoiFJHnu8iWmEu3a+tKXOt4nrhA5RrZIOanxR6Y0Q=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "e3e8ff545ef14f13c69a0f743078637fde952018",
+        "rev": "111d0cf02b7ef3ab6e0ca3413a9662e5b016d9fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                            |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`111d0cf0`](https://github.com/nix-community/srvos/commit/111d0cf02b7ef3ab6e0ca3413a9662e5b016d9fe) | `` fix: drop removed sound.enable option (#459) `` |