### PR TITLE
chore(flake/nur): `e2e7389a` -> `8906eb93`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -834,11 +834,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720957545,
-        "narHash": "sha256-sscfzvW+bSs/mt0jknFA9kiqhyk/PS25X+iycEgh8g4=",
+        "lastModified": 1720965490,
+        "narHash": "sha256-NtPA7GOK0LIz5ciMUqzHtwASldJzMKoYdAetGRpiSIY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e2e7389aca9b937f363c85a37e3eb17535ab8c8c",
+        "rev": "8906eb93e34a864a1b2e99fbf2bd6fb4be16b6a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8906eb93`](https://github.com/nix-community/NUR/commit/8906eb93e34a864a1b2e99fbf2bd6fb4be16b6a4) | `` automatic update `` |
| [`a2242153`](https://github.com/nix-community/NUR/commit/a2242153e82db4b76c110def6b23e1a3d05aa0bf) | `` automatic update `` |