### PR TITLE
chore(flake/emacs-overlay): `c217f519` -> `2bc3e071`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722820190,
-        "narHash": "sha256-4HmWzwv0lWveYrDmL/PctlwiqWZMHgI4j0DxZmjKKA8=",
+        "lastModified": 1722823227,
+        "narHash": "sha256-yhFFEqI1OYRaQXWZqsfU2V2X4Br3sBIW/bWBABZln0s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c217f5191c2d09b5f638dddb1e25f5f3091c39bf",
+        "rev": "2bc3e07187f2a800be5bc35e9938a477e6bc6b98",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`2bc3e071`](https://github.com/nix-community/emacs-overlay/commit/2bc3e07187f2a800be5bc35e9938a477e6bc6b98) | `` Updated emacs `` |
| [`3244696b`](https://github.com/nix-community/emacs-overlay/commit/3244696b590895d81fca834984afe6019b386aaf) | `` Updated melpa `` |