### PR TITLE
chore(flake/nix-index-database): `c0ca47e8` -> `97ca0a0f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -587,11 +587,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722136042,
-        "narHash": "sha256-x3FmT4QSyK28itMiR5zfYhUrG5nY+2dv+AIcKfmSp5A=",
+        "lastModified": 1722740924,
+        "narHash": "sha256-UQPgA5d8azLZuDHZMPmvDszhuKF1Ek89SrTRtqsQ4Ss=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "c0ca47e8523b578464014961059999d8eddd4aae",
+        "rev": "97ca0a0fca0391de835f57e44f369a283e37890f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`97ca0a0f`](https://github.com/nix-community/nix-index-database/commit/97ca0a0fca0391de835f57e44f369a283e37890f) | `` update generated.nix to release 2024-08-04-025735 `` |
| [`d4ad8de1`](https://github.com/nix-community/nix-index-database/commit/d4ad8de1d6220d3f853c1d7b97da0c59344ab59a) | `` flake.lock: Update ``                                |