### PR TITLE
chore(flake/srvos): `c9967dee` -> `27b3a9b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -914,11 +914,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721868370,
-        "narHash": "sha256-YvtVowRDBCCU/BTrhITzGFAYU2sMLrBqRUstVw5FX9s=",
+        "lastModified": 1721888498,
+        "narHash": "sha256-O5/s8e6CL99AQoKEn8k6F99UoJdAzQ8z9LZ7SxFJ3c4=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "c9967deecd58c0c9e80d45c0f8483f40666dc847",
+        "rev": "27b3a9b23847cb2e716334ee6ad58b82ddc3f7a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`722c1dc0`](https://github.com/nix-community/srvos/commit/722c1dc0681584fcc9e088582cfcb4312de6e452) | `` format tree ``                    |
| [`dc077505`](https://github.com/nix-community/srvos/commit/dc07750547c2ad257781216bd16cb952d7285d77) | `` treefmt: nixpkgs-fmt -> nixfmt `` |