### PR TITLE
chore(flake/emacs-overlay): `3f5b9a39` -> `03ec7b09`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722100240,
-        "narHash": "sha256-v77jAMwT3588euesCpt5aRI4XE7KA+7MZChDvqkx06g=",
+        "lastModified": 1722129161,
+        "narHash": "sha256-ishzYN9KoR5eEppW7yYZ3VhyCzki/lWHBQl+lvHBuwI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3f5b9a39a01538a802013d14f0ca374ee85d316c",
+        "rev": "03ec7b0945ae5f1533324be2c492db98f9014a5c",
         "type": "github"
       },
       "original": {
@@ -700,11 +700,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1721949857,
-        "narHash": "sha256-DID446r8KsmJhbCzx4el8d9SnPiE8qa6+eEQOJ40vR0=",
+        "lastModified": 1722087241,
+        "narHash": "sha256-2ShmEaFi0kJVOEEu5gmlykN5dwjWYWYUJmlRTvZQRpU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a1cc729dcbc31d9b0d11d86dc7436163548a9665",
+        "rev": "8c50662509100d53229d4be607f1a3a31157fa12",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`03ec7b09`](https://github.com/nix-community/emacs-overlay/commit/03ec7b0945ae5f1533324be2c492db98f9014a5c) | `` Updated elpa ``         |
| [`1ebfe528`](https://github.com/nix-community/emacs-overlay/commit/1ebfe528f07f0ba6d4b0d530332012749b36eee5) | `` Updated flake inputs `` |