### PR TITLE
chore(flake/nur): `7f3531fb` -> `d95fbf93`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722736646,
-        "narHash": "sha256-NLPIYcU+QTx2/tDVGxJHtk+3q06P300qWgH3+swvfLs=",
+        "lastModified": 1722739987,
+        "narHash": "sha256-jOZZQ2CrTx2R9zu+AZu57APxI0iDINhcmeyMKZiM1ls=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7f3531fbd0610b2d39c055795951527a0ef6a5ab",
+        "rev": "d95fbf93429f5c9f4e41249212d2386a995f0cc3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d95fbf93`](https://github.com/nix-community/NUR/commit/d95fbf93429f5c9f4e41249212d2386a995f0cc3) | `` automatic update `` |
| [`09377da4`](https://github.com/nix-community/NUR/commit/09377da4c48b13b1544460d15f2bc6d3b6e6a89a) | `` automatic update `` |