### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `c1ed4eec` -> `d6d35da7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -162,11 +162,11 @@
     "doomemacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1722322465,
-        "narHash": "sha256-gCbH94O3ddxqsCvBIRjhx/r8V1tSi/bCawK1wCwMk48=",
+        "lastModified": 1722329210,
+        "narHash": "sha256-cKSqMOxIETdSfrBNvqLRCBOTHeHvcs/EFnUJMUpE1jE=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "0bac5fe132bf791e3bfb6aef39d8b8978ce53dc9",
+        "rev": "8be1ef498b81628214ab5e78739661faaf9d950f",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722273087,
-        "narHash": "sha256-uELMts/UTJ4jTPQbQgOnE75flmdbWm672yDvL3QLWOI=",
+        "lastModified": 1722390378,
+        "narHash": "sha256-CxiGnCzxxaiE4MN3/ePTfO7q8TnTtrmS32TgwmsnR18=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "087cf45264b4487b2848e08548bb4c5f933d460c",
+        "rev": "a24bf55fe66fc100fc584e3a400287a5b92f721c",
         "type": "github"
       },
       "original": {
@@ -516,11 +516,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1722328314,
-        "narHash": "sha256-PESiaByYc/LvZvGXw2QPK9TX0BS6R2spreVx1TPYBnM=",
+        "lastModified": 1722414583,
+        "narHash": "sha256-j1To88a5OY4iRs91g16fCCkBegH8QtJKpS88EGPWfZc=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "c1ed4eecc9fd44d77d2861f4cb3d5c8c30ed31d5",
+        "rev": "d6d35da75904587aa90112f0d7472c6d3cb8bfbc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`d6d35da7`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/d6d35da75904587aa90112f0d7472c6d3cb8bfbc) | `` flake.lock: Update `` |