### PR TITLE
chore(flake/nur): `a561bbc7` -> `303e12ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721016287,
-        "narHash": "sha256-H9lKhfaBs//uKCEISF592W+2R6uy89Xze3Lrz3t7i34=",
+        "lastModified": 1721024546,
+        "narHash": "sha256-qYi8deAZzPsi1lV+iQrfMx/fZsL4mZLxuOZgw1GSPSc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a561bbc77cc396024f0408bb767f350081c22ba1",
+        "rev": "303e12efb7114c5c55899e96f914fb6228c12b0e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`303e12ef`](https://github.com/nix-community/NUR/commit/303e12efb7114c5c55899e96f914fb6228c12b0e) | `` automatic update `` |