### PR TITLE
chore(flake/nur): `4807c89c` -> `6193ade2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721983543,
-        "narHash": "sha256-6JmRrY7nIwKYadzJkolIXfGOC5JliYnB1EfGOY/Oh5g=",
+        "lastModified": 1721990708,
+        "narHash": "sha256-MRy/ORQjra+0Z5vNwGW6Gy1jGvr+zgCq6UfIUfOC5oI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4807c89cf4ece6a96eed72957dcf0d9b8e29b052",
+        "rev": "6193ade2aef8c8e75c813c8bcb1937c8ddd3cb06",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6193ade2`](https://github.com/nix-community/NUR/commit/6193ade2aef8c8e75c813c8bcb1937c8ddd3cb06) | `` automatic update `` |