### PR TITLE
chore(flake/emacs-overlay): `443b6591` -> `2e3aa163`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722157696,
-        "narHash": "sha256-UPzBMBUF89LzQ3zc7WY/bpw18o4pDOZInYfFM0J77ao=",
+        "lastModified": 1722186659,
+        "narHash": "sha256-qELRNkhK5Ox9zUWPAAiHayW8EWg77ppP7E/q+YKAMqw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "443b6591a1640ef4bf21dd8d29a0d8da6e401696",
+        "rev": "2e3aa16322991f8f97928815e5ad62b253e99a36",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`2e3aa163`](https://github.com/nix-community/emacs-overlay/commit/2e3aa16322991f8f97928815e5ad62b253e99a36) | `` Updated emacs `` |
| [`67fe128c`](https://github.com/nix-community/emacs-overlay/commit/67fe128ca01b54501f2e816aaac79f93363ec854) | `` Updated melpa `` |
| [`1f7571fc`](https://github.com/nix-community/emacs-overlay/commit/1f7571fcfea341a104d626ec12d3c0d46d90876b) | `` Updated elpa ``  |