### PR TITLE
chore(flake/nur): `d2041e87` -> `2cb2a37f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721859852,
-        "narHash": "sha256-V5d3+LiOx0xiGQbIhuAxGRfiwXPYipJIwufcXAWiot0=",
+        "lastModified": 1721879125,
+        "narHash": "sha256-AZSomWA8lb3x7RrEHdLweHTN9O3lpIOwFmvUtaIXHaI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d2041e87f4b2c103c66797829c4e4f5819b61ddd",
+        "rev": "2cb2a37f3bffdcef1e81b7c46bc389db1a919965",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2cb2a37f`](https://github.com/nix-community/NUR/commit/2cb2a37f3bffdcef1e81b7c46bc389db1a919965) | `` automatic update `` |
| [`b5cdfd09`](https://github.com/nix-community/NUR/commit/b5cdfd09dfc31e4d9f7f0bfd4e41b66e0170b497) | `` automatic update `` |
| [`0371422b`](https://github.com/nix-community/NUR/commit/0371422b217c5bacdfb33d637d9209d68169ee1d) | `` automatic update `` |