### PR TITLE
chore(flake/nur): `2807334a` -> `2cb5d10f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721828726,
-        "narHash": "sha256-vhhfwcNSVVEpH0C/9i62MlGF6RyspSIObTKIo5KWsiw=",
+        "lastModified": 1721843106,
+        "narHash": "sha256-hit3Wpb3587/a5yeAOAKmDsJxLrCNbusJWq/r1TyV5A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2807334afd5d150f55cdcfcff24698609fabdfe8",
+        "rev": "2cb5d10f9c40f92477b6fa2a8b73d541f9f88a75",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2cb5d10f`](https://github.com/nix-community/NUR/commit/2cb5d10f9c40f92477b6fa2a8b73d541f9f88a75) | `` automatic update `` |
| [`8d739e05`](https://github.com/nix-community/NUR/commit/8d739e05912fa10e65c919b2fbe6ed455a23ccec) | `` automatic update `` |