### PR TITLE
chore(flake/nur): `6f645601` -> `c44d0e4a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722450628,
-        "narHash": "sha256-El3ogv9x+0NMglw/cavXyWZAgoLzC0PRPyORuQOMbgU=",
+        "lastModified": 1722455170,
+        "narHash": "sha256-AstQS6WdzJthqUMpIXJS6HbCV2qUsp/qmHnL76p8U1M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6f645601159190be1c1ecddf14e738d2de45f6b6",
+        "rev": "c44d0e4abc611d991c6208a57e3a49e90a057fe3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c44d0e4a`](https://github.com/nix-community/NUR/commit/c44d0e4abc611d991c6208a57e3a49e90a057fe3) | `` automatic update `` |