### PR TITLE
chore(flake/nur): `38a21677` -> `0f8e8752`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721076946,
-        "narHash": "sha256-/Jl+z8tmA6m/DsCJyDSg+YCthBcgCRJz8D03NvQY3ng=",
+        "lastModified": 1721079452,
+        "narHash": "sha256-+YBOwlSHuLpGL8iqdglpuCa5aa8EYJQcHHQX0aoAEJE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "38a21677ebc39ce41d5c505c388621ccab1be5cb",
+        "rev": "0f8e87527c9dc31a77a86d4b7c563ea42f903a52",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0f8e8752`](https://github.com/nix-community/NUR/commit/0f8e87527c9dc31a77a86d4b7c563ea42f903a52) | `` automatic update `` |