### PR TITLE
chore(flake/nur): `c7c930c6` -> `85c4a46c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722483963,
-        "narHash": "sha256-YHzqiXEptvpB6npuEyg+C8NkIpiHqbrbhuBaq66DxwU=",
+        "lastModified": 1722494317,
+        "narHash": "sha256-TPS7h6uaIKxXYVjep3DJdVMNlo++tMdtljjdDwDcr7E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c7c930c6dff8e35e6a232b8e9bd19b091ad15f10",
+        "rev": "85c4a46c0ac51dc69cb44c0950f9ee0f2b9b1c8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`85c4a46c`](https://github.com/nix-community/NUR/commit/85c4a46c0ac51dc69cb44c0950f9ee0f2b9b1c8d) | `` automatic update `` |
| [`3bf06551`](https://github.com/nix-community/NUR/commit/3bf06551d5922d420607091f5a3321e712ece307) | `` automatic update `` |