### PR TITLE
chore(flake/nur): `7887ece2` -> `919caa93`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721130429,
-        "narHash": "sha256-e3G58acDuMmBN0FTRIVsccprEmpqnyv/na1hoUZM9Kg=",
+        "lastModified": 1721137506,
+        "narHash": "sha256-HfMHUCjFQUAe3sYrqJ/Dv8Tjs3gi9JvDDx8zxG6KiYA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7887ece202dcf1737ccecc3c5f00341e4b9f23bb",
+        "rev": "919caa9389ae9c9111dea19861a4ea42a19cade6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`919caa93`](https://github.com/nix-community/NUR/commit/919caa9389ae9c9111dea19861a4ea42a19cade6) | `` automatic update `` |