### PR TITLE
chore(flake/nur): `fbed8275` -> `24195906`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722210311,
-        "narHash": "sha256-KrCEvK41flzdvww/gF1q8Lz3Yf9FjBi0sMlpCRXZvQI=",
+        "lastModified": 1722219016,
+        "narHash": "sha256-h8Ub7/OuGIrO5/cW+eX+3k4chZo5DGFBqNsi0iIYsvw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fbed8275c38f13867fd75d2afb635e843b20bbb5",
+        "rev": "24195906a91aeb24d7afd4f236aedd1fc85b151b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`24195906`](https://github.com/nix-community/NUR/commit/24195906a91aeb24d7afd4f236aedd1fc85b151b) | `` automatic update `` |
| [`6819eb10`](https://github.com/nix-community/NUR/commit/6819eb1035f855556b8ec91950748cc4ba763579) | `` automatic update `` |
| [`3e5e3696`](https://github.com/nix-community/NUR/commit/3e5e3696ab0a8d5213cac11cc0f78915ad74ef7c) | `` automatic update `` |