### PR TITLE
chore(flake/home-manager): `bc2b96ac` -> `975b83ca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -410,11 +410,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721996913,
-        "narHash": "sha256-eqbhEBObarS6WsI0J1PVACQ8fXeq9OmSS0+iXBegoOI=",
+        "lastModified": 1722067813,
+        "narHash": "sha256-nxpzoKXwn+8RsxpxwD86mtEscOMw64ZD/vGSNWzGMlA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bc2b96acda50229bc99925dde5c8e561e90b0b00",
+        "rev": "975b83ca560d17db51a66cb2b0dc0e44213eab27",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`975b83ca`](https://github.com/nix-community/home-manager/commit/975b83ca560d17db51a66cb2b0dc0e44213eab27) | `` treewide: fix eval after Nixpkgs maintainer changes `` |
| [`180158b4`](https://github.com/nix-community/home-manager/commit/180158b46ea02f1c8f794367f122e8f2a2e49cf8) | `` mcfly: add settings option ``                          |