### PR TITLE
chore(flake/sops-nix): `eb34eb58` -> `8ae47795`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -894,11 +894,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1722114803,
-        "narHash": "sha256-s6YhI8UHwQvO4cIFLwl1wZ1eS5Cuuw7ld2VzUchdFP0=",
+        "lastModified": 1722897572,
+        "narHash": "sha256-3m/iyyjCdRBF8xyehf59QlckIcmShyTesymSb+N4Ap4=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "eb34eb588132d653e4c4925d862f1e5a227cc2ab",
+        "rev": "8ae477955dfd9cbf5fa4eb82a8db8ddbb94e79d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                        |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`8ae47795`](https://github.com/Mic92/sops-nix/commit/8ae477955dfd9cbf5fa4eb82a8db8ddbb94e79d9) | `` update vendorHash ``                                        |
| [`5d647b00`](https://github.com/Mic92/sops-nix/commit/5d647b003990ae09c09580eb724da2ed39c7ddce) | `` build(deps): bump golang.org/x/sys from 0.22.0 to 0.23.0 `` |