### PR TITLE
chore(flake/nur): `4eca3686` -> `61dc0c14`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -805,11 +805,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721443845,
-        "narHash": "sha256-nI1F7Ec0gzTwEDlEqstqGdP2jc61EWpZ8b80zBMAdpU=",
+        "lastModified": 1721450710,
+        "narHash": "sha256-7pFGERxbrvCzWLzYRziNmDciHp6JvWGnRG9hJdDt+/U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4eca3686323e1aee9ff8f71ad4943e3ac7b9e4c6",
+        "rev": "61dc0c143e29b742a51841415bae7c2b0513bba4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`61dc0c14`](https://github.com/nix-community/NUR/commit/61dc0c143e29b742a51841415bae7c2b0513bba4) | `` automatic update `` |
| [`a46e826c`](https://github.com/nix-community/NUR/commit/a46e826c8d0d498b54b1db5c720afa45dbe638ec) | `` automatic update `` |
| [`f3ca665d`](https://github.com/nix-community/NUR/commit/f3ca665d3bb7008472fe9f5bf50638c61429147e) | `` automatic update `` |
| [`e1922852`](https://github.com/nix-community/NUR/commit/e1922852a7d8617e71c29a6182f4f2743cd16444) | `` automatic update `` |
| [`75b6f7d1`](https://github.com/nix-community/NUR/commit/75b6f7d12d044b688904aaf5b5fd6be5fc7396e5) | `` automatic update `` |
| [`3e8a77af`](https://github.com/nix-community/NUR/commit/3e8a77af0aba6cee6701579801f0f16148b04cf1) | `` automatic update `` |
| [`3f8eb3a9`](https://github.com/nix-community/NUR/commit/3f8eb3a93cbbc9edc8ac5e130035ccedc28965e9) | `` automatic update `` |