### PR TITLE
chore(flake/nur): `23913254` -> `c34ae86f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722505514,
-        "narHash": "sha256-IDkU+iwzj1Xkrj7duPMu7DiWLjOmlGv7i0TohoPA3vI=",
+        "lastModified": 1722512694,
+        "narHash": "sha256-MxoMJDp+iFxy5ihtA4YpxBtdq6wLtoFxy+fNyDNwHqU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "23913254fceb5cca89b1e428d536dc9bfa58ec84",
+        "rev": "c34ae86f7397a21421f3e826da76b6928284ebc1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c34ae86f`](https://github.com/nix-community/NUR/commit/c34ae86f7397a21421f3e826da76b6928284ebc1) | `` automatic update `` |
| [`883ce50d`](https://github.com/nix-community/NUR/commit/883ce50da0a347787fecb88969c6d92452f058e5) | `` automatic update `` |