### PR TITLE
chore(flake/nur): `e62f5041` -> `535f25d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722138416,
-        "narHash": "sha256-l4Pg/wFQzh12oA6jIdMfR7ny5Ri1h1gOihCmch5MPeY=",
+        "lastModified": 1722145604,
+        "narHash": "sha256-9Q5ZQXd3CVd8FpqKUKeFH4UuirhpiB+XECT3if0Mc7I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e62f5041365f555567c8b113820104aad3afc9c4",
+        "rev": "535f25d2241ff02926e773704fa6ac1f1c764667",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`535f25d2`](https://github.com/nix-community/NUR/commit/535f25d2241ff02926e773704fa6ac1f1c764667) | `` automatic update `` |
| [`362daa33`](https://github.com/nix-community/NUR/commit/362daa33ef3eab751214cab364123d75aaea9155) | `` automatic update `` |