### PR TITLE
chore(flake/nixpkgs): `b73c2221` -> `52ec9ac3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1722062969,
-        "narHash": "sha256-QOS0ykELUmPbrrUGmegAUlpmUFznDQeR4q7rFhl8eQg=",
+        "lastModified": 1722185531,
+        "narHash": "sha256-veKR07psFoJjINLC8RK4DiLniGGMgF3QMlS4tb74S6k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b73c2221a46c13557b1b3be9c2070cc42cf01eb3",
+        "rev": "52ec9ac3b12395ad677e8b62106f0b98c1f8569d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`44244f71`](https://github.com/NixOS/nixpkgs/commit/44244f71c8108bc03000737de97fe49629405566) | `` python312Packages.pygtfs: drop nose dependency ``                                |
| [`b4edb67e`](https://github.com/NixOS/nixpkgs/commit/b4edb67e84a89beb039f4c52625a2184d9ca517d) | `` libsForQt5.kimageformats: provide dav1d, libaom and libyuv ``                    |
| [`c51caed3`](https://github.com/NixOS/nixpkgs/commit/c51caed3cc60aa303c0bf462154a6f5281bae492) | `` pylint: set meta.mainProgram (#330628) ``                                        |
| [`9a624d10`](https://github.com/NixOS/nixpkgs/commit/9a624d10e33c16f73d20366d4286b1a09483ffb2) | `` treewide: remove viric from meta.maintainers [orphans] ``                        |
| [`c124cdc8`](https://github.com/NixOS/nixpkgs/commit/c124cdc8d2eeaefa2bacb9abf28050aab2825996) | `` python312Packages.syncedlyrics: 1.0.0 -> 1.0.1 ``                                |
| [`aa64dffd`](https://github.com/NixOS/nixpkgs/commit/aa64dffde391f26e26b39f38af58c6b35089f852) | `` python312Packages.django-stubs-ext: 5.0.2 -> 5.0.3 ``                            |
| [`ecd8eba4`](https://github.com/NixOS/nixpkgs/commit/ecd8eba49d46cc758b1e63912dbc2405d8db9ac1) | `` python312Packages.pyngo: 2.0.1 -> 2.1.0 ``                                       |
| [`6add9cee`](https://github.com/NixOS/nixpkgs/commit/6add9ceeee6040ba144079faf6245cc8513f9de9) | `` ruby.rubygems: fix delete binstub lock files ``                                  |
| [`d96cceed`](https://github.com/NixOS/nixpkgs/commit/d96cceed9e546f8bbda81acfe35a5a8bf2606dec) | `` misconfig-mapper: 1.7.0 -> 1.8.0 ``                                              |
| [`c9deae12`](https://github.com/NixOS/nixpkgs/commit/c9deae12d786a062ad8096824cf8fa73b03202df) | `` treewide: remove viric from meta.maintainers [no orphans] ``                     |
| [`3be917a1`](https://github.com/NixOS/nixpkgs/commit/3be917a191d2d766dc7a3157b1f2c1323ef2c027) | `` release-lib: remove viric from crossMaintainers [orphans] ``                     |
| [`ee93a395`](https://github.com/NixOS/nixpkgs/commit/ee93a3955da8941ee5281a13bfcb5a2b53ffbf28) | `` git-igitt: init at 0.1.18 ``                                                     |
| [`558762f1`](https://github.com/NixOS/nixpkgs/commit/558762f114cf43495bd78e821fa33d2c66b4018a) | `` maintainer-list: add pinage404 ``                                                |
| [`23e718e2`](https://github.com/NixOS/nixpkgs/commit/23e718e21e40638008819a9c82f62aa77f08b82c) | `` emacs updater: add emacs.async dependency in promise ``                          |
| [`2901fae0`](https://github.com/NixOS/nixpkgs/commit/2901fae0e419110799c2fe639c70b47f8e7c1515) | `` emacs updater: trivialBuild -> melpaBuild ``                                     |
| [`6d053500`](https://github.com/NixOS/nixpkgs/commit/6d0535007ec51cf460a2331381f9a5be93e9d605) | `` jwx: 2.1.0 -> 2.1.1 ``                                                           |
| [`429bbdb5`](https://github.com/NixOS/nixpkgs/commit/429bbdb5ace7d1c68a851ab6fb132554aea46a95) | `` emacs: simplify manualPackages with packagesFromDirectoryRecursive ``            |
| [`7bb84e96`](https://github.com/NixOS/nixpkgs/commit/7bb84e96ffe7f2a6157185d20437c0a7c96e3d5f) | `` circumflex: 3.6 -> 3.7 ``                                                        |
| [`273848a3`](https://github.com/NixOS/nixpkgs/commit/273848a31a28dc935cd17a9528df9b5d8615dce8) | `` trufflehog: 3.80.0 -> 3.80.2 ``                                                  |
| [`d650b71d`](https://github.com/NixOS/nixpkgs/commit/d650b71d7abbece49b23d83fcad915f6ddc12ce5) | `` stats: 2.11.1 -> 2.11.4 ``                                                       |
| [`5f2c64dc`](https://github.com/NixOS/nixpkgs/commit/5f2c64dc00c9237148e7604a06af80e8feaadf85) | `` md-tui: 0.8.1 -> 0.8.3 ``                                                        |
| [`7a7956ea`](https://github.com/NixOS/nixpkgs/commit/7a7956ea7940c1bddf749a6dcb14064f804557eb) | `` yazi-unwrapped: auto update version, build date & hash ``                        |
| [`4d10225e`](https://github.com/NixOS/nixpkgs/commit/4d10225ee46c0ab16332a2450b493e0277d1741a) | `` python3Packages.nose-timer: drop ``                                              |
| [`5b2c9211`](https://github.com/NixOS/nixpkgs/commit/5b2c9211a3034492dfb6acec6491715c4ca56675) | `` python3Packages.androguard: drop nose dependency ``                              |
| [`5612d944`](https://github.com/NixOS/nixpkgs/commit/5612d9441888e47fa7e7ac6a28e8a4eb528bb7f3) | `` python3Packages.androguard: update for networkx changes ``                       |
| [`b24ddbbf`](https://github.com/NixOS/nixpkgs/commit/b24ddbbf57240f1a3fe88c00464ab1d7fba1d863) | `` python3Packages.androguard: convert to `pyproject` ``                            |
| [`90c7c39f`](https://github.com/NixOS/nixpkgs/commit/90c7c39fd5b9dbfe3eb1ab40785644420df0d141) | `` evcc: 0.128.4 -> 0.129.0 ``                                                      |
| [`3d2a21ed`](https://github.com/NixOS/nixpkgs/commit/3d2a21eddf2bb1723f81fa566b0a3092d93fb256) | `` virtualisation/{docker,podman}: update nvidia-ctk warning ``                     |
| [`bb19f848`](https://github.com/NixOS/nixpkgs/commit/bb19f848aed45c5769d148854776e85352d039bf) | `` ungoogled-chromium: 126.0.6478.182-1 -> 127.0.6533.72-1 ``                       |
| [`ff8359ab`](https://github.com/NixOS/nixpkgs/commit/ff8359ab31641d6235b64325552eb0c2d3306cdc) | `` boost: fix build for s390 ``                                                     |
| [`9e25f45e`](https://github.com/NixOS/nixpkgs/commit/9e25f45e6b9463c720fadf6256132f01d9f436c2) | `` kdePackages.marknote: 1.2.1 -> 1.3.0 ``                                          |
| [`1e9b3c1a`](https://github.com/NixOS/nixpkgs/commit/1e9b3c1af1e30618a267d0c2a8c7038696d6f71a) | `` nixos/speechd: avoid by default on headless systems ``                           |
| [`442b344f`](https://github.com/NixOS/nixpkgs/commit/442b344f589a3e6c1f16c416be1660b7d2b06f67) | `` mapnik: fix by using libxml2 with http support (again) ``                        |
| [`42663cda`](https://github.com/NixOS/nixpkgs/commit/42663cda2fb58ff64c90f356db3d28e290745fa3) | `` bitwig-studio5: remove bundled libxcb-imdkit ``                                  |
| [`15f01135`](https://github.com/NixOS/nixpkgs/commit/15f0113542c72e5aa3b2ef8ac11e10c72632f10b) | `` speedtest-rs: 0.1.5 -> 0.2.0 ``                                                  |
| [`8d43f4e7`](https://github.com/NixOS/nixpkgs/commit/8d43f4e731d0afee5bb3cd48896531e417514642) | `` turso-cli: 0.96.2 -> 0.96.3 ``                                                   |
| [`817eb5cf`](https://github.com/NixOS/nixpkgs/commit/817eb5cf2299b979b9c45393b2b19602a609f7c6) | `` c3c: rfc format ``                                                               |
| [`49fb0494`](https://github.com/NixOS/nixpkgs/commit/49fb0494b9213f25e7865138b888781f67168924) | `` c3c: add maintainer anas ``                                                      |
| [`842a15bf`](https://github.com/NixOS/nixpkgs/commit/842a15bf096f756df4265734332e159b33bff23a) | `` c3c: 0.5.5 -> 0.6.1 ``                                                           |
| [`578dc7ed`](https://github.com/NixOS/nixpkgs/commit/578dc7ed117259639a95677671e940e681604d74) | `` pdal: fix by using libxml2 with http support (again) ``                          |
| [`a2ee8306`](https://github.com/NixOS/nixpkgs/commit/a2ee8306f695af713086773f078050073383b0bf) | `` scdl: 2.11.2 -> 2.11.3 ``                                                        |
| [`99438044`](https://github.com/NixOS/nixpkgs/commit/99438044e72b80326e646de867038f6726681ad6) | `` druid: add passthru test ``                                                      |
| [`4bfc173d`](https://github.com/NixOS/nixpkgs/commit/4bfc173d8f3317b34a9282c0c8f5ccd63b028993) | `` nixos/druid: init module ``                                                      |
| [`52eab376`](https://github.com/NixOS/nixpkgs/commit/52eab37679574d8a725b032c3efdcb8ccd828df7) | `` druid: init at 30.0.0 ``                                                         |
| [`8a30a2b6`](https://github.com/NixOS/nixpkgs/commit/8a30a2b643a17776e24937855f63508b9ffedad1) | `` sqlite3-to-mysql: 2.2.1 -> 2.3.0 ``                                              |
| [`13239dca`](https://github.com/NixOS/nixpkgs/commit/13239dca19454ab48ae817bfb7f9b374e0a9c2ff) | `` stevenblack-blocklist: 3.14.88 -> 3.14.90 ``                                     |
| [`313ac78d`](https://github.com/NixOS/nixpkgs/commit/313ac78d0e79bca92b405a02fe2c0b7dcd31499a) | `` phpExtensions.soap: back to doCheck = false (except on Darwin) ``                |
| [`4ad90b93`](https://github.com/NixOS/nixpkgs/commit/4ad90b93c9aeb4944f088ef5419f0a8bf4cc6596) | `` oven-media-engine: 0.16.6 -> 0.16.8 ``                                           |
| [`8b484c86`](https://github.com/NixOS/nixpkgs/commit/8b484c868e5988deb86831226164fabadc915445) | `` httm: 0.40.1 -> 0.40.4 ``                                                        |
| [`a0297c66`](https://github.com/NixOS/nixpkgs/commit/a0297c66b34199beb9bf7c313f1b9f43f72bb00d) | `` linkerd_edge: 24.7.2 -> 24.7.5 ``                                                |
| [`ee3da00d`](https://github.com/NixOS/nixpkgs/commit/ee3da00d592822e508ee4c0e1b6a5ec1bf3051bd) | `` nixos/direnv: add enable{Bash,Fish,Zsh}Integrations ``                           |
| [`e2741f45`](https://github.com/NixOS/nixpkgs/commit/e2741f45d3aa102f4b2898d670aa326f621b8a75) | `` tenv: 2.6.1 -> 2.7.9 ``                                                          |
| [`57bda8cf`](https://github.com/NixOS/nixpkgs/commit/57bda8cfde3639e2051e93301f360219d9b8d332) | `` offat: 0.18.0 -> 0.19.1 ``                                                       |
| [`16680a70`](https://github.com/NixOS/nixpkgs/commit/16680a70d7355bacc49dfcdb5396b0953f1a9190) | `` elfutils: fix compiling with llvm ``                                             |
| [`46f73389`](https://github.com/NixOS/nixpkgs/commit/46f73389ca0fb01ac8c98746e4802108523d08ad) | `` ubuntu-sans-mono: 1.004 -> 1.006 ``                                              |
| [`c25de3eb`](https://github.com/NixOS/nixpkgs/commit/c25de3eb1cb2071ec941e8c913edf38bcde651a3) | `` magic-wormhole-rs: 0.7.0 -> 0.7.1 ``                                             |
| [`bf7e5803`](https://github.com/NixOS/nixpkgs/commit/bf7e58037c430599fa9284adbab8bc0a4e7066d1) | `` tuckr: 0.8.1 -> 0.9.0 ``                                                         |
| [`131df0bf`](https://github.com/NixOS/nixpkgs/commit/131df0bffa29aa3d70eb3132168c06da2e3cc944) | `` nodePackages: update to latest ``                                                |
| [`e6214535`](https://github.com/NixOS/nixpkgs/commit/e621453586dd8f8fe7cff02fea62c8426d130f66) | `` python312Packages.pynetdicom: 2.1.0 -> 2.1.1 ``                                  |
| [`10158879`](https://github.com/NixOS/nixpkgs/commit/101588795246d454f8f60682dc27d8b6079af29e) | `` haskell.compiler.ghc8107Binary: fix invalid code signatures on aarch64-darwin `` |
| [`532a0e5a`](https://github.com/NixOS/nixpkgs/commit/532a0e5a1b6502c08727c1f29cb2e523772e867e) | `` vatprism: init at 0.3.5 ``                                                       |
| [`83dba8f7`](https://github.com/NixOS/nixpkgs/commit/83dba8f7c8c728bb390d68a2f0e1b828d90544ae) | `` marwaita-red: 20.2-unstable-2024-07-01 -> 20.3.1 ``                              |
| [`a1e23f5a`](https://github.com/NixOS/nixpkgs/commit/a1e23f5a2401a314fcc97d431b7fb8949c8cd920) | `` makeBinaryWrapper: ensure wrapper works with llvm ``                             |
| [`8b2b3b6a`](https://github.com/NixOS/nixpkgs/commit/8b2b3b6a41823b327b60e602de363fc45ce9128b) | `` faiss: use autoAddDriverRunpath ``                                               |
| [`4076652b`](https://github.com/NixOS/nixpkgs/commit/4076652b7a57bd0f8c2469e6210583cf607d5be4) | `` faiss: use lib.cmakeFeature ``                                                   |
| [`fd70f041`](https://github.com/NixOS/nixpkgs/commit/fd70f041e576393ce1c52fe55d11ce933d6b1fe6) | `` faiss: nixfmt ``                                                                 |
| [`63f6dbf2`](https://github.com/NixOS/nixpkgs/commit/63f6dbf24762f34252109cab6638996bf6475455) | `` python3Packages.faiss: split into its own derivation ``                          |
| [`0961f648`](https://github.com/NixOS/nixpkgs/commit/0961f648facaf8bdbf193a1bd141248fe1e22e28) | `` linuxKernel.kernels.linux_zen: 6.9.8-lqx1 -> 6.9.11-lqx1 ``                      |
| [`83431a58`](https://github.com/NixOS/nixpkgs/commit/83431a5831471e975c4db5a3b30b530a7191795c) | `` linuxKernel.kernels.linux_zen: 6.9.8-zen1 -> 6.10.1-zen1 ``                      |
| [`6ea6737f`](https://github.com/NixOS/nixpkgs/commit/6ea6737f5e14cdac48c4b5716e0ccea9e6b2ab12) | `` reindeer: 2024.07.15.00 -> 2024.07.22.00 ``                                      |
| [`7294dbfb`](https://github.com/NixOS/nixpkgs/commit/7294dbfb1712158949c6c057097be3ffbe79e6d8) | `` faiss: reorder attrs in phase order ``                                           |
| [`c132bb95`](https://github.com/NixOS/nixpkgs/commit/c132bb95608051e3bcb600beb344374b5bbeaf74) | `` faiss: refactor: mv comment out of bash ``                                       |
| [`047fc47f`](https://github.com/NixOS/nixpkgs/commit/047fc47f2c7d22a712d861f9cc5515071d8bd39e) | `` faiss: addOpenGLRunpath -> addDriverRunpath ``                                   |
| [`9cdbe86e`](https://github.com/NixOS/nixpkgs/commit/9cdbe86ee2443ec7466808bde8c6c650f017865b) | `` atop: 2.10.0 -> 2.11.0 ``                                                        |
| [`863cba3a`](https://github.com/NixOS/nixpkgs/commit/863cba3a9d083b8ef7ec8834d0bdddae48392d79) | `` python312Packages.pywayland: 0.4.17 -> 0.4.18 ``                                 |
| [`9e024bf2`](https://github.com/NixOS/nixpkgs/commit/9e024bf24762093983628439d3df5ccc24516141) | `` rmpc: init at 0.2.1 ``                                                           |
| [`c5d71db7`](https://github.com/NixOS/nixpkgs/commit/c5d71db7fa340df116bfc4a36c059689a60158d2) | `` python312Packages.pyswitchbee: 1.8.0 -> 1.8.3 ``                                 |
| [`5fc5297b`](https://github.com/NixOS/nixpkgs/commit/5fc5297b59b2894b9f71f02bbd1ad04b7797bb81) | `` python3Packages.weboob: drop ``                                                  |
| [`d700c823`](https://github.com/NixOS/nixpkgs/commit/d700c823b45e2416aacfa3f40898a28a785b4fc0) | `` smassh: 3.1.3 -> 3.1.4 ``                                                        |
| [`38567a7e`](https://github.com/NixOS/nixpkgs/commit/38567a7e9840be535aa75fe690f9e9199012ed31) | `` vimPlugins.sniprun: 1.3.14 -> 1.3.15 ``                                          |
| [`36f00300`](https://github.com/NixOS/nixpkgs/commit/36f0030005c0621fb156e7652ede17fc136cb7c7) | `` kapp: 0.63.1 -> 0.63.2 ``                                                        |
| [`54735068`](https://github.com/NixOS/nixpkgs/commit/54735068a5adef31a2215c2f280fed8d50f36bc4) | `` python312Packages.testrail-api: 1.13.1 -> 1.13.2 ``                              |
| [`f39e0bc2`](https://github.com/NixOS/nixpkgs/commit/f39e0bc28be7b85cedd48d8418ecafb0845e5fdf) | `` yazi-unwrapped: add vergen environment variables ``                              |
| [`06276436`](https://github.com/NixOS/nixpkgs/commit/06276436e036cc0a22f14237306a0f8ac7311dc3) | `` nixd: add redyf as maintainer ``                                                 |
| [`889263cb`](https://github.com/NixOS/nixpkgs/commit/889263cb4de5f285031ce0ebe57e3de87c996c8d) | `` nixd: 2.2.3 -> 2.3.0 ``                                                          |
| [`c56f900d`](https://github.com/NixOS/nixpkgs/commit/c56f900d58de9e3442d1c75d6d77455b7dc02140) | `` opengrok: 1.13.7 -> 1.13.9 ``                                                    |
| [`9e330e94`](https://github.com/NixOS/nixpkgs/commit/9e330e9464f71a50985325137e178d9d508df4ec) | `` python312Packages.pysrt: drop nose dependency ``                                 |
| [`7f898a60`](https://github.com/NixOS/nixpkgs/commit/7f898a60245b32c8643a8130c2414350575e23e4) | `` ruff: Fix on darwin ``                                                           |
| [`cf1403f6`](https://github.com/NixOS/nixpkgs/commit/cf1403f6b231023d4bb353a0571e25481c5bf2f7) | `` prometheus-redis-exporter: 1.61.0 -> 1.62.0 ``                                   |