### PR TITLE
chore(flake/emacs-overlay): `3c3de3eb` -> `1f4e4263`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721783293,
-        "narHash": "sha256-gd4XJVB0fh01QI8X/9w/0YCacLVv0TUmz3Y4oFvx6MA=",
+        "lastModified": 1721786240,
+        "narHash": "sha256-RCnw9Uh3JQ7EaZWUHBKzbYXa7ebz7bsDOcsLHz/uzUg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3c3de3ebf4c722387607b12d6fe6c4d9b32ce777",
+        "rev": "1f4e4263a6a95d07efb23253b67e8205a4c4187d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`1f4e4263`](https://github.com/nix-community/emacs-overlay/commit/1f4e4263a6a95d07efb23253b67e8205a4c4187d) | `` Updated emacs `` |
| [`07cc763d`](https://github.com/nix-community/emacs-overlay/commit/07cc763d0c5adb901139b63f1e733e9d99bfdb08) | `` Updated melpa `` |