### PR TITLE
chore(flake/nur): `3b4a5123` -> `c76123f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722059573,
-        "narHash": "sha256-8afUAFT16xwQ+FEx2qe/LFbA7DSaxiVYgqd/20FD7Xk=",
+        "lastModified": 1722062916,
+        "narHash": "sha256-PA8whIHk8t9CeT6KqLes8aew9bcoL3F+85fjUQtfsCI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3b4a51237047fc774506f32350125a8d3b4b782a",
+        "rev": "c76123f6d42bd423495bb97296f45f7ac6873056",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c76123f6`](https://github.com/nix-community/NUR/commit/c76123f6d42bd423495bb97296f45f7ac6873056) | `` automatic update `` |