### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `f342804a` -> `d0fb5e87`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -162,11 +162,11 @@
     "doomemacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1721017423,
-        "narHash": "sha256-eKtkKSEm1bSYrwK5VGiREGDeXNkr6l9vOdiQ3GTMI58=",
+        "lastModified": 1721071376,
+        "narHash": "sha256-2PqQOvP+BT5bK1xofnUYhAWIpgVIr6wXxyfhk7IMJHc=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "ba3f30ef67f948438c4b8ec65d502108702be333",
+        "rev": "fb0402e89cd671955dd37ca9011ea2fdce3a5688",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721031505,
-        "narHash": "sha256-sFjiq1FF8qK25IX5hhQ7+7drfki37CEywt0dhHPkgd0=",
+        "lastModified": 1721118121,
+        "narHash": "sha256-pcbp4oK8b9a6FrdB3r15ysSZ+h0O/9RoZ0uytOLApHs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "39f173b9d8aa62957e05f6fe513eb2974c072b09",
+        "rev": "f6ec59723fa18425e4577decb2048d35442a15c1",
         "type": "github"
       },
       "original": {
@@ -519,11 +519,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1721032431,
-        "narHash": "sha256-iz0gFIRtpaiScmKBXfdX89Z2j9+ewSBQlFq+9nsQgfg=",
+        "lastModified": 1721126401,
+        "narHash": "sha256-BwBSgvQYce3UtMq3TogYZ7CRanojVr46EQ8Q0owUL3A=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "f342804a7faae5a3de62ab7137394c2544ac5016",
+        "rev": "d0fb5e8764208c2fd68470214cfd8cbca732c1e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                                          |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`d0fb5e87`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/d0fb5e8764208c2fd68470214cfd8cbca732c1e0) | `` Bump git-commit again to match magit again `` |
| [`f13d6cf8`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/f13d6cf870963af696acc3da7e12ee842d977919) | `` flake.lock: Update ``                         |