### PR TITLE
chore(flake/nur): `57b62933` -> `7dd53c8a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721752854,
-        "narHash": "sha256-ZB+XFyUXR47zS4luyE4cK6vmcVRgO0d48XQvDH7CUe0=",
+        "lastModified": 1721763933,
+        "narHash": "sha256-dFDyd981D3QlgygXJ6gq9SMFLGQrGZDDLe7xkEJsDi4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "57b62933a261bda227bbb095e22216565be6e3c2",
+        "rev": "7dd53c8a1891f68142c29af97c8786cc4b59d102",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7dd53c8a`](https://github.com/nix-community/NUR/commit/7dd53c8a1891f68142c29af97c8786cc4b59d102) | `` automatic update `` |
| [`4e33d58e`](https://github.com/nix-community/NUR/commit/4e33d58e5c3af29a2a33c3bd6e1db2a297dc3718) | `` automatic update `` |