### PR TITLE
chore(flake/nur): `8dd364c6` -> `ec7bf54a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722756402,
-        "narHash": "sha256-X4mvYCY/NSuZgOyxn22225Q+bcjt5S+d2MvNE4Dh9vw=",
+        "lastModified": 1722760668,
+        "narHash": "sha256-ua5sCl+yVP2KBrRVArfXixSXZYwDCIqv6gw/0djFVKs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8dd364c608805f12184594e309b3eb3bab9a74f8",
+        "rev": "ec7bf54a05fe88fdf6b471d660a15dcd92050b8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ec7bf54a`](https://github.com/nix-community/NUR/commit/ec7bf54a05fe88fdf6b471d660a15dcd92050b8f) | `` automatic update `` |
| [`13047044`](https://github.com/nix-community/NUR/commit/13047044a6e110ec81973cb90cfb5e7c01ad771b) | `` automatic update `` |