### PR TITLE
chore(flake/emacs-overlay): `e237f6ef` -> `d5cd0476`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722330665,
-        "narHash": "sha256-EFomVakrZ06L1RjA3Ux2Rf4uMSSSr6+Cvvlj7OhGxGA=",
+        "lastModified": 1722358644,
+        "narHash": "sha256-0Lrxd+7VntdGpw1incd8Jm/VF3ZZUtUo7OLdFWgTsyY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e237f6ef7ddd6d76c9e52125f88620a9051e85db",
+        "rev": "d5cd047625d3d653ae535287864c1bf89bc2392b",
         "type": "github"
       },
       "original": {
@@ -700,11 +700,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1722087241,
-        "narHash": "sha256-2ShmEaFi0kJVOEEu5gmlykN5dwjWYWYUJmlRTvZQRpU=",
+        "lastModified": 1722221733,
+        "narHash": "sha256-sga9SrrPb+pQJxG1ttJfMPheZvDOxApFfwXCFO0H9xw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8c50662509100d53229d4be607f1a3a31157fa12",
+        "rev": "12bf09802d77264e441f48e25459c10c93eada2e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`d5cd0476`](https://github.com/nix-community/emacs-overlay/commit/d5cd047625d3d653ae535287864c1bf89bc2392b) | `` Updated melpa ``        |
| [`541bfb0a`](https://github.com/nix-community/emacs-overlay/commit/541bfb0aa8675ea04dcad7df8dba534757bda606) | `` Updated elpa ``         |
| [`dad25825`](https://github.com/nix-community/emacs-overlay/commit/dad25825410285c0c23ce741134854a95bfb8799) | `` Updated nongnu ``       |
| [`3f03cd5f`](https://github.com/nix-community/emacs-overlay/commit/3f03cd5fed0e3f2665b0a5e8587f9fa640f49a1f) | `` Updated flake inputs `` |