### PR TITLE
chore(flake/nur): `d23063cc` -> `99aee73a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722638066,
-        "narHash": "sha256-vZMZSLOmlpEN1ZeEp6+jozv3GkbsY2JmNySQA4gtBxM=",
+        "lastModified": 1722642354,
+        "narHash": "sha256-/jj/PMT0ppAF+Fsxb6BJ3WQkIHp2mlFkqD+XuzXDSWA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d23063cc4df549ce168e950da9c57ff0b04c9d39",
+        "rev": "99aee73a6193fff32c3927f6cc18df73db45a3e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`99aee73a`](https://github.com/nix-community/NUR/commit/99aee73a6193fff32c3927f6cc18df73db45a3e4) | `` automatic update `` |