### PR TITLE
chore(flake/nur): `8e289dad` -> `b4365ef4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -805,11 +805,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721458926,
-        "narHash": "sha256-fpIFPjLBWoI5Jnd5zYrFfdwQg89BGv6eC15EzavzKm8=",
+        "lastModified": 1721472350,
+        "narHash": "sha256-XFGmZB6GhnYsTOFouj60lc40OkZxpdk6mL2nTT0fIkU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8e289dade712ce3fea20945a24dd49638fad593c",
+        "rev": "b4365ef44d92f9f6bd6ad3e54117d1719ebd2c57",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b4365ef4`](https://github.com/nix-community/NUR/commit/b4365ef44d92f9f6bd6ad3e54117d1719ebd2c57) | `` automatic update `` |
| [`bf62ce1d`](https://github.com/nix-community/NUR/commit/bf62ce1d0b41e23cbaf8b780e783119b50f1435c) | `` automatic update `` |
| [`cca26970`](https://github.com/nix-community/NUR/commit/cca26970ccce15cd6d0b14e5ecf13bfca16fe13e) | `` automatic update `` |
| [`c3b485f5`](https://github.com/nix-community/NUR/commit/c3b485f55d9f323e96f61d7cab306fc3dd3a8448) | `` automatic update `` |
| [`a434df4c`](https://github.com/nix-community/NUR/commit/a434df4c88fadf3d4a0a6c262f7b85c5f5999b80) | `` automatic update `` |