### PR TITLE
chore(flake/nur): `33a10c85` -> `ad992cc1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722913243,
-        "narHash": "sha256-O70STkohfF57h2ABLISvZIdzPZSrKPPEQ7cV+ctBXts=",
+        "lastModified": 1722915972,
+        "narHash": "sha256-KeRPkg4TZMKfI79xjpUW/PnW9qQedrr32zSVkzufBBw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "33a10c85b0b195632be41f3a3a180a516686448d",
+        "rev": "ad992cc1a47c15c24126b9966a76665e3e71b128",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ad992cc1`](https://github.com/nix-community/NUR/commit/ad992cc1a47c15c24126b9966a76665e3e71b128) | `` automatic update `` |