### PR TITLE
chore(flake/nur): `acc12fec` -> `66d42ad2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722657883,
-        "narHash": "sha256-0sEaq6RS86F0/FLDrSHbWUQ8lbwNjlBwWUc2xzmrfx0=",
+        "lastModified": 1722663715,
+        "narHash": "sha256-cjCnCh5nVfVlLGZ0zVOymosdcBXCYDyOwbhg32FsfXQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "acc12fecd4e6a31f2de32f1dc14d63112ec7f4d2",
+        "rev": "66d42ad2963c1952fef37e0bfedee98c5ed64dc7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`66d42ad2`](https://github.com/nix-community/NUR/commit/66d42ad2963c1952fef37e0bfedee98c5ed64dc7) | `` automatic update `` |