### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `d6d35da7` -> `e897d73b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -162,11 +162,11 @@
     "doomemacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1722329210,
-        "narHash": "sha256-cKSqMOxIETdSfrBNvqLRCBOTHeHvcs/EFnUJMUpE1jE=",
+        "lastModified": 1722375622,
+        "narHash": "sha256-yel7jpCePnqa/YhAy/hrgFTl4qmJHpATQUNSgRN2yQo=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "8be1ef498b81628214ab5e78739661faaf9d950f",
+        "rev": "cf7098528d2a21c29d497cd810faa0a77ecaf4cc",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722390378,
-        "narHash": "sha256-CxiGnCzxxaiE4MN3/ePTfO7q8TnTtrmS32TgwmsnR18=",
+        "lastModified": 1722503466,
+        "narHash": "sha256-/uMz2fgoe15us1OufkY+cLxtPvwQ8pujIae1KpiTGCc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a24bf55fe66fc100fc584e3a400287a5b92f721c",
+        "rev": "835be326735bff3737320bf61cb2ae1b54a26cbd",
         "type": "github"
       },
       "original": {
@@ -516,11 +516,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1722414583,
-        "narHash": "sha256-j1To88a5OY4iRs91g16fCCkBegH8QtJKpS88EGPWfZc=",
+        "lastModified": 1722513831,
+        "narHash": "sha256-pePOknsSpvZDY5ZNZgUcf+GOpeyPXpCHvhJAKdqwPCU=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "d6d35da75904587aa90112f0d7472c6d3cb8bfbc",
+        "rev": "e897d73b9916775128bd8d18868d0f9ab8275a09",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                                      |
| ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`e897d73b`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/e897d73b9916775128bd8d18868d0f9ab8275a09) | `` flake.lock: Update ``                     |
| [`a3e0988b`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/a3e0988b13deb711de8a746e863e0753092f95b3) | `` Force full clone for repo.or.cz ``        |
| [`6348a698`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/6348a6987682c389f03af3f4f33d7c935b52e540) | `` opencl-mode rename in nixpkgs-unstable `` |