### PR TITLE
chore(flake/nur): `cd0174c3` -> `eb0b037f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721966660,
-        "narHash": "sha256-WrXgS9MFq8zX773RbZVNVkcmcPwjPB6mAPS+PSKa1pY=",
+        "lastModified": 1721973203,
+        "narHash": "sha256-R1klojRlYbaZ0WMCZRIQvJTVr9ZwwQhJUBA/tCewvhw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cd0174c3bff1c74a371268d336a5246415b46d09",
+        "rev": "eb0b037fe4fe40e5ecc75eb61875d04dc4d7b81f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`eb0b037f`](https://github.com/nix-community/NUR/commit/eb0b037fe4fe40e5ecc75eb61875d04dc4d7b81f) | `` automatic update `` |
| [`9dc107c6`](https://github.com/nix-community/NUR/commit/9dc107c69c20807063e32b0241a63efa7c19ad8e) | `` automatic update `` |
| [`0b7331c9`](https://github.com/nix-community/NUR/commit/0b7331c9f01639caa9cb78d5c3633306e3fface7) | `` automatic update `` |