### PR TITLE
chore(flake/emacs-overlay): `b90aef58` -> `aac3291a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722474805,
-        "narHash": "sha256-T+e6zoOXIbJ/SoF2/JPfDa3SDYlFYKob5KuL3DfyWlE=",
+        "lastModified": 1722477789,
+        "narHash": "sha256-WNTuqbkeDZVatGlfBk/243r1XFEtNmTTZdXlxWX3U+8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b90aef5849fe0bcdedecb67d8b406b49bd939046",
+        "rev": "aac3291a78bbaef28fda1b2c1bd8f6e3a60c722f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`aac3291a`](https://github.com/nix-community/emacs-overlay/commit/aac3291a78bbaef28fda1b2c1bd8f6e3a60c722f) | `` Updated emacs `` |
| [`ca701f81`](https://github.com/nix-community/emacs-overlay/commit/ca701f81056cd3f6111aef668827a77051fb0199) | `` Updated melpa `` |