### PR TITLE
chore(flake/nur): `26200182` -> `1bb52b01`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721000719,
-        "narHash": "sha256-D/uM0pAcoyYHQZO6q8F2Yf5nC6wG36mJJzafVaSOfMU=",
+        "lastModified": 1721011980,
+        "narHash": "sha256-ekb1nPFCYoF4d0k/DbkrvGxVMyfSgnJlD/KoCD/zFk8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "262001820c965a1fb8f5392661687686c0414067",
+        "rev": "1bb52b016d84c1c04a7aaad0fd5416e3e2238ed1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1bb52b01`](https://github.com/nix-community/NUR/commit/1bb52b016d84c1c04a7aaad0fd5416e3e2238ed1) | `` automatic update `` |
| [`669d9c8a`](https://github.com/nix-community/NUR/commit/669d9c8a383cd54bf2b47e2a3bf67b0910bb7d6d) | `` automatic update `` |
| [`6d919fa4`](https://github.com/nix-community/NUR/commit/6d919fa451882092a8bb5f5302c139b5de458d07) | `` automatic update `` |