### PR TITLE
chore(flake/emacs-overlay): `11c06c64` -> `9dd72e16`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721148915,
-        "narHash": "sha256-I3Wllr6czC1TUbpPslCDJb7H+5IkrxxZSEf6ExCgw90=",
+        "lastModified": 1721178459,
+        "narHash": "sha256-pkBAQnaDCV+QfiAawRAfY75dCk/lYw0D7nKhquAL0rE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "11c06c6444c0336abda4c61441ed1e8b18c21748",
+        "rev": "9dd72e16f2ac68649d7fb5bdf1e3fbeb08503dbb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message            |
| ------------------------------------------------------------------------------------------------------------ | ------------------ |
| [`9dd72e16`](https://github.com/nix-community/emacs-overlay/commit/9dd72e16f2ac68649d7fb5bdf1e3fbeb08503dbb) | `` Updated elpa `` |