### PR TITLE
chore(flake/nur): `0ff08747` -> `b04b42dc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721188562,
-        "narHash": "sha256-RT2lWpGX3sPRVDMmMlcJnvA7P8aDEvpPWX8CyRjnRsw=",
+        "lastModified": 1721189052,
+        "narHash": "sha256-UZtykUnqVvOhU7dYsMYI109ZamPyKIqKFsED+982yLU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0ff087479d66b948e52822a8d84cbeba060fd58b",
+        "rev": "b04b42dccf5540f3c46c032c8e3c4014fe889c0a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b04b42dc`](https://github.com/nix-community/NUR/commit/b04b42dccf5540f3c46c032c8e3c4014fe889c0a) | `` automatic update `` |