### PR TITLE
chore(flake/nur): `2fdd27ed` -> `a439b714`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722830661,
-        "narHash": "sha256-vjWdcxThB5ukF6+ZAwmgl+RFdly1PwLK8Tow0AEV3UM=",
+        "lastModified": 1722836287,
+        "narHash": "sha256-yB49GVFiopmvCBlkfvfZWbQWMmqSSq4q5cP3vuarDHc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2fdd27ed1a5d1595ccaf29541534d8bb3a37f75a",
+        "rev": "a439b7142f7648731df29ac5b18ae556e9efaaa4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a439b714`](https://github.com/nix-community/NUR/commit/a439b7142f7648731df29ac5b18ae556e9efaaa4) | `` automatic update `` |