### PR TITLE
chore(flake/nur): `cda8788c` -> `01a2cce1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -805,11 +805,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721358031,
-        "narHash": "sha256-n4Fc9o5z9FDANQjP5YohVVkkTjf+nbg6CfctWXLJyMI=",
+        "lastModified": 1721361332,
+        "narHash": "sha256-ukHs3p/m+48Xe02fLgAuJa4ecDDERcR41LoYniNcHZA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cda8788cad2eb8798ee2d993150a135073b628d4",
+        "rev": "01a2cce1e1a39e08d46629525a2849d0cab72def",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`01a2cce1`](https://github.com/nix-community/NUR/commit/01a2cce1e1a39e08d46629525a2849d0cab72def) | `` automatic update `` |
| [`9e5c51bc`](https://github.com/nix-community/NUR/commit/9e5c51bcfc7be3b3cf009170d1a9d833dcbb35cc) | `` automatic update `` |
| [`4730e517`](https://github.com/nix-community/NUR/commit/4730e51701581b94777f5008e0ad4967610aa5f3) | `` automatic update `` |