### PR TITLE
chore(flake/nur): `fb634077` -> `a3b348eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -805,11 +805,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721569564,
-        "narHash": "sha256-NlZ2qQNpWXW01m64BEp1t7VfNiU/QMQn7vvLSlrpRe0=",
+        "lastModified": 1721571991,
+        "narHash": "sha256-0BFf1/dMFsAhKaX8PQTwkL81BItomTMEieAwjO23AKI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fb634077e36e6c3d221b3847a87a710718bb1912",
+        "rev": "a3b348eb642914b2c9c6f17e114869c47f869555",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a3b348eb`](https://github.com/nix-community/NUR/commit/a3b348eb642914b2c9c6f17e114869c47f869555) | `` automatic update `` |