### PR TITLE
chore(flake/nur): `a3f8a885` -> `9455ae47`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722577920,
-        "narHash": "sha256-+Nilyq9pr3f13pNqE3UaJ/zxB69fQ8MmkA5xu6oYtIs=",
+        "lastModified": 1722588567,
+        "narHash": "sha256-zBnePAIOpH1NDQ5F+h6CG7Zt2CiTB+wfxOg5iHhIN5o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a3f8a8853ee2e17c2efd5a33a5c91c1d79bc9c49",
+        "rev": "9455ae47b1a107b24d7464bee18ac2979e19c3dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9455ae47`](https://github.com/nix-community/NUR/commit/9455ae47b1a107b24d7464bee18ac2979e19c3dd) | `` automatic update `` |
| [`86014910`](https://github.com/nix-community/NUR/commit/860149102268c3b0f541fd5e06a98b41d7290d73) | `` automatic update `` |
| [`ece71a26`](https://github.com/nix-community/NUR/commit/ece71a2661d47c7a6da8536651987be8ccb4e7eb) | `` automatic update `` |