### PR TITLE
chore(flake/nixos-hardware): `d8bfbbf6` -> `ece5b120`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1721403706,
-        "narHash": "sha256-nK3RQXJRFWCT3VBpyfF1FzhZxtNW7a9QcavkWKPhMGc=",
+        "lastModified": 1721411914,
+        "narHash": "sha256-kq+Ot9SGmwLpUD9oPIrPz3GtRSnFNUUpVByJD7lBA2Q=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "d8bfbbf614881a110059f14bc2a5d28c5df115e5",
+        "rev": "ece5b120143233d5d19a5e6034ae8bc879c21e7a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                 |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`ece5b120`](https://github.com/NixOS/nixos-hardware/commit/ece5b120143233d5d19a5e6034ae8bc879c21e7a) | `` update README for omen 16-n0280nd `` |
| [`89a33c8e`](https://github.com/NixOS/nixos-hardware/commit/89a33c8e93a64d4f65ca3a2c7bc9da24216aa0b9) | `` omen 16-n0280nd: init ``             |
| [`71b92eab`](https://github.com/NixOS/nixos-hardware/commit/71b92eab15920df202dd6256c2e2a58cc6e48641) | `` asus-rog-strix-x570: init ``         |