### PR TITLE
chore(flake/nur): `0be20491` -> `03283d78`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721101511,
-        "narHash": "sha256-tZ2i3nKej/90TqoVfso/NgzZq28Qc2HMaqqxRn8DFpk=",
+        "lastModified": 1721102667,
+        "narHash": "sha256-El85FFgw6N3RWALQU9YrOPeNrf2VfP5CWdXTCCOmcm0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0be20491ff4d6ae1124c8eb48f7ee80375c7d11e",
+        "rev": "03283d78f70c9bcba42577a07c21315814aa704b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`03283d78`](https://github.com/nix-community/NUR/commit/03283d78f70c9bcba42577a07c21315814aa704b) | `` automatic update `` |