### PR TITLE
chore(flake/emacs-overlay): `b7940b26` -> `007c4a84`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721956005,
-        "narHash": "sha256-RNCtl/B/7qKGn0lyLEYvYyvsQ29DRBP+c+n+HVSSht0=",
+        "lastModified": 1721958965,
+        "narHash": "sha256-or+tlxQk8npXhTVvqVvHlZMXrz0FkfL9/J0pQvCOwkc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b7940b26504eae53f8d9d30b07e32679f232e703",
+        "rev": "007c4a84ed9f5b939a36a9aa765ad300858ee711",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`007c4a84`](https://github.com/nix-community/emacs-overlay/commit/007c4a84ed9f5b939a36a9aa765ad300858ee711) | `` Updated emacs `` |
| [`f22b1491`](https://github.com/nix-community/emacs-overlay/commit/f22b14910e7ea3f0a85b68654ba8d9ab8998e27b) | `` Updated melpa `` |