### PR TITLE
chore(flake/treefmt): `50104496` -> `888bfb10`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1016,11 +1016,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721382922,
-        "narHash": "sha256-GYpibTC0YYKRpFR9aftym9jjRdUk67ejw1IWiaQkaiU=",
+        "lastModified": 1721458737,
+        "narHash": "sha256-wNXLQ/ATs1S4Opg1PmuNoJ+Wamqj93rgZYV3Di7kxkg=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "50104496fb55c9140501ea80d183f3223d13ff65",
+        "rev": "888bfb10a9b091d9ed2f5f8064de8d488f7b7c97",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                   |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`888bfb10`](https://github.com/numtide/treefmt-nix/commit/888bfb10a9b091d9ed2f5f8064de8d488f7b7c97) | `` flake-modules.nix: allow empty specification (#204) `` |