### PR TITLE
chore(flake/srvos): `1f867a56` -> `46a59095`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -914,11 +914,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722263926,
-        "narHash": "sha256-xhuXR7hKOM4dQwDvHyZYn+aHbUDHnpi4+yPhsyP+mwU=",
+        "lastModified": 1722473484,
+        "narHash": "sha256-gl0NnSdNwjuAgIHfmGSVx/2jKHNfN5ie8Ex6OTjfczY=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "1f867a5658bfc4318ea6f83304b2a1bc4a0b28ee",
+        "rev": "46a59095dc9228a945bf1ee8160b397eb502ad6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`46a59095`](https://github.com/nix-community/srvos/commit/46a59095dc9228a945bf1ee8160b397eb502ad6c) | `` dev/private/flake.lock: Update `` |
| [`1eff3a09`](https://github.com/nix-community/srvos/commit/1eff3a09482407812d4d9349868d77b37e596028) | `` flake.lock: Update ``             |