### PR TITLE
chore(flake/nixos-hardware): `ece5b120` -> `ab165a8a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1721411914,
-        "narHash": "sha256-kq+Ot9SGmwLpUD9oPIrPz3GtRSnFNUUpVByJD7lBA2Q=",
+        "lastModified": 1721413321,
+        "narHash": "sha256-0GdiQScDceUrVGbxYpV819LHesK3szHOhJ09e6sgES4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "ece5b120143233d5d19a5e6034ae8bc879c21e7a",
+        "rev": "ab165a8a6cd12781d76fe9cbccb9e975d0fb634f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`ab165a8a`](https://github.com/NixOS/nixos-hardware/commit/ab165a8a6cd12781d76fe9cbccb9e975d0fb634f) | `` codeowners: Add Lyndeno for XPS-9560 ``             |
| [`05672b50`](https://github.com/NixOS/nixos-hardware/commit/05672b50f70e47df282e974e07534d38df4f8fd1) | `` dell/xps/15-9560: fix graphics options ``           |
| [`6a4ecebc`](https://github.com/NixOS/nixos-hardware/commit/6a4ecebce56727d0ae538b1277725cb03181124e) | `` dell/xps/15-9560: use graphics option ``            |
| [`42577dbb`](https://github.com/NixOS/nixos-hardware/commit/42577dbb0f75c1288a26864e40da32a0d67de853) | `` removed parts that are included in other modules `` |
| [`19e9c2fb`](https://github.com/NixOS/nixos-hardware/commit/19e9c2fb7a9877f2864922276cd6ca62b07fa37a) | `` naively pasted code from our forum discussion ``    |