### PR TITLE
chore(flake/nur): `1cbdff10` -> `b7d763bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721659002,
-        "narHash": "sha256-xTW+3zEOLtfBblZPSXsSSfMLnk6DgPjVCO+ZEGkGn84=",
+        "lastModified": 1721673663,
+        "narHash": "sha256-FErVK9tYpb3fYDw4fQLKoebFVjkP8XcVGSiHrmC2UW0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1cbdff10e618eaa7c0f9cfbde10adc648d45d536",
+        "rev": "b7d763bbc9218b98314bed6d7495eed12ae84ef4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b7d763bb`](https://github.com/nix-community/NUR/commit/b7d763bbc9218b98314bed6d7495eed12ae84ef4) | `` automatic update `` |
| [`30b928cd`](https://github.com/nix-community/NUR/commit/30b928cdbe23e5ade29510cb89e66f1d91e11d58) | `` automatic update `` |
| [`382e7f17`](https://github.com/nix-community/NUR/commit/382e7f1785b5366449ccc971c471ebd271274580) | `` automatic update `` |