### PR TITLE
chore(flake/emacs-overlay): `835be326` -> `cf319a3e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722503466,
-        "narHash": "sha256-/uMz2fgoe15us1OufkY+cLxtPvwQ8pujIae1KpiTGCc=",
+        "lastModified": 1722531457,
+        "narHash": "sha256-Tt+ip1eDDJ4k6JgNuLGLHEq1zA+Gor5ZIYN7qAfJoGk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "835be326735bff3737320bf61cb2ae1b54a26cbd",
+        "rev": "cf319a3e4f482b7b86434591ba6bc41b1f26389f",
         "type": "github"
       },
       "original": {
@@ -700,11 +700,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1722221733,
-        "narHash": "sha256-sga9SrrPb+pQJxG1ttJfMPheZvDOxApFfwXCFO0H9xw=",
+        "lastModified": 1722372011,
+        "narHash": "sha256-B2xRiC3NEJy/82ugtareBkRqEkPGpMyjaLxaR8LBxNs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "12bf09802d77264e441f48e25459c10c93eada2e",
+        "rev": "cf05eeada35e122770c5c14add958790fcfcbef5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`cf319a3e`](https://github.com/nix-community/emacs-overlay/commit/cf319a3e4f482b7b86434591ba6bc41b1f26389f) | `` Updated melpa ``        |
| [`804d1213`](https://github.com/nix-community/emacs-overlay/commit/804d1213abe4d865c8f4377d6a94e91d2a86b24e) | `` Updated elpa ``         |
| [`bae494ad`](https://github.com/nix-community/emacs-overlay/commit/bae494adba1b6b449e795922a1b20dfd1ef3df3e) | `` Updated nongnu ``       |
| [`8aa773e2`](https://github.com/nix-community/emacs-overlay/commit/8aa773e243343887d1e0f0c2a8236d2ae8a3b355) | `` Updated flake inputs `` |