### PR TITLE
chore(flake/srvos): `d10fbbd5` -> `ef4f2248`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -955,11 +955,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721225860,
-        "narHash": "sha256-JM/9bP6TBzGmayO9a2fXOYaMQNZtPs87VgHpgtsuXuk=",
+        "lastModified": 1721263500,
+        "narHash": "sha256-6l0+MciXkktANuZ+Rwc6BZJxtMi7jHZRiSnzG+xpwyk=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "d10fbbd58b728648d4f592aefbf987f4d01c49f3",
+        "rev": "ef4f2248e1bbd84a0dd269ab31b9927d9c0bf2e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`ef4f2248`](https://github.com/nix-community/srvos/commit/ef4f2248e1bbd84a0dd269ab31b9927d9c0bf2e6) | `` dev/private/flake.lock: Update `` |
| [`431e5c95`](https://github.com/nix-community/srvos/commit/431e5c957db92d5a5d7534d0d68a4cb9698c300b) | `` flake.lock: Update ``             |