### PR TITLE
chore(flake/nur): `ef567c82` -> `f532f647`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722859145,
-        "narHash": "sha256-Y0X6yzkq5hU/A8MlC9/DfMz1i6mXEauD9539xUkEvo8=",
+        "lastModified": 1722862453,
+        "narHash": "sha256-kYfrnK1fUZCrW5qJXgwsRXI0UCFNn5XmApWUeuTYgmU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ef567c82705d29b0b32d63ffd006c56c92953f4d",
+        "rev": "f532f647117954b533a47d2d675d49053e4dacd8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f532f647`](https://github.com/nix-community/NUR/commit/f532f647117954b533a47d2d675d49053e4dacd8) | `` automatic update `` |
| [`448dffbf`](https://github.com/nix-community/NUR/commit/448dffbfa1fe0379fde46bb7ba68d10dc95037d9) | `` automatic update `` |