### PR TITLE
chore(flake/nur): `3d3322c2` -> `dbb139ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721803625,
-        "narHash": "sha256-msjhIJSiM8UA5yVpx0efv2+fNJM2eN9CTZhCcdsCfTk=",
+        "lastModified": 1721814343,
+        "narHash": "sha256-4B9+kQjy2DiEMTZBVNVN8w0a2StFqybDYoJdxvtNh20=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3d3322c25f1b5df1911fe684950f1d5ae8b3b2db",
+        "rev": "dbb139acae2a6974987e1267432346d67487e3ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dbb139ac`](https://github.com/nix-community/NUR/commit/dbb139acae2a6974987e1267432346d67487e3ec) | `` automatic update `` |
| [`7546a391`](https://github.com/nix-community/NUR/commit/7546a391be461dd32e0779dde86b6c9035ae2877) | `` automatic update `` |
| [`7f6199a5`](https://github.com/nix-community/NUR/commit/7f6199a5c4eee99c7ed91ec6a83589f28bd02b6e) | `` automatic update `` |