### PR TITLE
chore(flake/nur): `757ffd59` -> `49a0f9ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721645101,
-        "narHash": "sha256-sDFQoprOP2IdoW1BeBHUabLo1NV7LUJY/ssr7tq/qU8=",
+        "lastModified": 1721648820,
+        "narHash": "sha256-iMB9s9ZUVEyJLVckYFSng3HzZgaiWwaBmhhf1J0/IwM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "757ffd59665f4ea42ee9fc1e724adb5d060541da",
+        "rev": "49a0f9ef7e0584c31f808417d0231d2c9309f90c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`49a0f9ef`](https://github.com/nix-community/NUR/commit/49a0f9ef7e0584c31f808417d0231d2c9309f90c) | `` automatic update `` |