### PR TITLE
chore(flake/nur): `09954f57` -> `f6ba8c37`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722195943,
-        "narHash": "sha256-ShbR3UcoMwTw1zuCKwi7hOE4VAgNJmh12vI9hMwXDG0=",
+        "lastModified": 1722198391,
+        "narHash": "sha256-bSm7KcVqhtIs5q/Y3ODbnyTXZE78rhZPZ7IN8Ayon+s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "09954f579bc30b1d1dffe9615e58eaf5d3ce8e61",
+        "rev": "f6ba8c3700738c9711fed250bf1b1b29410d2712",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f6ba8c37`](https://github.com/nix-community/NUR/commit/f6ba8c3700738c9711fed250bf1b1b29410d2712) | `` automatic update `` |