### PR TITLE
chore(flake/nur): `1dfbb9fc` -> `9ac382a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721601972,
-        "narHash": "sha256-/xHdnYAMJMsz02c1RIvG9nG/FveYQ4BAu6SInyJY1eE=",
+        "lastModified": 1721605603,
+        "narHash": "sha256-cEpkZl4fDw3xDIbFDcEDxpN69cvZEa+X5Gq9U15XjXE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1dfbb9fcf14382f6b59f1110f0b441331b2b66f3",
+        "rev": "9ac382a75a49ac66a9e90bc8619091664542d9f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9ac382a7`](https://github.com/nix-community/NUR/commit/9ac382a75a49ac66a9e90bc8619091664542d9f6) | `` automatic update `` |