### PR TITLE
chore(flake/nur): `65335688` -> `4a6c86b9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722689791,
-        "narHash": "sha256-jihroDqbOFLXWhG8dyTqRO3YdjMVa6kGnv8mO7Ypuiw=",
+        "lastModified": 1722696369,
+        "narHash": "sha256-Gfc9DP+oera1tp/LBxWSYdxz1jbOLOLCQhyM8rCe1rQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "653356880f0a34a19cc6bc9dbd72e0be850c2759",
+        "rev": "4a6c86b9e31f4c1075cbe264b3e95dd91761734b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4a6c86b9`](https://github.com/nix-community/NUR/commit/4a6c86b9e31f4c1075cbe264b3e95dd91761734b) | `` automatic update `` |