### PR TITLE
chore(flake/nur): `260b2faa` -> `5702ca95`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721147992,
-        "narHash": "sha256-nBVXmAoNvySkLibFgvOit+rZw0KOxHBFeDE0tKhSSho=",
+        "lastModified": 1721151892,
+        "narHash": "sha256-US3zr6IbNIhej9NVTTVu3H3DWrPEoL+582jH8Z8flUk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "260b2faa923ecc9e2a3b204682a4f964f2fa6cb5",
+        "rev": "5702ca953963fad411508589fc3505eaf86f85ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5702ca95`](https://github.com/nix-community/NUR/commit/5702ca953963fad411508589fc3505eaf86f85ac) | `` automatic update `` |