### PR TITLE
chore(flake/nur): `9ac382a7` -> `c1e642ec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721605603,
-        "narHash": "sha256-cEpkZl4fDw3xDIbFDcEDxpN69cvZEa+X5Gq9U15XjXE=",
+        "lastModified": 1721616701,
+        "narHash": "sha256-vr1TB29EpPQTtUl1vV/icYT0y6MAUQuT2s9m7GfNrlc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ac382a75a49ac66a9e90bc8619091664542d9f6",
+        "rev": "c1e642ec4d33780bd6ce4e7e34095ffeaab5af6f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c1e642ec`](https://github.com/nix-community/NUR/commit/c1e642ec4d33780bd6ce4e7e34095ffeaab5af6f) | `` automatic update `` |
| [`597342f0`](https://github.com/nix-community/NUR/commit/597342f065f40457154e6ba64f0d6ba1b675c485) | `` automatic update `` |
| [`690799da`](https://github.com/nix-community/NUR/commit/690799daa5bf181cbd1f8f79576c99e177db7c96) | `` automatic update `` |