### PR TITLE
chore(flake/emacs-overlay): `452daa6a` -> `c1d57dfc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722563865,
-        "narHash": "sha256-e2sGCBM40N7bFdpaMJYctXnB9F1laowrkjMXFEYvhlg=",
+        "lastModified": 1722589904,
+        "narHash": "sha256-MUg5/YtBUTKbN6aWFvHA3n7yWK/LTRAP2VkCLr+T/0o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "452daa6ae6b49c84676abf57f3a0720d78193afd",
+        "rev": "c1d57dfc41323f39f16ec7fe1c9d85402e6ec12d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`c1d57dfc`](https://github.com/nix-community/emacs-overlay/commit/c1d57dfc41323f39f16ec7fe1c9d85402e6ec12d) | `` Updated emacs `` |
| [`723d1acc`](https://github.com/nix-community/emacs-overlay/commit/723d1acc1d512677ea1592c9fabbe7bb85d4c9fc) | `` Updated melpa `` |