### PR TITLE
chore(flake/nur): `48e133aa` -> `5ef30229`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722786543,
-        "narHash": "sha256-GsxxNhE0vOv0w7UzEyFoY12SCefBaYcrmoqDn+Jlr3w=",
+        "lastModified": 1722789338,
+        "narHash": "sha256-N3kjiRvIenSdSMVjtAHyq2Stq+Cy/vs9Qu+iZZSC8+4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "48e133aafdf1dc51679bbf23a36010c5ab7aa666",
+        "rev": "5ef30229522f81aa70d6e6689ef1020eb93ac586",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5ef30229`](https://github.com/nix-community/NUR/commit/5ef30229522f81aa70d6e6689ef1020eb93ac586) | `` automatic update `` |