### PR TITLE
chore(flake/nur): `6a1e672f` -> `c2eb93c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722023086,
-        "narHash": "sha256-hOTXyWW5XIcyCRz0VEyVteIlvi+0U07EDg8Vpfz9mAo=",
+        "lastModified": 1722030396,
+        "narHash": "sha256-beDNnsQwVskYmaWaAPQFdu8YvS3uvzbiqd8gNykQtmY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6a1e672f89e718eebe36b89742ca75ac1850f49e",
+        "rev": "c2eb93c4f9e05dfe3efc9e60300b591927ee6978",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c2eb93c4`](https://github.com/nix-community/NUR/commit/c2eb93c4f9e05dfe3efc9e60300b591927ee6978) | `` automatic update `` |