### PR TITLE
chore(flake/nur): `fbab1eae` -> `1767b972`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721976903,
-        "narHash": "sha256-Ux3pvkKThCH9uIDWWF0bRnsKeQA9zBTh4mCdf4BOo5Y=",
+        "lastModified": 1721978777,
+        "narHash": "sha256-4hfzhKbj4LWmTbY7/udcwA7TGhsuimo6Q55+yJEtPnA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fbab1eae3475c0288b9ae3bb13d7eedd3a15102e",
+        "rev": "1767b9721f84f31784014e40320718a489ed7ad4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1767b972`](https://github.com/nix-community/NUR/commit/1767b9721f84f31784014e40320718a489ed7ad4) | `` automatic update `` |