### PR TITLE
chore(flake/srvos): `93685882` -> `c9967dee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -914,11 +914,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721612563,
-        "narHash": "sha256-6T6GkLuNVbgDKijcBY/5mUiK8gO2Xi2QFM13hUKa2a0=",
+        "lastModified": 1721868370,
+        "narHash": "sha256-YvtVowRDBCCU/BTrhITzGFAYU2sMLrBqRUstVw5FX9s=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "936858820dcad0e958f16f0e9652519bef045d5d",
+        "rev": "c9967deecd58c0c9e80d45c0f8483f40666dc847",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`c9967dee`](https://github.com/nix-community/srvos/commit/c9967deecd58c0c9e80d45c0f8483f40666dc847) | `` dev/private/flake.lock: Update `` |
| [`295bd9b0`](https://github.com/nix-community/srvos/commit/295bd9b0f12b0c29ece59d040abab517b5dc4cce) | `` flake.lock: Update ``             |