### PR TITLE
chore(flake/emacs-overlay): `ccf777d7` -> `0ef25dc0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722618700,
-        "narHash": "sha256-mZYSMqXrAN0gT6+WPh6X7IBd1sRjkVCai21TDbU51Zg=",
+        "lastModified": 1722647218,
+        "narHash": "sha256-v3i9hrfO2uvW7mrYHFFNP/fk/sUkTy/LbsDp8aMjMLM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ccf777d7dcaf160ea3a6125e33ab281963173ce7",
+        "rev": "0ef25dc00bf9ee0e2905b24dda6f83fc43053e44",
         "type": "github"
       },
       "original": {
@@ -700,11 +700,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1722372011,
-        "narHash": "sha256-B2xRiC3NEJy/82ugtareBkRqEkPGpMyjaLxaR8LBxNs=",
+        "lastModified": 1722519197,
+        "narHash": "sha256-VEdJmVU2eLFtLqCjTYJd1J7+Go8idAcZoT11IewFiRg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cf05eeada35e122770c5c14add958790fcfcbef5",
+        "rev": "05405724efa137a0b899cce5ab4dde463b4fd30b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`0ef25dc0`](https://github.com/nix-community/emacs-overlay/commit/0ef25dc00bf9ee0e2905b24dda6f83fc43053e44) | `` Updated elpa ``         |
| [`4e00488e`](https://github.com/nix-community/emacs-overlay/commit/4e00488efa01c743bbd338e245e399d9fb3d5c58) | `` Updated flake inputs `` |