### PR TITLE
chore(flake/emacs-overlay): `21c9330e` -> `c1ac8f21`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720977666,
-        "narHash": "sha256-B6jQofJsDj/LQYmS6VlFX2PBhcG60ba7pv7o9NBoAjU=",
+        "lastModified": 1721008673,
+        "narHash": "sha256-vHwCwrLuVa7djfjpUQRv7Cv3jAf0oB/qU9QjfWeyC5g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "21c9330e6de6d5412798a83883ec6da217668f1c",
+        "rev": "c1ac8f2191b2906bc4e43ac144e6ebc8a95cb9b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`c1ac8f21`](https://github.com/nix-community/emacs-overlay/commit/c1ac8f2191b2906bc4e43ac144e6ebc8a95cb9b3) | `` Updated emacs `` |
| [`ef442e07`](https://github.com/nix-community/emacs-overlay/commit/ef442e079f14a33c65724b977aa423997bf66441) | `` Updated melpa `` |
| [`fa0e9665`](https://github.com/nix-community/emacs-overlay/commit/fa0e96656954a654a8e891081091245f38aa075a) | `` Updated elpa ``  |