### PR TITLE
chore(flake/nur): `b7d763bb` -> `950ab593`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721673663,
-        "narHash": "sha256-FErVK9tYpb3fYDw4fQLKoebFVjkP8XcVGSiHrmC2UW0=",
+        "lastModified": 1721680003,
+        "narHash": "sha256-3mpQ/09tao0wjzNOjVW/i/Utz2nf0N5VuHRr48KTzss=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b7d763bbc9218b98314bed6d7495eed12ae84ef4",
+        "rev": "950ab5934cc89b498e2d82b7ac622c85b5fc7203",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`950ab593`](https://github.com/nix-community/NUR/commit/950ab5934cc89b498e2d82b7ac622c85b5fc7203) | `` automatic update `` |
| [`029c8d2c`](https://github.com/nix-community/NUR/commit/029c8d2c667a61bcbe085504f5e61644a565daf8) | `` automatic update `` |