### PR TITLE
chore(flake/emacs-overlay): `f5e69f54` -> `f765e26c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721466565,
-        "narHash": "sha256-OKRGw6BP/6+Nr3xi7wooyR8cSgJerE/0oaLUMRcCQXY=",
+        "lastModified": 1721494487,
+        "narHash": "sha256-TazCeQmCYe2xv0drW/Qehm7wdzFOnFGGMos/lUurevU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f5e69f54e55881c07792e278f622f7efb2146ef9",
+        "rev": "f765e26c7970f9d2ea74b901bdd25649c2622643",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`f765e26c`](https://github.com/nix-community/emacs-overlay/commit/f765e26c7970f9d2ea74b901bdd25649c2622643) | `` Updated melpa `` |
| [`55522f47`](https://github.com/nix-community/emacs-overlay/commit/55522f475afa8ce5bd89501e34d0cf96cdc6d276) | `` Updated elpa ``  |