### PR TITLE
chore(flake/nur): `b4345d37` -> `f1c74d04`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722700024,
-        "narHash": "sha256-yjiLjm6vqcLZ2QPILQBhX/FNBwqDwqEK4uU+uwgOwZs=",
+        "lastModified": 1722707255,
+        "narHash": "sha256-x/R64/HSHziLQgtTp565RR5+MS+F6LjGlzs7OMPr5ZQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b4345d37c5d51a68e1faf7ad63b365e6d239b4ef",
+        "rev": "f1c74d041fe60608a390afb855944c5203694aa3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f1c74d04`](https://github.com/nix-community/NUR/commit/f1c74d041fe60608a390afb855944c5203694aa3) | `` automatic update `` |