### PR TITLE
chore(flake/emacs-overlay): `753eca1c` -> `92d8f0cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722877946,
-        "narHash": "sha256-jMKkAEQL5AJd1HjjkbqUy851cBYB/8OA1cSdDq8k/x8=",
+        "lastModified": 1722906480,
+        "narHash": "sha256-QroR28EocfWyblzqQuUjr0Vt/3vOy4CrW0NAW05+Xqc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "753eca1ca6316fdeecf81811ca4611cfbcc82758",
+        "rev": "92d8f0cb018def3ab20d5f9946dfc3526ef391da",
         "type": "github"
       },
       "original": {
@@ -700,11 +700,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1722651103,
-        "narHash": "sha256-IRiJA0NVAoyaZeKZluwfb2DoTpBAj+FLI0KfybBeDU0=",
+        "lastModified": 1722791413,
+        "narHash": "sha256-rCTrlCWvHzMCNcKxPE3Z/mMK2gDZ+BvvpEVyRM4tKmU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a633d89c6dc9a2a8aae11813a62d7c58b2c0cc51",
+        "rev": "8b5b6723aca5a51edf075936439d9cd3947b7b2c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`92d8f0cb`](https://github.com/nix-community/emacs-overlay/commit/92d8f0cb018def3ab20d5f9946dfc3526ef391da) | `` Updated elpa ``         |
| [`2fe70a73`](https://github.com/nix-community/emacs-overlay/commit/2fe70a73dc88db5a07ea2032ce6d2c179ccd37dc) | `` Updated nongnu ``       |
| [`5192fb12`](https://github.com/nix-community/emacs-overlay/commit/5192fb127c3eec5ed54178aacdc127a22681d256) | `` Updated flake inputs `` |