### PR TITLE
chore(flake/nur): `b04b42dc` -> `181630ea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721189052,
-        "narHash": "sha256-UZtykUnqVvOhU7dYsMYI109ZamPyKIqKFsED+982yLU=",
+        "lastModified": 1721194933,
+        "narHash": "sha256-SLACn4mXm7xNFBDifNjhedRd0fOTBnaAPFdL5M8jRTE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b04b42dccf5540f3c46c032c8e3c4014fe889c0a",
+        "rev": "181630ea4eda5760043b2daeb3823a1e79cbce20",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`181630ea`](https://github.com/nix-community/NUR/commit/181630ea4eda5760043b2daeb3823a1e79cbce20) | `` automatic update `` |
| [`1337a3bd`](https://github.com/nix-community/NUR/commit/1337a3bdb40fb4649cfb087829d0dadd5ecb329f) | `` automatic update `` |
| [`999f001f`](https://github.com/nix-community/NUR/commit/999f001f979cd466f221003e0e835834bfaf9573) | `` fix naming typo ``  |