### PR TITLE
chore(flake/emacs-overlay): `aac3291a` -> `835be326`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722477789,
-        "narHash": "sha256-WNTuqbkeDZVatGlfBk/243r1XFEtNmTTZdXlxWX3U+8=",
+        "lastModified": 1722503466,
+        "narHash": "sha256-/uMz2fgoe15us1OufkY+cLxtPvwQ8pujIae1KpiTGCc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "aac3291a78bbaef28fda1b2c1bd8f6e3a60c722f",
+        "rev": "835be326735bff3737320bf61cb2ae1b54a26cbd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`835be326`](https://github.com/nix-community/emacs-overlay/commit/835be326735bff3737320bf61cb2ae1b54a26cbd) | `` Updated emacs `` |
| [`5a51bdfd`](https://github.com/nix-community/emacs-overlay/commit/5a51bdfd8dae135ce6ab3e47890900d1d2a44357) | `` Updated melpa `` |