### PR TITLE
chore(flake/nur): `5d18aa63` -> `3be1b168`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722296786,
-        "narHash": "sha256-sRrKpy1+oZxiXkJ2GSEdRi2ZNDFvfLDocepSvjyVHUc=",
+        "lastModified": 1722302766,
+        "narHash": "sha256-YhXqvvlvdLgHeR3Se0RBmQb5PHY2E8UzmNRkEVqUIYk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5d18aa637599db8f26537d568fe79803d03cca43",
+        "rev": "3be1b1689f5eb9dbb1bce7550db0d3315f1b99a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3be1b168`](https://github.com/nix-community/NUR/commit/3be1b1689f5eb9dbb1bce7550db0d3315f1b99a0) | `` automatic update `` |