### PR TITLE
chore(flake/nur): `c1e642ec` -> `6abd9135`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721616701,
-        "narHash": "sha256-vr1TB29EpPQTtUl1vV/icYT0y6MAUQuT2s9m7GfNrlc=",
+        "lastModified": 1721620571,
+        "narHash": "sha256-lJshAnoRbhfIIvVQ5TYRuF2dvN2mS2XERfPuCtdz+bI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c1e642ec4d33780bd6ce4e7e34095ffeaab5af6f",
+        "rev": "6abd9135d52574152fedc0fa80403f98f62eafd3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6abd9135`](https://github.com/nix-community/NUR/commit/6abd9135d52574152fedc0fa80403f98f62eafd3) | `` automatic update `` |
| [`eb7b18d5`](https://github.com/nix-community/NUR/commit/eb7b18d582770c88ec7fd0a15566e0e1fa441b99) | `` automatic update `` |