### PR TITLE
chore(flake/nur): `6193ade2` -> `434e9ce4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721990708,
-        "narHash": "sha256-MRy/ORQjra+0Z5vNwGW6Gy1jGvr+zgCq6UfIUfOC5oI=",
+        "lastModified": 1721998793,
+        "narHash": "sha256-ej0nHiXWZ2lrh+IfFuGnpmwsPnNpCikAtUcIIlEk9ZA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6193ade2aef8c8e75c813c8bcb1937c8ddd3cb06",
+        "rev": "434e9ce4c5055139c06386b36080db60617394d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`434e9ce4`](https://github.com/nix-community/NUR/commit/434e9ce4c5055139c06386b36080db60617394d9) | `` automatic update `` |
| [`0b35d84a`](https://github.com/nix-community/NUR/commit/0b35d84a31c41a2ad6c788b28060811635bbdfb5) | `` automatic update `` |
| [`122a14e9`](https://github.com/nix-community/NUR/commit/122a14e93353a27050385e8554a06114784f33a7) | `` automatic update `` |
| [`1914337a`](https://github.com/nix-community/NUR/commit/1914337af2f5e0e1a9b408550a0bd060e76e036a) | `` automatic update `` |