### PR TITLE
chore(flake/nur): `d7d84d39` -> `d4f7971a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722815131,
-        "narHash": "sha256-miH7EE/2kpK/orEH2nqJJZILpCsyOrT0eafA2GsoubE=",
+        "lastModified": 1722826128,
+        "narHash": "sha256-5xm226E5pEzrOGBl6e/lC3+ztHbWVp9AwvUFNlZx1tI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d7d84d3956bbeecfeceb1482942290dab8d3b559",
+        "rev": "d4f7971a154b0730b061584d894c563330055f78",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d4f7971a`](https://github.com/nix-community/NUR/commit/d4f7971a154b0730b061584d894c563330055f78) | `` automatic update `` |
| [`e388238b`](https://github.com/nix-community/NUR/commit/e388238bc994f8ffdc141d34280a2ddb2e182883) | `` automatic update `` |