### PR TITLE
chore(flake/nur): `99aee73a` -> `b38a39a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722642354,
-        "narHash": "sha256-/jj/PMT0ppAF+Fsxb6BJ3WQkIHp2mlFkqD+XuzXDSWA=",
+        "lastModified": 1722653576,
+        "narHash": "sha256-OSlKjwHqFZ++phMk7Fdnfp9oq0E7nFeaNVzfKTX1dbI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "99aee73a6193fff32c3927f6cc18df73db45a3e4",
+        "rev": "b38a39a762d013563ef714d381dccec5bb80f226",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b38a39a7`](https://github.com/nix-community/NUR/commit/b38a39a762d013563ef714d381dccec5bb80f226) | `` automatic update `` |
| [`03c28e3c`](https://github.com/nix-community/NUR/commit/03c28e3c767c27de04e2c484dcf433bda90605ae) | `` automatic update `` |