### PR TITLE
chore(flake/nur): `4b3c88da` -> `eb0eb747`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721205995,
-        "narHash": "sha256-+MMeNVtJBjbL9G/rQjZN4DYlIGTGrDpFzgEMajmkI44=",
+        "lastModified": 1721213093,
+        "narHash": "sha256-GLn33GH9KH7m0k7fsundhWoDNTwtB0yMBtU+RY9ncZE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4b3c88dac4244019c17e61ba3c2e736e27e4ff70",
+        "rev": "eb0eb747a84c7594b7e2278b6f58e8aed4a8b303",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`eb0eb747`](https://github.com/nix-community/NUR/commit/eb0eb747a84c7594b7e2278b6f58e8aed4a8b303) | `` automatic update `` |