### PR TITLE
chore(flake/nur): `a6a34c95` -> `029365c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721914019,
-        "narHash": "sha256-GxUnSVtfPCLHIJJ6OiwQUaFIPL0xMaH0wf+TuxS6Cwg=",
+        "lastModified": 1721922390,
+        "narHash": "sha256-Q34pkPhh8fRaHS1vZcam00dYv/BNhUR/+jb9O21PsbY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a6a34c95c22e8cddd6049a470fb843989d08ee86",
+        "rev": "029365c3e7a6349a706df71cc29dc8a0c1e909f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`029365c3`](https://github.com/nix-community/NUR/commit/029365c3e7a6349a706df71cc29dc8a0c1e909f8) | `` automatic update `` |
| [`bfc1e8c5`](https://github.com/nix-community/NUR/commit/bfc1e8c577d39b88b74e2be1534bfeb6a7682cfa) | `` automatic update `` |