### PR TITLE
chore(flake/nur): `33efec14` -> `4fbb78da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721882770,
-        "narHash": "sha256-dHSG5+5hfCCEqpyETpfvIfZME7lS/FKf+BhznTyZGa0=",
+        "lastModified": 1721886788,
+        "narHash": "sha256-yMGKGzsbr0HhtWtoz6Fanrf6S1zjk3s1s1J4Hw7ujzU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "33efec141a33e131d7f083fe305197835baf3d05",
+        "rev": "4fbb78daa6e22e1ccdcbb020091ac84532994bef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4fbb78da`](https://github.com/nix-community/NUR/commit/4fbb78daa6e22e1ccdcbb020091ac84532994bef) | `` automatic update `` |
| [`ed22b05c`](https://github.com/nix-community/NUR/commit/ed22b05c09da141b92f93559a83b79f4d096ceab) | `` automatic update `` |
| [`f385ae9f`](https://github.com/nix-community/NUR/commit/f385ae9f15f0ca823c3b1e819efc8fb4d032833a) | `` automatic update `` |