### PR TITLE
chore(flake/nur): `2729b2c9` -> `51808228`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722321523,
-        "narHash": "sha256-OvgYjUSL0n1Cg4h0a//21HOu2lls4aW8EU4W0UTtcys=",
+        "lastModified": 1722350417,
+        "narHash": "sha256-1MNpE3S9W7F1+2wg1WonX1+55c4j0WKFRPYq8JD7WxU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2729b2c9ffcdcd24bc1a5ab0614d9f8633f40b59",
+        "rev": "51808228e58e636d4b59228ed3881f7f971e7bf1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`51808228`](https://github.com/nix-community/NUR/commit/51808228e58e636d4b59228ed3881f7f971e7bf1) | `` automatic update `` |
| [`43fbf84e`](https://github.com/nix-community/NUR/commit/43fbf84e224465b606f3ee63f3c8a0448ecefb09) | `` automatic update `` |
| [`21d25733`](https://github.com/nix-community/NUR/commit/21d2573308314a35a4355081823b3eb144d6f021) | `` automatic update `` |
| [`98be6f7d`](https://github.com/nix-community/NUR/commit/98be6f7d1266a53ed64992e14b260a8393b7f1ba) | `` automatic update `` |
| [`306088ec`](https://github.com/nix-community/NUR/commit/306088eca1f431ce1075d4930c59c41b10d0103c) | `` automatic update `` |
| [`d80d03bf`](https://github.com/nix-community/NUR/commit/d80d03bfbf325e92e478c5468e4ba27bcb51dfb1) | `` automatic update `` |