### PR TITLE
chore(flake/emacs-overlay): `355921de` -> `f497642c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721379380,
-        "narHash": "sha256-poDZ9Hb/ldo6dMslDEzknvOsVpLpUx5ksHte9OSVuWM=",
+        "lastModified": 1721408138,
+        "narHash": "sha256-XgbXcmkZblw9+9JiX+QmkGbdCbV29yoWhAgBRmQAY48=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "355921de5ccda55682b37f181294bb70dbe7dfa3",
+        "rev": "f497642c635235c375ed8f9090768e91a8d5e29f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`f497642c`](https://github.com/nix-community/emacs-overlay/commit/f497642c635235c375ed8f9090768e91a8d5e29f) | `` Updated melpa ``  |
| [`93fa9461`](https://github.com/nix-community/emacs-overlay/commit/93fa94618a3048ccc427847d37c872fa46aa96c8) | `` Updated nongnu `` |