### PR TITLE
chore(flake/nur): `1ba95ac7` -> `c391109c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -805,11 +805,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721497138,
-        "narHash": "sha256-lHBXCSFd/iZwSoiHHFLVOeZmyvcOFxt8c0DyXj/cuiw=",
+        "lastModified": 1721504702,
+        "narHash": "sha256-sSfOjjfkkUECZ0sNHw/KX6Bak2NupfEfwPL6AsBxAaU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1ba95ac769d3c7c48f92482857c162be666aa06d",
+        "rev": "c391109c05698d5efaca90d93abffdd03dcd00d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c391109c`](https://github.com/nix-community/NUR/commit/c391109c05698d5efaca90d93abffdd03dcd00d5) | `` automatic update `` |
| [`db1971df`](https://github.com/nix-community/NUR/commit/db1971dfc68be28c8facb357738f7133ef275c4f) | `` automatic update `` |