### PR TITLE
chore(flake/nur): `95a150dd` -> `acc12fec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722656778,
-        "narHash": "sha256-TJvlYzdQRLFP1XZeCabuxYpgf9QvsADn9IqnwBjJUow=",
+        "lastModified": 1722657883,
+        "narHash": "sha256-0sEaq6RS86F0/FLDrSHbWUQ8lbwNjlBwWUc2xzmrfx0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "95a150dddee726f472938e9c1a6863ddbf443795",
+        "rev": "acc12fecd4e6a31f2de32f1dc14d63112ec7f4d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`acc12fec`](https://github.com/nix-community/NUR/commit/acc12fecd4e6a31f2de32f1dc14d63112ec7f4d2) | `` automatic update `` |