### PR TITLE
chore(flake/nur): `a3b348eb` -> `b6f5aa78`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -805,11 +805,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721571991,
-        "narHash": "sha256-0BFf1/dMFsAhKaX8PQTwkL81BItomTMEieAwjO23AKI=",
+        "lastModified": 1721576786,
+        "narHash": "sha256-jTQdNfAUYrpqKFiLLWq6Qn3wPUZIuMq1atsqfZI5A4Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a3b348eb642914b2c9c6f17e114869c47f869555",
+        "rev": "b6f5aa78adcc6b0a4dcb2e6b3c8bc52db60318db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b6f5aa78`](https://github.com/nix-community/NUR/commit/b6f5aa78adcc6b0a4dcb2e6b3c8bc52db60318db) | `` automatic update `` |