### PR TITLE
chore(flake/nur): `960c1f77` -> `cd5f1cf4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720971229,
-        "narHash": "sha256-D5FHhaF+Q6y7zDmmU8GRJLE8+M639WBszhiqKcH9dhs=",
+        "lastModified": 1720979318,
+        "narHash": "sha256-JdMrDpXPRpjjP6Un0t0eKS5Dx5cx6ZS6TJDTApV4QNM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "960c1f77cca3e17cd398519496dcd0bb6e495871",
+        "rev": "cd5f1cf414abad853f330c4768509b09aab5a9eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cd5f1cf4`](https://github.com/nix-community/NUR/commit/cd5f1cf414abad853f330c4768509b09aab5a9eb) | `` automatic update `` |
| [`e6a8fdf7`](https://github.com/nix-community/NUR/commit/e6a8fdf7215e0bdc401c37aeb3ba42513d95735a) | `` automatic update `` |