### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `d0fb5e87` -> `379dbd48`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -162,11 +162,11 @@
     "doomemacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1721071376,
-        "narHash": "sha256-2PqQOvP+BT5bK1xofnUYhAWIpgVIr6wXxyfhk7IMJHc=",
+        "lastModified": 1721144054,
+        "narHash": "sha256-+ZgbNFXWFGc6JAoow8s5zlchJ5TCEV07PxZQJz2KArs=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "fb0402e89cd671955dd37ca9011ea2fdce3a5688",
+        "rev": "13ed89f2354026b9c176f5c6861704aeda07723b",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721118121,
-        "narHash": "sha256-pcbp4oK8b9a6FrdB3r15ysSZ+h0O/9RoZ0uytOLApHs=",
+        "lastModified": 1721181422,
+        "narHash": "sha256-CSVzMT3j3160DRgDujPsPoPtyfQ0z3YGtlwyoHtnjVc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f6ec59723fa18425e4577decb2048d35442a15c1",
+        "rev": "b92d12e48fa86f107cbeaf09586b488854a83985",
         "type": "github"
       },
       "original": {
@@ -519,11 +519,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1721126401,
-        "narHash": "sha256-BwBSgvQYce3UtMq3TogYZ7CRanojVr46EQ8Q0owUL3A=",
+        "lastModified": 1721205183,
+        "narHash": "sha256-bQTUNdcxHKflrREBt/F1h/c+glp8RE7QLExJUqo/jtA=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "d0fb5e8764208c2fd68470214cfd8cbca732c1e0",
+        "rev": "379dbd487776694d5de5e7a175674b7893a4b95d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`379dbd48`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/379dbd487776694d5de5e7a175674b7893a4b95d) | `` flake.lock: Update `` |