### PR TITLE
chore(flake/nur): `358b1fd2` -> `31147cca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721690489,
-        "narHash": "sha256-29EBlXOk7zU4E7xkMD+F5Ac3Vm2/0fW5r38CtF5DmfE=",
+        "lastModified": 1721699455,
+        "narHash": "sha256-ba5BpcwO5uLlrA6yCIerBbIeTnzpmOfzmKeaBKy7V7Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "358b1fd26dcdec970e692a110230622112c94098",
+        "rev": "31147ccaccf74ad60de96aee0ec245845bfa984c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`31147cca`](https://github.com/nix-community/NUR/commit/31147ccaccf74ad60de96aee0ec245845bfa984c) | `` automatic update `` |