### PR TITLE
chore(flake/nur): `2ddd2a9c` -> `ee3c7e14`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722530076,
-        "narHash": "sha256-bOnX9S0+uMIUG0Id11XmRGWQbplmlcICDfJPQd2xafk=",
+        "lastModified": 1722538187,
+        "narHash": "sha256-yrS+MmES/blGB8PoA3A0Byno+1mPt4OKl5zbFmExVhc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2ddd2a9cd9b4be56055dfda21bb9f44e7ec9699e",
+        "rev": "ee3c7e146c632ec93cc7ac4b0fc54fb96c0d5799",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ee3c7e14`](https://github.com/nix-community/NUR/commit/ee3c7e146c632ec93cc7ac4b0fc54fb96c0d5799) | `` automatic update `` |