### PR TITLE
chore(flake/treefmt): `b92afa15` -> `0fb28f23`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1050,11 +1050,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720930114,
-        "narHash": "sha256-VZK73b5hG5bSeAn97TTcnPjXUXtV7j/AtS4KN8ggCS0=",
+        "lastModified": 1721059077,
+        "narHash": "sha256-gCICMMX7VMSKKt99giDDtRLkHJ0cwSgBtDijJAqTlto=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "b92afa1501ac73f1d745526adc4f89b527595f14",
+        "rev": "0fb28f237f83295b4dd05e342f333b447c097398",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                           |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`0fb28f23`](https://github.com/numtide/treefmt-nix/commit/0fb28f237f83295b4dd05e342f333b447c097398) | `` module-option: ignore npm lock files (#200) `` |