### PR TITLE
chore(flake/emacs-overlay): `e171f7ac` -> `81e2180f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722849151,
-        "narHash": "sha256-wGqVSf0u1B93PVk1evn2KYCpMxVE9D5a98dv5YwFEjo=",
+        "lastModified": 1722877001,
+        "narHash": "sha256-NhG7b9LfbgiuBTqzdgXtAkGSWXraP9JkO1GQd+Li42E=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e171f7ac85c6aba2463fee6f22288d6d249c9c7a",
+        "rev": "81e2180f4a1c669ff96b084953010c73a028f2fc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`81e2180f`](https://github.com/nix-community/emacs-overlay/commit/81e2180f4a1c669ff96b084953010c73a028f2fc) | `` Updated melpa `` |
| [`cd006b0c`](https://github.com/nix-community/emacs-overlay/commit/cd006b0c4505ce610b8d6b67f6b4e92e9bd794e9) | `` Updated elpa ``  |