### PR TITLE
chore(flake/nur): `a89a3198` -> `356b0193`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722167240,
-        "narHash": "sha256-o5DekEM13zsldIy9znDUpNAz6zHay1qLlkf0zZtK/A8=",
+        "lastModified": 1722171540,
+        "narHash": "sha256-5lqkNj2uPvEjR/NnFECn+aOgM2BqXlkUzIo5O8vaHqo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a89a3198c5d2d92073a71bfde50944567f04d280",
+        "rev": "356b019341d91a070b4919033442048ff3b23855",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`356b0193`](https://github.com/nix-community/NUR/commit/356b019341d91a070b4919033442048ff3b23855) | `` automatic update `` |