### PR TITLE
chore(flake/nur): `4bf1f4ae` -> `f74526a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722176547,
-        "narHash": "sha256-Z1nF2QaPEVdflInS3R1++mAJR0TIZ1V5hKNm8x6OjFA=",
+        "lastModified": 1722192323,
+        "narHash": "sha256-sbfkDGDcDXr9YdkV/LZmnjOGbggKYxQEw3eLNXo1Wr8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4bf1f4aecb27b07334f138eb22668c76d14ce62d",
+        "rev": "f74526a42c8a2ec2ed5b546c3504cbc105f39999",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f74526a4`](https://github.com/nix-community/NUR/commit/f74526a42c8a2ec2ed5b546c3504cbc105f39999) | `` automatic update `` |