### PR TITLE
chore(flake/nur): `917f4c77` -> `827a142c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722744246,
-        "narHash": "sha256-KVRFFZ2h5u+l7uoT+2QRfcROx2xDTBNHeFUdLK6RoSU=",
+        "lastModified": 1722754271,
+        "narHash": "sha256-dQ0iA6z22NoQJoIGia1xB/VMtLYfNDhFAFelXC/sXuQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "917f4c77e619387f3529e7c805536fc712e85f3e",
+        "rev": "827a142c3856b00aca69a4bac815cde9a4181b34",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`827a142c`](https://github.com/nix-community/NUR/commit/827a142c3856b00aca69a4bac815cde9a4181b34) | `` automatic update `` |
| [`dc0e258c`](https://github.com/nix-community/NUR/commit/dc0e258c4b4fc7202a66cf55e0ed37166d586f8c) | `` automatic update `` |