### PR TITLE
chore(flake/sops-nix): `909e8cfb` -> `aff2f882`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -894,11 +894,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1721531171,
-        "narHash": "sha256-AsvPw7T0tBLb53xZGcUC3YPqlIpdxoSx56u8vPCr6gU=",
+        "lastModified": 1721688883,
+        "narHash": "sha256-9jsjsRKtJRqNSTXKj9zuDFRf2PGix30nMx9VKyPgD2U=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "909e8cfb60d83321d85c8d17209d733658a21c95",
+        "rev": "aff2f88277dabe695de4773682842c34a0b7fd54",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                 |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`aff2f882`](https://github.com/Mic92/sops-nix/commit/aff2f88277dabe695de4773682842c34a0b7fd54) | `` update vendorHash ``                                 |
| [`7fb044cb`](https://github.com/Mic92/sops-nix/commit/7fb044cbe6d3dcdad7bb5266aaeb04232bbaaaa9) | `` build(deps): bump github.com/ProtonMail/go-crypto `` |