### PR TITLE
chore(flake/nur): `f80e85e5` -> `1261ebf6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722883188,
-        "narHash": "sha256-IahHa5WnNaiY7UANpVPgEWhQ9Yha9AWVBzckEs4twFw=",
+        "lastModified": 1722894411,
+        "narHash": "sha256-OUOJ/dglPQ/YAN/zYAdEzzhSUv84QF8px9JT4eQb4GA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f80e85e5a4f92e6aee6fd09c1c704425b48e9f8b",
+        "rev": "1261ebf63933d763c7eb2e3290782cf09d045fdb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1261ebf6`](https://github.com/nix-community/NUR/commit/1261ebf63933d763c7eb2e3290782cf09d045fdb) | `` automatic update `` |
| [`2c614d44`](https://github.com/nix-community/NUR/commit/2c614d442fde83f661dc1df40c518ede77140d41) | `` automatic update `` |