### PR TITLE
chore(flake/nur): `ec7bf54a` -> `5605ce77`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722760668,
-        "narHash": "sha256-ua5sCl+yVP2KBrRVArfXixSXZYwDCIqv6gw/0djFVKs=",
+        "lastModified": 1722770616,
+        "narHash": "sha256-A40yRytGkUb40yQYjspVU3Z/QBONgFYZqQiz00V1IJ4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ec7bf54a05fe88fdf6b471d660a15dcd92050b8f",
+        "rev": "5605ce776b3d21c0ee477fcd028a817bd3524e6f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5605ce77`](https://github.com/nix-community/NUR/commit/5605ce776b3d21c0ee477fcd028a817bd3524e6f) | `` automatic update `` |
| [`a1b4020a`](https://github.com/nix-community/NUR/commit/a1b4020a2c39d8c6bd1fdf586e13989b3303a146) | `` automatic update `` |