### PR TITLE
chore(flake/nur): `dff6469c` -> `6e46867f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -805,11 +805,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721331890,
-        "narHash": "sha256-uzj0lq+NhzaVMN1kiP4XcTPDbGONeZ9Ce2hevDNmGd8=",
+        "lastModified": 1721335575,
+        "narHash": "sha256-dry8Y8MwACIdIBVFDOFQGpKd8PmEIPv9Ej0UdrdOlG8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dff6469c5356be4e1e83d2ae64c4575fbece78eb",
+        "rev": "6e46867fdecc920a1de55dc1e553a16f54e2d2ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6e46867f`](https://github.com/nix-community/NUR/commit/6e46867fdecc920a1de55dc1e553a16f54e2d2ee) | `` automatic update `` |