### PR TITLE
chore(flake/nur): `f33f46c1` -> `9d824e97`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721241063,
-        "narHash": "sha256-jBAuwmtJmSNT6xwjtGINslFK0m3R3+Ydw+xrd+a3tSE=",
+        "lastModified": 1721251988,
+        "narHash": "sha256-eIOxl6Xq/7SKFoxW2q0968B6r1nYOOEC7H2lb2r/YpU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f33f46c1e38b07b20a978ac39208058ab9ddedb1",
+        "rev": "9d824e97d360a832131036684e30bc3d09d6f151",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9d824e97`](https://github.com/nix-community/NUR/commit/9d824e97d360a832131036684e30bc3d09d6f151) | `` automatic update `` |
| [`e4b352e5`](https://github.com/nix-community/NUR/commit/e4b352e596dee37e52c707996966336108bd8c11) | `` automatic update `` |