### PR TITLE
chore(flake/nur): `2cb5d10f` -> `424f1428`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721843106,
-        "narHash": "sha256-hit3Wpb3587/a5yeAOAKmDsJxLrCNbusJWq/r1TyV5A=",
+        "lastModified": 1721850718,
+        "narHash": "sha256-HU8hUqc0uFw6BgmB9ns0apHU7/CjYBVz7hT7soOKLhE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2cb5d10f9c40f92477b6fa2a8b73d541f9f88a75",
+        "rev": "424f1428c93af81ec79c3b3c19802e6cbd5dac98",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`424f1428`](https://github.com/nix-community/NUR/commit/424f1428c93af81ec79c3b3c19802e6cbd5dac98) | `` automatic update `` |
| [`16ca6806`](https://github.com/nix-community/NUR/commit/16ca6806f32cb938eb597bc33dd1173d9fa1dcac) | `` automatic update `` |
| [`a0647421`](https://github.com/nix-community/NUR/commit/a06474215b664df2d34d2337d9e0d860033500ba) | `` automatic update `` |