### PR TITLE
chore(flake/emacs-overlay): `659148d7` -> `3f4fe9c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721898788,
-        "narHash": "sha256-lRGWnzUlNVnNgGrurPxOvIYnDOWSgsEnKFMM3Eggaew=",
+        "lastModified": 1721926623,
+        "narHash": "sha256-1xq4fvX81KdlNrZMoHvir1BR4XUJ6RYkrEk7beuYShs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "659148d712070acc244ccacc7ca2e49e866bf9b3",
+        "rev": "3f4fe9c2ed3dd720ef5dee881faeb2664102fb9e",
         "type": "github"
       },
       "original": {
@@ -700,11 +700,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1721686456,
-        "narHash": "sha256-nw/BnNzATDPfzpJVTnY8mcSKKsz6BJMEFRkJ332QSN0=",
+        "lastModified": 1721821769,
+        "narHash": "sha256-PhmkdTJs2SfqKzSyDB74rDKp1MH4mGk0pG/+WqrnGEw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "575f3027caa1e291d24f1e9fb0e3a19c2f26d96b",
+        "rev": "d0907b75146a0ccc1ec0d6c3db287ec287588ef6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`3f4fe9c2`](https://github.com/nix-community/emacs-overlay/commit/3f4fe9c2ed3dd720ef5dee881faeb2664102fb9e) | `` Updated melpa ``        |
| [`629f2fd3`](https://github.com/nix-community/emacs-overlay/commit/629f2fd3c0c5179c09b5c3cb137f85aba926f8f8) | `` Updated elpa ``         |
| [`19ab45c7`](https://github.com/nix-community/emacs-overlay/commit/19ab45c775322251c223c909656405101758661f) | `` Updated flake inputs `` |