### PR TITLE
chore(flake/nur): `ee3c7e14` -> `13552826`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722538187,
-        "narHash": "sha256-yrS+MmES/blGB8PoA3A0Byno+1mPt4OKl5zbFmExVhc=",
+        "lastModified": 1722544106,
+        "narHash": "sha256-F4XQZjomgxAQEXc8zV99wayv99Zv1Fw+nNlmpnKkuO8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ee3c7e146c632ec93cc7ac4b0fc54fb96c0d5799",
+        "rev": "135528264a694819d60b36f3478d4080deff9ffb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`13552826`](https://github.com/nix-community/NUR/commit/135528264a694819d60b36f3478d4080deff9ffb) | `` automatic update `` |
| [`bfd7a502`](https://github.com/nix-community/NUR/commit/bfd7a502b7147e55fafb99d591b36bd5191b6f66) | `` automatic update `` |