### PR TITLE
chore(flake/nur): `aa7d4b00` -> `efd6fc5b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722404451,
-        "narHash": "sha256-kwjjfHQc8ZqzpW88tfQvoQVyshYRr8mHJ1U2bFuWE7E=",
+        "lastModified": 1722409351,
+        "narHash": "sha256-E4agC4tX1IsRupb5oq3cJiuxkwUjAg5FQMAMdtUYdWo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aa7d4b002128412eb0d60c75c07f9d84b7466448",
+        "rev": "efd6fc5b2df7748d3d7f51f70556031618ef4956",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`efd6fc5b`](https://github.com/nix-community/NUR/commit/efd6fc5b2df7748d3d7f51f70556031618ef4956) | `` automatic update `` |
| [`e357569c`](https://github.com/nix-community/NUR/commit/e357569ce827195d00bdc0414823deb2c80274c0) | `` automatic update `` |