### PR TITLE
chore(flake/nur): `ac1226f2` -> `afe4afbb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722709906,
-        "narHash": "sha256-I27FkJ3qSsxc5aZSwpYHMqJwLpvQt6eV4MrwGfVjCvM=",
+        "lastModified": 1722714302,
+        "narHash": "sha256-+WN9ZaS+vgu2CBwBgMLDhQacT2e7wS5yuFOAGMre4UQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ac1226f223779364c73f1a450654383768dab1b7",
+        "rev": "afe4afbb78687bdf71eb7300173c20c5554f5bc9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`afe4afbb`](https://github.com/nix-community/NUR/commit/afe4afbb78687bdf71eb7300173c20c5554f5bc9) | `` automatic update `` |