### PR TITLE
chore(flake/nur): `f2f47475` -> `2807334a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721824989,
-        "narHash": "sha256-GTQKeLMMvZe19hmrhSEk1w/PfzSb4EFynW8LMtYPDBo=",
+        "lastModified": 1721828726,
+        "narHash": "sha256-vhhfwcNSVVEpH0C/9i62MlGF6RyspSIObTKIo5KWsiw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f2f47475b92132b4358e441fc1993b6ac12398ee",
+        "rev": "2807334afd5d150f55cdcfcff24698609fabdfe8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2807334a`](https://github.com/nix-community/NUR/commit/2807334afd5d150f55cdcfcff24698609fabdfe8) | `` automatic update `` |