### PR TITLE
chore(flake/nur): `13552826` -> `92c785f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722544106,
-        "narHash": "sha256-F4XQZjomgxAQEXc8zV99wayv99Zv1Fw+nNlmpnKkuO8=",
+        "lastModified": 1722551232,
+        "narHash": "sha256-g49r6JTx4eScKZNiuq/PAohgzev2VrK9WAHxW0Ikt20=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "135528264a694819d60b36f3478d4080deff9ffb",
+        "rev": "92c785f9be9ecd34d523f8900237681948747da5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`92c785f9`](https://github.com/nix-community/NUR/commit/92c785f9be9ecd34d523f8900237681948747da5) | `` automatic update `` |