### PR TITLE
chore(flake/nixos-hardware): `c5013aa7` -> `ede1f14c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1720737798,
-        "narHash": "sha256-G/OtEAts7ZUvW5lrGMXSb8HqRp2Jr9I7reBuvCOL54w=",
+        "lastModified": 1721323232,
+        "narHash": "sha256-T4K2P8FayLshsIkY04i7M8qs0aQY5ugf8HsghqGONCc=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "c5013aa7ce2c7ec90acee5d965d950c8348db751",
+        "rev": "ede1f14cc21e811a605f16c6b69bd3e8425383d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                             |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`9a816e3d`](https://github.com/NixOS/nixos-hardware/commit/9a816e3d1c0649a7c88370c8eb80071f5891a4d8) | `` asus-rog-strix-g713ie: init ``                   |
| [`9a187879`](https://github.com/NixOS/nixos-hardware/commit/9a187879f47ba2cad0f737913d99ebc893125ee6) | `` lenovo-thinkpad-z13-gen2: move to asound.conf `` |