### PR TITLE
chore(flake/nur): `2841085e` -> `ee2282db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722260776,
-        "narHash": "sha256-7VkY+JazaTkqhWUdwIVzmv4MblfsTvC13VQk/qApAO8=",
+        "lastModified": 1722278990,
+        "narHash": "sha256-m5ZdgrIHZkgDQE68Tyt6ISDOEcWy+nh+L7BGfkwLmhU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2841085ef1492af76560a8e3067768e63b9c5b61",
+        "rev": "ee2282db9f45d0a0f05ebe8cf0b1abc18cf6de3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ee2282db`](https://github.com/nix-community/NUR/commit/ee2282db9f45d0a0f05ebe8cf0b1abc18cf6de3b) | `` automatic update `` |
| [`4c26db6e`](https://github.com/nix-community/NUR/commit/4c26db6e1e9dd449c408364307cc017ae82214f1) | `` automatic update `` |