### PR TITLE
chore(flake/nur): `52db53ba` -> `576d9ff4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722378172,
-        "narHash": "sha256-PHcYj4zYbPt6d3POdMoIIBksAne5ejnaypIVIUEVjyg=",
+        "lastModified": 1722394457,
+        "narHash": "sha256-ZYs+Ed/Kaw9LbdcUfoMAdD0GJNSse9YFMPxTNbdr4u4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "52db53bae3816bb35c871989e85f55bdbe44b117",
+        "rev": "576d9ff41e9eaf788204aa55b92a3463cf4ca41a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`576d9ff4`](https://github.com/nix-community/NUR/commit/576d9ff41e9eaf788204aa55b92a3463cf4ca41a) | `` automatic update `` |
| [`1d28c4e2`](https://github.com/nix-community/NUR/commit/1d28c4e2f4d75b33ebfd9a51c44ac343908b75aa) | `` automatic update `` |
| [`58871807`](https://github.com/nix-community/NUR/commit/588718072bfabc5edd0bc4ed2c05332cb2b6a96c) | `` automatic update `` |
| [`185662d6`](https://github.com/nix-community/NUR/commit/185662d6e39943da1a790b01ecba71a212c167e3) | `` automatic update `` |