### PR TITLE
chore(flake/emacs-overlay): `8d4db328` -> `52f334bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722070511,
-        "narHash": "sha256-sgMqkfh493iyT0s0QIxUY2QCu5QVfW7vwtSWcMjCY2g=",
+        "lastModified": 1722071359,
+        "narHash": "sha256-ihaxZ9gtQjGHGssQELv2oDQUYzKRS/EdGWGqmUPv1IM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8d4db3288333f08cf01b9f958954ee69743597ec",
+        "rev": "52f334bf7c461704ceb9685b5b1dceef29d8e049",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`52f334bf`](https://github.com/nix-community/emacs-overlay/commit/52f334bf7c461704ceb9685b5b1dceef29d8e049) | `` Updated emacs `` |