### PR TITLE
chore(flake/nur): `d00b0385` -> `e7c0415d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722592003,
-        "narHash": "sha256-2BXKCHXwTn9FInDQ+/CErk/9SqDLpHgjBuGaoz0CrOo=",
+        "lastModified": 1722597635,
+        "narHash": "sha256-ZEigaR68JrTWcrrcsRyfAJTvMz4qFIEw0ruHo6Iw0cs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d00b0385f99436b10afb78366306d842ae928269",
+        "rev": "e7c0415da5a9c20fe57f7ccd70ff16fb26b66309",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e7c0415d`](https://github.com/nix-community/NUR/commit/e7c0415da5a9c20fe57f7ccd70ff16fb26b66309) | `` automatic update `` |
| [`9568cd0e`](https://github.com/nix-community/NUR/commit/9568cd0e12895f1b658388f53c34f67118bf59ed) | `` automatic update `` |