### PR TITLE
chore(flake/nur): `4da3381a` -> `f33f46c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721227577,
-        "narHash": "sha256-BscHUVeZSetkrjIrzfkoH+j9RaMf9ZMlc08sBUvmTxY=",
+        "lastModified": 1721241063,
+        "narHash": "sha256-jBAuwmtJmSNT6xwjtGINslFK0m3R3+Ydw+xrd+a3tSE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4da3381a200d17b80d1160669aca218298524f9e",
+        "rev": "f33f46c1e38b07b20a978ac39208058ab9ddedb1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f33f46c1`](https://github.com/nix-community/NUR/commit/f33f46c1e38b07b20a978ac39208058ab9ddedb1) | `` automatic update `` |
| [`2f0aa2d8`](https://github.com/nix-community/NUR/commit/2f0aa2d8a13586fade2f62a749f4c4ccd310e655) | `` automatic update `` |
| [`c1c05d57`](https://github.com/nix-community/NUR/commit/c1c05d57f89745219a98af4e97dc5c4788adcc17) | `` automatic update `` |