### PR TITLE
chore(flake/nur): `6e46867f` -> `cda8788c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -805,11 +805,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721335575,
-        "narHash": "sha256-dry8Y8MwACIdIBVFDOFQGpKd8PmEIPv9Ej0UdrdOlG8=",
+        "lastModified": 1721358031,
+        "narHash": "sha256-n4Fc9o5z9FDANQjP5YohVVkkTjf+nbg6CfctWXLJyMI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6e46867fdecc920a1de55dc1e553a16f54e2d2ee",
+        "rev": "cda8788cad2eb8798ee2d993150a135073b628d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cda8788c`](https://github.com/nix-community/NUR/commit/cda8788cad2eb8798ee2d993150a135073b628d4) | `` automatic update `` |
| [`f72b6a1a`](https://github.com/nix-community/NUR/commit/f72b6a1ab3f167bf9cfc041d3eea368759e2287a) | `` automatic update `` |
| [`47c7c184`](https://github.com/nix-community/NUR/commit/47c7c1843314c9f33c3991f9f620d1caec0db491) | `` automatic update `` |