### PR TITLE
chore(flake/nur): `356b0193` -> `4bf1f4ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722171540,
-        "narHash": "sha256-5lqkNj2uPvEjR/NnFECn+aOgM2BqXlkUzIo5O8vaHqo=",
+        "lastModified": 1722176547,
+        "narHash": "sha256-Z1nF2QaPEVdflInS3R1++mAJR0TIZ1V5hKNm8x6OjFA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "356b019341d91a070b4919033442048ff3b23855",
+        "rev": "4bf1f4aecb27b07334f138eb22668c76d14ce62d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4bf1f4ae`](https://github.com/nix-community/NUR/commit/4bf1f4aecb27b07334f138eb22668c76d14ce62d) | `` automatic update `` |