### PR TITLE
chore(flake/nur): `12f15187` -> `3d3322c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721795364,
-        "narHash": "sha256-c7/0c5h+rlIcE84ELpR9oMuwkhguQkDofSvjcdb4PE4=",
+        "lastModified": 1721803625,
+        "narHash": "sha256-msjhIJSiM8UA5yVpx0efv2+fNJM2eN9CTZhCcdsCfTk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "12f15187ea8bf1c4d6fc712a861f8065481b77b3",
+        "rev": "3d3322c25f1b5df1911fe684950f1d5ae8b3b2db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3d3322c2`](https://github.com/nix-community/NUR/commit/3d3322c25f1b5df1911fe684950f1d5ae8b3b2db) | `` automatic update `` |
| [`32a9c982`](https://github.com/nix-community/NUR/commit/32a9c9823a3f3835b8e70f6357d67b4959f894f0) | `` automatic update `` |