### PR TITLE
chore(flake/nur): `424f1428` -> `8e943074`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721850718,
-        "narHash": "sha256-HU8hUqc0uFw6BgmB9ns0apHU7/CjYBVz7hT7soOKLhE=",
+        "lastModified": 1721852765,
+        "narHash": "sha256-rB9SmfXGron/jhXZh+qhMZK3HpMWYlXco/tVRWPLS0s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "424f1428c93af81ec79c3b3c19802e6cbd5dac98",
+        "rev": "8e943074abdd329f3b66453db97a2d5a5e365753",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8e943074`](https://github.com/nix-community/NUR/commit/8e943074abdd329f3b66453db97a2d5a5e365753) | `` automatic update `` |