### PR TITLE
chore(flake/nur): `9ddd9c86` -> `3c061c07`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722308075,
-        "narHash": "sha256-iUO9y4ZyBVrTk/TsQA9ArFj44TrpALeUXc3CFn5RY64=",
+        "lastModified": 1722311784,
+        "narHash": "sha256-5sAHX8ruMMoO0eP4pIdfI1lIFvMuiMVNcHTVCMca7KI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ddd9c86a0cdfc9b9b71ae1c91c6df35d6519fcc",
+        "rev": "3c061c079f692ba54dc43874790ebe1144ca6774",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3c061c07`](https://github.com/nix-community/NUR/commit/3c061c079f692ba54dc43874790ebe1144ca6774) | `` automatic update `` |
| [`0bd10c86`](https://github.com/nix-community/NUR/commit/0bd10c86fdb437cbaced37493755aceb30c42ebf) | `` automatic update `` |
| [`7e4060fc`](https://github.com/nix-community/NUR/commit/7e4060fc9f9bbbc67b802ccf1ae4bc1f2e6aff54) | `` automatic update `` |
| [`e491266f`](https://github.com/nix-community/NUR/commit/e491266f3f0e1fee7709c4d3d68130b5500dcd46) | `` automatic update `` |