### PR TITLE
chore(flake/nur): `eb0b037f` -> `fbab1eae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721973203,
-        "narHash": "sha256-R1klojRlYbaZ0WMCZRIQvJTVr9ZwwQhJUBA/tCewvhw=",
+        "lastModified": 1721976903,
+        "narHash": "sha256-Ux3pvkKThCH9uIDWWF0bRnsKeQA9zBTh4mCdf4BOo5Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eb0b037fe4fe40e5ecc75eb61875d04dc4d7b81f",
+        "rev": "fbab1eae3475c0288b9ae3bb13d7eedd3a15102e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fbab1eae`](https://github.com/nix-community/NUR/commit/fbab1eae3475c0288b9ae3bb13d7eedd3a15102e) | `` automatic update `` |