### PR TITLE
chore(flake/nur): `6c257a5a` -> `aa8c3424`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721299513,
-        "narHash": "sha256-yWrSf22Iky9qBQwCkhgZg4U7B/901HPGuHmVtKTqtTc=",
+        "lastModified": 1721307696,
+        "narHash": "sha256-BsZFpv9Hs+h6eVJ8YNj/KhEheon0Pw18CMZ2uUwZpzI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6c257a5a6aaec3037079ade2d0dfcc2164dd0e3a",
+        "rev": "aa8c3424a757732a7803b9b659b1881c3bb634e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`aa8c3424`](https://github.com/nix-community/NUR/commit/aa8c3424a757732a7803b9b659b1881c3bb634e4) | `` automatic update `` |