### PR TITLE
chore(flake/nur): `1c41a8f5` -> `840d89c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721933198,
-        "narHash": "sha256-Ac1dARPSjZmOX6Z1dyFkaH1v1vaxOnKjHPdkzaPd4nY=",
+        "lastModified": 1721936772,
+        "narHash": "sha256-GBvT3FYsyX6gv27WBuNcuPZXEiZ1c6fzpoNZnK9hFU8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1c41a8f5f588d50cddd815f948037b6eb7e86239",
+        "rev": "840d89c3d62c5eb50a10336a9130b9c75da58b8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`840d89c3`](https://github.com/nix-community/NUR/commit/840d89c3d62c5eb50a10336a9130b9c75da58b8b) | `` automatic update `` |