### PR TITLE
chore(flake/nixos-hardware): `ab165a8a` -> `405b6548`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -627,11 +627,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1721413321,
-        "narHash": "sha256-0GdiQScDceUrVGbxYpV819LHesK3szHOhJ09e6sgES4=",
+        "lastModified": 1721754224,
+        "narHash": "sha256-JEVfxzZRo+/zdWKBjHpAUG905SDZL9fmoLJxf9b5CGU=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "ab165a8a6cd12781d76fe9cbccb9e975d0fb634f",
+        "rev": "405b654893aba16c8014de6a17e84439d3fb8e46",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                            |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`405b6548`](https://github.com/NixOS/nixos-hardware/commit/405b654893aba16c8014de6a17e84439d3fb8e46) | `` Add Lenovo Thinkpad T14 Gen5 `` |