### PR TITLE
chore(flake/nur): `4a6c86b9` -> `b4345d37`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722696369,
-        "narHash": "sha256-Gfc9DP+oera1tp/LBxWSYdxz1jbOLOLCQhyM8rCe1rQ=",
+        "lastModified": 1722700024,
+        "narHash": "sha256-yjiLjm6vqcLZ2QPILQBhX/FNBwqDwqEK4uU+uwgOwZs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4a6c86b9e31f4c1075cbe264b3e95dd91761734b",
+        "rev": "b4345d37c5d51a68e1faf7ad63b365e6d239b4ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b4345d37`](https://github.com/nix-community/NUR/commit/b4345d37c5d51a68e1faf7ad63b365e6d239b4ef) | `` automatic update `` |