### PR TITLE
chore(flake/nur): `8906eb93` -> `960c1f77`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720965490,
-        "narHash": "sha256-NtPA7GOK0LIz5ciMUqzHtwASldJzMKoYdAetGRpiSIY=",
+        "lastModified": 1720971229,
+        "narHash": "sha256-D5FHhaF+Q6y7zDmmU8GRJLE8+M639WBszhiqKcH9dhs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8906eb93e34a864a1b2e99fbf2bd6fb4be16b6a4",
+        "rev": "960c1f77cca3e17cd398519496dcd0bb6e495871",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`960c1f77`](https://github.com/nix-community/NUR/commit/960c1f77cca3e17cd398519496dcd0bb6e495871) | `` automatic update `` |
| [`9b79e049`](https://github.com/nix-community/NUR/commit/9b79e049b942725059bea9ac0999096f66b10fba) | `` automatic update `` |
| [`cbe89ff1`](https://github.com/nix-community/NUR/commit/cbe89ff1e11f3d0cfeb05177c25e127793cca501) | `` automatic update `` |
| [`731c6d74`](https://github.com/nix-community/NUR/commit/731c6d74615f883d0a0d59451ef9d95d823b8cd9) | `` automatic update `` |
| [`fff3685a`](https://github.com/nix-community/NUR/commit/fff3685a7baa7c385a78977335196a7a2408f74b) | `` automatic update `` |