### PR TITLE
chore(flake/emacs-overlay): `0c240033` -> `443b6591`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722156894,
-        "narHash": "sha256-/sEiNEji7o+wlJgNyw/wpgGxusKntHlmHQRjDqp2d2E=",
+        "lastModified": 1722157696,
+        "narHash": "sha256-UPzBMBUF89LzQ3zc7WY/bpw18o4pDOZInYfFM0J77ao=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0c240033e4178a6555828df5e980685342ba5ad3",
+        "rev": "443b6591a1640ef4bf21dd8d29a0d8da6e401696",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`443b6591`](https://github.com/nix-community/emacs-overlay/commit/443b6591a1640ef4bf21dd8d29a0d8da6e401696) | `` Updated emacs `` |