### PR TITLE
chore(flake/emacs-overlay): `f497642c` -> `b3100595`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721408138,
-        "narHash": "sha256-XgbXcmkZblw9+9JiX+QmkGbdCbV29yoWhAgBRmQAY48=",
+        "lastModified": 1721437571,
+        "narHash": "sha256-w+FGfufCj2mugklWPycL8j4lM3gKrKgP3Fr4ez4GyGo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f497642c635235c375ed8f9090768e91a8d5e29f",
+        "rev": "b31005958cab83f8ea0683bfde0fa2df74d310a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`b3100595`](https://github.com/nix-community/emacs-overlay/commit/b31005958cab83f8ea0683bfde0fa2df74d310a1) | `` Updated elpa ``         |
| [`d2160011`](https://github.com/nix-community/emacs-overlay/commit/d21600113d97cd83a0a7271410a6b137a2853238) | `` Updated flake inputs `` |