### PR TITLE
chore(flake/nur): `f34f2774` -> `12f15187`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721789930,
-        "narHash": "sha256-diGa4oFvFA8n8xHMnmqWETCbtBHiIxHLw8h7Eso+cSs=",
+        "lastModified": 1721795364,
+        "narHash": "sha256-c7/0c5h+rlIcE84ELpR9oMuwkhguQkDofSvjcdb4PE4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f34f2774b0a2ec43c7e1d103d503d6681262ef05",
+        "rev": "12f15187ea8bf1c4d6fc712a861f8065481b77b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`12f15187`](https://github.com/nix-community/NUR/commit/12f15187ea8bf1c4d6fc712a861f8065481b77b3) | `` automatic update `` |
| [`5bd4d631`](https://github.com/nix-community/NUR/commit/5bd4d63130b7594dc7e12afd78b4946b0a925df9) | `` automatic update `` |
| [`a5607793`](https://github.com/nix-community/NUR/commit/a5607793a5686955acfc996f5aeb67300927b9b5) | `` automatic update `` |
| [`2f75d305`](https://github.com/nix-community/NUR/commit/2f75d3050199eedb1e4bea63eea6c06ee69b7fef) | `` automatic update `` |