### PR TITLE
chore(flake/nur): `4fbb78da` -> `1002ee1f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721886788,
-        "narHash": "sha256-yMGKGzsbr0HhtWtoz6Fanrf6S1zjk3s1s1J4Hw7ujzU=",
+        "lastModified": 1721890023,
+        "narHash": "sha256-Q0VVuQBsFuofMsneR4ilRp+eznN8Q/Gz+cv+BlslK6w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4fbb78daa6e22e1ccdcbb020091ac84532994bef",
+        "rev": "1002ee1f90ca51d8891642094d3a1e840d82b616",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1002ee1f`](https://github.com/nix-community/NUR/commit/1002ee1f90ca51d8891642094d3a1e840d82b616) | `` automatic update `` |