### PR TITLE
chore(flake/nur): `03283d78` -> `d2602044`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721102667,
-        "narHash": "sha256-El85FFgw6N3RWALQU9YrOPeNrf2VfP5CWdXTCCOmcm0=",
+        "lastModified": 1721109180,
+        "narHash": "sha256-ojWHj40leH7h3xbGn3zt0MP11Au16mzDIdMRBN3tbOI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "03283d78f70c9bcba42577a07c21315814aa704b",
+        "rev": "d2602044ec59b27fc759530678da7a1cb66afbf3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d2602044`](https://github.com/nix-community/NUR/commit/d2602044ec59b27fc759530678da7a1cb66afbf3) | `` automatic update `` |
| [`d7f9e135`](https://github.com/nix-community/NUR/commit/d7f9e135dcf9f38c3aed26019e28e211b96e0099) | `` automatic update `` |
| [`b46c5028`](https://github.com/nix-community/NUR/commit/b46c5028492f9a3936db0fb51891ff9cef3485be) | `` automatic update `` |
| [`eab15aaf`](https://github.com/nix-community/NUR/commit/eab15aafb3091c0bde354d822935bef59593fbe9) | `` automatic update `` |