### PR TITLE
chore(flake/nur): `a439b714` -> `a898d86c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722836287,
-        "narHash": "sha256-yB49GVFiopmvCBlkfvfZWbQWMmqSSq4q5cP3vuarDHc=",
+        "lastModified": 1722838469,
+        "narHash": "sha256-ojRQjLcyo0MpvN7Vu9mEhzQxrPE8Lsc3QDIWbFBV128=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a439b7142f7648731df29ac5b18ae556e9efaaa4",
+        "rev": "a898d86c3f524499778b1ac61e5102ef773bb210",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a898d86c`](https://github.com/nix-community/NUR/commit/a898d86c3f524499778b1ac61e5102ef773bb210) | `` automatic update `` |