### PR TITLE
chore(flake/nur): `4b27add1` -> `260b2faa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721138716,
-        "narHash": "sha256-VIYaXbGv8USc0zsp0ONDKCexK1YAGS7Fqy49MO+1Xg4=",
+        "lastModified": 1721147992,
+        "narHash": "sha256-nBVXmAoNvySkLibFgvOit+rZw0KOxHBFeDE0tKhSSho=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4b27add1d74509749a3e61c92b867c939c71116e",
+        "rev": "260b2faa923ecc9e2a3b204682a4f964f2fa6cb5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`260b2faa`](https://github.com/nix-community/NUR/commit/260b2faa923ecc9e2a3b204682a4f964f2fa6cb5) | `` automatic update `` |