### PR TITLE
chore(flake/emacs-overlay): `81e2180f` -> `753eca1c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722877001,
-        "narHash": "sha256-NhG7b9LfbgiuBTqzdgXtAkGSWXraP9JkO1GQd+Li42E=",
+        "lastModified": 1722877946,
+        "narHash": "sha256-jMKkAEQL5AJd1HjjkbqUy851cBYB/8OA1cSdDq8k/x8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "81e2180f4a1c669ff96b084953010c73a028f2fc",
+        "rev": "753eca1ca6316fdeecf81811ca4611cfbcc82758",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`753eca1c`](https://github.com/nix-community/emacs-overlay/commit/753eca1ca6316fdeecf81811ca4611cfbcc82758) | `` Updated emacs `` |