### PR TITLE
chore(flake/nur): `ccb34a1a` -> `808f88bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722282295,
-        "narHash": "sha256-G5fLtxpqzG0M+0s06Elz3lFBehSaSNvLvLGLijGugxc=",
+        "lastModified": 1722287256,
+        "narHash": "sha256-A5I4ZAr+uuFS0uHMpH0YvgjMdhk5Hv1t/qDXjv1F7uk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ccb34a1a64641008c94f3ed6b55c0e772f1dcec8",
+        "rev": "808f88bb6c63ee120d45a1cfb6c9f27f72a509b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`808f88bb`](https://github.com/nix-community/NUR/commit/808f88bb6c63ee120d45a1cfb6c9f27f72a509b7) | `` automatic update `` |
| [`0c2fbab8`](https://github.com/nix-community/NUR/commit/0c2fbab8fe2378c3bd4f87c5d0cc988a340b91a4) | `` automatic update `` |