### PR TITLE
chore(flake/agenix): `de96bd90` -> `3f1dae07`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,11 +16,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720546205,
-        "narHash": "sha256-boCXsjYVxDviyzoEyAk624600f3ZBo/DKtUdvMTpbGY=",
+        "lastModified": 1722339003,
+        "narHash": "sha256-ZeS51uJI30ehNkcZ4uKqT4ZDARPyqrHADSKAwv5vVCU=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "de96bd907d5fbc3b14fc33ad37d1b9a3cb15edc6",
+        "rev": "3f1dae074a12feb7327b4bf43cbac0d124488bb7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                  |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`40012e5e`](https://github.com/ryantm/agenix/commit/40012e5ed4affbb5af7ea59770eb8d8fd1a5991b) | `` Remove import for NixOS/HM modules `` |