### PR TITLE
chore(flake/nur): `1bb52b01` -> `a561bbc7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721011980,
-        "narHash": "sha256-ekb1nPFCYoF4d0k/DbkrvGxVMyfSgnJlD/KoCD/zFk8=",
+        "lastModified": 1721016287,
+        "narHash": "sha256-H9lKhfaBs//uKCEISF592W+2R6uy89Xze3Lrz3t7i34=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1bb52b016d84c1c04a7aaad0fd5416e3e2238ed1",
+        "rev": "a561bbc77cc396024f0408bb767f350081c22ba1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a561bbc7`](https://github.com/nix-community/NUR/commit/a561bbc77cc396024f0408bb767f350081c22ba1) | `` automatic update `` |
| [`9fef028e`](https://github.com/nix-community/NUR/commit/9fef028efd2b60ef492d39f3e7f4c06193c39bc4) | `` automatic update `` |
| [`193e5707`](https://github.com/nix-community/NUR/commit/193e570768fb7a82ed67025fb1a7cdd338d98393) | `` automatic update `` |