### PR TITLE
chore(flake/nur): `5ef30229` -> `698dd639`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722789338,
-        "narHash": "sha256-N3kjiRvIenSdSMVjtAHyq2Stq+Cy/vs9Qu+iZZSC8+4=",
+        "lastModified": 1722800704,
+        "narHash": "sha256-5BTf6w2XwDb1rpO9sf4p2XCLC9TyVBV+r5DrsbH9DQ0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5ef30229522f81aa70d6e6689ef1020eb93ac586",
+        "rev": "698dd639d4d825a7e16bb390ee6a24e4f9d97381",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`698dd639`](https://github.com/nix-community/NUR/commit/698dd639d4d825a7e16bb390ee6a24e4f9d97381) | `` automatic update `` |
| [`b21dbe8d`](https://github.com/nix-community/NUR/commit/b21dbe8dc42201d9e60f41a72e9383814bcf257b) | `` automatic update `` |