### PR TITLE
chore(flake/nur): `f6ba8c37` -> `60a785e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722198391,
-        "narHash": "sha256-bSm7KcVqhtIs5q/Y3ODbnyTXZE78rhZPZ7IN8Ayon+s=",
+        "lastModified": 1722204966,
+        "narHash": "sha256-aBlJPx+dsK9Ot2qbt6eGNaxoDLEUAoFc0Ewqyo9LACE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f6ba8c3700738c9711fed250bf1b1b29410d2712",
+        "rev": "60a785e669ef431c8a46627847576bf5577bd452",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`60a785e6`](https://github.com/nix-community/NUR/commit/60a785e669ef431c8a46627847576bf5577bd452) | `` automatic update `` |