### PR TITLE
chore(flake/nur): `15afd41d` -> `6f706fc9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -805,11 +805,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721363543,
-        "narHash": "sha256-aNH6r/7zzEmiGdjkV+m4xxqnzLKNFV1FFeHQBBwqBOA=",
+        "lastModified": 1721377996,
+        "narHash": "sha256-NzYdE21HzPPlFK9oziN63GveiI1PUCHqGhAxtYwYvvw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "15afd41de2dd589a3da9ed431f832889f456ad1f",
+        "rev": "6f706fc9bb7294afd762ebf6b87dc6872308de10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6f706fc9`](https://github.com/nix-community/NUR/commit/6f706fc9bb7294afd762ebf6b87dc6872308de10) | `` automatic update `` |
| [`ef41448c`](https://github.com/nix-community/NUR/commit/ef41448cdd9bce9337c75ed65f3bcf808f1dab85) | `` automatic update `` |