### PR TITLE
chore(flake/nur): `2cb2a37f` -> `33efec14`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721879125,
-        "narHash": "sha256-AZSomWA8lb3x7RrEHdLweHTN9O3lpIOwFmvUtaIXHaI=",
+        "lastModified": 1721882770,
+        "narHash": "sha256-dHSG5+5hfCCEqpyETpfvIfZME7lS/FKf+BhznTyZGa0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2cb2a37f3bffdcef1e81b7c46bc389db1a919965",
+        "rev": "33efec141a33e131d7f083fe305197835baf3d05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`33efec14`](https://github.com/nix-community/NUR/commit/33efec141a33e131d7f083fe305197835baf3d05) | `` automatic update `` |
| [`11e97388`](https://github.com/nix-community/NUR/commit/11e973882f5263a3e8339d8dabb7fc59d30378a2) | `` automatic update `` |
| [`a33256ce`](https://github.com/nix-community/NUR/commit/a33256ce9d04d97791c3e1fe00871704809ff099) | `` automatic update `` |