### PR TITLE
chore(flake/nur): `83890edf` -> `b8733510`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722236015,
-        "narHash": "sha256-JXv70YOqAN+TaB0b/H8efrGk9dCLZgx+LE/YhH4AljY=",
+        "lastModified": 1722249943,
+        "narHash": "sha256-k+2SRfYSy9FvOrid9H8C9rh8MQ56UaY4TT+K1V6XOh0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "83890edff37e69bdf57d29faff9e5c9e275d52cd",
+        "rev": "b8733510af25eae31ba47553758dae62b1aa1f41",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b8733510`](https://github.com/nix-community/NUR/commit/b8733510af25eae31ba47553758dae62b1aa1f41) | `` automatic update `` |
| [`1200fd65`](https://github.com/nix-community/NUR/commit/1200fd65a29c610bc6b82fbd3e784b0eb6923183) | `` automatic update `` |