### PR TITLE
chore(flake/nur): `0f8e8752` -> `95a95741`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721079452,
-        "narHash": "sha256-+YBOwlSHuLpGL8iqdglpuCa5aa8EYJQcHHQX0aoAEJE=",
+        "lastModified": 1721087090,
+        "narHash": "sha256-kYEd9ZIIVBlsWrIFf0urR9lnqjjhv3PyjO/+pCO6/H0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0f8e87527c9dc31a77a86d4b7c563ea42f903a52",
+        "rev": "95a95741cca75d1cb0f4431f8a3069c28c24c426",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`95a95741`](https://github.com/nix-community/NUR/commit/95a95741cca75d1cb0f4431f8a3069c28c24c426) | `` automatic update `` |