### PR TITLE
chore(flake/emacs-overlay): `8851dd60` -> `24c391d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721984198,
-        "narHash": "sha256-MHJPtyO3HeHcFFxNTCtGTS8FIvU4gpTo/KBR1WgaTmo=",
+        "lastModified": 1721985045,
+        "narHash": "sha256-EGeUu2Veg2p4fiGZ+22kNSpucrYxZn6NTdXVS989GGk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8851dd60fa094d0fbe16a6fc01f0e74a08e91785",
+        "rev": "24c391d8fe03854d1eedea66c241b176e97f5f6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`24c391d8`](https://github.com/nix-community/emacs-overlay/commit/24c391d8fe03854d1eedea66c241b176e97f5f6c) | `` Updated emacs `` |