### PR TITLE
chore(flake/emacs-overlay): `2bc3e071` -> `98dbb7af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722823227,
-        "narHash": "sha256-yhFFEqI1OYRaQXWZqsfU2V2X4Br3sBIW/bWBABZln0s=",
+        "lastModified": 1722848263,
+        "narHash": "sha256-eTP4pOxiCdl5YmJx3c+JKbcY/ZnMuPLSLyXIr/DFtPM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2bc3e07187f2a800be5bc35e9938a477e6bc6b98",
+        "rev": "98dbb7afc846b67efdb5761e4d6efcd4a4882396",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`98dbb7af`](https://github.com/nix-community/emacs-overlay/commit/98dbb7afc846b67efdb5761e4d6efcd4a4882396) | `` Updated melpa `` |