### PR TITLE
chore(flake/nur): `4739b056` -> `38a21677`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721072700,
-        "narHash": "sha256-QS4U01vwydBY9oFeXjW6edjMuYikzmOFkCjXD7ZX75U=",
+        "lastModified": 1721076946,
+        "narHash": "sha256-/Jl+z8tmA6m/DsCJyDSg+YCthBcgCRJz8D03NvQY3ng=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4739b056773ba85baa3bcbbc6f28bbdc9c8b7a6f",
+        "rev": "38a21677ebc39ce41d5c505c388621ccab1be5cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`38a21677`](https://github.com/nix-community/NUR/commit/38a21677ebc39ce41d5c505c388621ccab1be5cb) | `` automatic update `` |