### PR TITLE
chore(flake/nur): `9e2de53c` -> `f80e85e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722876350,
-        "narHash": "sha256-v3C2N6m7ewIc5pDcG28Zv40VNu+aEf0iAcpPCQV8RQE=",
+        "lastModified": 1722883188,
+        "narHash": "sha256-IahHa5WnNaiY7UANpVPgEWhQ9Yha9AWVBzckEs4twFw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9e2de53ce79922e20b330224d4014dabe134f068",
+        "rev": "f80e85e5a4f92e6aee6fd09c1c704425b48e9f8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f80e85e5`](https://github.com/nix-community/NUR/commit/f80e85e5a4f92e6aee6fd09c1c704425b48e9f8b) | `` automatic update `` |