### PR TITLE
chore(flake/emacs-overlay): `7e5ec6c9` -> `21c9330e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720948403,
-        "narHash": "sha256-zzxXV2Kpslj4hOCfX2p1j6EDdqw/TBAgnZTzl9xVYCU=",
+        "lastModified": 1720977666,
+        "narHash": "sha256-B6jQofJsDj/LQYmS6VlFX2PBhcG60ba7pv7o9NBoAjU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7e5ec6c999ac57992e70d6983ae4ea1634e41ad9",
+        "rev": "21c9330e6de6d5412798a83883ec6da217668f1c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`21c9330e`](https://github.com/nix-community/emacs-overlay/commit/21c9330e6de6d5412798a83883ec6da217668f1c) | `` Updated emacs `` |
| [`8104ab45`](https://github.com/nix-community/emacs-overlay/commit/8104ab457e4041a3f406504096c0f3de85ff64d3) | `` Updated melpa `` |
| [`bb942440`](https://github.com/nix-community/emacs-overlay/commit/bb942440280672e820ede7066c602265681c30a0) | `` Updated elpa ``  |