### PR TITLE
chore(flake/nur): `5fe91e7a` -> `0ff08747`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721173497,
-        "narHash": "sha256-iiVuW6yDRWPhftSyv7A2FRhYwvfrBivWwwgLLPGPdvU=",
+        "lastModified": 1721188562,
+        "narHash": "sha256-RT2lWpGX3sPRVDMmMlcJnvA7P8aDEvpPWX8CyRjnRsw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5fe91e7aa31adf62e44c50250820dce5d761844b",
+        "rev": "0ff087479d66b948e52822a8d84cbeba060fd58b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0ff08747`](https://github.com/nix-community/NUR/commit/0ff087479d66b948e52822a8d84cbeba060fd58b) | `` automatic update `` |
| [`0b0fe1c8`](https://github.com/nix-community/NUR/commit/0b0fe1c82875c34a5db8d660972c7e99577ca615) | `` automatic update `` |
| [`5bcc9c44`](https://github.com/nix-community/NUR/commit/5bcc9c44e4cc596cc9a1825faab0aba694bcf09c) | `` automatic update `` |
| [`e4e85b3f`](https://github.com/nix-community/NUR/commit/e4e85b3f3160fcf47932444786d87ccaff4888e4) | `` automatic update `` |