### PR TITLE
chore(flake/nur): `f1c74d04` -> `ac1226f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722707255,
-        "narHash": "sha256-x/R64/HSHziLQgtTp565RR5+MS+F6LjGlzs7OMPr5ZQ=",
+        "lastModified": 1722709906,
+        "narHash": "sha256-I27FkJ3qSsxc5aZSwpYHMqJwLpvQt6eV4MrwGfVjCvM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f1c74d041fe60608a390afb855944c5203694aa3",
+        "rev": "ac1226f223779364c73f1a450654383768dab1b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ac1226f2`](https://github.com/nix-community/NUR/commit/ac1226f223779364c73f1a450654383768dab1b7) | `` automatic update `` |