### PR TITLE
chore(flake/nur): `31147cca` -> `33fa7d88`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721699455,
-        "narHash": "sha256-ba5BpcwO5uLlrA6yCIerBbIeTnzpmOfzmKeaBKy7V7Y=",
+        "lastModified": 1721706458,
+        "narHash": "sha256-2A2T/0TRxEj0j+d0kt9N9dh/P9GoDKhikUKXYyK0oBc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "31147ccaccf74ad60de96aee0ec245845bfa984c",
+        "rev": "33fa7d8808279036a30a46ae0913a06193ad4421",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`33fa7d88`](https://github.com/nix-community/NUR/commit/33fa7d8808279036a30a46ae0913a06193ad4421) | `` automatic update `` |
| [`8a3961c0`](https://github.com/nix-community/NUR/commit/8a3961c076c2addab4a49ede2838792ccf26fcb2) | `` automatic update `` |