### PR TITLE
chore(flake/nur): `33fa7d88` -> `6795f7f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721706458,
-        "narHash": "sha256-2A2T/0TRxEj0j+d0kt9N9dh/P9GoDKhikUKXYyK0oBc=",
+        "lastModified": 1721710281,
+        "narHash": "sha256-glKN1ZFfkjcfPzVQ/C97TVr3LXuJt79j1O72cUxf5hw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "33fa7d8808279036a30a46ae0913a06193ad4421",
+        "rev": "6795f7f6662e9cd3d5138012b52c93c9594353df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6795f7f6`](https://github.com/nix-community/NUR/commit/6795f7f6662e9cd3d5138012b52c93c9594353df) | `` automatic update `` |
| [`72091f12`](https://github.com/nix-community/NUR/commit/72091f1233cdb1be012a2177c6767dd70cfa28a4) | `` automatic update `` |