### PR TITLE
chore(flake/home-manager): `90ae324e` -> `afd2021b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -410,11 +410,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720734513,
-        "narHash": "sha256-neWQ8eNtLTd+YMesb7WjKl1SVCbDyCm46LUgP/g/hdo=",
+        "lastModified": 1721135958,
+        "narHash": "sha256-H548rpPMsn25LDKn1PCFmPxmWlClJJGnvdzImHkqjuY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "90ae324e2c56af10f20549ab72014804a3064c7f",
+        "rev": "afd2021bedff2de92dfce0e257a3d03ae65c603d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`afd2021b`](https://github.com/nix-community/home-manager/commit/afd2021bedff2de92dfce0e257a3d03ae65c603d) | `` papis: add `program.papis.package` option ``         |
| [`a38f8804`](https://github.com/nix-community/home-manager/commit/a38f88045e464c7ad5686e8d5fdaac39d3360e5b) | `` khard: add option to contact module for khard dir `` |