### PR TITLE
chore(flake/nur): `808f88bb` -> `5d18aa63`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722287256,
-        "narHash": "sha256-A5I4ZAr+uuFS0uHMpH0YvgjMdhk5Hv1t/qDXjv1F7uk=",
+        "lastModified": 1722296786,
+        "narHash": "sha256-sRrKpy1+oZxiXkJ2GSEdRi2ZNDFvfLDocepSvjyVHUc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "808f88bb6c63ee120d45a1cfb6c9f27f72a509b7",
+        "rev": "5d18aa637599db8f26537d568fe79803d03cca43",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5d18aa63`](https://github.com/nix-community/NUR/commit/5d18aa637599db8f26537d568fe79803d03cca43) | `` automatic update `` |
| [`b9f5a204`](https://github.com/nix-community/NUR/commit/b9f5a2048012700c030a3e701c02170a25032338) | `` automatic update `` |