### PR TITLE
chore(flake/nur): `c2eb93c4` -> `43fbf899`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722030396,
-        "narHash": "sha256-beDNnsQwVskYmaWaAPQFdu8YvS3uvzbiqd8gNykQtmY=",
+        "lastModified": 1722037580,
+        "narHash": "sha256-r/EKiPZl6l/soX4kc/d7oYTawGFbRHuOOcQ+ALoontU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c2eb93c4f9e05dfe3efc9e60300b591927ee6978",
+        "rev": "43fbf899324cd4e4d2be902141362aeba08d68b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`43fbf899`](https://github.com/nix-community/NUR/commit/43fbf899324cd4e4d2be902141362aeba08d68b7) | `` automatic update `` |