### PR TITLE
chore(flake/nur): `309731f9` -> `a6a34c95`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721912414,
-        "narHash": "sha256-VrdKUrQlrKhymzSleoNZWvUrIfRvKzVzH7h8QN2H4xM=",
+        "lastModified": 1721914019,
+        "narHash": "sha256-GxUnSVtfPCLHIJJ6OiwQUaFIPL0xMaH0wf+TuxS6Cwg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "309731f9f92994288dab65b3af79045086d0139b",
+        "rev": "a6a34c95c22e8cddd6049a470fb843989d08ee86",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a6a34c95`](https://github.com/nix-community/NUR/commit/a6a34c95c22e8cddd6049a470fb843989d08ee86) | `` automatic update `` |