### PR TITLE
chore(flake/nur): `d57a6c64` -> `f5ad38f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721289710,
-        "narHash": "sha256-EMJ31HN9h5jmuaQ7GDW5z6nyKgRncmk6PNbVRCU2EBs=",
+        "lastModified": 1721292361,
+        "narHash": "sha256-/wBS56xoS21WNrtgA/vMwsODHMC+YBv+YNRNxVIacuQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d57a6c642cca0cb55ca4de67dcd2d53ac8b66f4a",
+        "rev": "f5ad38f18ce4c6a25831a50919a7614863859b30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f5ad38f1`](https://github.com/nix-community/NUR/commit/f5ad38f18ce4c6a25831a50919a7614863859b30) | `` automatic update `` |