### PR TITLE
chore(flake/emacs-overlay): `6f278c19` -> `3bbe0ad8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721236247,
-        "narHash": "sha256-ppnFOXRkgmh4UbdVYwfhe3u0iaNl0tXVD8HW1RS7kcQ=",
+        "lastModified": 1721266930,
+        "narHash": "sha256-V8UuYJyWqKPgDPEaOBduwg2IXVNWzdJkSQvsd3XPBgQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6f278c19282d891942272ee10cadcbd16678fda8",
+        "rev": "3bbe0ad8b6c1f771b1777022d9aa69f83dbe7f3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`3bbe0ad8`](https://github.com/nix-community/emacs-overlay/commit/3bbe0ad8b6c1f771b1777022d9aa69f83dbe7f3b) | `` Updated melpa ``  |
| [`551b77a2`](https://github.com/nix-community/emacs-overlay/commit/551b77a23374230ec96cd43835872f7e0ec6894a) | `` Updated elpa ``   |
| [`9ad5a95f`](https://github.com/nix-community/emacs-overlay/commit/9ad5a95fcf6cec20c7f0ab68feec1a2fdde01851) | `` Updated nongnu `` |