### PR TITLE
chore(flake/srvos): `36905a23` -> `d10fbbd5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -955,11 +955,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721032527,
-        "narHash": "sha256-4hpsvyoWYRdZ4u6xDQ8uK5BhKDqHwqNQBi1R7y3n5aI=",
+        "lastModified": 1721225860,
+        "narHash": "sha256-JM/9bP6TBzGmayO9a2fXOYaMQNZtPs87VgHpgtsuXuk=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "36905a236dc466b8eff20df84314d23c95da3f6c",
+        "rev": "d10fbbd58b728648d4f592aefbf987f4d01c49f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                               |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`d10fbbd5`](https://github.com/nix-community/srvos/commit/d10fbbd58b728648d4f592aefbf987f4d01c49f3) | `` feat(zfs): set default networking.hostId (#465) `` |