### PR TITLE
chore(flake/nur): `b8733510` -> `06eb16dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722249943,
-        "narHash": "sha256-k+2SRfYSy9FvOrid9H8C9rh8MQ56UaY4TT+K1V6XOh0=",
+        "lastModified": 1722258086,
+        "narHash": "sha256-PG96IFCeoVKcpHpZxo/OdswKFt0BiCRTMRlptAwP6Cw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b8733510af25eae31ba47553758dae62b1aa1f41",
+        "rev": "06eb16dd245d29b16968fb1d03bbebecae70dc5a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`06eb16dd`](https://github.com/nix-community/NUR/commit/06eb16dd245d29b16968fb1d03bbebecae70dc5a) | `` automatic update `` |