### PR TITLE
chore(flake/nur): `cf909e50` -> `cd0174c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721965481,
-        "narHash": "sha256-/IEBOxwfOc1/416y8IadiWx1OmIMnz+oVgu+Iio6+NI=",
+        "lastModified": 1721966660,
+        "narHash": "sha256-WrXgS9MFq8zX773RbZVNVkcmcPwjPB6mAPS+PSKa1pY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cf909e50de716316a277b3ca9e0a928a60196fac",
+        "rev": "cd0174c3bff1c74a371268d336a5246415b46d09",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cd0174c3`](https://github.com/nix-community/NUR/commit/cd0174c3bff1c74a371268d336a5246415b46d09) | `` automatic update `` |