### PR TITLE
chore(flake/emacs-overlay): `e3dcebb7` -> `fb91e18d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721581020,
-        "narHash": "sha256-vcjJljkmwAeVyP4kjT4ajfMyko8H3yJSHa7VRh+kZ4k=",
+        "lastModified": 1721581856,
+        "narHash": "sha256-TYs1Ekwwnxvdjamq2XDVlB1s71XBZ31PMKeWiE/WrcQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e3dcebb7675ef9526800c81ba8bb6aeaccd8ab24",
+        "rev": "fb91e18dab80d78ccbde35e5fc696f0656cfba0f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`fb91e18d`](https://github.com/nix-community/emacs-overlay/commit/fb91e18dab80d78ccbde35e5fc696f0656cfba0f) | `` Updated emacs `` |