### PR TITLE
chore(flake/emacs-overlay): `1114419e` -> `e67c0cec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722675441,
-        "narHash": "sha256-Jjz7knsH3q1wFIvrRnosJgp9yU++nmXl2K/O3PQwUFU=",
+        "lastModified": 1722676249,
+        "narHash": "sha256-E8jHN1aWxNgR+NBCR6sfwKiT3RAigMxVH0vqyn6rEs0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1114419e691c8d89c35182e123643c94c915f158",
+        "rev": "e67c0cec68f7df91c79ab06b97e2cc24023665cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`e67c0cec`](https://github.com/nix-community/emacs-overlay/commit/e67c0cec68f7df91c79ab06b97e2cc24023665cf) | `` Updated emacs `` |