### PR TITLE
chore(flake/nur): `c0cdc702` -> `a0502531`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721947103,
-        "narHash": "sha256-+yzj4QQMGhuk/KhdYT51t2QB9/rwIbVMsxhHctJ+f9Y=",
+        "lastModified": 1721958695,
+        "narHash": "sha256-666nHQms7cAsOPTxLvnGF2B2J+CaQoFOQzK61fv53tU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c0cdc702bf33188ebd6518af5fc94d1bdab702e3",
+        "rev": "a050253113bbd3804bbfc1ac819951da92de5a43",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a0502531`](https://github.com/nix-community/NUR/commit/a050253113bbd3804bbfc1ac819951da92de5a43) | `` automatic update `` |
| [`3cf3ed77`](https://github.com/nix-community/NUR/commit/3cf3ed77509f5ab3f8a7e5307e279177d88967a5) | `` automatic update `` |
| [`29feafba`](https://github.com/nix-community/NUR/commit/29feafba5d06bf12f22ec4748482adeba1158f70) | `` automatic update `` |
| [`f1fa0c41`](https://github.com/nix-community/NUR/commit/f1fa0c419658366e5071b61af8bd9112dc886245) | `` automatic update `` |