### PR TITLE
chore(flake/nur): `6769ab39` -> `c20d0590`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722149347,
-        "narHash": "sha256-mrRQOFfQtps1NctSrlJ+vTWF+O+l7IkICmHZaN69vro=",
+        "lastModified": 1722153156,
+        "narHash": "sha256-edzknwFxbIpX5zdq6rspYQpYFz3uhXXH00IJzdjMCxY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6769ab39607d7689b4f2fa9cf2d4b98a6d19f9da",
+        "rev": "c20d05903e7cad473b58f6809851c110cc88c350",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c20d0590`](https://github.com/nix-community/NUR/commit/c20d05903e7cad473b58f6809851c110cc88c350) | `` automatic update `` |
| [`e574cb55`](https://github.com/nix-community/NUR/commit/e574cb55e69d494d3d8e1f25000244c657f061e8) | `` automatic update `` |