### PR TITLE
chore(flake/nur): `919caa93` -> `4b27add1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721137506,
-        "narHash": "sha256-HfMHUCjFQUAe3sYrqJ/Dv8Tjs3gi9JvDDx8zxG6KiYA=",
+        "lastModified": 1721138716,
+        "narHash": "sha256-VIYaXbGv8USc0zsp0ONDKCexK1YAGS7Fqy49MO+1Xg4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "919caa9389ae9c9111dea19861a4ea42a19cade6",
+        "rev": "4b27add1d74509749a3e61c92b867c939c71116e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4b27add1`](https://github.com/nix-community/NUR/commit/4b27add1d74509749a3e61c92b867c939c71116e) | `` automatic update `` |