### PR TITLE
chore(flake/nur): `ac7d7224` -> `010342de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -805,11 +805,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721524767,
-        "narHash": "sha256-/We22DYkClfnB9OWrR0gzW6di/iLn/7aRbpGHYK3Qec=",
+        "lastModified": 1721541099,
+        "narHash": "sha256-dn3VIVZiCENVkAz9HbXbi1InwfC+NAU/wEDVJiRI5Yk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ac7d7224d18cd1622f5903e231f5e4e65475c156",
+        "rev": "010342de58322237c2c38fc4335d88ab44e8b5a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`010342de`](https://github.com/nix-community/NUR/commit/010342de58322237c2c38fc4335d88ab44e8b5a8) | `` automatic update `` |
| [`0f61f0a7`](https://github.com/nix-community/NUR/commit/0f61f0a7e37cd8c15446b40ac3b09186bc58c7b1) | `` automatic update `` |
| [`cb34a522`](https://github.com/nix-community/NUR/commit/cb34a5223f2f7af079698f784d533372696466d1) | `` automatic update `` |
| [`19b7c451`](https://github.com/nix-community/NUR/commit/19b7c45163db1a0b9a30ab095b407adbfa9cef67) | `` automatic update `` |
| [`aa8b3b99`](https://github.com/nix-community/NUR/commit/aa8b3b992d06e43b353263ded516e9bb54e15296) | `` automatic update `` |
| [`c7fbe53f`](https://github.com/nix-community/NUR/commit/c7fbe53f969ac43d6a6c3f08b4be147f5940f92d) | `` automatic update `` |