### PR TITLE
chore(flake/nur): `d4f7971a` -> `c191e2ca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722826128,
-        "narHash": "sha256-5xm226E5pEzrOGBl6e/lC3+ztHbWVp9AwvUFNlZx1tI=",
+        "lastModified": 1722829573,
+        "narHash": "sha256-FJCFyUDeveJ8cULKARiZr3diwPjlsmg6d9HHMDjbERI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d4f7971a154b0730b061584d894c563330055f78",
+        "rev": "c191e2ca9f39fb293355a3c53da8a37d86ee1f1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c191e2ca`](https://github.com/nix-community/NUR/commit/c191e2ca9f39fb293355a3c53da8a37d86ee1f1f) | `` automatic update `` |
| [`ddfd2fd0`](https://github.com/nix-community/NUR/commit/ddfd2fd06c4d9f9fff4d0d3f1a652143abdfac35) | `` automatic update `` |