### PR TITLE
chore(flake/nur): `80763468` -> `de4be60e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722105112,
-        "narHash": "sha256-w3+tS3JhNls3+/q6MeVFs4VtPAy2t/+82zQbV+UJHlE=",
+        "lastModified": 1722109497,
+        "narHash": "sha256-6AG9bKouzPguBXOjMPT/eiKpuOFEKaoTOWWRfrgDmk8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "807634684ff2685543cfe77c01a7c116304fb2c8",
+        "rev": "de4be60e145694db7069ecfd7a42b789d2489663",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`de4be60e`](https://github.com/nix-community/NUR/commit/de4be60e145694db7069ecfd7a42b789d2489663) | `` automatic update `` |