### PR TITLE
chore(flake/emacs-overlay): `dff87248` -> `e237f6ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722329854,
-        "narHash": "sha256-tIMA2IJgKUD+iQ/5tjgSz2N1plx3c4WUs/hkibfL4oQ=",
+        "lastModified": 1722330665,
+        "narHash": "sha256-EFomVakrZ06L1RjA3Ux2Rf4uMSSSr6+Cvvlj7OhGxGA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "dff87248d2f71044be58701d0675780f15daad07",
+        "rev": "e237f6ef7ddd6d76c9e52125f88620a9051e85db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`e237f6ef`](https://github.com/nix-community/emacs-overlay/commit/e237f6ef7ddd6d76c9e52125f88620a9051e85db) | `` Updated emacs `` |