### PR TITLE
chore(flake/nur): `60a785e6` -> `fbed8275`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722204966,
-        "narHash": "sha256-aBlJPx+dsK9Ot2qbt6eGNaxoDLEUAoFc0Ewqyo9LACE=",
+        "lastModified": 1722210311,
+        "narHash": "sha256-KrCEvK41flzdvww/gF1q8Lz3Yf9FjBi0sMlpCRXZvQI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "60a785e669ef431c8a46627847576bf5577bd452",
+        "rev": "fbed8275c38f13867fd75d2afb635e843b20bbb5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fbed8275`](https://github.com/nix-community/NUR/commit/fbed8275c38f13867fd75d2afb635e843b20bbb5) | `` automatic update `` |