### PR TITLE
chore(flake/emacs-overlay): `65fb8336` -> `76894d02`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721613500,
-        "narHash": "sha256-KyWkSGj79yb60GAM7W2O6X8G/IqTCxLTwOOFeh78kjo=",
+        "lastModified": 1721639635,
+        "narHash": "sha256-4rBRvKrwk70QsE14bfdxF53+SsRwoTVR+B0AtIkPbmc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "65fb83360b883ecf3c2ef6fc616e13df33087077",
+        "rev": "76894d029f43323bd650bfa97aa7dabb0d9ab0b6",
         "type": "github"
       },
       "original": {
@@ -700,11 +700,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1721409541,
-        "narHash": "sha256-b6PLr0Ty7JPDBtJtjnYzlBf02bbH9alWMAgispMkTwk=",
+        "lastModified": 1721548954,
+        "narHash": "sha256-7cCC8+Tdq1+3OPyc3+gVo9dzUNkNIQfwSDJ2HSi2u3o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c53b6b8c2a3e46c68e04417e247bba660689c9d",
+        "rev": "63d37ccd2d178d54e7fb691d7ec76000740ea24a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`76894d02`](https://github.com/nix-community/emacs-overlay/commit/76894d029f43323bd650bfa97aa7dabb0d9ab0b6) | `` Updated emacs ``        |
| [`97e5554d`](https://github.com/nix-community/emacs-overlay/commit/97e5554d3e59c1c27d41d8a45e677e1a991b4323) | `` Updated melpa ``        |
| [`67a90aca`](https://github.com/nix-community/emacs-overlay/commit/67a90aca5db402d3384ee5bb56c3709b0d649e66) | `` Updated flake inputs `` |