### PR TITLE
chore(flake/nur): `fce67a4c` -> `eb83849d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722224799,
-        "narHash": "sha256-RyMKS1HQg83XjIyZlITn+0EBxeFM5Mpic84uGmJ21LY=",
+        "lastModified": 1722225847,
+        "narHash": "sha256-Xdj15fexe2FTGab45plhZDkCGP2w4hx+1/reMUqpSJQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fce67a4cad28e178db3d6c268e1b34dcb8b73f10",
+        "rev": "eb83849dc38d29dcaf11171209ea001f4a96d13b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`eb83849d`](https://github.com/nix-community/NUR/commit/eb83849dc38d29dcaf11171209ea001f4a96d13b) | `` automatic update `` |