### PR TITLE
chore(flake/emacs-overlay): `b90a7328` -> `a24bf55f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722387423,
-        "narHash": "sha256-yDMYk8Jo0/BitTFVqOC0Y7nktHQd1vl/9qVnT8+Muzo=",
+        "lastModified": 1722390378,
+        "narHash": "sha256-CxiGnCzxxaiE4MN3/ePTfO7q8TnTtrmS32TgwmsnR18=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b90a73284d3a7ad098c60b57a641492dd74f0c32",
+        "rev": "a24bf55fe66fc100fc584e3a400287a5b92f721c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`a24bf55f`](https://github.com/nix-community/emacs-overlay/commit/a24bf55fe66fc100fc584e3a400287a5b92f721c) | `` Updated emacs `` |
| [`e0dd2809`](https://github.com/nix-community/emacs-overlay/commit/e0dd2809968ffe70240ca48b3c3841bdf23821fa) | `` Updated melpa `` |