### PR TITLE
chore(flake/nur): `029365c3` -> `1c41a8f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721922390,
-        "narHash": "sha256-Q34pkPhh8fRaHS1vZcam00dYv/BNhUR/+jb9O21PsbY=",
+        "lastModified": 1721933198,
+        "narHash": "sha256-Ac1dARPSjZmOX6Z1dyFkaH1v1vaxOnKjHPdkzaPd4nY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "029365c3e7a6349a706df71cc29dc8a0c1e909f8",
+        "rev": "1c41a8f5f588d50cddd815f948037b6eb7e86239",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1c41a8f5`](https://github.com/nix-community/NUR/commit/1c41a8f5f588d50cddd815f948037b6eb7e86239) | `` automatic update `` |
| [`68e8556d`](https://github.com/nix-community/NUR/commit/68e8556d169e8298579ca09c837934d41f2e12a7) | `` automatic update `` |
| [`3ea857d2`](https://github.com/nix-community/NUR/commit/3ea857d2abb7f3825976cefc50894d35ca55f8c4) | `` automatic update `` |
| [`f769fc25`](https://github.com/nix-community/NUR/commit/f769fc25d19d5521a997686ffd66c08a3d23334f) | `` automatic update `` |