### PR TITLE
chore(flake/nur): `d1c06c3f` -> `3b4a5123`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722052460,
-        "narHash": "sha256-NvzpKDeEYkDMKmy/iN4TTeQe1wOXTAv2YHiN3j6NfhU=",
+        "lastModified": 1722059573,
+        "narHash": "sha256-8afUAFT16xwQ+FEx2qe/LFbA7DSaxiVYgqd/20FD7Xk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d1c06c3f3779cd0f0a1fe95cbaac937d2c22f185",
+        "rev": "3b4a51237047fc774506f32350125a8d3b4b782a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3b4a5123`](https://github.com/nix-community/NUR/commit/3b4a51237047fc774506f32350125a8d3b4b782a) | `` automatic update `` |
| [`141e2444`](https://github.com/nix-community/NUR/commit/141e2444389e4a387d11768ee110ee5b67b8d1a1) | `` automatic update `` |