### PR TITLE
chore(flake/nur): `798afce2` -> `3a24dfcc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -805,11 +805,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721407097,
-        "narHash": "sha256-y2uFuCkJs6hT9Ll6HnJgIVF8V3TmcW6kTyIRHwYQrWg=",
+        "lastModified": 1721420802,
+        "narHash": "sha256-8kmavDJgzkEwUujFAJCkoLk79r5DRuyVfu5TlLap624=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "798afce2460905c4e7a84f5428e8d7b36a286c24",
+        "rev": "3a24dfcc6b7bc383112e5a9e13d7c04cb659eff8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                      |
| -------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`3a24dfcc`](https://github.com/nix-community/NUR/commit/3a24dfcc6b7bc383112e5a9e13d7c04cb659eff8) | `` automatic update ``       |
| [`24cef5d3`](https://github.com/nix-community/NUR/commit/24cef5d3ddafca22b65bc762e837d267b1018d65) | `` automatic update ``       |
| [`d735068b`](https://github.com/nix-community/NUR/commit/d735068b6db280a8aa30a737b488639071fde259) | `` add jerrita repository `` |