### PR TITLE
chore(flake/nur): `c9927fe7` -> `1ba95ac7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -805,11 +805,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721490395,
-        "narHash": "sha256-+Dfesi/WXkFRi6isU6290Y4TC+fXX6WXzs/lpqW5wbc=",
+        "lastModified": 1721497138,
+        "narHash": "sha256-lHBXCSFd/iZwSoiHHFLVOeZmyvcOFxt8c0DyXj/cuiw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c9927fe73cae0e1d11bd136a9e0e446af3623004",
+        "rev": "1ba95ac769d3c7c48f92482857c162be666aa06d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1ba95ac7`](https://github.com/nix-community/NUR/commit/1ba95ac769d3c7c48f92482857c162be666aa06d) | `` automatic update `` |
| [`cd04c57a`](https://github.com/nix-community/NUR/commit/cd04c57aa89f999c964378ba250f023919c13036) | `` automatic update `` |