### PR TITLE
chore(flake/nur): `dbb139ac` -> `f2f47475`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721814343,
-        "narHash": "sha256-4B9+kQjy2DiEMTZBVNVN8w0a2StFqybDYoJdxvtNh20=",
+        "lastModified": 1721824989,
+        "narHash": "sha256-GTQKeLMMvZe19hmrhSEk1w/PfzSb4EFynW8LMtYPDBo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dbb139acae2a6974987e1267432346d67487e3ec",
+        "rev": "f2f47475b92132b4358e441fc1993b6ac12398ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f2f47475`](https://github.com/nix-community/NUR/commit/f2f47475b92132b4358e441fc1993b6ac12398ee) | `` automatic update `` |
| [`40b989b0`](https://github.com/nix-community/NUR/commit/40b989b0f1a9054455ff38cdbaee719044624806) | `` automatic update `` |
| [`ff194a14`](https://github.com/nix-community/NUR/commit/ff194a1486c1145fffe5551f04ba3fc8c3c3fd1c) | `` automatic update `` |