### PR TITLE
chore(flake/nur): `b6f5aa78` -> `e0e6117c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721576786,
-        "narHash": "sha256-jTQdNfAUYrpqKFiLLWq6Qn3wPUZIuMq1atsqfZI5A4Y=",
+        "lastModified": 1721591079,
+        "narHash": "sha256-79hX1xAsZ8CHEmu2Hp/l4F7itTixmBlKGVHkEYBDmx8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b6f5aa78adcc6b0a4dcb2e6b3c8bc52db60318db",
+        "rev": "e0e6117cb3b072a16a1472caeb65ca66ffa28624",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e0e6117c`](https://github.com/nix-community/NUR/commit/e0e6117cb3b072a16a1472caeb65ca66ffa28624) | `` automatic update `` |
| [`d75bb088`](https://github.com/nix-community/NUR/commit/d75bb088566e977b3f98dbed3d4642e2d8c3eae2) | `` automatic update `` |
| [`e5c39e79`](https://github.com/nix-community/NUR/commit/e5c39e7968233a4a482ec16b19bb9c7d90b8b0ca) | `` automatic update `` |