### PR TITLE
chore(flake/nur): `6795f7f6` -> `a567cb05`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721710281,
-        "narHash": "sha256-glKN1ZFfkjcfPzVQ/C97TVr3LXuJt79j1O72cUxf5hw=",
+        "lastModified": 1721717193,
+        "narHash": "sha256-hU5VQrEOF7MaNjZfG7tLsnlm8HGIRQs59WXe83Lsp2c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6795f7f6662e9cd3d5138012b52c93c9594353df",
+        "rev": "a567cb05cff5358c5d412ff98dd4d65a13e9b06b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a567cb05`](https://github.com/nix-community/NUR/commit/a567cb05cff5358c5d412ff98dd4d65a13e9b06b) | `` automatic update `` |