### PR TITLE
chore(flake/nur): `db96d61c` -> `f34f2774`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721773979,
-        "narHash": "sha256-rZBcGFWjPeX55+fz1sXjXFRUx2h4gZ6WXdzHUPZZ/fA=",
+        "lastModified": 1721789930,
+        "narHash": "sha256-diGa4oFvFA8n8xHMnmqWETCbtBHiIxHLw8h7Eso+cSs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "db96d61c1f6ee0d40691050b74a79ae47354abc3",
+        "rev": "f34f2774b0a2ec43c7e1d103d503d6681262ef05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f34f2774`](https://github.com/nix-community/NUR/commit/f34f2774b0a2ec43c7e1d103d503d6681262ef05) | `` automatic update `` |
| [`366383a1`](https://github.com/nix-community/NUR/commit/366383a1210a91b52bf4ae6ad7556719c4d3b172) | `` automatic update `` |
| [`e3ec2f8a`](https://github.com/nix-community/NUR/commit/e3ec2f8abe45808205fc0cccdb65c5c880fdda60) | `` automatic update `` |