### PR TITLE
chore(flake/emacs-overlay): `d2e9b1e2` -> `6ad922f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721869664,
-        "narHash": "sha256-1rmB86ARz/IbWkh5moQQa+6ovVGq78sPZ0aJwpr80F0=",
+        "lastModified": 1721872697,
+        "narHash": "sha256-GXx+viSegNL3HH2oUVh5DJE/JhK38GCJjKmTIj4aF0c=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d2e9b1e2799db376de58699e3b82843e2586611b",
+        "rev": "6ad922f8168b6b6aa8c5894dbbcc82840758aea5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`6ad922f8`](https://github.com/nix-community/emacs-overlay/commit/6ad922f8168b6b6aa8c5894dbbcc82840758aea5) | `` Updated emacs `` |
| [`83af36b5`](https://github.com/nix-community/emacs-overlay/commit/83af36b5cc1c68a9e78b9d35ff9031a8e72b9b85) | `` Updated melpa `` |