### PR TITLE
chore(flake/nur): `d998ec70` -> `7f3531fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722728705,
-        "narHash": "sha256-JKdFS4B4Qlh2XIlbXyEAWDHM8RLWp07jm6gBh4g6T5k=",
+        "lastModified": 1722736646,
+        "narHash": "sha256-NLPIYcU+QTx2/tDVGxJHtk+3q06P300qWgH3+swvfLs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d998ec700a2ea7116940073775fe8df2439bd656",
+        "rev": "7f3531fbd0610b2d39c055795951527a0ef6a5ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7f3531fb`](https://github.com/nix-community/NUR/commit/7f3531fbd0610b2d39c055795951527a0ef6a5ab) | `` automatic update `` |