### PR TITLE
chore(flake/copilot_pkgs): `d2caadf6` -> `25455e44`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -62,11 +62,11 @@
     },
     "copilot_pkgs": {
       "locked": {
-        "lastModified": 1715018990,
-        "narHash": "sha256-VXBqugtCdjHlhyvDNE7pmoexWm3IWXC6K7Uys7F5Z/4=",
+        "lastModified": 1721720993,
+        "narHash": "sha256-Qr1Gk4/0emU3rDDPPHdc5dv6wLBgxa94/ZJron4Muag=",
         "owner": "bbigras",
         "repo": "nixpkgs",
-        "rev": "d2caadf6feee0638f72963c076e64e553ee915b6",
+        "rev": "25455e4474c214aa786523fcd785b82f1ef9b2f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                                  |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
| [`25455e44`](https://github.com/bbigras/nixpkgs/commit/25455e4474c214aa786523fcd785b82f1ef9b2f9) | `` copilot: 0-unstable-2023-12-26 -> 0-unstable-2024-05-01 ``                            |
| [`cbc0982d`](https://github.com/bbigras/nixpkgs/commit/cbc0982defb8d4722fb110cf2e1b36650bcda5e2) | `` path-of-building.data: 2.42.0 -> 2.44.1 ``                                            |
| [`681e984f`](https://github.com/bbigras/nixpkgs/commit/681e984f8e3d66f4fd8a94ea28bb7a8b87b27216) | `` coqPackages.equations: 1.3.1 for Coq 8.20 ``                                          |
| [`67783fd0`](https://github.com/bbigras/nixpkgs/commit/67783fd0d59bacf55765580b6f8a8c95a1d761f2) | `` telegraf: 1.31.1 -> 1.31.2 ``                                                         |
| [`2deb3dd4`](https://github.com/bbigras/nixpkgs/commit/2deb3dd45f1f7238053ae043f11caeb1223a4902) | `` llvmPackages_git.compiler-rt: disable codesign ``                                     |
| [`a1814d2d`](https://github.com/bbigras/nixpkgs/commit/a1814d2dbf15dcc7950ad8a15c8b2c930633f99c) | `` ffmpeg: remove arthsmn from the maintainers ``                                        |
| [`598659a4`](https://github.com/bbigras/nixpkgs/commit/598659a488918341d44a0f195f107dcc475879a3) | `` ff2mpv-rust: remove arthsmn from the maintainers ``                                   |
| [`2923c0c1`](https://github.com/bbigras/nixpkgs/commit/2923c0c14a33c78a2f195fa8cef4df84d0b825bc) | `` emacsPackages.rect-mark: adopted by AndersonTorres ``                                 |
| [`9859c235`](https://github.com/bbigras/nixpkgs/commit/9859c235846a8dec293df62b805f7bbb0cfdbf87) | `` manuskript: add strawbee as maintainer ``                                             |
| [`4ac9e605`](https://github.com/bbigras/nixpkgs/commit/4ac9e605fa712087ff1975c110379e7ff8b0c9eb) | `` manuskript: override python version ``                                                |
| [`c26ba30c`](https://github.com/bbigras/nixpkgs/commit/c26ba30c69d2f9dfe415576d78b5c3e99c4a6ed5) | `` maintainers: add strawbee ``                                                          |
| [`50eaa301`](https://github.com/bbigras/nixpkgs/commit/50eaa3013005bcf181a9e38c65d4801f3a7b8235) | `` emacsPackages.elisp-ffi: adopted by AndersonTorres ``                                 |
| [`93d84f95`](https://github.com/bbigras/nixpkgs/commit/93d84f953f0f05017a32c0fac82b91be962dd830) | `` autoprefixer.tests: fix the eval ``                                                   |
| [`0840cd62`](https://github.com/bbigras/nixpkgs/commit/0840cd62c0597f1c8e429ec20357987f5b85b555) | `` Revert "glew: default enableEGL to true" ``                                           |
| [`c2ac76bf`](https://github.com/bbigras/nixpkgs/commit/c2ac76bfdae507a5675359d2cdc2e29d697b4d90) | `` emacsPackages.voicemacs: adopted by AndersonTorres ``                                 |
| [`c675eb8c`](https://github.com/bbigras/nixpkgs/commit/c675eb8ce9db110e04e5528ba8d6446240d68dff) | `` emacsPackages.font-lock-plus: adopted by AndersonTorres ``                            |
| [`bdb7b33b`](https://github.com/bbigras/nixpkgs/commit/bdb7b33b731d87e2bb904aa09797a50bc139ea5b) | `` python312Packages.leanblueprint: init at 0.0.10 ``                                    |
| [`c46383a5`](https://github.com/bbigras/nixpkgs/commit/c46383a57c59a15d0931d0893b3bd52a7c9adfda) | `` python312Packages.plastexshowmore: init at 0.0.2 ``                                   |
| [`8ca7bd84`](https://github.com/bbigras/nixpkgs/commit/8ca7bd846e0e75ecea1d3c2c2f0124e35743a88d) | `` python312Packages.plastexdepgraph: init at 0.0.4 ``                                   |
| [`bd5255a1`](https://github.com/bbigras/nixpkgs/commit/bd5255a137ca6b947f3a49c076d5cec04bebb343) | `` python312Packages.plasTeX: init at 3.1 ``                                             |
| [`71ae199b`](https://github.com/bbigras/nixpkgs/commit/71ae199b9eda5ff93a171ad2b61e6f24dc821821) | `` seaweedfs: 3.69 -> 3.71 ``                                                            |
| [`bd8ac353`](https://github.com/bbigras/nixpkgs/commit/bd8ac353db4f13fd5da98aaea96162d9ab730e7f) | `` emacsPackages.wat-mode: remove redundant commentary ``                                |
| [`034c174d`](https://github.com/bbigras/nixpkgs/commit/034c174d850b4fccb98024a075ad8ee6656dd447) | `` emacsPackages.wat-mode: implement passthru.updateScript ``                            |
| [`6ab627b3`](https://github.com/bbigras/nixpkgs/commit/6ab627b36ef1acf7ac95ff89d6d3eae4c974d668) | `` python312Packages.cyclopts: 2.9.3 -> 2.9.4 ``                                         |
| [`4acb6adf`](https://github.com/bbigras/nixpkgs/commit/4acb6adf1d0fdf788007ab5cc62570930f287201) | `` wasmtime: 22.0.0 -> 23.0.1 ``                                                         |
| [`89f3f084`](https://github.com/bbigras/nixpkgs/commit/89f3f084d04346eb9afe5f0fc4705e2798bc1339) | `` mpv-subs-popout: init at 0.5.2 ``                                                     |
| [`ccceb0bb`](https://github.com/bbigras/nixpkgs/commit/ccceb0bbaeede126728e70d47ba1e4d713493afa) | `` python312Packages.pure-protobuf: 3.1.0 -> 3.1.1 ``                                    |
| [`438d6f7c`](https://github.com/bbigras/nixpkgs/commit/438d6f7cc730eda8f44af4e97be3b610bd4791e9) | `` hol_light: 2024-05-10 → 2024-07-07 ``                                                 |
| [`1049aef0`](https://github.com/bbigras/nixpkgs/commit/1049aef047ba3e922b6fd369907c84159206539b) | `` doppler: fix build failure with shell completion (#326008) ``                         |
| [`7329174d`](https://github.com/bbigras/nixpkgs/commit/7329174db714317d6cf99da08b517eb1fc3f2ff9) | `` kluctl: migrate to by-name ``                                                         |
| [`3540a35e`](https://github.com/bbigras/nixpkgs/commit/3540a35ec94d94bc744a9d1acaabdb41903d2e0c) | `` vimPlugins.lz-n: use `luaAttr` as source ``                                           |
| [`d79df175`](https://github.com/bbigras/nixpkgs/commit/d79df175309f23b9ab501d36499393112ebad645) | `` luaPackages.lz-n: 1.4.2-1 -> 1.4.3-1 ``                                               |
| [`afab44c4`](https://github.com/bbigras/nixpkgs/commit/afab44c4bcab4186b5b307dac2e27a9df2861072) | `` python312Packages.soundcloud-v2: 1.5.3 -> 1.5.4 ``                                    |
| [`6aaaa708`](https://github.com/bbigras/nixpkgs/commit/6aaaa70856ba19a7e20dd41fba17f654736b71b4) | `` python311Packages.cohere: 5.6.1 -> 5.6.2 ``                                           |
| [`f29fa25a`](https://github.com/bbigras/nixpkgs/commit/f29fa25a150f319eb3e49fd66b4dc08e62866156) | `` Revert "dasbus: unstable-11-10-2022 -> 0-unstable-2023-07-10" ``                      |
| [`2ece9131`](https://github.com/bbigras/nixpkgs/commit/2ece9131207b82a3e5b3dfec4be6e0b28b347126) | `` home-assistant-custom-components.govee-lan: tests are broken ``                       |
| [`c393e12e`](https://github.com/bbigras/nixpkgs/commit/c393e12e5b0a0963124b7dc64cf38cb5531450e1) | `` imposm: 0.13.2 -> 0.14.0 ``                                                           |
| [`9205db19`](https://github.com/bbigras/nixpkgs/commit/9205db197e513d81d0ab6a68fa0d9b4fd03187c6) | `` home-assistant.python.pkgs.pytest-homeassistant-custom-component: init at 0.13.147 `` |
| [`daf16944`](https://github.com/bbigras/nixpkgs/commit/daf16944571a9470cac86f1cde3db43961419ebb) | `` xdg-desktop-portal-hyprland: nixfmt-rfc-style, updateScript ``                        |
| [`f0f1070d`](https://github.com/bbigras/nixpkgs/commit/f0f1070dc5aa1aea3473f925831a6c893a763451) | `` spotify: 1.2.37.701.ge66eb7bc -> 1.2.40.599.g606b7f29 ``                              |
| [`bdde8b12`](https://github.com/bbigras/nixpkgs/commit/bdde8b1226ba00ef91243967fe9fd00bbb1a7681) | `` vimPlugins.grug-far-nvim: init at 2024-07-22 ``                                       |
| [`20868b68`](https://github.com/bbigras/nixpkgs/commit/20868b68ecec99a2fa2500d6d488b464b8f445f2) | `` python312Packages.reolink-aio: 0.9.4 -> 0.9.5 ``                                      |
| [`13ea40f2`](https://github.com/bbigras/nixpkgs/commit/13ea40f2d8b060b837257c0a2538e20dfd626b30) | `` python312Packages.ptpython: 3.0.27 -> 3.0.28 ``                                       |
| [`a298a03b`](https://github.com/bbigras/nixpkgs/commit/a298a03ba6f2759fc9ed7f0e484799f565d44aa6) | `` ngrok: 3.10.1 -> 3.13.0 (#328897) ``                                                  |
| [`0f4326b2`](https://github.com/bbigras/nixpkgs/commit/0f4326b2f17d0a470f72ef9f0791dfd5dd93ab4f) | `` flameshot: add flag for wlr support ``                                                |
| [`2bad3487`](https://github.com/bbigras/nixpkgs/commit/2bad3487c6c3fc69d8aeb308cc22d8d8fc6ddafd) | `` flameshot: 12.1.0 -> 12.1.0-unstable-2024-07-02 ``                                    |
| [`5af98120`](https://github.com/bbigras/nixpkgs/commit/5af98120ad5e871a7b79a663388d7b2714d98306) | `` flameshot: use unstable version in update script ``                                   |
| [`4650385d`](https://github.com/bbigras/nixpkgs/commit/4650385d09e43a8250f639243b0ee869af7674ba) | `` flameshot: move to by-name ``                                                         |
| [`cb1a4601`](https://github.com/bbigras/nixpkgs/commit/cb1a4601f53280d63bdd34493a3cdf950dd63d7e) | `` vscode-extensions.fill-labs.dependi: 0.7.2 -> 0.7.4 ``                                |
| [`5806503f`](https://github.com/bbigras/nixpkgs/commit/5806503fbc266283561e7702fd60aaa4535454ef) | `` xdg-desktop-portal-hyprland: 1.3.2 -> 1.3.3 ``                                        |
| [`40a1300a`](https://github.com/bbigras/nixpkgs/commit/40a1300abf6750419b4e9d9e4c3b8ce8eccf5414) | `` python312Packages.aiolifx-themes: 0.4.21 -> 0.4.27 ``                                 |
| [`d51dad7c`](https://github.com/bbigras/nixpkgs/commit/d51dad7c7766199c8ad12a317315b0bd6f53459c) | `` neovim: stop inheriting meta.position from neovim-unwrapped ``                        |
| [`fe58e885`](https://github.com/bbigras/nixpkgs/commit/fe58e8856f206406a9b988e70b1f383cbb3ea331) | `` nixos/ollama: make host example dualstack wildcard ``                                 |
| [`bd473cea`](https://github.com/bbigras/nixpkgs/commit/bd473ceae3f53d8f10bb3656d7a764158e856f66) | `` nixos/doc/rl-2411: add ollama changes ``                                              |
| [`12897b37`](https://github.com/bbigras/nixpkgs/commit/12897b37a8a0e5cb186f809773afdbc403947353) | `` nixos/ollama: harden systemd unit ``                                                  |
| [`be7bce87`](https://github.com/bbigras/nixpkgs/commit/be7bce879faf4aaeb666c48f17c0d9812ac1210a) | `` nixos/ollama: remove writablePaths option ``                                          |
| [`809ea5c6`](https://github.com/bbigras/nixpkgs/commit/809ea5c6bd44535e02e93ae4277c01e1c0d1b46d) | `` nixos/ollama: replace flawed sandboxing option ``                                     |
| [`a52c6d92`](https://github.com/bbigras/nixpkgs/commit/a52c6d92e10fab2902f6eb7898ec7b2d7f318f07) | `` python312Packages.pyscf: disable more failing tests ``                                |
| [`4f37fc7a`](https://github.com/bbigras/nixpkgs/commit/4f37fc7a48712cea23ea3cd8d7b5bc0cbaaaa22e) | `` python311Packages.nitime: fix pyproject.toml substitution ``                          |
| [`9eae9c20`](https://github.com/bbigras/nixpkgs/commit/9eae9c20350ad5b133bdfd63d27a2029a5734a79) | `` diffoscope: disable another broken test ``                                            |
| [`57b0c6d8`](https://github.com/bbigras/nixpkgs/commit/57b0c6d8413b3865021b0efe42bf30c6c89d93a5) | `` python311Packages.pymatgen: mark as broken ``                                         |
| [`a75a635e`](https://github.com/bbigras/nixpkgs/commit/a75a635ecae236aa140e4348ee18789b08d00080) | `` python311Packages.aplpy: mark as broken ``                                            |
| [`37217cbd`](https://github.com/bbigras/nixpkgs/commit/37217cbd084cc927bd77d7bbec94f1e03c01e56b) | `` python311Packages.outlines: mark as broken ``                                         |
| [`2798c7a0`](https://github.com/bbigras/nixpkgs/commit/2798c7a0d0f460008014454708a96acf15d49a28) | `` python311Packages.objax: mark as broken ``                                            |
| [`be4a8aa3`](https://github.com/bbigras/nixpkgs/commit/be4a8aa31a78785caa7541506b4811b1c79b19a4) | `` python311Packages.mne-python: disable failing test ``                                 |
| [`6828970a`](https://github.com/bbigras/nixpkgs/commit/6828970a95f160294bdfb542421a21a10d28494d) | `` python311Packages.hoomd-blue: mark as broken ``                                       |
| [`4f6b37d1`](https://github.com/bbigras/nixpkgs/commit/4f6b37d15372cbed55aa1a1639fe0c025b0e2d23) | `` python312Packages.h5py-mpi: fix build ``                                              |
| [`d90f155b`](https://github.com/bbigras/nixpkgs/commit/d90f155b78d1aa319cd3b77084e9775039d5b622) | `` planify: 4.8.4 -> 4.9.0 ``                                                            |
| [`ca61124d`](https://github.com/bbigras/nixpkgs/commit/ca61124d6ac330d7fcb2d8d1dd4c0ca7cb11e214) | `` python3Packages.deform: remove nose dependency ``                                     |
| [`b6cd1dd3`](https://github.com/bbigras/nixpkgs/commit/b6cd1dd3f0feda181eb0d7ea3c853ef03cb743b4) | `` errands: 46.2.3 -> 46.2.4 ``                                                          |
| [`07a6fb71`](https://github.com/bbigras/nixpkgs/commit/07a6fb712dec10892c5dc16c2dd76fe22e8b8d10) | `` python311Packages.pylsp-rope: add missing setuptools build dependency ``              |
| [`623403fd`](https://github.com/bbigras/nixpkgs/commit/623403fdd5b778ca7cc41e23d12a2ddff6cf4ae1) | `` typescript-language-server: fix requires typescript ``                                |
| [`c80f6ff2`](https://github.com/bbigras/nixpkgs/commit/c80f6ff2c5f048f442b88963f3e39c494d150055) | `` ecs-agent: 1.85.0 -> 1.85.1 ``                                                        |
| [`1e91ddb3`](https://github.com/bbigras/nixpkgs/commit/1e91ddb346b83ac9e17f95ef38cf60d454277af5) | `` neocmakelsp: 0.7.8 -> 0.7.9 ``                                                        |
| [`aa03ccf6`](https://github.com/bbigras/nixpkgs/commit/aa03ccf61d9f0e8e27e8bd601b80989575f528bd) | `` lnd: 0.18.0 -> 0.18.2 ``                                                              |
| [`9db0b1cd`](https://github.com/bbigras/nixpkgs/commit/9db0b1cdfbbd2b685d9af7658a5c3a4c1092879d) | `` python312Packages.pyoverkiz: 1.13.13 -> 1.13.14 ``                                    |
| [`c4e2ca2e`](https://github.com/bbigras/nixpkgs/commit/c4e2ca2e7dbfea04831ca07c0873fda8144b1990) | `` ntpd-rs: 1.2.2 -> 1.2.3 ``                                                            |
| [`e1a816e0`](https://github.com/bbigras/nixpkgs/commit/e1a816e08cbea6945aa0b6bdc97c2414500325a6) | `` hugo: 0.128.2 -> 0.129.0 ``                                                           |
| [`6070d7f9`](https://github.com/bbigras/nixpkgs/commit/6070d7f93fbf85077f64dd7d7745c56c31dcd7a4) | `` hypr{wayland-scanner,lock}: add johnrtitor as maintainer ``                           |
| [`dcaa3e87`](https://github.com/bbigras/nixpkgs/commit/dcaa3e8792b046829dda024dd601fc144a491879) | `` aquamarine: init at 0.1.1 ``                                                          |
| [`0d40d3a1`](https://github.com/bbigras/nixpkgs/commit/0d40d3a1ff082aa0ea314d8170f46d66f0b82c8b) | `` hyprwayland-scanner: 0.3.10 -> 0.4.0 ``                                               |
| [`7c7f909e`](https://github.com/bbigras/nixpkgs/commit/7c7f909ee45f4681119b49b503f85b5b02f02f08) | `` hyprlock: 0.4.0 -> 0.4.1 ``                                                           |
| [`4742394e`](https://github.com/bbigras/nixpkgs/commit/4742394e5aaca73aa3abd94d6583afc1fa09cae8) | `` credhub-cli: 2.9.33 -> 2.9.35 (#326661) ``                                            |
| [`c8f2bb1b`](https://github.com/bbigras/nixpkgs/commit/c8f2bb1b650e90e51d8180f6b02882bfb741a90b) | `` nixos/tandoor-recipes: revert 'GUNICORN_MEDIA=1' ``                                   |
| [`662d615a`](https://github.com/bbigras/nixpkgs/commit/662d615a812702b315c786edf3de31b88d50f929) | `` dbeaver-bin: 24.1.2 -> 24.1.3 ``                                                      |
| [`ac9ee278`](https://github.com/bbigras/nixpkgs/commit/ac9ee278f51c826bcec315e1efe91e45df095abe) | `` ocamlPackages.ocamlbuild: 0.14.3 for OCaml < 4.07 ``                                  |
| [`46389dec`](https://github.com/bbigras/nixpkgs/commit/46389dec02b25c40295155d122b9dd677b97d0f2) | `` labwc: 0.7.3 -> 0.7.4 ``                                                              |
| [`eae2b102`](https://github.com/bbigras/nixpkgs/commit/eae2b1022116314784eb4529ed0dc2a33af62bf9) | `` numworks-epsilon: 23.2.2 -> 23.2.3 ``                                                 |
| [`2349ba8c`](https://github.com/bbigras/nixpkgs/commit/2349ba8cc772bbe75b33b9ae8c6901afc070136e) | `` r0vm: 1.0.2 -> 1.0.3 ``                                                               |
| [`3712e396`](https://github.com/bbigras/nixpkgs/commit/3712e396b05c6e809330a75d451aecfb35117a0b) | `` python312Packages.typeshed-client: 2.6.0 -> 2.7.0 ``                                  |
| [`80f1af4d`](https://github.com/bbigras/nixpkgs/commit/80f1af4dc0969a8b4b0761f8d08ac9e77a53fe15) | `` cargo-hack: 0.6.29 -> 0.6.30 ``                                                       |
| [`9244263a`](https://github.com/bbigras/nixpkgs/commit/9244263a9752a0ecf387522b9f3abec608136801) | `` lazysql: 0.2.1 -> 0.2.3 ``                                                            |
| [`3f063cbb`](https://github.com/bbigras/nixpkgs/commit/3f063cbb20be5667b3bfb461303da41137efc27d) | `` pscale: 0.204.0 -> 0.205.0 ``                                                         |
| [`fe2284e4`](https://github.com/bbigras/nixpkgs/commit/fe2284e4a6627eaf275fd701b7cd14c494e5612e) | `` pulumi-bin: 3.124.0 -> 3.125.0 ``                                                     |
| [`5e164bd3`](https://github.com/bbigras/nixpkgs/commit/5e164bd35434ceac77dddbc8bd01958bad5e13ea) | `` haylxon: init at 1.0.0 ``                                                             |
| [`00b9fc64`](https://github.com/bbigras/nixpkgs/commit/00b9fc64d8b8765731cdb2e93312b8cb5c89c517) | `` gnome-obfuscate: use gettext from nixpkgs ``                                          |
| [`6353b500`](https://github.com/bbigras/nixpkgs/commit/6353b500645db0039c8bd73cbe3ecc19dff76414) | `` vcmi: 1.5.4 -> 1.5.5 ``                                                               |
| [`0cbceb39`](https://github.com/bbigras/nixpkgs/commit/0cbceb396bcc1022bca4194985cf1b7e3a885994) | `` shadowsocks-rust: 1.20.1 -> 1.20.2 ``                                                 |
| [`575cc24b`](https://github.com/bbigras/nixpkgs/commit/575cc24b60cd0d532a3ad0a5fd140918a391393d) | `` jql: 7.1.12 -> 7.1.13 ``                                                              |
| [`f9538372`](https://github.com/bbigras/nixpkgs/commit/f95383724b9f736ff986c848a82b8f220ce1406f) | `` step-cli: 0.27.1 -> 0.27.2 ``                                                         |
| [`0b0f10ab`](https://github.com/bbigras/nixpkgs/commit/0b0f10abe4a177b5988c4ac727f9404a90f774fc) | `` nomad-driver-podman: 0.6.0 -> 0.6.1 ``                                                |
| [`2ea39f14`](https://github.com/bbigras/nixpkgs/commit/2ea39f146e4e8b796b25ba871da1aea230604142) | `` python312Packages.fastembed: 0.3.1 -> 0.3.4 ``                                        |
| [`32ea32eb`](https://github.com/bbigras/nixpkgs/commit/32ea32eb1e3c0ec0fff643c5540ea1695d2fa027) | `` vdr: 2.6.8 -> 2.6.9 ``                                                                |
| [`bd3c5140`](https://github.com/bbigras/nixpkgs/commit/bd3c514096c01eb27b4ceecd1148418777a7cb70) | `` python312Packages.tencentcloud-sdk-python: 3.0.1193 -> 3.0.1194 ``                    |