### PR TITLE
chore(flake/nur): `2ed5571f` -> `2c4636c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721267475,
-        "narHash": "sha256-NlMApJs43ao6XhzG27HTkz8xK/UeeyfosVy7EswgzRg=",
+        "lastModified": 1721281972,
+        "narHash": "sha256-yfCYAcLbOy+9TUxp/OQ8xY9oc4MegmlN3RptsG0UBlA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2ed5571f569d46f5b450dee4d4a1de6cb20ded55",
+        "rev": "2c4636c712746b15f1a6347683cf9c5229983e03",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2c4636c7`](https://github.com/nix-community/NUR/commit/2c4636c712746b15f1a6347683cf9c5229983e03) | `` automatic update `` |
| [`59afaf25`](https://github.com/nix-community/NUR/commit/59afaf250be0d201029c828800c8721c415f0d89) | `` automatic update `` |