### PR TITLE
chore(flake/emacs-overlay): `966ce440` -> `4dd596a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722733997,
-        "narHash": "sha256-geZNPzFHOG1N/524BP15SFpNzQExqHo3426YzsRPRew=",
+        "lastModified": 1722736950,
+        "narHash": "sha256-Ml84KeK5G+YBf0LgIKPMpLlRPyu5RVUxJy2dUPGTMhw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "966ce44017c95df1112466fb9d3fcedc5caff6d1",
+        "rev": "4dd596a5638a325f9d253d69ac35182d3388114f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`4dd596a5`](https://github.com/nix-community/emacs-overlay/commit/4dd596a5638a325f9d253d69ac35182d3388114f) | `` Updated emacs `` |
| [`d203881a`](https://github.com/nix-community/emacs-overlay/commit/d203881a857d4cd40d50876b1e3637d5eeb81889) | `` Updated melpa `` |