### PR TITLE
chore(flake/nur): `c44d0e4a` -> `65ce48a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722455170,
-        "narHash": "sha256-AstQS6WdzJthqUMpIXJS6HbCV2qUsp/qmHnL76p8U1M=",
+        "lastModified": 1722457606,
+        "narHash": "sha256-cjMPHr5X/URMYCMXS33MjpBIPlZcCUQ2gedhMuVo13U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c44d0e4abc611d991c6208a57e3a49e90a057fe3",
+        "rev": "65ce48a07e02a8dfd637e31d59861ef2d02b287c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`65ce48a0`](https://github.com/nix-community/NUR/commit/65ce48a07e02a8dfd637e31d59861ef2d02b287c) | `` automatic update `` |