### PR TITLE
chore(flake/nur): `9041234a` -> `c21bff35`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722671525,
-        "narHash": "sha256-o/gfqKoXdjbgt7/OAZkExfFLy76qm17enDLZTrfKqbI=",
+        "lastModified": 1722682055,
+        "narHash": "sha256-PeLj82SERzk9b86sfCAUaw4uiU+gkUtwaZWHV12JvJ0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9041234a4516d6fa06dfdada87a95dd0f44e56cc",
+        "rev": "c21bff35967745b285a266622d0f4d8c1f2dc6f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c21bff35`](https://github.com/nix-community/NUR/commit/c21bff35967745b285a266622d0f4d8c1f2dc6f6) | `` automatic update `` |
| [`84da6ee1`](https://github.com/nix-community/NUR/commit/84da6ee133ab640e54d9abedc72effb7f81d39ea) | `` automatic update `` |
| [`96af18ab`](https://github.com/nix-community/NUR/commit/96af18ab4d2f2f4cedb2941fce2a0f19e7affd5a) | `` automatic update `` |