### PR TITLE
chore(flake/emacs-overlay): `7c521a93` -> `0adbb017`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721063376,
-        "narHash": "sha256-di+YqstcANGipdJP+lQ/vPOlB+UIFNSZjg6rlpMOyFs=",
+        "lastModified": 1721120232,
+        "narHash": "sha256-tIa/KLQyIEDW+9o+Tn5dc1Yy/KUfJpOYL7d+qxSIIEk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7c521a93160b3f3deb2325ba5485eabaecc76100",
+        "rev": "0adbb017f8a566bb6f6a6ce9ca421e5811b03cd7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`0adbb017`](https://github.com/nix-community/emacs-overlay/commit/0adbb017f8a566bb6f6a6ce9ca421e5811b03cd7) | `` Updated melpa ``  |
| [`f6ec5972`](https://github.com/nix-community/emacs-overlay/commit/f6ec59723fa18425e4577decb2048d35442a15c1) | `` Updated elpa ``   |
| [`57c23dc6`](https://github.com/nix-community/emacs-overlay/commit/57c23dc60fc0184da4da3fcd5e481a0c0851d087) | `` Updated nongnu `` |