### PR TITLE
chore(flake/nur): `47677f66` -> `fb634077`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -805,11 +805,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721566628,
-        "narHash": "sha256-yTXMmF5rlalhgfFxR0ePEAGzK8MWRgdu/xEqq8zSGp0=",
+        "lastModified": 1721569564,
+        "narHash": "sha256-NlZ2qQNpWXW01m64BEp1t7VfNiU/QMQn7vvLSlrpRe0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "47677f66e7c51e83505718528a8b3dc2ddcb1e9c",
+        "rev": "fb634077e36e6c3d221b3847a87a710718bb1912",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fb634077`](https://github.com/nix-community/NUR/commit/fb634077e36e6c3d221b3847a87a710718bb1912) | `` automatic update `` |