### PR TITLE
chore(flake/nur): `3c061c07` -> `a91f84af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722311784,
-        "narHash": "sha256-5sAHX8ruMMoO0eP4pIdfI1lIFvMuiMVNcHTVCMca7KI=",
+        "lastModified": 1722317557,
+        "narHash": "sha256-BE4lWNWhgyUZif8I6LBAOmdEaySsHD4pWXaA4Q9FuZw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3c061c079f692ba54dc43874790ebe1144ca6774",
+        "rev": "a91f84af1c43183e4af8cea6ceca8df50dcd1e3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a91f84af`](https://github.com/nix-community/NUR/commit/a91f84af1c43183e4af8cea6ceca8df50dcd1e3b) | `` automatic update `` |
| [`e742011e`](https://github.com/nix-community/NUR/commit/e742011e03beb6042cdc77c7f6907a557de67bab) | `` automatic update `` |
| [`e0c0a300`](https://github.com/nix-community/NUR/commit/e0c0a30031a7aa89abafea3f811d5c12da6f005a) | `` automatic update `` |