### PR TITLE
chore(flake/nur): `61dc0c14` -> `fd8f3790`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -805,11 +805,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721450710,
-        "narHash": "sha256-7pFGERxbrvCzWLzYRziNmDciHp6JvWGnRG9hJdDt+/U=",
+        "lastModified": 1721454799,
+        "narHash": "sha256-0a0qNvwbI9TeP5BvlNxOzPdrmopS+RnNnNhRc+8lolo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "61dc0c143e29b742a51841415bae7c2b0513bba4",
+        "rev": "fd8f37901547bb8b84e64ef63e0c712c1668c5a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fd8f3790`](https://github.com/nix-community/NUR/commit/fd8f37901547bb8b84e64ef63e0c712c1668c5a4) | `` automatic update `` |
| [`beb94e3d`](https://github.com/nix-community/NUR/commit/beb94e3d85cd77c163acdcb4814cc7870cab5d65) | `` automatic update `` |