### PR TITLE
chore(flake/nur): `6cfe9fb0` -> `9ddd9c86`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722304333,
-        "narHash": "sha256-fC+PkQuMo1DykB7my6VLPOQi6ugnZuOGdGmAAKCmFVY=",
+        "lastModified": 1722308075,
+        "narHash": "sha256-iUO9y4ZyBVrTk/TsQA9ArFj44TrpALeUXc3CFn5RY64=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6cfe9fb0882d3d57fd67c783905757bb10b9115e",
+        "rev": "9ddd9c86a0cdfc9b9b71ae1c91c6df35d6519fcc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9ddd9c86`](https://github.com/nix-community/NUR/commit/9ddd9c86a0cdfc9b9b71ae1c91c6df35d6519fcc) | `` automatic update `` |