### PR TITLE
chore(flake/emacs-overlay): `23699d9f` -> `ab15d82f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721527310,
-        "narHash": "sha256-aJTZjouEw9L17JTnvcfNrBbGP9+1o/3/+/QvrojtItg=",
+        "lastModified": 1721552966,
+        "narHash": "sha256-zvzQgQEMxTaRpvtHlsNMjgdOiOvexfCE2hRaadSS6OY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "23699d9fc7faba4eb84719109cad6eee3a17e143",
+        "rev": "ab15d82f94c8f6373fec1f363c5b6c631453950b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`ab15d82f`](https://github.com/nix-community/emacs-overlay/commit/ab15d82f94c8f6373fec1f363c5b6c631453950b) | `` Updated emacs `` |
| [`e16eb52f`](https://github.com/nix-community/emacs-overlay/commit/e16eb52f5e739a646dbca648324fd6c8950240d5) | `` Updated melpa `` |