### PR TITLE
chore(flake/nixpkgs): `1d9c2c9b` -> `68c9ed8b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1721379653,
-        "narHash": "sha256-8MUgifkJ7lkZs3u99UDZMB4kbOxvMEXQZ31FO3SopZ0=",
+        "lastModified": 1721562059,
+        "narHash": "sha256-Tybxt65eyOARf285hMHIJ2uul8SULjFZbT9ZaEeUnP8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1d9c2c9b3e71b9ee663d11c5d298727dace8d374",
+        "rev": "68c9ed8bbed9dfce253cc91560bf9043297ef2fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                          |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
| [`c19d62ad`](https://github.com/NixOS/nixpkgs/commit/c19d62ad2265b16e2199c5feb4650fe459ca1c46) | `` edl: add udev rules (#323878) ``                                                                              |
| [`bc90ad3e`](https://github.com/NixOS/nixpkgs/commit/bc90ad3e30583408834af38610f90d980aabd47c) | `` gitlab: 17.1.2 -> 17.2.0 ``                                                                                   |
| [`d1d1d8da`](https://github.com/NixOS/nixpkgs/commit/d1d1d8daed8089727af6d440f8951128d1408f70) | `` python312Packages.xknx: drop superfluous patch ``                                                             |
| [`4f5626ad`](https://github.com/NixOS/nixpkgs/commit/4f5626ada045171b05b93755a1847bf21d838949) | `` openfga: 1.5.5 -> 1.5.6 ``                                                                                    |
| [`211db1ee`](https://github.com/NixOS/nixpkgs/commit/211db1ee089a7892753181c8a39d337ac789bed7) | `` genimage: 17 -> 18 ``                                                                                         |
| [`1747de44`](https://github.com/NixOS/nixpkgs/commit/1747de44166321d0af9ffe812b7b81bce557d256) | `` fd: disable shell completions for cross ``                                                                    |
| [`a51494d9`](https://github.com/NixOS/nixpkgs/commit/a51494d9befe5d4cfeb1e74f5a369632f5fe9bcd) | `` python312Packages.psd-tools: 1.9.33 -> 1.9.34 ``                                                              |
| [`531eb8e1`](https://github.com/NixOS/nixpkgs/commit/531eb8e1acf4b186bd335f811d16fa7eecfb4a14) | `` authentik: add rissson as maintainer (#328793) ``                                                             |
| [`e43be26e`](https://github.com/NixOS/nixpkgs/commit/e43be26ee83d081c2440820095a7a7b72e207783) | `` python3Packages.debugpy: disable tests for unmaintained pythons ``                                            |
| [`2b6b8e29`](https://github.com/NixOS/nixpkgs/commit/2b6b8e29c7696deaf8aefb7c666325354a9e2399) | `` git: fix build on FreeBSD native (#328779) ``                                                                 |
| [`5a861ed4`](https://github.com/NixOS/nixpkgs/commit/5a861ed43f368b56fb230f9a690e482b0d7e7a2f) | `` mpvScripts.mpv-webm: 0-unstable-2024-05-13 -> 0-unstable-2024-07-20 ``                                        |
| [`30febb3d`](https://github.com/NixOS/nixpkgs/commit/30febb3dd4042314e0eea2f71fcc7387a34dbb1b) | `` gomp: 1.1.0 -> 1.1.1 ``                                                                                       |
| [`e1ed616c`](https://github.com/NixOS/nixpkgs/commit/e1ed616cbc34dd1ebad720fc837cb75f02c6c33e) | `` authentik: 2024.6.0 -> 2024.6.1 ``                                                                            |
| [`ce8730ad`](https://github.com/NixOS/nixpkgs/commit/ce8730adbd6c1075e65e2843829591225df5dca0) | `` python312Packages.django-health-check: 3.18.2 -> 3.18.3 ``                                                    |
| [`9b820422`](https://github.com/NixOS/nixpkgs/commit/9b82042250d2964b829947987831d0b87046cbe3) | `` rye: 0.36.0 -> 0.37.0 ``                                                                                      |
| [`ea6220f7`](https://github.com/NixOS/nixpkgs/commit/ea6220f7f05c8fe3634c7c9280aed26472aeebae) | `` lime3ds: 2115 -> 2116 ``                                                                                      |
| [`c167f4e1`](https://github.com/NixOS/nixpkgs/commit/c167f4e1dbcb4401e455a499a7d6182772ac7d37) | `` libretro.ppsspp: unstable-2024-07-02 -> unstable-2024-07-20 ``                                                |
| [`ad026a5c`](https://github.com/NixOS/nixpkgs/commit/ad026a5c64c23d485604c082919873fa1e49e530) | `` libretro.mame2003-plus: unstable-2024-07-08 -> unstable-2024-07-20 ``                                         |
| [`f5e3df01`](https://github.com/NixOS/nixpkgs/commit/f5e3df01135209829fb85e7558a88051439647b3) | `` libretro.smsplus-gx: unstable-2023-10-31 -> unstable-2024-07-20 ``                                            |
| [`54ca7f91`](https://github.com/NixOS/nixpkgs/commit/54ca7f9154964c2fb6d4d4edbd48e1e1f02124ac) | `` any-nix-shell: 1.2.1 -> 2.0.0 ``                                                                              |
| [`31798c17`](https://github.com/NixOS/nixpkgs/commit/31798c17aa3e4ff62d396d95d1e59db557295b89) | `` any-nix-shell: run preInstall/postInstall hooks, remove `with lib` ``                                         |
| [`9a8e69dd`](https://github.com/NixOS/nixpkgs/commit/9a8e69dd4ea3cd27fca6a71143eace1a3a5cf3de) | `` any-nix-shell: update description ``                                                                          |
| [`119f78fd`](https://github.com/NixOS/nixpkgs/commit/119f78fd477a2b33f9ea84e3d3d3135227d26169) | `` any-nix-shell: add runtime dependencies ``                                                                    |
| [`aed4a507`](https://github.com/NixOS/nixpkgs/commit/aed4a5070d92f3338239ca01b8a46f42d79fc2a0) | `` any-nix-shell: reformat with RFC166 ``                                                                        |
| [`f709e908`](https://github.com/NixOS/nixpkgs/commit/f709e908130c380efd8fe257eb4cd9e0d8b17bdf) | `` any-nix-shell: move to pkgs/by-name ``                                                                        |
| [`cbadffdc`](https://github.com/NixOS/nixpkgs/commit/cbadffdc4b5ef1801f63ac61967f09a73eafc85c) | `` libretro.beetle-pce: unstable-2024-06-14 -> unstable-2024-07-19 ``                                            |
| [`c9ea1b96`](https://github.com/NixOS/nixpkgs/commit/c9ea1b965605c0be5f94ba1e8ede53fc7bf44a98) | `` unhide-gui: init at 20220611 ``                                                                               |
| [`ddc72ce5`](https://github.com/NixOS/nixpkgs/commit/ddc72ce5195528e4d29924a58fed98ec8603ec52) | `` libretro.beetle-pce-fast: unstable-2024-06-28 -> unstable-2024-07-19 ``                                       |
| [`8df4e6de`](https://github.com/NixOS/nixpkgs/commit/8df4e6de87888cdd098dc7b9a2aa2df07d4baf5f) | `` libretro.pcsx-rearmed: unstable-2024-06-29 -> unstable-2024-07-16 ``                                          |
| [`4d5b2a78`](https://github.com/NixOS/nixpkgs/commit/4d5b2a78098b63c76efeb18c6c8847b9775684a3) | `` libretro.snes9x: unstable-2024-07-07 -> unstable-2024-07-14 ``                                                |
| [`ee39f65f`](https://github.com/NixOS/nixpkgs/commit/ee39f65f3409bc76657c66b6aaa2f9bf216db550) | `` libretro.beetle-psx-hw: unstable-2024-07-05 -> unstable-2024-07-19 ``                                         |
| [`2a8375b9`](https://github.com/NixOS/nixpkgs/commit/2a8375b956a0777735df1b341a0853a55c58bfcf) | `` vscode-extensions.ms-python.black-formatter: 2023.4.1 -> 2024.2.0 ``                                          |
| [`612f04e5`](https://github.com/NixOS/nixpkgs/commit/612f04e5592f3f417e3cbd1dc06994674b80b8f0) | `` vscode-extensions.ms-python.pylint: init at 2023.10.1 ``                                                      |
| [`4e7c116a`](https://github.com/NixOS/nixpkgs/commit/4e7c116a912a45576c728cdd45e9d529755d8f05) | `` vscode-extensions.ms-python.flake8: init at 2023.10.0 ``                                                      |
| [`914c26bf`](https://github.com/NixOS/nixpkgs/commit/914c26bf0889b105f48c7e2c4c43771891f1438a) | `` maintainers: add amadejkastelic ``                                                                            |
| [`a1740925`](https://github.com/NixOS/nixpkgs/commit/a174092571796e7c624b9bca4161a0ec50cb303d) | `` vscode-extensions.charliermarsh.ruff: 2024.4.0 -> 2024.34.0 ``                                                |
| [`88001829`](https://github.com/NixOS/nixpkgs/commit/88001829673b5bff764ea86566e2cde33327fc8f) | `` nixseparatedebuginfod: 0.3.4 -> 0.4.0 ``                                                                      |
| [`e79bacd1`](https://github.com/NixOS/nixpkgs/commit/e79bacd1e736ce27f576b9ce2c8d76d779f613eb) | `` iosevka: 30.3.2 -> 30.3.3 ``                                                                                  |
| [`af0baa47`](https://github.com/NixOS/nixpkgs/commit/af0baa47c1fe4b725c0fd9e4933695cb924c7ff9) | `` python3Packages.objexplore: add sigmanificient to maintainers ``                                              |
| [`98028b79`](https://github.com/NixOS/nixpkgs/commit/98028b791b722d7ceca5df8622686ca78f989f5f) | `` python3Packages.objexplore: refactor ``                                                                       |
| [`1456a3e2`](https://github.com/NixOS/nixpkgs/commit/1456a3e237209732a405880298514a40b1b74bca) | `` wstunnel: 9.7.2 -> 9.7.4 ``                                                                                   |
| [`700c95c3`](https://github.com/NixOS/nixpkgs/commit/700c95c3ce77335bbbca0b91bb7c94f4a776d156) | `` tui-journal: 0.9.0 -> 0.9.1 ``                                                                                |
| [`cd57bc84`](https://github.com/NixOS/nixpkgs/commit/cd57bc844b5e542b3f9319c0078ab2fe2687ab2d) | `` python312Packages.tplink-omada-client: 1.4.0 -> 1.4.1 ``                                                      |
| [`ef593c9e`](https://github.com/NixOS/nixpkgs/commit/ef593c9e1f3dd59be42b0955c24320806b03ab00) | `` telegram-desktop: 5.2.2 -> 5.2.3 ``                                                                           |
| [`321c7fff`](https://github.com/NixOS/nixpkgs/commit/321c7fffaa8cb500da8166a73d57a09a07531c45) | `` python312Packages.formulae: 0.5.3 -> 0.5.4 ``                                                                 |
| [`595151c3`](https://github.com/NixOS/nixpkgs/commit/595151c300fb8d3b9f7be552d9552e0016ab77f0) | `` applet-window-buttons6: init at 0.13.0 ``                                                                     |
| [`ceafec21`](https://github.com/NixOS/nixpkgs/commit/ceafec213ff2514791848b1999e01ebf17dd6ceb) | `` nixos/proxmox-lxc: fix nixos-rebuild ``                                                                       |
| [`c501d3fa`](https://github.com/NixOS/nixpkgs/commit/c501d3fa9798c3e198369a76b6b2cc7fcf6faf62) | `` nixos/proxmox-lxc: fix getty start ``                                                                         |
| [`4aa419c0`](https://github.com/NixOS/nixpkgs/commit/4aa419c04630436af36c233a21573b20301bfbca) | `` nixos/proxmox-lxc: reformat ``                                                                                |
| [`de83d38d`](https://github.com/NixOS/nixpkgs/commit/de83d38d29d9d2634c5c7a66ff95f10ad2e6d32c) | `` cinnamon.cinnamon-session: 6.2.0 -> 6.2.1 ``                                                                  |
| [`066e65c2`](https://github.com/NixOS/nixpkgs/commit/066e65c2f0c6e6bbe05efecf2d09c6ecc1227066) | `` cinnamon.pix: 3.4.1 -> 3.4.2 ``                                                                               |
| [`28555fca`](https://github.com/NixOS/nixpkgs/commit/28555fca2a873315cf415523da6e7f1bd9fd9964) | `` xdg-desktop-portal-xapp: 1.0.7 -> 1.0.8 ``                                                                    |
| [`8afba669`](https://github.com/NixOS/nixpkgs/commit/8afba669e2a9c116f06e8852495a71cb2462343d) | `` nixos/wrappers: use normal mount for /run/wrappers ``                                                         |
| [`88cf071f`](https://github.com/NixOS/nixpkgs/commit/88cf071fb903118e21b1d2aae996ad3f4a36f215) | `` vscodium: 1.90.2.24171 -> 1.91.1.24193 ``                                                                     |
| [`28922c44`](https://github.com/NixOS/nixpkgs/commit/28922c4421b4a8d8f583913607da4f6db59e65a2) | `` incus: fix OVMF path backward compatibility ``                                                                |
| [`58b9659b`](https://github.com/NixOS/nixpkgs/commit/58b9659b655cf540a66e25bcaa0ba4b0e89cf428) | `` bustle: use gettext from nixpkgs ``                                                                           |
| [`2cc58226`](https://github.com/NixOS/nixpkgs/commit/2cc58226b0205fae68ff9266aa6edef09df06f6d) | `` python3Packages.torch.tests.*compile*: init ``                                                                |
| [`3b76c334`](https://github.com/NixOS/nixpkgs/commit/3b76c33407a6b09d78b70717f43a2b32eda35902) | `` python311Packages.torch.tests.tester-*Available: unbreak for non-default python package sets ``               |
| [`e863b584`](https://github.com/NixOS/nixpkgs/commit/e863b5843a3223998adf3f634aa1e6e7af0db6d4) | `` cudaPackages.writeGpuTestPython: accept makeWrapperArgs ``                                                    |
| [`904c5631`](https://github.com/NixOS/nixpkgs/commit/904c5631f5506b90d3b72a34b0a73cfc92bc0290) | `` gnome-font-viewer: fix build with clang 16 ``                                                                 |
| [`92956d96`](https://github.com/NixOS/nixpkgs/commit/92956d9644c6a6848a7a723afd9582ab47c15c36) | `` python312Packages.uv: 0.2.26 -> 0.2.27 ``                                                                     |
| [`7fd39bfe`](https://github.com/NixOS/nixpkgs/commit/7fd39bfeb3985731de890627c707539eed610857) | `` python312Packages.python-smarttub: 0.0.36 -> 0.0.37 ``                                                        |
| [`32cc50a2`](https://github.com/NixOS/nixpkgs/commit/32cc50a240ee8badcd62f0d4e9a128a8694a9c1b) | `` kubernetes-helmPlugins.helm-git: 0.17.0 -> 1.3.0 ``                                                           |
| [`2d5e573a`](https://github.com/NixOS/nixpkgs/commit/2d5e573acf2af54df6a8d6bcc4dc5dce639b2d72) | `` cudaPackages.writeGpuTestPython: sync the attr and the filesystem paths ``                                    |
| [`2e0e46fd`](https://github.com/NixOS/nixpkgs/commit/2e0e46fd3848a9d5b5a3e3eff818cba7d10daa24) | `` bemenu: 0.6.22 -> 0.6.23 ``                                                                                   |
| [`c774c7bf`](https://github.com/NixOS/nixpkgs/commit/c774c7bffe0d5fbf3da5c61e9b8bc3a8d8b11cf7) | `` cudaPackages.writeGpuTestPython: allow a selector for `libraries` to accommodate different python versions `` |
| [`cad8d8bf`](https://github.com/NixOS/nixpkgs/commit/cad8d8bf430197ab27896d91202f150fe70b3626) | `` silice: 0-unstable-2024-06-23 -> 0-unstable-2024-07-15 ``                                                     |
| [`6477b404`](https://github.com/NixOS/nixpkgs/commit/6477b404f05e53f9c151f977fd7f0f61d0c13416) | `` osu-lazer: 2024.718.0 -> 2024.718.1 ``                                                                        |
| [`243cd1b5`](https://github.com/NixOS/nixpkgs/commit/243cd1b556785ae00f081ff38c1a9b8a682a5daa) | `` vscode-extensions.42crunch.vscode-openapi: 4.25.3 -> 4.27.0 ``                                                |
| [`d63af425`](https://github.com/NixOS/nixpkgs/commit/d63af425e9721d68745e7bd324c3734dcb505fa4) | `` osu-lazer-bin: 2024.718.0 -> 2024.718.1 ``                                                                    |
| [`a978b3f9`](https://github.com/NixOS/nixpkgs/commit/a978b3f9bb5ca6028bdfa3732afa69265d8be9ae) | `` python312Packages.cohere: 5.6.0 -> 5.6.1 ``                                                                   |
| [`e160c28c`](https://github.com/NixOS/nixpkgs/commit/e160c28cccec5ded3c2303b58afd6c4f6fad2836) | `` erigon: 2.60.2 -> 2.60.4 ``                                                                                   |
| [`e4df72e3`](https://github.com/NixOS/nixpkgs/commit/e4df72e3287eab32cc4437661cfb3ff1608306e8) | `` python312Packages.quaternion: 2023.0.3 -> 2023.0.4 ``                                                         |
| [`768070f0`](https://github.com/NixOS/nixpkgs/commit/768070f0c1b0720c8c0c55b295a4de7cd3db59d4) | `` androidStudioPackages.beta: 2024.1.1.10 -> 2024.1.2.9 ``                                                      |
| [`64b7de15`](https://github.com/NixOS/nixpkgs/commit/64b7de15d30e8f88de4cee0db401c6a0098b92f4) | `` linuxPackages_latest.rust-out-of-tree-module: 0-unstable-2023-08-29 -> 0-unstable-2024-05-06 ``               |
| [`9e59b233`](https://github.com/NixOS/nixpkgs/commit/9e59b233691cb83269197a345a90fb56c067603d) | `` linuxPackages_latest.rust-out-of-tree-module.updateScript: init ``                                            |
| [`29934c94`](https://github.com/NixOS/nixpkgs/commit/29934c94085540f2b4683816c6cbd27d8400ff53) | `` llvm: fix broken llvm-config-native for canExecute ``                                                         |
| [`14b378d7`](https://github.com/NixOS/nixpkgs/commit/14b378d7b068e8b1fd706ed22b1b269c5dbf08ff) | `` virtiofsd: 1.11.0 -> 1.11.1 ``                                                                                |
| [`4408f22c`](https://github.com/NixOS/nixpkgs/commit/4408f22cc95ef3b904646f0548bdcd36a10a51e9) | `` python312Packages.gtts: 2.5.1 -> 2.5.2 ``                                                                     |
| [`ab42ca14`](https://github.com/NixOS/nixpkgs/commit/ab42ca141a289b8afc0e42dafb5e6172fb398cd6) | `` doc: Remove indefinite article and ending period from example meta.description ``                             |
| [`7bd3602b`](https://github.com/NixOS/nixpkgs/commit/7bd3602bd17da03d9f675c26bfb39ce6edd57219) | `` open-scq30: add CoreBluetooth framework on Darwin ``                                                          |
| [`510ff7e5`](https://github.com/NixOS/nixpkgs/commit/510ff7e57879d63060180f20728a863be3a01fd8) | `` beanhub-cli: 1.2.2 -> 1.2.3 ``                                                                                |
| [`2b2d6041`](https://github.com/NixOS/nixpkgs/commit/2b2d6041aeb93bbd8692a8b59e0091b22aff2166) | `` python312Packages.rotary-embedding-torch: 0.6.2 -> 0.6.4 ``                                                   |
| [`e56a0db7`](https://github.com/NixOS/nixpkgs/commit/e56a0db7b3470168bc725808e472688ff145e101) | `` python312Packages.distributed: 2024.7.0 -> 2024.7.1 ``                                                        |
| [`742a358a`](https://github.com/NixOS/nixpkgs/commit/742a358a9375d7a1ae99bdac2ca85347854d8cbd) | `` emacsPackages.ott-mode: trivialBuild -> melpaBuild ``                                                         |
| [`77b84751`](https://github.com/NixOS/nixpkgs/commit/77b84751b6c8ac5e24370d5fe6265a8af4917b0c) | `` emacsPackages.jam-mode: trivialBuild -> melpaBuild ``                                                         |
| [`78b16966`](https://github.com/NixOS/nixpkgs/commit/78b16966964481b69b77b97170021d2460f851a0) | `` emacsPackages.hsc3-mode: trivialBuild -> melpaBuild ``                                                        |
| [`e4a86349`](https://github.com/NixOS/nixpkgs/commit/e4a86349e6b7cec98117c2cf950e643db9d61796) | `` emacsPackages.lsp-bridge: 0-unstable-2024-06-29 -> 0-unstable-2024-07-14 ``                                   |
| [`5317c2ed`](https://github.com/NixOS/nixpkgs/commit/5317c2ed17889e6eb875504d8785181438cce5cc) | `` python312Packages.yfinance: 0.2.40 -> 0.2.41 ``                                                               |
| [`f2a6b12a`](https://github.com/NixOS/nixpkgs/commit/f2a6b12af7bb1160c214b83aa3ecd9a73dd2cba3) | `` ntpd-rs: disable testsuite, too flaky ``                                                                      |
| [`bb1b6afb`](https://github.com/NixOS/nixpkgs/commit/bb1b6afbe28c0b89f6d92df7a488eee40b4c0989) | `` mark: 9.12.0 -> 9.13.0 ``                                                                                     |
| [`d56ca2cc`](https://github.com/NixOS/nixpkgs/commit/d56ca2cc3c43f4380c450295f74bdf5766aa4386) | `` python312Packages.homeassistant-stubs: 2024.7.2 -> 2024.7.3 ``                                                |
| [`ff6f53e8`](https://github.com/NixOS/nixpkgs/commit/ff6f53e8018ca5efc65040bdf148ad3666ddc6f2) | `` home-assistant: 2024.7.2 -> 2024.7.3 ``                                                                       |
| [`ee12a84c`](https://github.com/NixOS/nixpkgs/commit/ee12a84c708ec8809e37c3b22e9418848cd53c32) | `` .github/labeler.yml: add pkgs/build-support/testers/** ``                                                     |
| [`4308f960`](https://github.com/NixOS/nixpkgs/commit/4308f96052ed478d1fc800575c9d0600e9a32266) | `` obs-studio-plugins.obs-move-transition: 3.0.1 -> 3.0.2 ``                                                     |
| [`183c48e9`](https://github.com/NixOS/nixpkgs/commit/183c48e99e7bbab447b555f7caf9d5e778660433) | `` python312Packages.upb-lib: 0.5.7 -> 0.5.8 ``                                                                  |
| [`31f445c0`](https://github.com/NixOS/nixpkgs/commit/31f445c003a177df40271b9b29c57f34cc8283ab) | `` python312Packages.python-kasa: 0.7.0.3 -> 0.7.0.5 ``                                                          |
| [`451fb7a2`](https://github.com/NixOS/nixpkgs/commit/451fb7a2bdb61e37df33e4e8e4876eb89097e7cc) | `` python312Packages.pytedee-async: 0.2.17 -> 0.2.20 ``                                                          |
| [`ab11ce32`](https://github.com/NixOS/nixpkgs/commit/ab11ce32aec390ad814b15470ae82d763c114729) | `` python312Packages.holidays: 0.52 -> 0.53 ``                                                                   |
| [`44a500aa`](https://github.com/NixOS/nixpkgs/commit/44a500aa336a1eb4c86ac517fea69bf3077de5aa) | `` safeeyes: add missing setuptools dependency ``                                                                |
| [`296370e7`](https://github.com/NixOS/nixpkgs/commit/296370e75f0099b9782f576b84b744ee76135d70) | `` cargo-modules: 0.16.3 -> 0.16.6 ``                                                                            |
| [`b40d043d`](https://github.com/NixOS/nixpkgs/commit/b40d043d5a2a1fb473f1c6c853dac444ceadab62) | `` test.testers: update tests for testers.testEqualContents ``                                                   |
| [`9946cc14`](https://github.com/NixOS/nixpkgs/commit/9946cc142a05a865ccee79de967f38145a816249) | `` kustomize: 5.4.2 -> 5.4.3 ``                                                                                  |
| [`5f1a5c13`](https://github.com/NixOS/nixpkgs/commit/5f1a5c1383c38c2894c639bedc6cbfc9f5314ffc) | `` python312Packages.lmfit: 1.3.1 -> 1.3.2 ``                                                                    |
| [`1a94e0f3`](https://github.com/NixOS/nixpkgs/commit/1a94e0f389b1e68eb3c172ca082eb3ffac25bc88) | `` python312Packages.app-model: 0.2.7 -> 0.2.8 ``                                                                |
| [`8a6b6167`](https://github.com/NixOS/nixpkgs/commit/8a6b6167bbf6178f9ff150025a4f06a48b02f039) | `` go: support FreeBSD ``                                                                                        |
| [`9f8234f1`](https://github.com/NixOS/nixpkgs/commit/9f8234f17e88f545449f03e8a1bc4c1c25ac707e) | `` ntpd-rs: 1.2.0 -> 1.2.2 ``                                                                                    |