### PR TITLE
chore(flake/nur): `c21bff35` -> `65335688`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722682055,
-        "narHash": "sha256-PeLj82SERzk9b86sfCAUaw4uiU+gkUtwaZWHV12JvJ0=",
+        "lastModified": 1722689791,
+        "narHash": "sha256-jihroDqbOFLXWhG8dyTqRO3YdjMVa6kGnv8mO7Ypuiw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c21bff35967745b285a266622d0f4d8c1f2dc6f6",
+        "rev": "653356880f0a34a19cc6bc9dbd72e0be850c2759",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`65335688`](https://github.com/nix-community/NUR/commit/653356880f0a34a19cc6bc9dbd72e0be850c2759) | `` automatic update `` |
| [`2d49a3f2`](https://github.com/nix-community/NUR/commit/2d49a3f26b4bc876def1c82afa9e777afc5a07ba) | `` automatic update `` |
| [`e9a8092e`](https://github.com/nix-community/NUR/commit/e9a8092e3bd458f2560b5d4c49b32eac44bf0dfd) | `` automatic update `` |