### PR TITLE
chore(flake/nur): `92c785f9` -> `bf00edd2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722551232,
-        "narHash": "sha256-g49r6JTx4eScKZNiuq/PAohgzev2VrK9WAHxW0Ikt20=",
+        "lastModified": 1722563495,
+        "narHash": "sha256-CYY8w4jUxaEgb8ddUI/ZFIR/2kLeflv8zvYNlUAdtyY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "92c785f9be9ecd34d523f8900237681948747da5",
+        "rev": "bf00edd2a0b117c6d1152563324e09ecafb73888",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bf00edd2`](https://github.com/nix-community/NUR/commit/bf00edd2a0b117c6d1152563324e09ecafb73888) | `` automatic update `` |
| [`2f48eed0`](https://github.com/nix-community/NUR/commit/2f48eed087e71bcaf366221f7f10103d41004c03) | `` automatic update `` |
| [`86964a60`](https://github.com/nix-community/NUR/commit/86964a60ed807e75c084e2068bd276e92e6c28ef) | `` automatic update `` |