### PR TITLE
chore(flake/nur): `a91f84af` -> `2729b2c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722317557,
-        "narHash": "sha256-BE4lWNWhgyUZif8I6LBAOmdEaySsHD4pWXaA4Q9FuZw=",
+        "lastModified": 1722321523,
+        "narHash": "sha256-OvgYjUSL0n1Cg4h0a//21HOu2lls4aW8EU4W0UTtcys=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a91f84af1c43183e4af8cea6ceca8df50dcd1e3b",
+        "rev": "2729b2c9ffcdcd24bc1a5ab0614d9f8633f40b59",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2729b2c9`](https://github.com/nix-community/NUR/commit/2729b2c9ffcdcd24bc1a5ab0614d9f8633f40b59) | `` automatic update `` |
| [`36c9a64b`](https://github.com/nix-community/NUR/commit/36c9a64b14fca98d562041d5ab690e2958c5b549) | `` automatic update `` |