### PR TITLE
chore(flake/nixos-hardware): `a7432eba` -> `5bd0371d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -627,11 +627,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1721839713,
-        "narHash": "sha256-apTv16L9h5ONS2VTPbKEgwAOVmWGku0MsfprjgwBFHo=",
+        "lastModified": 1721900127,
+        "narHash": "sha256-Rk+zRS8HCK0Kd9CAklqywB2LOgOehC3xblppHuLxVUs=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "a7432ebaefc9a400dcda399d48b949230378d784",
+        "rev": "5bd0371d3ff4c121b03450de8cfd643547b11fe1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`5bd0371d`](https://github.com/NixOS/nixos-hardware/commit/5bd0371d3ff4c121b03450de8cfd643547b11fe1) | `` Create lenovo-yoga-7-14ARH7-amdgpu and lenovo-yoga-7-14ARH7-nvidia entries `` |
| [`226e5178`](https://github.com/NixOS/nixos-hardware/commit/226e517854aec947b139e28e9edb6394fe256d32) | `` surface: fix default kernel version ``                                        |
| [`39ac67a5`](https://github.com/NixOS/nixos-hardware/commit/39ac67a5feba7ac99165e39a6def08da39de5da5) | `` surface: fix isVersionOf check ``                                             |
| [`37d3f206`](https://github.com/NixOS/nixos-hardware/commit/37d3f20674ad0d7ecc0367345ede6c550d1be819) | `` Update README.md ``                                                           |
| [`ea9f6719`](https://github.com/NixOS/nixos-hardware/commit/ea9f6719b17ab3a13271ed1d1306b174b19f510b) | `` Update README.md ``                                                           |
| [`6187754b`](https://github.com/NixOS/nixos-hardware/commit/6187754bdda54b330bfa46f383840221d2c5d9e4) | `` Update README.md ``                                                           |
| [`c6b440dc`](https://github.com/NixOS/nixos-hardware/commit/c6b440dcd63fdb65dbde486d41bf63ef228335b6) | ``  apple/macbook-pro/14-1/README.md: use markdown checkboxes ``                 |
| [`d403b7f6`](https://github.com/NixOS/nixos-hardware/commit/d403b7f6ae7e513f1c7384b1dca80074a991a7cb) | `` apple/imac/18-2/README.md: use markdown checkboxes ``                         |
| [`d33e3e71`](https://github.com/NixOS/nixos-hardware/commit/d33e3e71477521f50af926a3570527e9f2e37879) | `` apple-imac-18-2: add flake support ``                                         |
| [`40e296b2`](https://github.com/NixOS/nixos-hardware/commit/40e296b2b3f6dc674191013c7583a67778228166) | `` apple-imac-18-2: add imac, add imac-18-2 ``                                   |
| [`d3ef6d0c`](https://github.com/NixOS/nixos-hardware/commit/d3ef6d0c7c0525d9d306d47245ae761904a6211f) | `` apple-macbookpro-14-1: update info, simplify and fix config ``                |