### PR TITLE
chore(flake/srvos): `75c12f43` -> `1f867a56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -914,11 +914,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722216732,
-        "narHash": "sha256-wBsD6JfFvhIqVHDzupvlXccMIyMgfflO+5oQE4taKng=",
+        "lastModified": 1722263926,
+        "narHash": "sha256-xhuXR7hKOM4dQwDvHyZYn+aHbUDHnpi4+yPhsyP+mwU=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "75c12f43baca31528e9bbf50662ce2a983045dda",
+        "rev": "1f867a5658bfc4318ea6f83304b2a1bc4a0b28ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                        |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`1f867a56`](https://github.com/nix-community/srvos/commit/1f867a5658bfc4318ea6f83304b2a1bc4a0b28ee) | `` use mkDefault for nix.optimise.automatic `` |
| [`abb6ee6e`](https://github.com/nix-community/srvos/commit/abb6ee6eb25289cb1a159ded4b43a27285b286b4) | `` nix: enable auto-optimize-store ``          |
| [`d2cc7630`](https://github.com/nix-community/srvos/commit/d2cc7630a9821f90859f484cb422be4113069f96) | `` nix-experimental: use nixVersions.latest `` |