### PR TITLE
chore(flake/emacs-overlay): `dc8dcea0` -> `c4f6796e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722761696,
-        "narHash": "sha256-13WtlSH2iAIvLoQl6WSl3Zz/pZC5Fnj6oHviyk0LY9M=",
+        "lastModified": 1722791415,
+        "narHash": "sha256-7n9UqBkTAF/RikFzCyHKz50kzBDF5GYgVb3J5wCh4EY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "dc8dcea003994cabed49d84e448cab3a781527ec",
+        "rev": "c4f6796e5c499cf6370a45fff08a03e848b9abad",
         "type": "github"
       },
       "original": {
@@ -700,11 +700,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1722519197,
-        "narHash": "sha256-VEdJmVU2eLFtLqCjTYJd1J7+Go8idAcZoT11IewFiRg=",
+        "lastModified": 1722651103,
+        "narHash": "sha256-IRiJA0NVAoyaZeKZluwfb2DoTpBAj+FLI0KfybBeDU0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "05405724efa137a0b899cce5ab4dde463b4fd30b",
+        "rev": "a633d89c6dc9a2a8aae11813a62d7c58b2c0cc51",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`c4f6796e`](https://github.com/nix-community/emacs-overlay/commit/c4f6796e5c499cf6370a45fff08a03e848b9abad) | `` Updated emacs ``        |
| [`60aa595e`](https://github.com/nix-community/emacs-overlay/commit/60aa595e8124ac7ecc00b56b5a1de38596c2a456) | `` Updated melpa ``        |
| [`8e7378f0`](https://github.com/nix-community/emacs-overlay/commit/8e7378f0e954d5b8f8d102cb692030cbb51f86f9) | `` Updated elpa ``         |
| [`77049b6a`](https://github.com/nix-community/emacs-overlay/commit/77049b6a510629cedbab9ceaa3057e8cfee9a47c) | `` Updated flake inputs `` |