### PR TITLE
chore(flake/emacs-overlay): `173aa23e` -> `23699d9f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721495293,
-        "narHash": "sha256-L6U8CEsRNfz3SeJGlKNgga4O89z4QNmU577Eyq9PVCU=",
+        "lastModified": 1721527310,
+        "narHash": "sha256-aJTZjouEw9L17JTnvcfNrBbGP9+1o/3/+/QvrojtItg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "173aa23e22b32c9d3585a96df74ec7c53d64de92",
+        "rev": "23699d9fc7faba4eb84719109cad6eee3a17e143",
         "type": "github"
       },
       "original": {
@@ -703,11 +703,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1721226092,
-        "narHash": "sha256-UBvzVpo5sXSi2S/Av+t+Q+C2mhMIw/LBEZR+d6NMjws=",
+        "lastModified": 1721409541,
+        "narHash": "sha256-b6PLr0Ty7JPDBtJtjnYzlBf02bbH9alWMAgispMkTwk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c716603a63aca44f39bef1986c13402167450e0a",
+        "rev": "0c53b6b8c2a3e46c68e04417e247bba660689c9d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`23699d9f`](https://github.com/nix-community/emacs-overlay/commit/23699d9fc7faba4eb84719109cad6eee3a17e143) | `` Updated emacs ``        |
| [`21ae5ddf`](https://github.com/nix-community/emacs-overlay/commit/21ae5ddfc3cfe05093ca65c2227944d733a4cbe0) | `` Updated melpa ``        |
| [`717ae15d`](https://github.com/nix-community/emacs-overlay/commit/717ae15d3131b195df37cc807ec3c4bff2342c06) | `` Updated elpa ``         |
| [`d5e3454d`](https://github.com/nix-community/emacs-overlay/commit/d5e3454df11542bd7a8e1a2c17ba431a43070633) | `` Updated flake inputs `` |