### PR TITLE
chore(flake/nixos-hardware): `405b6548` -> `a7432eba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -627,11 +627,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1721754224,
-        "narHash": "sha256-JEVfxzZRo+/zdWKBjHpAUG905SDZL9fmoLJxf9b5CGU=",
+        "lastModified": 1721839713,
+        "narHash": "sha256-apTv16L9h5ONS2VTPbKEgwAOVmWGku0MsfprjgwBFHo=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "405b654893aba16c8014de6a17e84439d3fb8e46",
+        "rev": "a7432ebaefc9a400dcda399d48b949230378d784",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                         |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`a7432eba`](https://github.com/NixOS/nixos-hardware/commit/a7432ebaefc9a400dcda399d48b949230378d784) | `` framework/16-inch: Mark keyboard as internal for libinput `` |
| [`b501c5fb`](https://github.com/NixOS/nixos-hardware/commit/b501c5fbf657b4bbe2a61a66fc1483ad0ec40d7b) | `` Add configuration for Lenovo IdeaPad Gaming 3 15ach6 ``      |