### PR TITLE
chore(flake/nur): `24195906` -> `fce67a4c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722219016,
-        "narHash": "sha256-h8Ub7/OuGIrO5/cW+eX+3k4chZo5DGFBqNsi0iIYsvw=",
+        "lastModified": 1722224799,
+        "narHash": "sha256-RyMKS1HQg83XjIyZlITn+0EBxeFM5Mpic84uGmJ21LY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "24195906a91aeb24d7afd4f236aedd1fc85b151b",
+        "rev": "fce67a4cad28e178db3d6c268e1b34dcb8b73f10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fce67a4c`](https://github.com/nix-community/NUR/commit/fce67a4cad28e178db3d6c268e1b34dcb8b73f10) | `` automatic update `` |
| [`2049c4b5`](https://github.com/nix-community/NUR/commit/2049c4b5bc8640c4a153d78775602df1b4d3dcb7) | `` automatic update `` |
| [`021b38de`](https://github.com/nix-community/NUR/commit/021b38de49f8678496e9286e87fa46dd23ab3d84) | `` automatic update `` |
| [`2f1416dc`](https://github.com/nix-community/NUR/commit/2f1416dc21a97b4c425281e4aee5956fc08d7903) | `` automatic update `` |