### PR TITLE
chore(flake/nur): `6f706fc9` -> `c7790457`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -805,11 +805,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721377996,
-        "narHash": "sha256-NzYdE21HzPPlFK9oziN63GveiI1PUCHqGhAxtYwYvvw=",
+        "lastModified": 1721382321,
+        "narHash": "sha256-gVfoOk2M7Vd/AoqpTVwTLHJc2k+V1q+OXRTbFNezMgk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6f706fc9bb7294afd762ebf6b87dc6872308de10",
+        "rev": "c77904579746bd25f8195bad2361cb0c266bb2c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c7790457`](https://github.com/nix-community/NUR/commit/c77904579746bd25f8195bad2361cb0c266bb2c8) | `` automatic update `` |