### PR TITLE
chore(flake/nur): `aa8c3424` -> `6a52aa02`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721307696,
-        "narHash": "sha256-BsZFpv9Hs+h6eVJ8YNj/KhEheon0Pw18CMZ2uUwZpzI=",
+        "lastModified": 1721308608,
+        "narHash": "sha256-9+sG0T06cECg/WR19qX6k0t1BQz4qMmfB7k9N+1QGS8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aa8c3424a757732a7803b9b659b1881c3bb634e4",
+        "rev": "6a52aa02e9c127a4bbdee2412123b6df5caa02de",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6a52aa02`](https://github.com/nix-community/NUR/commit/6a52aa02e9c127a4bbdee2412123b6df5caa02de) | `` automatic update `` |