### PR TITLE
chore(flake/nur): `576d9ff4` -> `5d06d3a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722394457,
-        "narHash": "sha256-ZYs+Ed/Kaw9LbdcUfoMAdD0GJNSse9YFMPxTNbdr4u4=",
+        "lastModified": 1722397946,
+        "narHash": "sha256-T7gggkNRplYLUYhYNLsTCCC3VB/DqB2ZtEwriwDuR5E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "576d9ff41e9eaf788204aa55b92a3463cf4ca41a",
+        "rev": "5d06d3a5887081939d6cd95d915ef484773ef5c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5d06d3a5`](https://github.com/nix-community/NUR/commit/5d06d3a5887081939d6cd95d915ef484773ef5c3) | `` automatic update `` |
| [`ccd23ddd`](https://github.com/nix-community/NUR/commit/ccd23ddd949bbe567ecdb661d4ac13597cf6a4a2) | `` automatic update `` |
| [`3ae4ee6b`](https://github.com/nix-community/NUR/commit/3ae4ee6b07db957b5222298ffe55381d25e03fa1) | `` automatic update `` |
| [`5b621057`](https://github.com/nix-community/NUR/commit/5b621057d54fe48501b8d6ce0ddd8c32d375725c) | `` automatic update `` |