### PR TITLE
chore(flake/nur): `de4be60e` -> `5f237e65`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722109497,
-        "narHash": "sha256-6AG9bKouzPguBXOjMPT/eiKpuOFEKaoTOWWRfrgDmk8=",
+        "lastModified": 1722135413,
+        "narHash": "sha256-AzQpTaG8ureBeX2b/EVV8QnaVlmpToZA/ABOyPDxYJM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "de4be60e145694db7069ecfd7a42b789d2489663",
+        "rev": "5f237e6531133297a9155e3f37af2d81361bd36f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5f237e65`](https://github.com/nix-community/NUR/commit/5f237e6531133297a9155e3f37af2d81361bd36f) | `` automatic update `` |
| [`3d1b2642`](https://github.com/nix-community/NUR/commit/3d1b26424f984e150277e6b0a3a6351238685f87) | `` automatic update `` |
| [`86c5c9f9`](https://github.com/nix-community/NUR/commit/86c5c9f9aeefa98727dccf233ebf9ada1298ae50) | `` automatic update `` |
| [`f15804f8`](https://github.com/nix-community/NUR/commit/f15804f8826fcc76e8bee5beafe48bf8dee04051) | `` automatic update `` |