### PR TITLE
chore(flake/srvos): `ef4f2248` -> `93685882`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -914,11 +914,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721263500,
-        "narHash": "sha256-6l0+MciXkktANuZ+Rwc6BZJxtMi7jHZRiSnzG+xpwyk=",
+        "lastModified": 1721612563,
+        "narHash": "sha256-6T6GkLuNVbgDKijcBY/5mUiK8gO2Xi2QFM13hUKa2a0=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "ef4f2248e1bbd84a0dd269ab31b9927d9c0bf2e6",
+        "rev": "936858820dcad0e958f16f0e9652519bef045d5d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`93685882`](https://github.com/nix-community/srvos/commit/936858820dcad0e958f16f0e9652519bef045d5d) | `` dev/private/flake.lock: Update `` |
| [`b0ea73f9`](https://github.com/nix-community/srvos/commit/b0ea73f986b3eb13d7690a2df1a7b33e1bfdb7c6) | `` flake.lock: Update ``             |