### PR TITLE
chore(flake/nur): `c76123f6` -> `dcab27e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722062916,
-        "narHash": "sha256-PA8whIHk8t9CeT6KqLes8aew9bcoL3F+85fjUQtfsCI=",
+        "lastModified": 1722084094,
+        "narHash": "sha256-ToqDBxui/djNJKDvugSzR9mj/qez1rLQs8eqfyUYCb0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c76123f6d42bd423495bb97296f45f7ac6873056",
+        "rev": "dcab27e862be74415bac6266e4edbdf83c2ecb96",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dcab27e8`](https://github.com/nix-community/NUR/commit/dcab27e862be74415bac6266e4edbdf83c2ecb96) | `` automatic update `` |
| [`7bbc4501`](https://github.com/nix-community/NUR/commit/7bbc4501547af04f7c0c0b7163c572b40de37796) | `` automatic update `` |
| [`5a048a70`](https://github.com/nix-community/NUR/commit/5a048a702c733a917b6cdb760b3db8c20f705557) | `` automatic update `` |
| [`d1a7dd15`](https://github.com/nix-community/NUR/commit/d1a7dd156877de06a68a41ceb6e8d0262104be79) | `` automatic update `` |