### PR TITLE
chore(flake/nur): `a87130c2` -> `d23063cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722631088,
-        "narHash": "sha256-8z1yD7vW6+xoCJEaIbypy7QFNiyOuyuF3pHIzLxnz9U=",
+        "lastModified": 1722638066,
+        "narHash": "sha256-vZMZSLOmlpEN1ZeEp6+jozv3GkbsY2JmNySQA4gtBxM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a87130c250a7803900f248ff080188a018c6d9b8",
+        "rev": "d23063cc4df549ce168e950da9c57ff0b04c9d39",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d23063cc`](https://github.com/nix-community/NUR/commit/d23063cc4df549ce168e950da9c57ff0b04c9d39) | `` automatic update `` |
| [`e7ae5f8c`](https://github.com/nix-community/NUR/commit/e7ae5f8c8734c7b05d88d251b7c683e3a1993b2c) | `` automatic update `` |