### PR TITLE
chore(flake/nur): `85c4a46c` -> `23913254`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722494317,
-        "narHash": "sha256-TPS7h6uaIKxXYVjep3DJdVMNlo++tMdtljjdDwDcr7E=",
+        "lastModified": 1722505514,
+        "narHash": "sha256-IDkU+iwzj1Xkrj7duPMu7DiWLjOmlGv7i0TohoPA3vI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "85c4a46c0ac51dc69cb44c0950f9ee0f2b9b1c8d",
+        "rev": "23913254fceb5cca89b1e428d536dc9bfa58ec84",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`23913254`](https://github.com/nix-community/NUR/commit/23913254fceb5cca89b1e428d536dc9bfa58ec84) | `` automatic update `` |
| [`b7e77f1b`](https://github.com/nix-community/NUR/commit/b7e77f1bfae52c33d80ab6e49c009c772749fa34) | `` automatic update `` |
| [`f2b5c061`](https://github.com/nix-community/NUR/commit/f2b5c061a7b1c5a515cc09fc45ba68257b13c14a) | `` automatic update `` |