### PR TITLE
chore(flake/nur): `c391109c` -> `33e72497`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -805,11 +805,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721504702,
-        "narHash": "sha256-sSfOjjfkkUECZ0sNHw/KX6Bak2NupfEfwPL6AsBxAaU=",
+        "lastModified": 1721511336,
+        "narHash": "sha256-xOtN5XatJcd0L+bJ5uHYIwOqoVqmi0R4dFGPARmhCKg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c391109c05698d5efaca90d93abffdd03dcd00d5",
+        "rev": "33e724977d42710629afacd156a72ed4df45ecc6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`33e72497`](https://github.com/nix-community/NUR/commit/33e724977d42710629afacd156a72ed4df45ecc6) | `` automatic update `` |
| [`7901d2c1`](https://github.com/nix-community/NUR/commit/7901d2c1cec3e045368efe0bf2c21ccba3832174) | `` automatic update `` |