### PR TITLE
chore(flake/nur): `eb83849d` -> `83890edf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722225847,
-        "narHash": "sha256-Xdj15fexe2FTGab45plhZDkCGP2w4hx+1/reMUqpSJQ=",
+        "lastModified": 1722236015,
+        "narHash": "sha256-JXv70YOqAN+TaB0b/H8efrGk9dCLZgx+LE/YhH4AljY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eb83849dc38d29dcaf11171209ea001f4a96d13b",
+        "rev": "83890edff37e69bdf57d29faff9e5c9e275d52cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`83890edf`](https://github.com/nix-community/NUR/commit/83890edff37e69bdf57d29faff9e5c9e275d52cd) | `` automatic update `` |
| [`3fd59720`](https://github.com/nix-community/NUR/commit/3fd597207aaffb54e349dc932d4cf41563999697) | `` automatic update `` |