### PR TITLE
chore(flake/nur): `e0e6117c` -> `407d9b1f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721591079,
-        "narHash": "sha256-79hX1xAsZ8CHEmu2Hp/l4F7itTixmBlKGVHkEYBDmx8=",
+        "lastModified": 1721593721,
+        "narHash": "sha256-fgnKPO+ONI8d919CBHwE7m8cGpvr49xZdN4gvbk6RoE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e0e6117cb3b072a16a1472caeb65ca66ffa28624",
+        "rev": "407d9b1fe380e1c3b4d37bdf3a36be7dfc443217",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`407d9b1f`](https://github.com/nix-community/NUR/commit/407d9b1fe380e1c3b4d37bdf3a36be7dfc443217) | `` automatic update `` |