### PR TITLE
chore(flake/nur): `49a0f9ef` -> `13379ed4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721648820,
-        "narHash": "sha256-iMB9s9ZUVEyJLVckYFSng3HzZgaiWwaBmhhf1J0/IwM=",
+        "lastModified": 1721653238,
+        "narHash": "sha256-GgdBazQSCX3qRBxuw77E5NMmPVnuk7VVVTtTBq9ljvY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "49a0f9ef7e0584c31f808417d0231d2c9309f90c",
+        "rev": "13379ed4f3e4fe4c9959a0d21fa5c9b016aef653",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`13379ed4`](https://github.com/nix-community/NUR/commit/13379ed4f3e4fe4c9959a0d21fa5c9b016aef653) | `` automatic update `` |
| [`8b2885c4`](https://github.com/nix-community/NUR/commit/8b2885c429a6464c78a0002d246f47b0f2e8e6b9) | `` automatic update `` |
| [`400330a1`](https://github.com/nix-community/NUR/commit/400330a1c922507c9c224f4dbbc4689dffd144f7) | `` automatic update `` |