### PR TITLE
chore(flake/darwin): `2ae24bca` -> `884f3fe6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -104,11 +104,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721655289,
-        "narHash": "sha256-eJQQwXOKWjom9gtb7HvHd3+Wj5Sp+WrYR44r0EnaO5w=",
+        "lastModified": 1721719500,
+        "narHash": "sha256-nnkqjv4Y37Hydjh6HE9wW4kSkV5Q7q4iIXlL5lwUFOw=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "2ae24bcafdb88fdf70b061cc8b18d070dbd9013a",
+        "rev": "884f3fe6d9bf056ba0017c132c39c1f0d07d4fec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                              |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
| [`fe99aa96`](https://github.com/LnL7/nix-darwin/commit/fe99aa9699e7dd4ce6a81a8a623d010cedbe7eef) | `` github-runnners: fix workDir missing on reboot `` |