### PR TITLE
chore(flake/nur): `fb94373b` -> `64f752e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721111312,
-        "narHash": "sha256-e9dEXzJvK0USACzsCs4TqjrA+Zwl+FyaYnimkviXkLA=",
+        "lastModified": 1721116862,
+        "narHash": "sha256-4dZ2AM7eOKnzcZgCE+QUSZUgQGskYeNGbB7neDzo8d8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fb94373b5852a86518fecf5b9c3c5632c830669b",
+        "rev": "64f752e6fbf6d89da13f417fa34225a8b081ce92",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`64f752e6`](https://github.com/nix-community/NUR/commit/64f752e6fbf6d89da13f417fa34225a8b081ce92) | `` automatic update `` |
| [`90d6a675`](https://github.com/nix-community/NUR/commit/90d6a6759c216ee84e51b6340bc729ea99c97535) | `` automatic update `` |
| [`9a184926`](https://github.com/nix-community/NUR/commit/9a184926e9f114f28858614fc2e6d6be28662db3) | `` automatic update `` |