### PR TITLE
chore(flake/nur): `4bbdf635` -> `0be20491`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721098414,
-        "narHash": "sha256-oOtYLdELFvIYwLjY6Al7DR3/ftq0aAOAgRi9cBfPR4w=",
+        "lastModified": 1721101511,
+        "narHash": "sha256-tZ2i3nKej/90TqoVfso/NgzZq28Qc2HMaqqxRn8DFpk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4bbdf635e8bf0a0fb68853cfd818ec8f2be36846",
+        "rev": "0be20491ff4d6ae1124c8eb48f7ee80375c7d11e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0be20491`](https://github.com/nix-community/NUR/commit/0be20491ff4d6ae1124c8eb48f7ee80375c7d11e) | `` automatic update `` |
| [`740ebae7`](https://github.com/nix-community/NUR/commit/740ebae75e4074b0178729c6738db6492614edea) | `` automatic update `` |