### PR TITLE
chore(flake/nur): `95a95741` -> `9cfde8a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721087090,
-        "narHash": "sha256-kYEd9ZIIVBlsWrIFf0urR9lnqjjhv3PyjO/+pCO6/H0=",
+        "lastModified": 1721092880,
+        "narHash": "sha256-EaMjyTwku1P2DisjrHwb5sjp3phY7o9vd85K/GbCGdk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "95a95741cca75d1cb0f4431f8a3069c28c24c426",
+        "rev": "9cfde8a7bcfe8058b75488a9bc79f3d2b7b8335f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9cfde8a7`](https://github.com/nix-community/NUR/commit/9cfde8a7bcfe8058b75488a9bc79f3d2b7b8335f) | `` automatic update `` |