### PR TITLE
chore(flake/nur): `b192263b` -> `1dfbb9fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721598702,
-        "narHash": "sha256-I2XMrTBvPrux+IEF53QZKqOF1Udjo0fuf5KrDxqYEco=",
+        "lastModified": 1721601972,
+        "narHash": "sha256-/xHdnYAMJMsz02c1RIvG9nG/FveYQ4BAu6SInyJY1eE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b192263b66e338e093720b520d9983a0566666cb",
+        "rev": "1dfbb9fcf14382f6b59f1110f0b441331b2b66f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1dfbb9fc`](https://github.com/nix-community/NUR/commit/1dfbb9fcf14382f6b59f1110f0b441331b2b66f3) | `` automatic update `` |
| [`02ea8aaa`](https://github.com/nix-community/NUR/commit/02ea8aaa46ce09348d77bc2df4b440fccfb217a0) | `` automatic update `` |