### PR TITLE
chore(flake/lanzaboote): `60e4578f` -> `f3b4ade1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -447,9 +447,6 @@
         "flake-parts": [
           "flake-parts"
         ],
-        "flake-utils": [
-          "flake-utils"
-        ],
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -459,11 +456,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1721501207,
-        "narHash": "sha256-umzgs8hXYUyQe6wJm7AnJ3kx8M/h0/WXR2OemAZs3Qs=",
+        "lastModified": 1721581642,
+        "narHash": "sha256-Bd9ujkwkxwAYCnYKEKeY1fjsvD4vyiFjFS20Lxr/FD4=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "60e4578feca3d894f1474a9b08780c9a5433ad08",
+        "rev": "f3b4ade14392861388265e949b7007a8b62e21dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                 |
| --------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`0dba013c`](https://github.com/nix-community/lanzaboote/commit/0dba013cf35c296800b9e362cfe834c2aef81bd0) | `` Drop no longer existing overwrite `` |