### PR TITLE
chore(flake/nur): `c687b389` -> `d1c06c3f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722048641,
-        "narHash": "sha256-PVlBfOO624A5Dv7Xi6qpWDy45x6hGtGHDQHTEAZu6zY=",
+        "lastModified": 1722052460,
+        "narHash": "sha256-NvzpKDeEYkDMKmy/iN4TTeQe1wOXTAv2YHiN3j6NfhU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c687b3895ce630668b186352e5bde19af321c3b2",
+        "rev": "d1c06c3f3779cd0f0a1fe95cbaac937d2c22f185",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d1c06c3f`](https://github.com/nix-community/NUR/commit/d1c06c3f3779cd0f0a1fe95cbaac937d2c22f185) | `` automatic update `` |
| [`397fbf82`](https://github.com/nix-community/NUR/commit/397fbf827d08f074dc868fc85e2990afb7515465) | `` automatic update `` |
| [`92955118`](https://github.com/nix-community/NUR/commit/9295511815a2c52686dfa88efd883700c26ca16c) | `` automatic update `` |