### PR TITLE
chore(flake/nur): `2cee621f` -> `80763468`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722095184,
-        "narHash": "sha256-SgPV4cR3UUczwzf+DOhMGoOWfnguy7/U6/JlCMZVvaw=",
+        "lastModified": 1722105112,
+        "narHash": "sha256-w3+tS3JhNls3+/q6MeVFs4VtPAy2t/+82zQbV+UJHlE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2cee621f9f4a49361f929d914aa90ab645aeb704",
+        "rev": "807634684ff2685543cfe77c01a7c116304fb2c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`80763468`](https://github.com/nix-community/NUR/commit/807634684ff2685543cfe77c01a7c116304fb2c8) | `` automatic update `` |
| [`57229578`](https://github.com/nix-community/NUR/commit/572295788918c73cbf00fb1514a6296abb6ee036) | `` automatic update `` |