### PR TITLE
chore(flake/nur): `be300193` -> `4b3c88da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721198247,
-        "narHash": "sha256-mqRYYRfG6hn1VlI7jM8f4KGmMHDhAjPhtzwPm7AEKgs=",
+        "lastModified": 1721205995,
+        "narHash": "sha256-+MMeNVtJBjbL9G/rQjZN4DYlIGTGrDpFzgEMajmkI44=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "be30019339c72ce3310ad5775dc9b95a685915f4",
+        "rev": "4b3c88dac4244019c17e61ba3c2e736e27e4ff70",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4b3c88da`](https://github.com/nix-community/NUR/commit/4b3c88dac4244019c17e61ba3c2e736e27e4ff70) | `` automatic update `` |
| [`6005506b`](https://github.com/nix-community/NUR/commit/6005506b80a9997b49cf916ff7efb59e416cccd9) | `` automatic update `` |