### PR TITLE
chore(flake/nur): `66d42ad2` -> `9041234a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722663715,
-        "narHash": "sha256-cjCnCh5nVfVlLGZ0zVOymosdcBXCYDyOwbhg32FsfXQ=",
+        "lastModified": 1722671525,
+        "narHash": "sha256-o/gfqKoXdjbgt7/OAZkExfFLy76qm17enDLZTrfKqbI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "66d42ad2963c1952fef37e0bfedee98c5ed64dc7",
+        "rev": "9041234a4516d6fa06dfdada87a95dd0f44e56cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9041234a`](https://github.com/nix-community/NUR/commit/9041234a4516d6fa06dfdada87a95dd0f44e56cc) | `` automatic update `` |
| [`eb5c3bbd`](https://github.com/nix-community/NUR/commit/eb5c3bbd3fbb7b0a8fd4105fc5f389c3bc613028) | `` automatic update `` |