### PR TITLE
chore(flake/nur): `f92c9769` -> `6a1e672f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722005195,
-        "narHash": "sha256-2pZXkHoSvPyQbKSIR/beR4+leceDIVSo60gGPzyJDeE=",
+        "lastModified": 1722023086,
+        "narHash": "sha256-hOTXyWW5XIcyCRz0VEyVteIlvi+0U07EDg8Vpfz9mAo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f92c976912f1f3f52f8a9220afae6ec349b3f51d",
+        "rev": "6a1e672f89e718eebe36b89742ca75ac1850f49e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                     |
| -------------------------------------------------------------------------------------------------- | --------------------------- |
| [`6a1e672f`](https://github.com/nix-community/NUR/commit/6a1e672f89e718eebe36b89742ca75ac1850f49e) | `` automatic update ``      |
| [`e23c8ca0`](https://github.com/nix-community/NUR/commit/e23c8ca0ad2c49b91465c62641f53161141ffa18) | `` automatic update ``      |
| [`b51ebdb7`](https://github.com/nix-community/NUR/commit/b51ebdb75573c51ddc621ba1bd3ea3488b2afc99) | `` automatic update ``      |
| [`2308f5ba`](https://github.com/nix-community/NUR/commit/2308f5ba2aa1288c01f2c1af4d4c1cbcefcde0f0) | `` automatic update ``      |
| [`a3c30e4e`](https://github.com/nix-community/NUR/commit/a3c30e4efe768365a9f6c908cc986af37ffa5e94) | `` add sebrut repository `` |
| [`2b6ba0fa`](https://github.com/nix-community/NUR/commit/2b6ba0fa0f5bbde4a753ba4b3e62b61e3f46ce11) | `` automatic update ``      |
| [`320e40a9`](https://github.com/nix-community/NUR/commit/320e40a9c33b700b19ea8704715b1112b0cbfc56) | `` automatic update ``      |