### PR TITLE
chore(flake/nur): `3be1b168` -> `6cfe9fb0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722302766,
-        "narHash": "sha256-YhXqvvlvdLgHeR3Se0RBmQb5PHY2E8UzmNRkEVqUIYk=",
+        "lastModified": 1722304333,
+        "narHash": "sha256-fC+PkQuMo1DykB7my6VLPOQi6ugnZuOGdGmAAKCmFVY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3be1b1689f5eb9dbb1bce7550db0d3315f1b99a0",
+        "rev": "6cfe9fb0882d3d57fd67c783905757bb10b9115e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6cfe9fb0`](https://github.com/nix-community/NUR/commit/6cfe9fb0882d3d57fd67c783905757bb10b9115e) | `` automatic update `` |