### PR TITLE
chore(flake/nur): `f74526a4` -> `09954f57`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722192323,
-        "narHash": "sha256-sbfkDGDcDXr9YdkV/LZmnjOGbggKYxQEw3eLNXo1Wr8=",
+        "lastModified": 1722195943,
+        "narHash": "sha256-ShbR3UcoMwTw1zuCKwi7hOE4VAgNJmh12vI9hMwXDG0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f74526a42c8a2ec2ed5b546c3504cbc105f39999",
+        "rev": "09954f579bc30b1d1dffe9615e58eaf5d3ce8e61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`09954f57`](https://github.com/nix-community/NUR/commit/09954f579bc30b1d1dffe9615e58eaf5d3ce8e61) | `` automatic update `` |