### PR TITLE
chore(flake/nur): `7310faa2` -> `757926f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722357384,
-        "narHash": "sha256-Fbo5xgdoj99EfScQN4RokWF8JiWSFp+wYU9lxSG6gRc=",
+        "lastModified": 1722365184,
+        "narHash": "sha256-s/ooK77Z5jyVqOlQOgu9TwwsuY0/Ek8L6+IsdW6epfc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7310faa255a26f8ceba0a1572191cad6f51f9a93",
+        "rev": "757926f23f8e5377f394519da7c3b635fea28dd8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`757926f2`](https://github.com/nix-community/NUR/commit/757926f23f8e5377f394519da7c3b635fea28dd8) | `` automatic update `` |
| [`c96302f9`](https://github.com/nix-community/NUR/commit/c96302f9ba5788dd1913ea4d001c29ed29101bd2) | `` automatic update `` |
| [`7b59ff7d`](https://github.com/nix-community/NUR/commit/7b59ff7d4b2fa20b4804608ca29383fb9dceed38) | `` automatic update `` |