### PR TITLE
chore(flake/emacs-overlay): `b92d12e4` -> `cec5116c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721181422,
-        "narHash": "sha256-CSVzMT3j3160DRgDujPsPoPtyfQ0z3YGtlwyoHtnjVc=",
+        "lastModified": 1721235408,
+        "narHash": "sha256-N861emvZTeafOtAxwAeN3iH2XqAaqWmpc+qlQhQLVew=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b92d12e48fa86f107cbeaf09586b488854a83985",
+        "rev": "cec5116cb48b950f71faa35a0b0b252e33ab388d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`cec5116c`](https://github.com/nix-community/emacs-overlay/commit/cec5116cb48b950f71faa35a0b0b252e33ab388d) | `` Updated melpa `` |
| [`9aa34421`](https://github.com/nix-community/emacs-overlay/commit/9aa34421d15e96046b0cab8df3c3478a3391ff45) | `` Updated elpa ``  |