### PR TITLE
chore(flake/nur): `a0d7e573` -> `b414f4b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722371324,
-        "narHash": "sha256-Y6wR7/aE5znv17/tYSf2o7fLyR8RKkvOzYNJHZpcNQQ=",
+        "lastModified": 1722376140,
+        "narHash": "sha256-ozcPSFPvJJ0oyXF2VTK22lRRl2yxsospuh3kxz4V/1U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a0d7e5734c800a3dba5cc8b0fba4989e0b98bbc3",
+        "rev": "b414f4b79e689caad59a4ca57fafb60538cd45a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b414f4b7`](https://github.com/nix-community/NUR/commit/b414f4b79e689caad59a4ca57fafb60538cd45a4) | `` automatic update `` |