### PR TITLE
chore(flake/emacs-overlay): `b3100595` -> `56a27553`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721437571,
-        "narHash": "sha256-w+FGfufCj2mugklWPycL8j4lM3gKrKgP3Fr4ez4GyGo=",
+        "lastModified": 1721440596,
+        "narHash": "sha256-ZSn70TYYIRD/N44Ao5mSHGEqz6Ltu8YENGn3g7q1ReM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b31005958cab83f8ea0683bfde0fa2df74d310a1",
+        "rev": "56a275531c6bc329a0851ba34902a2b5f021a03f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`56a27553`](https://github.com/nix-community/emacs-overlay/commit/56a275531c6bc329a0851ba34902a2b5f021a03f) | `` Updated emacs `` |
| [`60cdeb60`](https://github.com/nix-community/emacs-overlay/commit/60cdeb609b14991cad7c1eb2ab06038288596cca) | `` Updated melpa `` |