### PR TITLE
chore(flake/nur): `9ba05057` -> `c7c930c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722465185,
-        "narHash": "sha256-vNu8ztiqTTAvgqYBatM/AuFn9qpJXfNuqGFYA95oVWk=",
+        "lastModified": 1722483963,
+        "narHash": "sha256-YHzqiXEptvpB6npuEyg+C8NkIpiHqbrbhuBaq66DxwU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ba05057d90d2c8fda1f40685871c0d8dbf81402",
+        "rev": "c7c930c6dff8e35e6a232b8e9bd19b091ad15f10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c7c930c6`](https://github.com/nix-community/NUR/commit/c7c930c6dff8e35e6a232b8e9bd19b091ad15f10) | `` automatic update `` |
| [`26ed1d53`](https://github.com/nix-community/NUR/commit/26ed1d5375b6fde1fcc70eef4cc40d9e40f64a6f) | `` automatic update `` |
| [`2ce72091`](https://github.com/nix-community/NUR/commit/2ce7209139a84d026abf8c78cc08a64debbd6d7f) | `` automatic update `` |