### PR TITLE
chore(flake/nur): `181630ea` -> `be300193`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721194933,
-        "narHash": "sha256-SLACn4mXm7xNFBDifNjhedRd0fOTBnaAPFdL5M8jRTE=",
+        "lastModified": 1721198247,
+        "narHash": "sha256-mqRYYRfG6hn1VlI7jM8f4KGmMHDhAjPhtzwPm7AEKgs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "181630ea4eda5760043b2daeb3823a1e79cbce20",
+        "rev": "be30019339c72ce3310ad5775dc9b95a685915f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`be300193`](https://github.com/nix-community/NUR/commit/be30019339c72ce3310ad5775dc9b95a685915f4) | `` automatic update `` |
| [`3e979b15`](https://github.com/nix-community/NUR/commit/3e979b151f29a5f1c1fbb11e9aa89048008ec2cb) | `` automatic update `` |