### PR TITLE
chore(flake/nur): `c84d6fd7` -> `a87130c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722617047,
-        "narHash": "sha256-pR27oxlnzGffQH5+djQFmY8JcgRNSOa+J1BajtipABU=",
+        "lastModified": 1722631088,
+        "narHash": "sha256-8z1yD7vW6+xoCJEaIbypy7QFNiyOuyuF3pHIzLxnz9U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c84d6fd7b6d560e6bf1f52cc70ae2861a8633a83",
+        "rev": "a87130c250a7803900f248ff080188a018c6d9b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a87130c2`](https://github.com/nix-community/NUR/commit/a87130c250a7803900f248ff080188a018c6d9b8) | `` automatic update `` |
| [`850662b6`](https://github.com/nix-community/NUR/commit/850662b652b6fb092f13a0f121241d04854d74db) | `` automatic update `` |