### PR TITLE
chore(flake/nur): `5f237e65` -> `e62f5041`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722135413,
-        "narHash": "sha256-AzQpTaG8ureBeX2b/EVV8QnaVlmpToZA/ABOyPDxYJM=",
+        "lastModified": 1722138416,
+        "narHash": "sha256-l4Pg/wFQzh12oA6jIdMfR7ny5Ri1h1gOihCmch5MPeY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5f237e6531133297a9155e3f37af2d81361bd36f",
+        "rev": "e62f5041365f555567c8b113820104aad3afc9c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e62f5041`](https://github.com/nix-community/NUR/commit/e62f5041365f555567c8b113820104aad3afc9c4) | `` automatic update `` |
| [`ad7056b4`](https://github.com/nix-community/NUR/commit/ad7056b477de1bf3e1fa5ed2c3da1340d6820277) | `` automatic update `` |