### PR TITLE
chore(flake/emacs-overlay): `6ad922f8` -> `0e17249c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721872697,
-        "narHash": "sha256-GXx+viSegNL3HH2oUVh5DJE/JhK38GCJjKmTIj4aF0c=",
+        "lastModified": 1721897840,
+        "narHash": "sha256-XAVpSDcjYQgUod41xyle2b8dCJ1q0llD61Dv0b1vpXM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6ad922f8168b6b6aa8c5894dbbcc82840758aea5",
+        "rev": "0e17249c87ae24e5aaae68d45372e6d44be7b250",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`0e17249c`](https://github.com/nix-community/emacs-overlay/commit/0e17249c87ae24e5aaae68d45372e6d44be7b250) | `` Updated melpa `` |