### PR TITLE
chore(flake/nur): `43fbf899` -> `e7f293c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722037580,
-        "narHash": "sha256-r/EKiPZl6l/soX4kc/d7oYTawGFbRHuOOcQ+ALoontU=",
+        "lastModified": 1722046414,
+        "narHash": "sha256-aOT9mnYqQUE7ngofXcs7qmNbOQLto8KOhos1nn+y0Sk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "43fbf899324cd4e4d2be902141362aeba08d68b7",
+        "rev": "e7f293c6f96f615adc42f5cacb5b35177d8abb80",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e7f293c6`](https://github.com/nix-community/NUR/commit/e7f293c6f96f615adc42f5cacb5b35177d8abb80) | `` automatic update `` |
| [`baedb769`](https://github.com/nix-community/NUR/commit/baedb769128fbdff9ac62ddc5492727505f825be) | `` automatic update `` |
| [`53a76fc7`](https://github.com/nix-community/NUR/commit/53a76fc706e7737871c5af4998f39bec6602871c) | `` automatic update `` |