### PR TITLE
chore(flake/nur): `dea74f1e` -> `0148eac2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722570814,
-        "narHash": "sha256-XxvBeWhLd7y4ZXwK9tY6QIckTOB1UMDpOKU/7aSGW+0=",
+        "lastModified": 1722571473,
+        "narHash": "sha256-8Vl4zELD8LVpMQRAKRrhxNN2bZq89XDpGYptK76L6PQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dea74f1e37fa6506360344d9383068c9a6d90658",
+        "rev": "0148eac2b41491f6192547c659d49de9065aeec5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0148eac2`](https://github.com/nix-community/NUR/commit/0148eac2b41491f6192547c659d49de9065aeec5) | `` automatic update `` |