### PR TITLE
chore(flake/nur): `e51aad4e` -> `6b482c7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720982174,
-        "narHash": "sha256-pvxGCzYXduGqM9E1uXrjGGYsH/eLUU2vgmKohHo87bc=",
+        "lastModified": 1720986293,
+        "narHash": "sha256-mLf2Kq2yZXd5k4bksZBuItiWgo315BiPrTxY/xLn2Oo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e51aad4e3402b4cf0a2f0e3e34e78fb206c56f65",
+        "rev": "6b482c7d09cfe670b794fe676935cb6b442435f5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6b482c7d`](https://github.com/nix-community/NUR/commit/6b482c7d09cfe670b794fe676935cb6b442435f5) | `` automatic update `` |