### PR TITLE
chore(flake/nur): `3a24dfcc` -> `4eca3686`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -805,11 +805,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721420802,
-        "narHash": "sha256-8kmavDJgzkEwUujFAJCkoLk79r5DRuyVfu5TlLap624=",
+        "lastModified": 1721443845,
+        "narHash": "sha256-nI1F7Ec0gzTwEDlEqstqGdP2jc61EWpZ8b80zBMAdpU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3a24dfcc6b7bc383112e5a9e13d7c04cb659eff8",
+        "rev": "4eca3686323e1aee9ff8f71ad4943e3ac7b9e4c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4eca3686`](https://github.com/nix-community/NUR/commit/4eca3686323e1aee9ff8f71ad4943e3ac7b9e4c6) | `` automatic update `` |
| [`77773ed5`](https://github.com/nix-community/NUR/commit/77773ed5da96cd8fb066539823449011107dabc6) | `` automatic update `` |
| [`d00506e9`](https://github.com/nix-community/NUR/commit/d00506e980727a462eaceadcfd4713d090d308c1) | `` automatic update `` |