### PR TITLE
chore(flake/nur): `c191e2ca` -> `2fdd27ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722829573,
-        "narHash": "sha256-FJCFyUDeveJ8cULKARiZr3diwPjlsmg6d9HHMDjbERI=",
+        "lastModified": 1722830661,
+        "narHash": "sha256-vjWdcxThB5ukF6+ZAwmgl+RFdly1PwLK8Tow0AEV3UM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c191e2ca9f39fb293355a3c53da8a37d86ee1f1f",
+        "rev": "2fdd27ed1a5d1595ccaf29541534d8bb3a37f75a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2fdd27ed`](https://github.com/nix-community/NUR/commit/2fdd27ed1a5d1595ccaf29541534d8bb3a37f75a) | `` automatic update `` |