### PR TITLE
chore(flake/nur): `a4c5fbcd` -> `c9927fe7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -805,11 +805,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721483124,
-        "narHash": "sha256-pWsDpSZ/8necd7nvjV9P+EAARWaYgvn8tIDfUo6kJ/c=",
+        "lastModified": 1721490395,
+        "narHash": "sha256-+Dfesi/WXkFRi6isU6290Y4TC+fXX6WXzs/lpqW5wbc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a4c5fbcd97777ae321523253b042b13de0941a25",
+        "rev": "c9927fe73cae0e1d11bd136a9e0e446af3623004",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c9927fe7`](https://github.com/nix-community/NUR/commit/c9927fe73cae0e1d11bd136a9e0e446af3623004) | `` automatic update `` |
| [`d3bcf854`](https://github.com/nix-community/NUR/commit/d3bcf854a30dabaeaa31c888eb4e0e90410ab4b1) | `` automatic update `` |
| [`5fb39493`](https://github.com/nix-community/NUR/commit/5fb394930f5fb0862ad4bb97c170efee4d65a7b5) | `` automatic update `` |