### PR TITLE
chore(flake/nur): `9455ae47` -> `d00b0385`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722588567,
-        "narHash": "sha256-zBnePAIOpH1NDQ5F+h6CG7Zt2CiTB+wfxOg5iHhIN5o=",
+        "lastModified": 1722592003,
+        "narHash": "sha256-2BXKCHXwTn9FInDQ+/CErk/9SqDLpHgjBuGaoz0CrOo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9455ae47b1a107b24d7464bee18ac2979e19c3dd",
+        "rev": "d00b0385f99436b10afb78366306d842ae928269",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d00b0385`](https://github.com/nix-community/NUR/commit/d00b0385f99436b10afb78366306d842ae928269) | `` automatic update `` |