### PR TITLE
chore(flake/nur): `1261ebf6` -> `33a10c85`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722894411,
-        "narHash": "sha256-OUOJ/dglPQ/YAN/zYAdEzzhSUv84QF8px9JT4eQb4GA=",
+        "lastModified": 1722913243,
+        "narHash": "sha256-O70STkohfF57h2ABLISvZIdzPZSrKPPEQ7cV+ctBXts=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1261ebf63933d763c7eb2e3290782cf09d045fdb",
+        "rev": "33a10c85b0b195632be41f3a3a180a516686448d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`33a10c85`](https://github.com/nix-community/NUR/commit/33a10c85b0b195632be41f3a3a180a516686448d) | `` automatic update `` |
| [`da675171`](https://github.com/nix-community/NUR/commit/da675171e9cb7852d2e775afdec892ac25539fc9) | `` automatic update `` |
| [`612d60a7`](https://github.com/nix-community/NUR/commit/612d60a7ff424d5ea5dde60881bcf0edb0e34cd2) | `` automatic update `` |