### PR TITLE
chore(flake/nur): `407d9b1f` -> `b192263b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721593721,
-        "narHash": "sha256-fgnKPO+ONI8d919CBHwE7m8cGpvr49xZdN4gvbk6RoE=",
+        "lastModified": 1721598702,
+        "narHash": "sha256-I2XMrTBvPrux+IEF53QZKqOF1Udjo0fuf5KrDxqYEco=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "407d9b1fe380e1c3b4d37bdf3a36be7dfc443217",
+        "rev": "b192263b66e338e093720b520d9983a0566666cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b192263b`](https://github.com/nix-community/NUR/commit/b192263b66e338e093720b520d9983a0566666cb) | `` automatic update `` |
| [`febcda0d`](https://github.com/nix-community/NUR/commit/febcda0da1f8b770173ff1dad0db2449f67d6a7e) | `` automatic update `` |