### PR TITLE
chore(flake/nur): `c7790457` -> `0ddac69e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -805,11 +805,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721382321,
-        "narHash": "sha256-gVfoOk2M7Vd/AoqpTVwTLHJc2k+V1q+OXRTbFNezMgk=",
+        "lastModified": 1721385890,
+        "narHash": "sha256-GOPpYb2g3jEEfayAB5bOXK+XGiFBU7aAuQ9+qKbAHxM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c77904579746bd25f8195bad2361cb0c266bb2c8",
+        "rev": "0ddac69ec4f8578a281a898273323fa66504f749",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0ddac69e`](https://github.com/nix-community/NUR/commit/0ddac69ec4f8578a281a898273323fa66504f749) | `` automatic update `` |