### PR TITLE
chore(flake/nur): `c1edc6df` -> `a0d7e573`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722368740,
-        "narHash": "sha256-oYXUTzFGDqlZo0u+pHQ8jmmsjJjxpLKYG1ou3yyZuX8=",
+        "lastModified": 1722371324,
+        "narHash": "sha256-Y6wR7/aE5znv17/tYSf2o7fLyR8RKkvOzYNJHZpcNQQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c1edc6df5b9eeb2f2f9d780b2f87de190fc15ba5",
+        "rev": "a0d7e5734c800a3dba5cc8b0fba4989e0b98bbc3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a0d7e573`](https://github.com/nix-community/NUR/commit/a0d7e5734c800a3dba5cc8b0fba4989e0b98bbc3) | `` automatic update `` |