### PR TITLE
chore(flake/nur): `bf00edd2` -> `dea74f1e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722563495,
-        "narHash": "sha256-CYY8w4jUxaEgb8ddUI/ZFIR/2kLeflv8zvYNlUAdtyY=",
+        "lastModified": 1722570814,
+        "narHash": "sha256-XxvBeWhLd7y4ZXwK9tY6QIckTOB1UMDpOKU/7aSGW+0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bf00edd2a0b117c6d1152563324e09ecafb73888",
+        "rev": "dea74f1e37fa6506360344d9383068c9a6d90658",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dea74f1e`](https://github.com/nix-community/NUR/commit/dea74f1e37fa6506360344d9383068c9a6d90658) | `` automatic update `` |
| [`7b413a5a`](https://github.com/nix-community/NUR/commit/7b413a5a249a0682a3933114d0cff27d6aecfa06) | `` automatic update `` |
| [`347d68a6`](https://github.com/nix-community/NUR/commit/347d68a621cde4c7bf1e3c1ccf0938ec5d74618e) | `` automatic update `` |