### PR TITLE
chore(flake/nur): `29839ba1` -> `aa7d4b00`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722400300,
-        "narHash": "sha256-3hmREcJWNhCzztHam0aUB4NNesP2mLFBPAeVwGXV0TM=",
+        "lastModified": 1722404451,
+        "narHash": "sha256-kwjjfHQc8ZqzpW88tfQvoQVyshYRr8mHJ1U2bFuWE7E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "29839ba195a9c8751a86ac2402ac40c4a7c2438e",
+        "rev": "aa7d4b002128412eb0d60c75c07f9d84b7466448",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`aa7d4b00`](https://github.com/nix-community/NUR/commit/aa7d4b002128412eb0d60c75c07f9d84b7466448) | `` automatic update `` |