### PR TITLE
chore(flake/nur): `b0d3dca8` -> `45f00d39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721745148,
-        "narHash": "sha256-2drs6Hx5jKX6ThFzJI7mt8Z5HbKeOahy4oOwSH+K64w=",
+        "lastModified": 1721749502,
+        "narHash": "sha256-GZGj8cT+p3lqQA+2lphLQOYC/E2+iUPgOdC5v9c9T6A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b0d3dca877f0ef165e955d0ddd8c1df6670707b9",
+        "rev": "45f00d395933a7ecb27fb91c9e61eb01f4976b6d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`45f00d39`](https://github.com/nix-community/NUR/commit/45f00d395933a7ecb27fb91c9e61eb01f4976b6d) | `` automatic update `` |