### PR TITLE
chore(flake/catppuccin): `d75d5803` -> `8bdb55cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1720472194,
-        "narHash": "sha256-CYscFEts6tyvosc1T29nxhzIYJAj/1CCEkV3ZMzSN/c=",
+        "lastModified": 1721784420,
+        "narHash": "sha256-bgF6fN4Qgk7NErFKGuuqWXcLORsiykTYyqMUFRiAUBY=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "d75d5803852fb0833767dc969a4581ac13204e22",
+        "rev": "8bdb55cc1c13f572b6e4307a3c0d64f1ae286a4f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                   |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`8bdb55cc`](https://github.com/catppuccin/nix/commit/8bdb55cc1c13f572b6e4307a3c0d64f1ae286a4f) | `` feat(home-manager/mpv): add support for uosc (#291) `` |