### PR TITLE
chore(flake/nur): `2c4636c7` -> `d57a6c64`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721281972,
-        "narHash": "sha256-yfCYAcLbOy+9TUxp/OQ8xY9oc4MegmlN3RptsG0UBlA=",
+        "lastModified": 1721289710,
+        "narHash": "sha256-EMJ31HN9h5jmuaQ7GDW5z6nyKgRncmk6PNbVRCU2EBs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2c4636c712746b15f1a6347683cf9c5229983e03",
+        "rev": "d57a6c642cca0cb55ca4de67dcd2d53ac8b66f4a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d57a6c64`](https://github.com/nix-community/NUR/commit/d57a6c642cca0cb55ca4de67dcd2d53ac8b66f4a) | `` automatic update `` |