### PR TITLE
chore(flake/nur): `9cfde8a7` -> `4bbdf635`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721092880,
-        "narHash": "sha256-EaMjyTwku1P2DisjrHwb5sjp3phY7o9vd85K/GbCGdk=",
+        "lastModified": 1721098414,
+        "narHash": "sha256-oOtYLdELFvIYwLjY6Al7DR3/ftq0aAOAgRi9cBfPR4w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9cfde8a7bcfe8058b75488a9bc79f3d2b7b8335f",
+        "rev": "4bbdf635e8bf0a0fb68853cfd818ec8f2be36846",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4bbdf635`](https://github.com/nix-community/NUR/commit/4bbdf635e8bf0a0fb68853cfd818ec8f2be36846) | `` automatic update `` |
| [`f31d255a`](https://github.com/nix-community/NUR/commit/f31d255a55e1737c9787461f360cdce47552250d) | `` automatic update `` |