### PR TITLE
chore(flake/nur): `ad992cc1` -> `647b6650`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722915972,
-        "narHash": "sha256-KeRPkg4TZMKfI79xjpUW/PnW9qQedrr32zSVkzufBBw=",
+        "lastModified": 1722918018,
+        "narHash": "sha256-SQ9cHHQK5dCfwA1wDaxTEtLfvIp/r4gTQDu5X7YLL34=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ad992cc1a47c15c24126b9966a76665e3e71b128",
+        "rev": "647b6650052d9384149d631f44b88aa0bf64ddf7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`647b6650`](https://github.com/nix-community/NUR/commit/647b6650052d9384149d631f44b88aa0bf64ddf7) | `` automatic update `` |
| [`6a61d252`](https://github.com/nix-community/NUR/commit/6a61d252c5f255310912453d47f44207ba0876cf) | `` automatic update `` |