### PR TITLE
chore(flake/nixpkgs): `5ad6a14c` -> `b73c2221`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1721924956,
-        "narHash": "sha256-Sb1jlyRO+N8jBXEX9Pg9Z1Qb8Bw9QyOgLDNMEpmjZ2M=",
+        "lastModified": 1722062969,
+        "narHash": "sha256-QOS0ykELUmPbrrUGmegAUlpmUFznDQeR4q7rFhl8eQg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5ad6a14c6bf098e98800b091668718c336effc95",
+        "rev": "b73c2221a46c13557b1b3be9c2070cc42cf01eb3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`8116f5ca`](https://github.com/NixOS/nixpkgs/commit/8116f5caa2c6eac1efdf2c3163b1816a1eacc1a3) | `` python312Packages.apprise: 1.8.0 -> 1.8.1 ``                                             |
| [`7a85d268`](https://github.com/NixOS/nixpkgs/commit/7a85d2680e475a88c155cc5704f99400d23b0974) | `` python312Packages.mkdocstrings: 0.25.1 -> 0.25.2 ``                                      |
| [`860120af`](https://github.com/NixOS/nixpkgs/commit/860120afe4a56687e069af33f265beeb303de048) | `` sapling: 0.2.202401116 -> 0.2.20240718 ``                                                |
| [`759ee151`](https://github.com/NixOS/nixpkgs/commit/759ee151e75ee9aec951308f9a2305567cf048ac) | `` nixosTests.pantheon: Disable flaky test for closing multitasking view ``                 |
| [`718bd3d7`](https://github.com/NixOS/nixpkgs/commit/718bd3d7ce5fc13633992ddccb80f9fd897c308d) | `` python312Packages.plotly: refactor ``                                                    |
| [`8210dab5`](https://github.com/NixOS/nixpkgs/commit/8210dab583fb2f26d4e1717ed23d0a291f3c6c89) | `` python312Packages.azure-mgmt-keyvault: refactor ``                                       |
| [`bd081b70`](https://github.com/NixOS/nixpkgs/commit/bd081b709bdb519477dfda87b741836096842227) | `` python311Packages.yanc: drop ``                                                          |
| [`62e632d4`](https://github.com/NixOS/nixpkgs/commit/62e632d4308bf7a8e896a1af10e5a88db0d2f326) | `` python312Packages.cgroup-utils: remove nose dependency and modernize ``                  |
| [`fada29bf`](https://github.com/NixOS/nixpkgs/commit/fada29bff667770f2fbf64018c73e54d58cd09a1) | `` python311Packages.pygogo: drop ``                                                        |
| [`0a23f138`](https://github.com/NixOS/nixpkgs/commit/0a23f138457e001a044d655740d576febc1ceaf4) | `` python312Packages.yt-dlp-dearrow: init at 2023.01.01 ``                                  |
| [`27bffc8c`](https://github.com/NixOS/nixpkgs/commit/27bffc8cc2a116755172ebe32ecaba1f1f67586a) | `` python312Packages.selectors2: drop ``                                                    |
| [`f7df69b5`](https://github.com/NixOS/nixpkgs/commit/f7df69b5b9d3b8698543d717918043aa6061c0be) | `` python312Packages.unicode-slugify: drop nose dependency ``                               |
| [`d265ac73`](https://github.com/NixOS/nixpkgs/commit/d265ac739de52474f56e7170da47335d07c6f72e) | `` libgssglue: 0.4 -> 0.9 ``                                                                |
| [`67e13a13`](https://github.com/NixOS/nixpkgs/commit/67e13a134c47a4bfd0e2707fa8984b9fe5786b50) | `` python312Packages.vxi11: drop nose dependency ``                                         |
| [`43550751`](https://github.com/NixOS/nixpkgs/commit/435507519c28210d39891b8d091e41ef1a2fad77) | `` python312Packages.sampledata: drop ``                                                    |
| [`eac58dca`](https://github.com/NixOS/nixpkgs/commit/eac58dca33ebbf70993a555927c076fe3b67bcdc) | `` Revert "Partially revert "build(deps): bump cachix/install-nix-action from 26 to 27"" `` |
| [`3fafc1a3`](https://github.com/NixOS/nixpkgs/commit/3fafc1a39b8f52f51460b2b3fc009a41726ac5ba) | `` python312Packages.telfhash: migrate to pyproject ``                                      |
| [`0fe7950b`](https://github.com/NixOS/nixpkgs/commit/0fe7950b9049f6eec15a3664b367b58ed4c2643a) | `` nixpkgs-check-by-name: 0.1.1 -> 0.1.2 ``                                                 |
| [`e492adef`](https://github.com/NixOS/nixpkgs/commit/e492adefbc460013aad16a74cb6222294ad5aeea) | `` python312Packages.datauri: 2.1.1 -> 2.2.0 ``                                             |
| [`d3dd5a36`](https://github.com/NixOS/nixpkgs/commit/d3dd5a36cc5a2ec3c3895ba6aaa12e4f32e57708) | `` python312Packages.braintree: modernize and enable more tests ``                          |
| [`2aee0cec`](https://github.com/NixOS/nixpkgs/commit/2aee0cec37260bba0ee0eedca4ea4fb35ffef5f6) | `` python312Packages.braintree: 4.14.0 -> 4.29.0 ``                                         |
| [`f5371064`](https://github.com/NixOS/nixpkgs/commit/f5371064183aaf94dbb8619ac4a0e2cf767c2c43) | `` toolong: init at 1.4.0 ``                                                                |
| [`b8954a88`](https://github.com/NixOS/nixpkgs/commit/b8954a889c2f2ec1f96324373f044fc1eae1e488) | `` python312Packages.xlwt: 1.3.0 -> 1.3.0-unstable-2018-09-16 ``                            |
| [`f8c5e1ea`](https://github.com/NixOS/nixpkgs/commit/f8c5e1ea1ebd45b780a49b0b461e1fa476e488c1) | `` python312Packages.xlwt: Remove nose dependency ``                                        |
| [`fdc84b48`](https://github.com/NixOS/nixpkgs/commit/fdc84b488f402f84850f6f74ff4966404ec032d6) | `` python312Packages.citeproc-py: modernize ``                                              |
| [`65ca8514`](https://github.com/NixOS/nixpkgs/commit/65ca851437b4ff1e37a3601465a3b535d6936e90) | `` python312Packages.citeproc-py: Remove nose dependency and re-enable tests ``             |
| [`348bc2e4`](https://github.com/NixOS/nixpkgs/commit/348bc2e4b54c2335d7bb7d67628c3f2d32275460) | `` python3Packages.pymee: init at 2.2.0 ``                                                  |
| [`cef0a490`](https://github.com/NixOS/nixpkgs/commit/cef0a490120bf64c7f81a5a45705173c5bbf18d5) | `` hexfiend: add auto update script ``                                                      |
| [`f695337c`](https://github.com/NixOS/nixpkgs/commit/f695337c7b9b156e34cffc672a3440becc4ba95a) | `` pyright: 1.1.370 -> 1.1.373 ``                                                           |
| [`1f550850`](https://github.com/NixOS/nixpkgs/commit/1f550850bb36afbce67c3069642033cc5740926d) | `` python3Packages.ruff-api: add libiconv on Darwin ``                                      |
| [`18dc1231`](https://github.com/NixOS/nixpkgs/commit/18dc1231d4bc498ff6d330aefc5300efba8e068c) | `` libvpx_1_8: remove ``                                                                    |
| [`99da0d64`](https://github.com/NixOS/nixpkgs/commit/99da0d648a6340ba3bcec0d0ceba169e7b752c51) | `` python311Packages.python-designateclient: init at 6.0.1 (#328506) ``                     |
| [`b2df3187`](https://github.com/NixOS/nixpkgs/commit/b2df3187bcfc42f8ab398b3edd84bd3cd881096a) | `` python312Packages.ax: relax botorch version requirement ``                               |
| [`61d0d004`](https://github.com/NixOS/nixpkgs/commit/61d0d004f84343bfffb9a631092b21e41adf6ded) | `` python312Packages.botorch: relax gpytorch version requirement ``                         |
| [`b846df0a`](https://github.com/NixOS/nixpkgs/commit/b846df0a2e241fb0b6e0e987af977f1238520574) | `` nixpkgs-manual: inline common.nix ``                                                     |
| [`eaa78111`](https://github.com/NixOS/nixpkgs/commit/eaa78111043c898f26e870668593299526ae5db1) | `` nixpkgs-manual: move shell to package ``                                                 |
| [`b5dc8284`](https://github.com/NixOS/nixpkgs/commit/b5dc82844f7d0bb2c9c38b9b696de68e6be23d8d) | `` nixpkgs-manual: init ``                                                                  |
| [`4252286f`](https://github.com/NixOS/nixpkgs/commit/4252286f210a6c3b2310e6736eb1ef59917c9c89) | `` doc: extract nixpkgs-manual into its own package ``                                      |
| [`8bb7777a`](https://github.com/NixOS/nixpkgs/commit/8bb7777aee22d012e05a44206202b73939e1dfac) | `` doc: extract manpage-urls test into its own package ``                                   |
| [`2266280a`](https://github.com/NixOS/nixpkgs/commit/2266280af7c3fd3d3248dbff4ac463efb6c435d8) | `` doc: reshape python-interpreter-table.nix into a normal callPackage ``                   |
| [`eac67316`](https://github.com/NixOS/nixpkgs/commit/eac67316dc522d9c2f4d46e791e97bb9ddddfd10) | `` doc: extract optionsDoc into its own package ``                                          |
| [`ee6a243e`](https://github.com/NixOS/nixpkgs/commit/ee6a243ea4014753ee3606781c190c5836414d32) | `` doc: extract epub manual stub into its own package ``                                    |
| [`87b8931d`](https://github.com/NixOS/nixpkgs/commit/87b8931d74d9e744a16a00503003a46584f03b4a) | `` doc: make ./doc-support/lib-function-docs.nix callPackage style ``                       |
| [`849cf137`](https://github.com/NixOS/nixpkgs/commit/849cf137253f668d8544be3b0cb4e606be20134f) | `` web-devmode: call as package ``                                                          |
| [`a3910735`](https://github.com/NixOS/nixpkgs/commit/a39107357761c76a61bd083aa25c47e92577ff06) | `` discord-development: 0.0.23 -> 0.0.24 ``                                                 |
| [`17698703`](https://github.com/NixOS/nixpkgs/commit/17698703dd62c8a7e5e3eb5bf3e47fcd9b5c6fec) | `` phpunit: 11.2.7 -> 11.2.8 ``                                                             |
| [`4a006564`](https://github.com/NixOS/nixpkgs/commit/4a00656438544e0d77a16ff8d9353c45ba4bbcf7) | `` agate: 3.3.7 → 3.3.8 ``                                                                  |
| [`ee732eb2`](https://github.com/NixOS/nixpkgs/commit/ee732eb25c5fd211c37f9311eaaaafe71406d497) | `` agate: migrate to by-name ``                                                             |
| [`a5c855f0`](https://github.com/NixOS/nixpkgs/commit/a5c855f0492013a47890b484ba5078fe6056e1e8) | `` caido: 0.33.0 -> 0.39.0 (#328499) ``                                                     |
| [`ee537a1d`](https://github.com/NixOS/nixpkgs/commit/ee537a1d185d265d138f9b57898c0aa4a5622729) | `` mailpit: implement `passthru.updateScript` (#324302) ``                                  |
| [`c5b56451`](https://github.com/NixOS/nixpkgs/commit/c5b56451ae511df9a036a19bbd071aae19b7721a) | `` python312Packages.botocore-stubs: 1.34.147 -> 1.34.149 ``                                |
| [`aab2e118`](https://github.com/NixOS/nixpkgs/commit/aab2e118931f9fd6bb7537640bdfe992ca974727) | `` python312Packages.boto3-stubs: 1.34.147 -> 1.34.149 ``                                   |
| [`d84a6a88`](https://github.com/NixOS/nixpkgs/commit/d84a6a88308b06ae0affc01452def6d1a64c0ac2) | `` python312Packages.tencentcloud-sdk-python: 3.0.1197 -> 3.0.1198 ``                       |
| [`9587ddd2`](https://github.com/NixOS/nixpkgs/commit/9587ddd261329f6a90900233a3542efd5c32d4f0) | `` nixos/nix-channel: don't set `nix-path` (#327683) ``                                     |
| [`3304ae40`](https://github.com/NixOS/nixpkgs/commit/3304ae4078f4e30af642deee8d0335b600cb77d9) | `` checkov: 3.2.207 -> 3.2.208 ``                                                           |
| [`df6e2c43`](https://github.com/NixOS/nixpkgs/commit/df6e2c4311d2768a9d4b523148f52b9915d4a639) | `` xournalpp: fix missing icons that prevent start ``                                       |
| [`1c6d14cc`](https://github.com/NixOS/nixpkgs/commit/1c6d14cc7238517637b035286d34317504b02f14) | `` python3Packages.bablefont: fix building ``                                               |
| [`e8fd0cf3`](https://github.com/NixOS/nixpkgs/commit/e8fd0cf3f66f928feb3fc5ef83d9ded5d14d7f4e) | `` python3Packages.vfblib: init at 0.7.0 ``                                                 |
| [`12010031`](https://github.com/NixOS/nixpkgs/commit/1201003125cf2dbc0600d71f8d638a15871e0672) | `` symfony-cli: 5.9.1 -> 5.10.2 ``                                                          |
| [`a6f1107c`](https://github.com/NixOS/nixpkgs/commit/a6f1107c90680034364384c705db52774b940a77) | `` starship: 1.19.0 -> 1.20.0 ``                                                            |
| [`38ba8353`](https://github.com/NixOS/nixpkgs/commit/38ba83534f09ad3bc44d85c18ae1447302e5fc7d) | `` python312Packages.pypass: Modernize ``                                                   |
| [`93201c2d`](https://github.com/NixOS/nixpkgs/commit/93201c2d232a6c5c61474b8a0bad978757e2972a) | `` python312Packages.pypass: Remove nose dependency ``                                      |
| [`52e5b77c`](https://github.com/NixOS/nixpkgs/commit/52e5b77cf12601635396edbf676d67402c8ee431) | `` pidginPackages: re-add recurseIntoAttrs ``                                               |
| [`58e9d6e9`](https://github.com/NixOS/nixpkgs/commit/58e9d6e92dcc6c80c01a3fcfb51a9bd230025e9d) | `` python312Packages.onnxruntime: fix CUDA build; add missing nccl dependency. (#330044) `` |
| [`4f441c24`](https://github.com/NixOS/nixpkgs/commit/4f441c2408e1f59b81b433dbba89132dde720f77) | `` woodpecker-plugin-git: 2.5.1 -> 2.5.2 ``                                                 |
| [`1a367877`](https://github.com/NixOS/nixpkgs/commit/1a367877db79dc81b8078b3df505b0707b8d3b3b) | `` qlog: 0.37.1 -> 0.37.2 ``                                                                |
| [`c32b73a2`](https://github.com/NixOS/nixpkgs/commit/c32b73a2d6bdcfed21cace94f8b8789172e50d34) | `` nixos/plasma6: add libplasma to SDDM wrapper ``                                          |
| [`02f18154`](https://github.com/NixOS/nixpkgs/commit/02f1815436f5548392ace9693e28848ff79ecce7) | `` libreoffice: Add meta.mainProgram ``                                                     |
| [`ec0dc6ae`](https://github.com/NixOS/nixpkgs/commit/ec0dc6aec1c056fecd3e58191322ca2222c55245) | `` Avoid top-level `with ...;` in pkgs/development/node-packages/aliases.nix ``             |
| [`852453aa`](https://github.com/NixOS/nixpkgs/commit/852453aae1e7d25257b4b817b9a82ea3f600705b) | `` coqPackages: restor recurseIntoAttrs ``                                                  |
| [`369f63c0`](https://github.com/NixOS/nixpkgs/commit/369f63c0f4e1ff0a87d82d41456f8e83f0d296d8) | `` python{311,312}Packages: restore recurseIntoAttrs for package sets ``                    |
| [`f9235516`](https://github.com/NixOS/nixpkgs/commit/f92355165f2edc6f718e622f97475e8639845e26) | `` python311Packages.transformers: 4.43.2 -> 4.43.3 ``                                      |
| [`cb567491`](https://github.com/NixOS/nixpkgs/commit/cb567491b296af6b8a1221d9a5220b5826fc6031) | `` nuclei-templates: 9.9.1 -> 9.9.2 ``                                                      |
| [`87b7b8c7`](https://github.com/NixOS/nixpkgs/commit/87b7b8c7bdacc4921adb1d67d6c83efe9155f60d) | `` imsprog: 1.4.2 -> 1.4.3 ``                                                               |
| [`83d54ca4`](https://github.com/NixOS/nixpkgs/commit/83d54ca4d47288f93d89b75028f49881638e7386) | `` firefox-bin-unwrapped: 128.0.2 -> 128.0.3 ``                                             |
| [`cfc0d8dc`](https://github.com/NixOS/nixpkgs/commit/cfc0d8dcc251540fd1d298f7aa173654d73effca) | `` firefox-unwrapped: 128.0.2 -> 128.0.3 ``                                                 |
| [`a5f8d3fe`](https://github.com/NixOS/nixpkgs/commit/a5f8d3fe024035724f4d4eb09e3b54654148e661) | `` nixos/home-assistant: customComponents must use buildHomeAssistantComponent ``           |
| [`ad9a6e0d`](https://github.com/NixOS/nixpkgs/commit/ad9a6e0d22778f06e4caeabd22011199b9bb7f2c) | `` Revert "faiss: 1.7.4 -> 1.8.0" (#330183) ``                                              |
| [`6f43c10b`](https://github.com/NixOS/nixpkgs/commit/6f43c10be8e13be6a5f2247876a14070fd68304d) | `` pantheon.elementary-videos: 3.0.0 -> 8.0.0 ``                                            |
| [`e9b7cd7b`](https://github.com/NixOS/nixpkgs/commit/e9b7cd7b7237160dd163e0901ceb1f31c5dff1f7) | `` ginkgo: 2.19.0 -> 2.19.1 ``                                                              |
| [`5197abc1`](https://github.com/NixOS/nixpkgs/commit/5197abc1a2a1e1b366c55dc39d7dd94878f1641b) | `` faas-cli: 0.16.30 -> 0.16.31 ``                                                          |
| [`2980f5d1`](https://github.com/NixOS/nixpkgs/commit/2980f5d17eaaf93fe2ba0e7ffca664acbcb352c1) | `` pantheon.elementary-music: 7.1.0 -> 8.0.0 ``                                             |
| [`4de56f19`](https://github.com/NixOS/nixpkgs/commit/4de56f190b392c9584e9775227e450d4a599aeca) | `` pantheon.elementary-screenshot: 6.0.4 -> 8.0.0 ``                                        |
| [`9f13d0bc`](https://github.com/NixOS/nixpkgs/commit/9f13d0bce28f43075239e85ddef104718c9ac392) | `` yt-dlp: add curl impersonation support ``                                                |
| [`0f0687f6`](https://github.com/NixOS/nixpkgs/commit/0f0687f6b3c1fab69715f8d7ca8d65fefb777d12) | `` yt-dlp: move to by-name ``                                                               |
| [`c9b408ea`](https://github.com/NixOS/nixpkgs/commit/c9b408ea5d6277213462690eee46ae1ab1b03a92) | `` luaPackages.rustaceanvim: 4.25.1 -> 5.0.0 (#330157) ``                                   |
| [`33316af5`](https://github.com/NixOS/nixpkgs/commit/33316af5e5a78350ee7a6674c5aa9cb80f385a59) | `` pantheon.elementary-settings-daemon: 1.3.1 -> 8.0.0 ``                                   |