### PR TITLE
chore(flake/home-manager): `89670e27` -> `4fcd54df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -410,11 +410,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722226883,
-        "narHash": "sha256-bCCH8YDJ8Ws623VDQo9/PW8jb3hh5yrRuYFayDx/ZZQ=",
+        "lastModified": 1722321190,
+        "narHash": "sha256-WeVWVRqkgrbLzmk6FfJoloJ7Xe7HWD27Pv950IUG2kI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "89670e27e101b9b30f5900fc1eb6530258d316b1",
+        "rev": "4fcd54df7cbb1d79cbe81209909ee8514d6b17a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`4fcd54df`](https://github.com/nix-community/home-manager/commit/4fcd54df7cbb1d79cbe81209909ee8514d6b17a4) | `` firefox: fix userChrome example ``                    |
| [`d34aaf7b`](https://github.com/nix-community/home-manager/commit/d34aaf7b3b4c98f2aefe0429b8946f2bcd36a59a) | `` nix-gc: set service type to oneshot ``                |
| [`db40fead`](https://github.com/nix-community/home-manager/commit/db40fead89db185dfd863aed5dad1d675f82a3fc) | `` nix-gc: call nix-collect-garbage in a shell script `` |