### PR TITLE
chore(flake/emacs-overlay): `e32cafd5` -> `39bfba26`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722218324,
-        "narHash": "sha256-QLxcPlVJHQd83urOPISjlLD4z4pRdKVTFGn9AKinHXw=",
+        "lastModified": 1722243491,
+        "narHash": "sha256-aH5dMU65einX60W5nL5s8vQRKq2Vb8pqoqzm3Rv9ZNE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e32cafd5b6e25f3bd1629177c8abdf2c0ca7030e",
+        "rev": "39bfba263aba4644c4a68986b3c651bb5f0cb1a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`39bfba26`](https://github.com/nix-community/emacs-overlay/commit/39bfba263aba4644c4a68986b3c651bb5f0cb1a2) | `` Updated melpa `` |