### PR TITLE
chore(flake/nur): `ee2282db` -> `ccb34a1a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722278990,
-        "narHash": "sha256-m5ZdgrIHZkgDQE68Tyt6ISDOEcWy+nh+L7BGfkwLmhU=",
+        "lastModified": 1722282295,
+        "narHash": "sha256-G5fLtxpqzG0M+0s06Elz3lFBehSaSNvLvLGLijGugxc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ee2282db9f45d0a0f05ebe8cf0b1abc18cf6de3b",
+        "rev": "ccb34a1a64641008c94f3ed6b55c0e772f1dcec8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ccb34a1a`](https://github.com/nix-community/NUR/commit/ccb34a1a64641008c94f3ed6b55c0e772f1dcec8) | `` automatic update `` |