### PR TITLE
chore(flake/nur): `7dd53c8a` -> `a6160422`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721763933,
-        "narHash": "sha256-dFDyd981D3QlgygXJ6gq9SMFLGQrGZDDLe7xkEJsDi4=",
+        "lastModified": 1721771144,
+        "narHash": "sha256-XWOhdlTNf58pR8Mwu3a59vrA7aOftt/KSt4EI2GwZNY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7dd53c8a1891f68142c29af97c8786cc4b59d102",
+        "rev": "a6160422592deae0a754b2d969cf611f9339f212",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a6160422`](https://github.com/nix-community/NUR/commit/a6160422592deae0a754b2d969cf611f9339f212) | `` automatic update `` |