### PR TITLE
chore(flake/nur): `65ce48a0` -> `9ba05057`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722457606,
-        "narHash": "sha256-cjMPHr5X/URMYCMXS33MjpBIPlZcCUQ2gedhMuVo13U=",
+        "lastModified": 1722465185,
+        "narHash": "sha256-vNu8ztiqTTAvgqYBatM/AuFn9qpJXfNuqGFYA95oVWk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "65ce48a07e02a8dfd637e31d59861ef2d02b287c",
+        "rev": "9ba05057d90d2c8fda1f40685871c0d8dbf81402",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9ba05057`](https://github.com/nix-community/NUR/commit/9ba05057d90d2c8fda1f40685871c0d8dbf81402) | `` automatic update `` |
| [`4655674d`](https://github.com/nix-community/NUR/commit/4655674d374a1331db113867238e3a7bbed3c394) | `` automatic update `` |
| [`9394fb69`](https://github.com/nix-community/NUR/commit/9394fb698b5e24eff41fa6aee17031595ddf79fa) | `` automatic update `` |