### PR TITLE
chore(flake/nur): `c20d0590` -> `a89a3198`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722153156,
-        "narHash": "sha256-edzknwFxbIpX5zdq6rspYQpYFz3uhXXH00IJzdjMCxY=",
+        "lastModified": 1722167240,
+        "narHash": "sha256-o5DekEM13zsldIy9znDUpNAz6zHay1qLlkf0zZtK/A8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c20d05903e7cad473b58f6809851c110cc88c350",
+        "rev": "a89a3198c5d2d92073a71bfde50944567f04d280",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a89a3198`](https://github.com/nix-community/NUR/commit/a89a3198c5d2d92073a71bfde50944567f04d280) | `` automatic update `` |
| [`ae0db30e`](https://github.com/nix-community/NUR/commit/ae0db30ec8d636603931885cf448640d97f261e5) | `` automatic update `` |
| [`f33acd7a`](https://github.com/nix-community/NUR/commit/f33acd7a4aebb1d84612ded3fe5ed0bf1d840c60) | `` automatic update `` |
| [`3729fb90`](https://github.com/nix-community/NUR/commit/3729fb903a7e4cd9a9841cb38081f59e4c3a9713) | `` automatic update `` |