### PR TITLE
chore(flake/nur): `8e943074` -> `43fa2ed9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721852765,
-        "narHash": "sha256-rB9SmfXGron/jhXZh+qhMZK3HpMWYlXco/tVRWPLS0s=",
+        "lastModified": 1721857592,
+        "narHash": "sha256-jHBpoWPYCXRYr1bjiy5PDhmwl8g4K343afHBiHNdxeA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8e943074abdd329f3b66453db97a2d5a5e365753",
+        "rev": "43fa2ed900db2d65879c4f2b1bb03645ea264dcc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`43fa2ed9`](https://github.com/nix-community/NUR/commit/43fa2ed900db2d65879c4f2b1bb03645ea264dcc) | `` automatic update `` |