### PR TITLE
chore(flake/lanzaboote): `0e6457c9` -> `60e4578f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -84,11 +84,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718474113,
-        "narHash": "sha256-UKrfy/46YF2TRnxTtKCYzqf2f5ZPRRWwKCCJb7O5X8U=",
+        "lastModified": 1718730147,
+        "narHash": "sha256-QmD6B6FYpuoCqu6ZuPJH896ItNquDkn0ulQlOn4ykN8=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "0095fd8ea00ae0a9e6014f39c375e40c2fbd3386",
+        "rev": "32c21c29b034d0a93fdb2379d6fabc40fc3d0e6c",
         "type": "github"
       },
       "original": {
@@ -459,11 +459,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1719818887,
-        "narHash": "sha256-Bogl1pJlgby7OpR16jp8zwOWV7FHRxCsnNxHcisyIq0=",
+        "lastModified": 1721501207,
+        "narHash": "sha256-umzgs8hXYUyQe6wJm7AnJ3kx8M/h0/WXR2OemAZs3Qs=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "0e6457c98547ec8866714d4222545e7e8c1ae429",
+        "rev": "60e4578feca3d894f1474a9b08780c9a5433ad08",
         "type": "github"
       },
       "original": {
@@ -854,21 +854,17 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": [
-          "lanzaboote",
-          "flake-utils"
-        ],
         "nixpkgs": [
           "lanzaboote",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1718504420,
-        "narHash": "sha256-F2HT/abCfr0CDpkvXwYCscJyD66XDTLMVfdrIMRp2ck=",
+        "lastModified": 1719109180,
+        "narHash": "sha256-96dwGCV2yQxDozDATqbsM3YU0ft3Isw3cwVDO/eNCv8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "0043c3f92304823cc2c0a4354b0feaa61dfb4cd9",
+        "rev": "5fc5f3a0d7eabf7db86851e6423f9d7fbceaf89d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                                      |
| --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`9d205aa0`](https://github.com/nix-community/lanzaboote/commit/9d205aa0f9c4f93852aae2ec62e20a9893f9452b) | `` chore(deps): lock file maintenance ``                                     |
| [`2cee36f1`](https://github.com/nix-community/lanzaboote/commit/2cee36f14d9016b3d9147ffd0bc76dfb965b10e1) | `` stub: simplify `compute_pad4` ``                                          |
| [`a15fab25`](https://github.com/nix-community/lanzaboote/commit/a15fab25ed840f3fbf48c0908189bccf9aa0213b) | `` linux-bootloader: slay a panic ``                                         |
| [`6f0cd98c`](https://github.com/nix-community/lanzaboote/commit/6f0cd98cc474ffd3abe0ecb401b29fd13a17f4db) | `` stub: slay more panics ``                                                 |
| [`1352b0ab`](https://github.com/nix-community/lanzaboote/commit/1352b0ab82adf64df4a5a261cf3a5ef2a2ed6bc5) | `` stub: warn about failed device path to text errors ``                     |
| [`19ff63da`](https://github.com/nix-community/lanzaboote/commit/19ff63da319297fc7f4237b1d5b66b143dece775) | `` stub(*): upgrade to uefi 0.28.0 ``                                        |
| [`cd772abd`](https://github.com/nix-community/lanzaboote/commit/cd772abdcf55f929a8a62fddf768e2a6deb02bc8) | `` stub(thin): align initrds! ``                                             |
| [`c42bd372`](https://github.com/nix-community/lanzaboote/commit/c42bd37269e5ee7a7519a2354e2a1434041fab43) | `` stub: measure companion initrds ``                                        |
| [`4573a9dd`](https://github.com/nix-community/lanzaboote/commit/4573a9dd9bd27c054444623cc4b1aca1a109d4d9) | `` stub: discover credentials and system extensions and load them ``         |
| [`d419d049`](https://github.com/nix-community/lanzaboote/commit/d419d0499d3216a554f321f54ab41dee3aef1816) | `` linux-bootloader: support code for cpio and discovery ``                  |
| [`8a2d205a`](https://github.com/nix-community/lanzaboote/commit/8a2d205adb68d37563a447edf4a8f83496f18741) | `` linux-bootloader: take note of the `image_device_path` in `PeInMemory` `` |
| [`69b445b3`](https://github.com/nix-community/lanzaboote/commit/69b445b3cfd9f026387c5aaae2580cd20320742e) | `` cargo: use git for `uefi-rs` ``                                           |