### PR TITLE
chore(flake/nur): `8df0ba5b` -> `e2e7389a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -834,11 +834,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720940415,
-        "narHash": "sha256-G7RqSP/imRCFEjr9MpcYOjBGiCdns4mw0J9XftfdQLA=",
+        "lastModified": 1720957545,
+        "narHash": "sha256-sscfzvW+bSs/mt0jknFA9kiqhyk/PS25X+iycEgh8g4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8df0ba5bc2dee58da09f28f7a9ccb71cb2fe12ad",
+        "rev": "e2e7389aca9b937f363c85a37e3eb17535ab8c8c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e2e7389a`](https://github.com/nix-community/NUR/commit/e2e7389aca9b937f363c85a37e3eb17535ab8c8c) | `` automatic update `` |
| [`af5b13ef`](https://github.com/nix-community/NUR/commit/af5b13efbb4e51edc21bd297ab32719c1c227eac) | `` automatic update `` |
| [`bebd5f46`](https://github.com/nix-community/NUR/commit/bebd5f46e28da8cffd71bc15e93797441ddc45be) | `` automatic update `` |
| [`530f509d`](https://github.com/nix-community/NUR/commit/530f509dccc946b2ff4fe5d676d3909d5a1f1f66) | `` automatic update `` |