### PR TITLE
chore(flake/nur): `434e9ce4` -> `f92c9769`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721998793,
-        "narHash": "sha256-ej0nHiXWZ2lrh+IfFuGnpmwsPnNpCikAtUcIIlEk9ZA=",
+        "lastModified": 1722005195,
+        "narHash": "sha256-2pZXkHoSvPyQbKSIR/beR4+leceDIVSo60gGPzyJDeE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "434e9ce4c5055139c06386b36080db60617394d9",
+        "rev": "f92c976912f1f3f52f8a9220afae6ec349b3f51d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f92c9769`](https://github.com/nix-community/NUR/commit/f92c976912f1f3f52f8a9220afae6ec349b3f51d) | `` automatic update `` |
| [`ed2b0ce6`](https://github.com/nix-community/NUR/commit/ed2b0ce6c369dc778cbdd8eab90f3f96e8d7560c) | `` automatic update `` |