### PR TITLE
chore(flake/nur): `8a323381` -> `c0cdc702`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721943908,
-        "narHash": "sha256-2eXS/Yn/wib1wXAWxuQyqW5ktT3vP8AVUg1uukxIs5A=",
+        "lastModified": 1721947103,
+        "narHash": "sha256-+yzj4QQMGhuk/KhdYT51t2QB9/rwIbVMsxhHctJ+f9Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8a3233815a29fd644dd472dbc2e531302ac6b7db",
+        "rev": "c0cdc702bf33188ebd6518af5fc94d1bdab702e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c0cdc702`](https://github.com/nix-community/NUR/commit/c0cdc702bf33188ebd6518af5fc94d1bdab702e3) | `` automatic update `` |
| [`2900824f`](https://github.com/nix-community/NUR/commit/2900824f207ed9da0c17de0f5a08d5f77823c004) | `` automatic update `` |