### PR TITLE
chore(flake/emacs-overlay): `76894d02` -> `0beb30e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721639635,
-        "narHash": "sha256-4rBRvKrwk70QsE14bfdxF53+SsRwoTVR+B0AtIkPbmc=",
+        "lastModified": 1721667405,
+        "narHash": "sha256-MpMMfsRY9vtkvL7wBR0Jq4Z9AepLYM0c1GkDQbG2xF0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "76894d029f43323bd650bfa97aa7dabb0d9ab0b6",
+        "rev": "0beb30e0d89b86d27e01386abcc6d5a7c58faac1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`0beb30e0`](https://github.com/nix-community/emacs-overlay/commit/0beb30e0d89b86d27e01386abcc6d5a7c58faac1) | `` Updated melpa ``  |
| [`5dbd58b2`](https://github.com/nix-community/emacs-overlay/commit/5dbd58b2c594b5718b98497628fdf9236a4a929b) | `` Updated elpa ``   |
| [`97a62e58`](https://github.com/nix-community/emacs-overlay/commit/97a62e58c990d0c907fc2b79e5db335fad841a79) | `` Updated nongnu `` |