### PR TITLE
chore(flake/nur): `5d06d3a5` -> `29839ba1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722397946,
-        "narHash": "sha256-T7gggkNRplYLUYhYNLsTCCC3VB/DqB2ZtEwriwDuR5E=",
+        "lastModified": 1722400300,
+        "narHash": "sha256-3hmREcJWNhCzztHam0aUB4NNesP2mLFBPAeVwGXV0TM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5d06d3a5887081939d6cd95d915ef484773ef5c3",
+        "rev": "29839ba195a9c8751a86ac2402ac40c4a7c2438e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`29839ba1`](https://github.com/nix-community/NUR/commit/29839ba195a9c8751a86ac2402ac40c4a7c2438e) | `` automatic update `` |
| [`a06fbcf6`](https://github.com/nix-community/NUR/commit/a06fbcf661b91deba5497e64545d5875d97932ac) | `` automatic update `` |