### PR TITLE
chore(flake/nur): `b76c62fb` -> `4da3381a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721223981,
-        "narHash": "sha256-FV/5hfqVwmpk+jD+U3lQpsDFJlKlt/WDi/u8quxELUU=",
+        "lastModified": 1721227577,
+        "narHash": "sha256-BscHUVeZSetkrjIrzfkoH+j9RaMf9ZMlc08sBUvmTxY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b76c62fb9acae0598d1198ab8e5568e58b99e1d1",
+        "rev": "4da3381a200d17b80d1160669aca218298524f9e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4da3381a`](https://github.com/nix-community/NUR/commit/4da3381a200d17b80d1160669aca218298524f9e) | `` automatic update `` |