### PR TITLE
chore(flake/emacs-overlay): `9dd72e16` -> `b92d12e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721178459,
-        "narHash": "sha256-pkBAQnaDCV+QfiAawRAfY75dCk/lYw0D7nKhquAL0rE=",
+        "lastModified": 1721181422,
+        "narHash": "sha256-CSVzMT3j3160DRgDujPsPoPtyfQ0z3YGtlwyoHtnjVc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9dd72e16f2ac68649d7fb5bdf1e3fbeb08503dbb",
+        "rev": "b92d12e48fa86f107cbeaf09586b488854a83985",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`b92d12e4`](https://github.com/nix-community/emacs-overlay/commit/b92d12e48fa86f107cbeaf09586b488854a83985) | `` Updated emacs `` |
| [`754cbb7c`](https://github.com/nix-community/emacs-overlay/commit/754cbb7ce6f33dc11161c02b512d800d1542c5d6) | `` Updated melpa `` |