### PR TITLE
chore(flake/emacs-overlay): `69f9e0a5` -> `ccf777d7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722617815,
-        "narHash": "sha256-MTWnSZxPk+dIrhksNHcQyXXJOzfs3CZZ12JUeZVl8Oo=",
+        "lastModified": 1722618700,
+        "narHash": "sha256-mZYSMqXrAN0gT6+WPh6X7IBd1sRjkVCai21TDbU51Zg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "69f9e0a57cdc3aad8dd564c0ffce7ac210018b7c",
+        "rev": "ccf777d7dcaf160ea3a6125e33ab281963173ce7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`ccf777d7`](https://github.com/nix-community/emacs-overlay/commit/ccf777d7dcaf160ea3a6125e33ab281963173ce7) | `` Updated emacs `` |