### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `d81e519c` -> `51e61c24`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -519,11 +519,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1721464266,
-        "narHash": "sha256-2EXaF79kAFOj7ZnWu1345YeWtkzhO9mohy8uFqiHzkM=",
+        "lastModified": 1721529158,
+        "narHash": "sha256-fbz+mAD8ezlEI9dyhrT4D+Z/0gkBlkQcON0k++MLbLw=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "d81e519c86d2acbd61a8fec1301c56db1b4a5bd6",
+        "rev": "51e61c24fe03cc1221791ef2a72814b717ba6399",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message            |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------ |
| [`51e61c24`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/51e61c24fe03cc1221791ef2a72814b717ba6399) | `` Avoid mktemp `` |