### PR TITLE
chore(flake/nur): `8c17f08a` -> `4ffd1850`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -805,11 +805,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721544403,
-        "narHash": "sha256-3/wvzzxFKXav4CV+o1+x5b6vVYtFQ9smjWLAtHhT+Sg=",
+        "lastModified": 1721547539,
+        "narHash": "sha256-pSjYyotfyI/9nlZutw575y+9/D4MHwM+E/djoyDeJ8Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8c17f08a0db53c1a59221174903199dc41eab9b0",
+        "rev": "4ffd18505681f8bc4ac9ee2fb1dc5e9216a1c96b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4ffd1850`](https://github.com/nix-community/NUR/commit/4ffd18505681f8bc4ac9ee2fb1dc5e9216a1c96b) | `` automatic update `` |