### PR TITLE
chore(flake/nur): `d95fbf93` -> `917f4c77`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722739987,
-        "narHash": "sha256-jOZZQ2CrTx2R9zu+AZu57APxI0iDINhcmeyMKZiM1ls=",
+        "lastModified": 1722744246,
+        "narHash": "sha256-KVRFFZ2h5u+l7uoT+2QRfcROx2xDTBNHeFUdLK6RoSU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d95fbf93429f5c9f4e41249212d2386a995f0cc3",
+        "rev": "917f4c77e619387f3529e7c805536fc712e85f3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`917f4c77`](https://github.com/nix-community/NUR/commit/917f4c77e619387f3529e7c805536fc712e85f3e) | `` automatic update `` |