### PR TITLE
chore(flake/nur): `827a142c` -> `8dd364c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722754271,
-        "narHash": "sha256-dQ0iA6z22NoQJoIGia1xB/VMtLYfNDhFAFelXC/sXuQ=",
+        "lastModified": 1722756402,
+        "narHash": "sha256-X4mvYCY/NSuZgOyxn22225Q+bcjt5S+d2MvNE4Dh9vw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "827a142c3856b00aca69a4bac815cde9a4181b34",
+        "rev": "8dd364c608805f12184594e309b3eb3bab9a74f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8dd364c6`](https://github.com/nix-community/NUR/commit/8dd364c608805f12184594e309b3eb3bab9a74f8) | `` automatic update `` |