### PR TITLE
chore(flake/emacs-overlay): `a4058dae` -> `b7940b26`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721927573,
-        "narHash": "sha256-/oFYB0HU/VGir0OWGQADvgwj+TjbUN3qtD1/EShu2os=",
+        "lastModified": 1721956005,
+        "narHash": "sha256-RNCtl/B/7qKGn0lyLEYvYyvsQ29DRBP+c+n+HVSSht0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a4058dae60d3034fe97bda79ec4897938d1e69ed",
+        "rev": "b7940b26504eae53f8d9d30b07e32679f232e703",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`b7940b26`](https://github.com/nix-community/emacs-overlay/commit/b7940b26504eae53f8d9d30b07e32679f232e703) | `` Updated elpa ``   |
| [`51c6a6c7`](https://github.com/nix-community/emacs-overlay/commit/51c6a6c79c90dd9313057f7d5155e04e3599d049) | `` Updated nongnu `` |