### PR TITLE
chore(flake/nur): `f532f647` -> `d3ba1125`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722862453,
-        "narHash": "sha256-kYfrnK1fUZCrW5qJXgwsRXI0UCFNn5XmApWUeuTYgmU=",
+        "lastModified": 1722864865,
+        "narHash": "sha256-W271AVeWwMXYRCpTGmdku2/Sg0yfbgylO75/TMVhRnA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f532f647117954b533a47d2d675d49053e4dacd8",
+        "rev": "d3ba11250bf54f978969bdf202560321520ed336",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d3ba1125`](https://github.com/nix-community/NUR/commit/d3ba11250bf54f978969bdf202560321520ed336) | `` automatic update `` |