### PR TITLE
chore(flake/nur): `e7f293c6` -> `c687b389`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722046414,
-        "narHash": "sha256-aOT9mnYqQUE7ngofXcs7qmNbOQLto8KOhos1nn+y0Sk=",
+        "lastModified": 1722048641,
+        "narHash": "sha256-PVlBfOO624A5Dv7Xi6qpWDy45x6hGtGHDQHTEAZu6zY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e7f293c6f96f615adc42f5cacb5b35177d8abb80",
+        "rev": "c687b3895ce630668b186352e5bde19af321c3b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c687b389`](https://github.com/nix-community/NUR/commit/c687b3895ce630668b186352e5bde19af321c3b2) | `` automatic update `` |