### PR TITLE
chore(flake/nur): `535f25d2` -> `6769ab39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722145604,
-        "narHash": "sha256-9Q5ZQXd3CVd8FpqKUKeFH4UuirhpiB+XECT3if0Mc7I=",
+        "lastModified": 1722149347,
+        "narHash": "sha256-mrRQOFfQtps1NctSrlJ+vTWF+O+l7IkICmHZaN69vro=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "535f25d2241ff02926e773704fa6ac1f1c764667",
+        "rev": "6769ab39607d7689b4f2fa9cf2d4b98a6d19f9da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6769ab39`](https://github.com/nix-community/NUR/commit/6769ab39607d7689b4f2fa9cf2d4b98a6d19f9da) | `` automatic update `` |
| [`c592c369`](https://github.com/nix-community/NUR/commit/c592c36926b33d824d4279bb4642c0b24f2d3ad9) | `` automatic update `` |