### PR TITLE
chore(flake/nur): `afe4afbb` -> `f32ba1e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722714302,
-        "narHash": "sha256-+WN9ZaS+vgu2CBwBgMLDhQacT2e7wS5yuFOAGMre4UQ=",
+        "lastModified": 1722724256,
+        "narHash": "sha256-Vflr/x/QumRSioHGu76n3AjVEGCORmNfCVafTz18gzw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "afe4afbb78687bdf71eb7300173c20c5554f5bc9",
+        "rev": "f32ba1e1cc4b2f9780b60cbd0cc3288aa25e59b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f32ba1e1`](https://github.com/nix-community/NUR/commit/f32ba1e1cc4b2f9780b60cbd0cc3288aa25e59b9) | `` automatic update `` |