### PR TITLE
chore(flake/emacs-overlay): `cec5116c` -> `6f278c19`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721235408,
-        "narHash": "sha256-N861emvZTeafOtAxwAeN3iH2XqAaqWmpc+qlQhQLVew=",
+        "lastModified": 1721236247,
+        "narHash": "sha256-ppnFOXRkgmh4UbdVYwfhe3u0iaNl0tXVD8HW1RS7kcQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cec5116cb48b950f71faa35a0b0b252e33ab388d",
+        "rev": "6f278c19282d891942272ee10cadcbd16678fda8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`6f278c19`](https://github.com/nix-community/emacs-overlay/commit/6f278c19282d891942272ee10cadcbd16678fda8) | `` Updated emacs `` |