### PR TITLE
chore(flake/emacs-overlay): `39bfba26` -> `07fcd70d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722243491,
-        "narHash": "sha256-aH5dMU65einX60W5nL5s8vQRKq2Vb8pqoqzm3Rv9ZNE=",
+        "lastModified": 1722272276,
+        "narHash": "sha256-1d7ZJHlKIEk6Yih8jRIOPBgGqC1xVl2h0SpowbX9HLo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "39bfba263aba4644c4a68986b3c651bb5f0cb1a2",
+        "rev": "07fcd70dca60adaf114f2739fef27f20e2e3ff42",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`07fcd70d`](https://github.com/nix-community/emacs-overlay/commit/07fcd70dca60adaf114f2739fef27f20e2e3ff42) | `` Updated melpa ``  |
| [`10d9aaa7`](https://github.com/nix-community/emacs-overlay/commit/10d9aaa73d465c9bfc48d8eae4c51cc5b8e8c4e4) | `` Updated elpa ``   |
| [`15abcf02`](https://github.com/nix-community/emacs-overlay/commit/15abcf023994ffba0a59420ec752b5450cad946d) | `` Updated nongnu `` |