### PR TITLE
chore(flake/nur): `a898d86c` -> `ef567c82`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722838469,
-        "narHash": "sha256-ojRQjLcyo0MpvN7Vu9mEhzQxrPE8Lsc3QDIWbFBV128=",
+        "lastModified": 1722859145,
+        "narHash": "sha256-Y0X6yzkq5hU/A8MlC9/DfMz1i6mXEauD9539xUkEvo8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a898d86c3f524499778b1ac61e5102ef773bb210",
+        "rev": "ef567c82705d29b0b32d63ffd006c56c92953f4d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ef567c82`](https://github.com/nix-community/NUR/commit/ef567c82705d29b0b32d63ffd006c56c92953f4d) | `` automatic update `` |
| [`65e39219`](https://github.com/nix-community/NUR/commit/65e39219c9c601a8b19e8938d992f5361df1558f) | `` automatic update `` |
| [`00a914ac`](https://github.com/nix-community/NUR/commit/00a914ace91a5ec471523a552c4acb1833a96673) | `` automatic update `` |
| [`2a3f3a3f`](https://github.com/nix-community/NUR/commit/2a3f3a3f34c528ba219bbb26123468344311cff8) | `` automatic update `` |
| [`2c6780f9`](https://github.com/nix-community/NUR/commit/2c6780f99382c0a4282f4e1320b52b4e75bda1c8) | `` automatic update `` |
| [`d17565f4`](https://github.com/nix-community/NUR/commit/d17565f41480cfa04ff355956cf45fa8b6c9fe39) | `` automatic update `` |