### PR TITLE
chore(flake/nur): `efd6fc5b` -> `078f67af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722409351,
-        "narHash": "sha256-E4agC4tX1IsRupb5oq3cJiuxkwUjAg5FQMAMdtUYdWo=",
+        "lastModified": 1722422688,
+        "narHash": "sha256-cNf+YxvNyUvsoDm1bHC/vvY3srSSpgwaHzmlOOHiP04=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "efd6fc5b2df7748d3d7f51f70556031618ef4956",
+        "rev": "078f67af4da2208c9577d8377cd33acd320473c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`078f67af`](https://github.com/nix-community/NUR/commit/078f67af4da2208c9577d8377cd33acd320473c4) | `` automatic update `` |
| [`37eb139c`](https://github.com/nix-community/NUR/commit/37eb139cf80798ecdb946d1cf8c3e6cee7e9d0d9) | `` automatic update `` |