### PR TITLE
chore(flake/nur): `b38a39a7` -> `95a150dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722653576,
-        "narHash": "sha256-OSlKjwHqFZ++phMk7Fdnfp9oq0E7nFeaNVzfKTX1dbI=",
+        "lastModified": 1722656778,
+        "narHash": "sha256-TJvlYzdQRLFP1XZeCabuxYpgf9QvsADn9IqnwBjJUow=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b38a39a762d013563ef714d381dccec5bb80f226",
+        "rev": "95a150dddee726f472938e9c1a6863ddbf443795",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`95a150dd`](https://github.com/nix-community/NUR/commit/95a150dddee726f472938e9c1a6863ddbf443795) | `` automatic update `` |