### PR TITLE
chore(flake/nur): `cd5f1cf4` -> `e51aad4e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720979318,
-        "narHash": "sha256-JdMrDpXPRpjjP6Un0t0eKS5Dx5cx6ZS6TJDTApV4QNM=",
+        "lastModified": 1720982174,
+        "narHash": "sha256-pvxGCzYXduGqM9E1uXrjGGYsH/eLUU2vgmKohHo87bc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cd5f1cf414abad853f330c4768509b09aab5a9eb",
+        "rev": "e51aad4e3402b4cf0a2f0e3e34e78fb206c56f65",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e51aad4e`](https://github.com/nix-community/NUR/commit/e51aad4e3402b4cf0a2f0e3e34e78fb206c56f65) | `` automatic update `` |