### PR TITLE
chore(flake/nur): `a7f5d16d` -> `6f645601`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722429951,
-        "narHash": "sha256-BIzCDu3wMU3TGoCHkqd4+M4Zu7lbyJU6UtLWIngL0Wc=",
+        "lastModified": 1722450628,
+        "narHash": "sha256-El3ogv9x+0NMglw/cavXyWZAgoLzC0PRPyORuQOMbgU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a7f5d16dc0839bc3907a53c94ac69ce8da9dd070",
+        "rev": "6f645601159190be1c1ecddf14e738d2de45f6b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6f645601`](https://github.com/nix-community/NUR/commit/6f645601159190be1c1ecddf14e738d2de45f6b6) | `` automatic update `` |
| [`9f2aa102`](https://github.com/nix-community/NUR/commit/9f2aa102ffef8ba91293be5b68684ccf5a8b3b94) | `` automatic update `` |