### PR TITLE
chore(flake/emacs-overlay): `70497f8b` -> `445662a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722416168,
-        "narHash": "sha256-m4CoX6bQzCg6atdfx2cstBEfadnKArnTwwv48OI4BD0=",
+        "lastModified": 1722445825,
+        "narHash": "sha256-N6DtC62HY/2PA+PqIW6uH17pOZDmgd++ay5Iv2YW7ZI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "70497f8b17f0bdafddc197b125f54cd5f73162cf",
+        "rev": "445662a366f5360a8a1b1cf1dbf21df483cd5a5b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`445662a3`](https://github.com/nix-community/emacs-overlay/commit/445662a366f5360a8a1b1cf1dbf21df483cd5a5b) | `` Updated emacs `` |
| [`fb62874b`](https://github.com/nix-community/emacs-overlay/commit/fb62874b50788a4772ce8235454582eda838cdc7) | `` Updated melpa `` |
| [`4e79bd57`](https://github.com/nix-community/emacs-overlay/commit/4e79bd5756f66dfdccc5ddf3d1fe91e80f3f0183) | `` Updated elpa ``  |