### PR TITLE
chore(flake/nur): `47842720` -> `d7d84d39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722804382,
-        "narHash": "sha256-PxqFletWBILWtpDbPSSpJqAKnxyGN+GgsRxxAfDE8xQ=",
+        "lastModified": 1722815131,
+        "narHash": "sha256-miH7EE/2kpK/orEH2nqJJZILpCsyOrT0eafA2GsoubE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4784272020d8814909f278b59a13e2b3cf63344e",
+        "rev": "d7d84d3956bbeecfeceb1482942290dab8d3b559",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d7d84d39`](https://github.com/nix-community/NUR/commit/d7d84d3956bbeecfeceb1482942290dab8d3b559) | `` automatic update `` |