### PR TITLE
chore(flake/nur): `b414f4b7` -> `52db53ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722376140,
-        "narHash": "sha256-ozcPSFPvJJ0oyXF2VTK22lRRl2yxsospuh3kxz4V/1U=",
+        "lastModified": 1722378172,
+        "narHash": "sha256-PHcYj4zYbPt6d3POdMoIIBksAne5ejnaypIVIUEVjyg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b414f4b79e689caad59a4ca57fafb60538cd45a4",
+        "rev": "52db53bae3816bb35c871989e85f55bdbe44b117",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`52db53ba`](https://github.com/nix-community/NUR/commit/52db53bae3816bb35c871989e85f55bdbe44b117) | `` automatic update `` |