### PR TITLE
chore(flake/nur): `698dd639` -> `47842720`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722800704,
-        "narHash": "sha256-5BTf6w2XwDb1rpO9sf4p2XCLC9TyVBV+r5DrsbH9DQ0=",
+        "lastModified": 1722804382,
+        "narHash": "sha256-PxqFletWBILWtpDbPSSpJqAKnxyGN+GgsRxxAfDE8xQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "698dd639d4d825a7e16bb390ee6a24e4f9d97381",
+        "rev": "4784272020d8814909f278b59a13e2b3cf63344e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`47842720`](https://github.com/nix-community/NUR/commit/4784272020d8814909f278b59a13e2b3cf63344e) | `` automatic update `` |
| [`161e94cd`](https://github.com/nix-community/NUR/commit/161e94cdfcaf37a3418992abdef5b2537e5ac4ce) | `` automatic update `` |