### PR TITLE
chore(flake/emacs-overlay): `56a27553` -> `5f86ac8c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721440596,
-        "narHash": "sha256-ZSn70TYYIRD/N44Ao5mSHGEqz6Ltu8YENGn3g7q1ReM=",
+        "lastModified": 1721465706,
+        "narHash": "sha256-zIE4byBZkylqjuRu7xhfqgnzWz9/Tq+4WHriAQpjdcQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "56a275531c6bc329a0851ba34902a2b5f021a03f",
+        "rev": "5f86ac8cbd9aff1f8f86ca1a569a10a077d9db54",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`5f86ac8c`](https://github.com/nix-community/emacs-overlay/commit/5f86ac8cbd9aff1f8f86ca1a569a10a077d9db54) | `` Updated melpa `` |