### PR TITLE
chore(flake/nur): `840d89c3` -> `8a323381`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721936772,
-        "narHash": "sha256-GBvT3FYsyX6gv27WBuNcuPZXEiZ1c6fzpoNZnK9hFU8=",
+        "lastModified": 1721943908,
+        "narHash": "sha256-2eXS/Yn/wib1wXAWxuQyqW5ktT3vP8AVUg1uukxIs5A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "840d89c3d62c5eb50a10336a9130b9c75da58b8b",
+        "rev": "8a3233815a29fd644dd472dbc2e531302ac6b7db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8a323381`](https://github.com/nix-community/NUR/commit/8a3233815a29fd644dd472dbc2e531302ac6b7db) | `` automatic update `` |
| [`740979f9`](https://github.com/nix-community/NUR/commit/740979f9fb24276a43a217dde7ad4a5316c88997) | `` automatic update `` |