### PR TITLE
chore(flake/srvos): `a025944e` -> `36905a23`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -955,11 +955,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721004418,
-        "narHash": "sha256-jfmWtz2Md9kL/3suesHZQ6zYtho8YH3l3b6IGRzWypk=",
+        "lastModified": 1721032527,
+        "narHash": "sha256-4hpsvyoWYRdZ4u6xDQ8uK5BhKDqHwqNQBi1R7y3n5aI=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "a025944e2de625045eaa1522ee69a568a469e476",
+        "rev": "36905a236dc466b8eff20df84314d23c95da3f6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`9c9db0b3`](https://github.com/nix-community/srvos/commit/9c9db0b387e7919ec13d6f4d762d4088c0c2d180) | `` darwin: drop removed services.openssh.authorizedKeysFiles option `` |
| [`eaa9f7d1`](https://github.com/nix-community/srvos/commit/eaa9f7d1476462bcf4e412c14a95573e1f4090eb) | `` fix vim warning ``                                                  |