### PR TITLE
chore(flake/nur): `dcab27e8` -> `2cee621f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722084094,
-        "narHash": "sha256-ToqDBxui/djNJKDvugSzR9mj/qez1rLQs8eqfyUYCb0=",
+        "lastModified": 1722095184,
+        "narHash": "sha256-SgPV4cR3UUczwzf+DOhMGoOWfnguy7/U6/JlCMZVvaw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dcab27e862be74415bac6266e4edbdf83c2ecb96",
+        "rev": "2cee621f9f4a49361f929d914aa90ab645aeb704",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2cee621f`](https://github.com/nix-community/NUR/commit/2cee621f9f4a49361f929d914aa90ab645aeb704) | `` automatic update `` |
| [`154aeb47`](https://github.com/nix-community/NUR/commit/154aeb47f1685501779908a24c5c93f787b1320e) | `` automatic update `` |