### PR TITLE
chore(flake/nur): `fd8f3790` -> `8e289dad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -805,11 +805,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721454799,
-        "narHash": "sha256-0a0qNvwbI9TeP5BvlNxOzPdrmopS+RnNnNhRc+8lolo=",
+        "lastModified": 1721458926,
+        "narHash": "sha256-fpIFPjLBWoI5Jnd5zYrFfdwQg89BGv6eC15EzavzKm8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fd8f37901547bb8b84e64ef63e0c712c1668c5a4",
+        "rev": "8e289dade712ce3fea20945a24dd49638fad593c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8e289dad`](https://github.com/nix-community/NUR/commit/8e289dade712ce3fea20945a24dd49638fad593c) | `` automatic update `` |
| [`5dd26541`](https://github.com/nix-community/NUR/commit/5dd265419865cf491ce7c8086b9946b6a774c466) | `` automatic update `` |
| [`ba4b8146`](https://github.com/nix-community/NUR/commit/ba4b8146d46804bf4a5a91af43103699b800907d) | `` automatic update `` |