### PR TITLE
chore(flake/nur): `950ab593` -> `1e61b6be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721680003,
-        "narHash": "sha256-3mpQ/09tao0wjzNOjVW/i/Utz2nf0N5VuHRr48KTzss=",
+        "lastModified": 1721683480,
+        "narHash": "sha256-BTzDCajRv6t3a4L2shIZVCO7xdcSKvG1FnyGpI1wFfA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "950ab5934cc89b498e2d82b7ac622c85b5fc7203",
+        "rev": "1e61b6befabc73d29e03331099a27486f3871297",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1e61b6be`](https://github.com/nix-community/NUR/commit/1e61b6befabc73d29e03331099a27486f3871297) | `` automatic update `` |