### PR TITLE
chore(flake/nur): `757926f2` -> `c1edc6df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722365184,
-        "narHash": "sha256-s/ooK77Z5jyVqOlQOgu9TwwsuY0/Ek8L6+IsdW6epfc=",
+        "lastModified": 1722368740,
+        "narHash": "sha256-oYXUTzFGDqlZo0u+pHQ8jmmsjJjxpLKYG1ou3yyZuX8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "757926f23f8e5377f394519da7c3b635fea28dd8",
+        "rev": "c1edc6df5b9eeb2f2f9d780b2f87de190fc15ba5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c1edc6df`](https://github.com/nix-community/NUR/commit/c1edc6df5b9eeb2f2f9d780b2f87de190fc15ba5) | `` automatic update `` |