### PR TITLE
chore(flake/nur): `1767b972` -> `4807c89c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721978777,
-        "narHash": "sha256-4hfzhKbj4LWmTbY7/udcwA7TGhsuimo6Q55+yJEtPnA=",
+        "lastModified": 1721983543,
+        "narHash": "sha256-6JmRrY7nIwKYadzJkolIXfGOC5JliYnB1EfGOY/Oh5g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1767b9721f84f31784014e40320718a489ed7ad4",
+        "rev": "4807c89cf4ece6a96eed72957dcf0d9b8e29b052",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4807c89c`](https://github.com/nix-community/NUR/commit/4807c89cf4ece6a96eed72957dcf0d9b8e29b052) | `` automatic update `` |
| [`03b8999a`](https://github.com/nix-community/NUR/commit/03b8999ace69ee26be5a9eacac109dacd63e6bbe) | `` automatic update `` |