### PR TITLE
chore(flake/nixpkgs): `68c9ed8b` -> `dc14ed91`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1721562059,
-        "narHash": "sha256-Tybxt65eyOARf285hMHIJ2uul8SULjFZbT9ZaEeUnP8=",
+        "lastModified": 1721743106,
+        "narHash": "sha256-adRZhFpBTnHiK3XIELA3IBaApz70HwCYfv7xNrHjebA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "68c9ed8bbed9dfce253cc91560bf9043297ef2fe",
+        "rev": "dc14ed91132ee3a26255d01d8fd0c1f5bff27b2f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                  |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`f9e9e915`](https://github.com/NixOS/nixpkgs/commit/f9e9e91587171c2e110cd454b556265a0dc24022) | `` kerberos/heimdal: use jdk_headless in nativeCheckInputs (#329158) ``                  |
| [`5aaf334b`](https://github.com/NixOS/nixpkgs/commit/5aaf334b768ed098850fd82c48d047389fa3217b) | `` roddhjav-apparmor-rules: 0-unstable-2024-07-12 -> 0-unstable-2024-07-20 ``            |
| [`13fb2ec2`](https://github.com/NixOS/nixpkgs/commit/13fb2ec22968fcbc52a91f8544f603777c0f3f04) | `` Warn about deprecated coqhammer ``                                                    |
| [`b0c3089a`](https://github.com/NixOS/nixpkgs/commit/b0c3089aff3190fad2f3165ed18d8b48e9967a71) | `` ffmpeg_7-full: Reenable withQuirc ``                                                  |
| [`fd067e42`](https://github.com/NixOS/nixpkgs/commit/fd067e42dc7cd4054120f49e9e4e58546b31ec3e) | `` ffmpeg_7: Reenable withAVFoundation ``                                                |
| [`bc556c56`](https://github.com/NixOS/nixpkgs/commit/bc556c56864a8b593cc05c39421475e8187e5367) | `` lib.warn: Update docs ``                                                              |
| [`01b21d1d`](https://github.com/NixOS/nixpkgs/commit/01b21d1d6538c0b33dbb8a50ca7599b2aa658538) | `` boinc: 8.0.2 -> 8.0.4 ``                                                              |
| [`17a5b124`](https://github.com/NixOS/nixpkgs/commit/17a5b1248c821923aa3548608ef0e8d5a39be4e3) | `` bibtex-tidy: 1.11.0 -> 1.13.0 ``                                                      |
| [`a9e5f6bf`](https://github.com/NixOS/nixpkgs/commit/a9e5f6bfcd6d8025f6ee98c563c8e31eb322ec75) | `` coqPackages: Enable override with dev branches (#329356) ``                           |
| [`b9a17a6e`](https://github.com/NixOS/nixpkgs/commit/b9a17a6e7eda0fb21fffb02c20da7f725c731eea) | `` firefly-iii: 6.1.18 -> 6.1.19 ``                                                      |
| [`d401481a`](https://github.com/NixOS/nixpkgs/commit/d401481a74011169cd44f0418dc3049b3c728973) | `` lxd-ui: 0.11 -> 0.12 ``                                                               |
| [`25455e44`](https://github.com/NixOS/nixpkgs/commit/25455e4474c214aa786523fcd785b82f1ef9b2f9) | `` copilot: 0-unstable-2023-12-26 -> 0-unstable-2024-05-01 ``                            |
| [`dc9bed84`](https://github.com/NixOS/nixpkgs/commit/dc9bed84a9b836ce0b8f8ff7e3127585053cdad5) | `` terragrunt: 0.62.0 -> 0.63.2 ``                                                       |
| [`08112ba7`](https://github.com/NixOS/nixpkgs/commit/08112ba7c2a602e34db08b4bf8c61777e0bbc083) | `` bicep: 0.28.1 -> 0.29.47 ``                                                           |
| [`0fb7268b`](https://github.com/NixOS/nixpkgs/commit/0fb7268b9bc3d4e682c18e0716f52a54cb4affe8) | `` Init IFM service at version 4.0.2 ``                                                  |
| [`cbc0982d`](https://github.com/NixOS/nixpkgs/commit/cbc0982defb8d4722fb110cf2e1b36650bcda5e2) | `` path-of-building.data: 2.42.0 -> 2.44.1 ``                                            |
| [`681e984f`](https://github.com/NixOS/nixpkgs/commit/681e984f8e3d66f4fd8a94ea28bb7a8b87b27216) | `` coqPackages.equations: 1.3.1 for Coq 8.20 ``                                          |
| [`0e14bb41`](https://github.com/NixOS/nixpkgs/commit/0e14bb41c7ed394b1277ce1f2f4e74d694f7edad) | `` cnspec: 11.12.2 -> 11.13.0 ``                                                         |
| [`78af0a46`](https://github.com/NixOS/nixpkgs/commit/78af0a46aee9435ea4002c9ccc2891bb01c75842) | `` ledger-live-desktop: 2.83.0 -> 2.84.0 ``                                              |
| [`67783fd0`](https://github.com/NixOS/nixpkgs/commit/67783fd0d59bacf55765580b6f8a8c95a1d761f2) | `` telegraf: 1.31.1 -> 1.31.2 ``                                                         |
| [`2deb3dd4`](https://github.com/NixOS/nixpkgs/commit/2deb3dd45f1f7238053ae043f11caeb1223a4902) | `` llvmPackages_git.compiler-rt: disable codesign ``                                     |
| [`fd3f5e4b`](https://github.com/NixOS/nixpkgs/commit/fd3f5e4b4980081aed0ea50a0f3719a071b3afc4) | `` cinnamon.nemo-emblems: 6.2.0 -> 6.2.1 ``                                              |
| [`4874d8db`](https://github.com/NixOS/nixpkgs/commit/4874d8db3647829ed1a2c17867679462cb06063b) | `` fast-float: 6.1.1 -> 6.1.2 ``                                                         |
| [`a1814d2d`](https://github.com/NixOS/nixpkgs/commit/a1814d2dbf15dcc7950ad8a15c8b2c930633f99c) | `` ffmpeg: remove arthsmn from the maintainers ``                                        |
| [`598659a4`](https://github.com/NixOS/nixpkgs/commit/598659a488918341d44a0f195f107dcc475879a3) | `` ff2mpv-rust: remove arthsmn from the maintainers ``                                   |
| [`2923c0c1`](https://github.com/NixOS/nixpkgs/commit/2923c0c14a33c78a2f195fa8cef4df84d0b825bc) | `` emacsPackages.rect-mark: adopted by AndersonTorres ``                                 |
| [`eee2cc8a`](https://github.com/NixOS/nixpkgs/commit/eee2cc8a9bcc0297dd3dad88e68659601e2a8e10) | `` audacity: 3.6.0 -> 3.6.1 ``                                                           |
| [`9859c235`](https://github.com/NixOS/nixpkgs/commit/9859c235846a8dec293df62b805f7bbb0cfdbf87) | `` manuskript: add strawbee as maintainer ``                                             |
| [`4ac9e605`](https://github.com/NixOS/nixpkgs/commit/4ac9e605fa712087ff1975c110379e7ff8b0c9eb) | `` manuskript: override python version ``                                                |
| [`c26ba30c`](https://github.com/NixOS/nixpkgs/commit/c26ba30c69d2f9dfe415576d78b5c3e99c4a6ed5) | `` maintainers: add strawbee ``                                                          |
| [`50eaa301`](https://github.com/NixOS/nixpkgs/commit/50eaa3013005bcf181a9e38c65d4801f3a7b8235) | `` emacsPackages.elisp-ffi: adopted by AndersonTorres ``                                 |
| [`93d84f95`](https://github.com/NixOS/nixpkgs/commit/93d84f953f0f05017a32c0fac82b91be962dd830) | `` autoprefixer.tests: fix the eval ``                                                   |
| [`0840cd62`](https://github.com/NixOS/nixpkgs/commit/0840cd62c0597f1c8e429ec20357987f5b85b555) | `` Revert "glew: default enableEGL to true" ``                                           |
| [`c2ac76bf`](https://github.com/NixOS/nixpkgs/commit/c2ac76bfdae507a5675359d2cdc2e29d697b4d90) | `` emacsPackages.voicemacs: adopted by AndersonTorres ``                                 |
| [`c675eb8c`](https://github.com/NixOS/nixpkgs/commit/c675eb8ce9db110e04e5528ba8d6446240d68dff) | `` emacsPackages.font-lock-plus: adopted by AndersonTorres ``                            |
| [`bdb7b33b`](https://github.com/NixOS/nixpkgs/commit/bdb7b33b731d87e2bb904aa09797a50bc139ea5b) | `` python312Packages.leanblueprint: init at 0.0.10 ``                                    |
| [`c46383a5`](https://github.com/NixOS/nixpkgs/commit/c46383a57c59a15d0931d0893b3bd52a7c9adfda) | `` python312Packages.plastexshowmore: init at 0.0.2 ``                                   |
| [`8ca7bd84`](https://github.com/NixOS/nixpkgs/commit/8ca7bd846e0e75ecea1d3c2c2f0124e35743a88d) | `` python312Packages.plastexdepgraph: init at 0.0.4 ``                                   |
| [`bd5255a1`](https://github.com/NixOS/nixpkgs/commit/bd5255a137ca6b947f3a49c076d5cec04bebb343) | `` python312Packages.plasTeX: init at 3.1 ``                                             |
| [`33076bb5`](https://github.com/NixOS/nixpkgs/commit/33076bb539d007e3379044830bc959a5873dbed8) | `` python312Packages.google-cloud-firestore: 2.16.1 -> 2.17.0 ``                         |
| [`71ae199b`](https://github.com/NixOS/nixpkgs/commit/71ae199b9eda5ff93a171ad2b61e6f24dc821821) | `` seaweedfs: 3.69 -> 3.71 ``                                                            |
| [`bd8ac353`](https://github.com/NixOS/nixpkgs/commit/bd8ac353db4f13fd5da98aaea96162d9ab730e7f) | `` emacsPackages.wat-mode: remove redundant commentary ``                                |
| [`034c174d`](https://github.com/NixOS/nixpkgs/commit/034c174d850b4fccb98024a075ad8ee6656dd447) | `` emacsPackages.wat-mode: implement passthru.updateScript ``                            |
| [`6ab627b3`](https://github.com/NixOS/nixpkgs/commit/6ab627b36ef1acf7ac95ff89d6d3eae4c974d668) | `` python312Packages.cyclopts: 2.9.3 -> 2.9.4 ``                                         |
| [`4acb6adf`](https://github.com/NixOS/nixpkgs/commit/4acb6adf1d0fdf788007ab5cc62570930f287201) | `` wasmtime: 22.0.0 -> 23.0.1 ``                                                         |
| [`89f3f084`](https://github.com/NixOS/nixpkgs/commit/89f3f084d04346eb9afe5f0fc4705e2798bc1339) | `` mpv-subs-popout: init at 0.5.2 ``                                                     |
| [`ccceb0bb`](https://github.com/NixOS/nixpkgs/commit/ccceb0bbaeede126728e70d47ba1e4d713493afa) | `` python312Packages.pure-protobuf: 3.1.0 -> 3.1.1 ``                                    |
| [`438d6f7c`](https://github.com/NixOS/nixpkgs/commit/438d6f7cc730eda8f44af4e97be3b610bd4791e9) | `` hol_light: 2024-05-10 → 2024-07-07 ``                                                 |
| [`08215d1b`](https://github.com/NixOS/nixpkgs/commit/08215d1b8886fb14a5092d8a572a9128b4e7e2db) | `` maxima: add patch for CVE-2024-34490 ``                                               |
| [`1049aef0`](https://github.com/NixOS/nixpkgs/commit/1049aef047ba3e922b6fd369907c84159206539b) | `` doppler: fix build failure with shell completion (#326008) ``                         |
| [`7329174d`](https://github.com/NixOS/nixpkgs/commit/7329174db714317d6cf99da08b517eb1fc3f2ff9) | `` kluctl: migrate to by-name ``                                                         |
| [`3540a35e`](https://github.com/NixOS/nixpkgs/commit/3540a35ec94d94bc744a9d1acaabdb41903d2e0c) | `` vimPlugins.lz-n: use `luaAttr` as source ``                                           |
| [`d79df175`](https://github.com/NixOS/nixpkgs/commit/d79df175309f23b9ab501d36499393112ebad645) | `` luaPackages.lz-n: 1.4.2-1 -> 1.4.3-1 ``                                               |
| [`afab44c4`](https://github.com/NixOS/nixpkgs/commit/afab44c4bcab4186b5b307dac2e27a9df2861072) | `` python312Packages.soundcloud-v2: 1.5.3 -> 1.5.4 ``                                    |
| [`e7b3b91f`](https://github.com/NixOS/nixpkgs/commit/e7b3b91fa25189af50174bef740b431afdf7b80a) | `` python311Packages.extruct: 0.16.0 -> 0.17.0 ``                                        |
| [`6aaaa708`](https://github.com/NixOS/nixpkgs/commit/6aaaa70856ba19a7e20dd41fba17f654736b71b4) | `` python311Packages.cohere: 5.6.1 -> 5.6.2 ``                                           |
| [`f29fa25a`](https://github.com/NixOS/nixpkgs/commit/f29fa25a150f319eb3e49fd66b4dc08e62866156) | `` Revert "dasbus: unstable-11-10-2022 -> 0-unstable-2023-07-10" ``                      |
| [`2ece9131`](https://github.com/NixOS/nixpkgs/commit/2ece9131207b82a3e5b3dfec4be6e0b28b347126) | `` home-assistant-custom-components.govee-lan: tests are broken ``                       |
| [`c393e12e`](https://github.com/NixOS/nixpkgs/commit/c393e12e5b0a0963124b7dc64cf38cb5531450e1) | `` imposm: 0.13.2 -> 0.14.0 ``                                                           |
| [`9205db19`](https://github.com/NixOS/nixpkgs/commit/9205db197e513d81d0ab6a68fa0d9b4fd03187c6) | `` home-assistant.python.pkgs.pytest-homeassistant-custom-component: init at 0.13.147 `` |
| [`c1751004`](https://github.com/NixOS/nixpkgs/commit/c1751004cdf65ffb9cba20e94ceb8457b4f8a605) | `` jmol: 16.2.17 -> 16.2.19 ``                                                           |
| [`daf16944`](https://github.com/NixOS/nixpkgs/commit/daf16944571a9470cac86f1cde3db43961419ebb) | `` xdg-desktop-portal-hyprland: nixfmt-rfc-style, updateScript ``                        |
| [`f0f1070d`](https://github.com/NixOS/nixpkgs/commit/f0f1070dc5aa1aea3473f925831a6c893a763451) | `` spotify: 1.2.37.701.ge66eb7bc -> 1.2.40.599.g606b7f29 ``                              |
| [`bdde8b12`](https://github.com/NixOS/nixpkgs/commit/bdde8b1226ba00ef91243967fe9fd00bbb1a7681) | `` vimPlugins.grug-far-nvim: init at 2024-07-22 ``                                       |
| [`d72024e2`](https://github.com/NixOS/nixpkgs/commit/d72024e247123c84f6577a228c05796e698fac11) | `` python312Packages.uiprotect: 5.3.0 -> 5.4.0 ``                                        |
| [`20868b68`](https://github.com/NixOS/nixpkgs/commit/20868b68ecec99a2fa2500d6d488b464b8f445f2) | `` python312Packages.reolink-aio: 0.9.4 -> 0.9.5 ``                                      |
| [`a1e46148`](https://github.com/NixOS/nixpkgs/commit/a1e46148164ec676f22c73634f8ccf236d23ba46) | `` xapp: 2.8.4 -> 2.8.5 ``                                                               |
| [`13ea40f2`](https://github.com/NixOS/nixpkgs/commit/13ea40f2d8b060b837257c0a2538e20dfd626b30) | `` python312Packages.ptpython: 3.0.27 -> 3.0.28 ``                                       |
| [`ab66e057`](https://github.com/NixOS/nixpkgs/commit/ab66e0577d6c80ec58244e9f561787731521c74c) | `` sticky: 1.21 -> 1.22 ``                                                               |
| [`24f17a2a`](https://github.com/NixOS/nixpkgs/commit/24f17a2a294779805e212e6d5874954ab227fb03) | `` python312Packages.azure-mgmt-containerservice: 30.0.0 -> 31.0.0 ``                    |
| [`a298a03b`](https://github.com/NixOS/nixpkgs/commit/a298a03ba6f2759fc9ed7f0e484799f565d44aa6) | `` ngrok: 3.10.1 -> 3.13.0 (#328897) ``                                                  |
| [`0f4326b2`](https://github.com/NixOS/nixpkgs/commit/0f4326b2f17d0a470f72ef9f0791dfd5dd93ab4f) | `` flameshot: add flag for wlr support ``                                                |
| [`2bad3487`](https://github.com/NixOS/nixpkgs/commit/2bad3487c6c3fc69d8aeb308cc22d8d8fc6ddafd) | `` flameshot: 12.1.0 -> 12.1.0-unstable-2024-07-02 ``                                    |
| [`5af98120`](https://github.com/NixOS/nixpkgs/commit/5af98120ad5e871a7b79a663388d7b2714d98306) | `` flameshot: use unstable version in update script ``                                   |
| [`4650385d`](https://github.com/NixOS/nixpkgs/commit/4650385d09e43a8250f639243b0ee869af7674ba) | `` flameshot: move to by-name ``                                                         |
| [`b529aae8`](https://github.com/NixOS/nixpkgs/commit/b529aae8dc61af6ca8633c26c444a01e83466dfa) | `` python312Packages.google-cloud-container: 2.47.1 -> 2.49.0 ``                         |
| [`cb1a4601`](https://github.com/NixOS/nixpkgs/commit/cb1a4601f53280d63bdd34493a3cdf950dd63d7e) | `` vscode-extensions.fill-labs.dependi: 0.7.2 -> 0.7.4 ``                                |
| [`b0d668ad`](https://github.com/NixOS/nixpkgs/commit/b0d668ad8f01507850fd49e6e8032472ed7a4dcf) | `` python312Packages.google-cloud-tasks: 2.16.3 -> 2.16.4 ``                             |
| [`5806503f`](https://github.com/NixOS/nixpkgs/commit/5806503fbc266283561e7702fd60aaa4535454ef) | `` xdg-desktop-portal-hyprland: 1.3.2 -> 1.3.3 ``                                        |
| [`40a1300a`](https://github.com/NixOS/nixpkgs/commit/40a1300abf6750419b4e9d9e4c3b8ce8eccf5414) | `` python312Packages.aiolifx-themes: 0.4.21 -> 0.4.27 ``                                 |
| [`a7904840`](https://github.com/NixOS/nixpkgs/commit/a79048405dbede2c31afd235a98ca44610bdc8df) | `` python312Packages.fastcore: 1.5.53 -> 1.5.54 ``                                       |
| [`d67092b4`](https://github.com/NixOS/nixpkgs/commit/d67092b4c4ece85c4cf38eeab1a639f119c9363b) | `` mint-l-icons: 1.7.1 -> 1.7.2 ``                                                       |
| [`d51dad7c`](https://github.com/NixOS/nixpkgs/commit/d51dad7c7766199c8ad12a317315b0bd6f53459c) | `` neovim: stop inheriting meta.position from neovim-unwrapped ``                        |
| [`fdff4458`](https://github.com/NixOS/nixpkgs/commit/fdff445831f94cfd8b3ad70c1fb42830a0be9a2d) | `` python312Packages.alpha-vantage: 2.3.1 -> 3.0.0 ``                                    |
| [`b95b05d0`](https://github.com/NixOS/nixpkgs/commit/b95b05d0a5bf9082bbbe6ab083ec317f3148d57a) | `` folder-color-switcher: 1.6.3 -> 1.6.4 ``                                              |
| [`fe58e885`](https://github.com/NixOS/nixpkgs/commit/fe58e8856f206406a9b988e70b1f383cbb3ea331) | `` nixos/ollama: make host example dualstack wildcard ``                                 |
| [`bd473cea`](https://github.com/NixOS/nixpkgs/commit/bd473ceae3f53d8f10bb3656d7a764158e856f66) | `` nixos/doc/rl-2411: add ollama changes ``                                              |