### PR TITLE
chore(flake/srvos): `111d0cf0` -> `a025944e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -955,11 +955,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720947127,
-        "narHash": "sha256-xvFoiFJHnu8iWmEu3a+tKXOt4nrhA5RrZIOanxR6Y0Q=",
+        "lastModified": 1721004418,
+        "narHash": "sha256-jfmWtz2Md9kL/3suesHZQ6zYtho8YH3l3b6IGRzWypk=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "111d0cf02b7ef3ab6e0ca3413a9662e5b016d9fe",
+        "rev": "a025944e2de625045eaa1522ee69a568a469e476",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`a025944e`](https://github.com/nix-community/srvos/commit/a025944e2de625045eaa1522ee69a568a469e476) | `` dev/private/flake.lock: Update `` |
| [`9799a21d`](https://github.com/nix-community/srvos/commit/9799a21d3032e0f2f9f6b373f2d3ea80f4c9e867) | `` flake.lock: Update ``             |