### PR TITLE
chore(flake/nur): `a567cb05` -> `8fc77d81`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721717193,
-        "narHash": "sha256-hU5VQrEOF7MaNjZfG7tLsnlm8HGIRQs59WXe83Lsp2c=",
+        "lastModified": 1721727831,
+        "narHash": "sha256-H3cnWQ/qE1SB0tIjsYou3NemtmnNEZNXwQm9Jq3tdDQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a567cb05cff5358c5d412ff98dd4d65a13e9b06b",
+        "rev": "8fc77d8151bf1c7df600d8c5bac16ae974c1903c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8fc77d81`](https://github.com/nix-community/NUR/commit/8fc77d8151bf1c7df600d8c5bac16ae974c1903c) | `` automatic update `` |
| [`cd79921c`](https://github.com/nix-community/NUR/commit/cd79921ce3422c87902f4abe4ef1f1674938ffdf) | `` automatic update `` |
| [`788d1695`](https://github.com/nix-community/NUR/commit/788d16952749db7ca9760938847c9e2341f38d2e) | `` automatic update `` |
| [`f2abbaae`](https://github.com/nix-community/NUR/commit/f2abbaae85edfc330b1c584c23e5794aed393406) | `` automatic update `` |