### PR TITLE
chore(flake/nur): `15294a76` -> `4739b056`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721061640,
-        "narHash": "sha256-0yoiWJBeoCLWo89YLyCbaPhW/3eXrtwQKU8NgxgEjAo=",
+        "lastModified": 1721072700,
+        "narHash": "sha256-QS4U01vwydBY9oFeXjW6edjMuYikzmOFkCjXD7ZX75U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "15294a7608667827abcf4a98753feec08a3eab71",
+        "rev": "4739b056773ba85baa3bcbbc6f28bbdc9c8b7a6f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4739b056`](https://github.com/nix-community/NUR/commit/4739b056773ba85baa3bcbbc6f28bbdc9c8b7a6f) | `` automatic update `` |