### PR TITLE
chore(flake/nixpkgs): `d0495308` -> `cb9a96f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -748,11 +748,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1722630782,
-        "narHash": "sha256-hMyG9/WlUi0Ho9VkRrrez7SeNlDzLxalm9FwY7n/Noo=",
+        "lastModified": 1722813957,
+        "narHash": "sha256-IAoYyYnED7P8zrBFMnmp7ydaJfwTnwcnqxUElC1I26Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d04953086551086b44b6f3c6b7eeb26294f207da",
+        "rev": "cb9a96f23c491c081b38eab96d22fa958043c9fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`1714981f`](https://github.com/NixOS/nixpkgs/commit/1714981f49ebed15d0ca748ea14d84eae62ce0a0) | `` tinymist: 0.11.16 -> 0.11.18 ``                                              |
| [`2f2010f6`](https://github.com/NixOS/nixpkgs/commit/2f2010f63cc0550d9fb1d313e61f96b20a3f731f) | `` msmtp: 1.8.22 -> 1.8.25 ``                                                   |
| [`1efde08d`](https://github.com/NixOS/nixpkgs/commit/1efde08d47fe58a89f296b8f3008322436bfbdac) | `` msmtp: update repo URL ``                                                    |
| [`d7302093`](https://github.com/NixOS/nixpkgs/commit/d7302093dace41b03b54aec34f1c41cdd25bbead) | `` bluesnarfer: init at 0.1 ``                                                  |
| [`d01aeead`](https://github.com/NixOS/nixpkgs/commit/d01aeead73e66279a2da7a3486888f01221b50f6) | `` halo: 2.17.2 -> 2.18.0 ``                                                    |
| [`11fb6504`](https://github.com/NixOS/nixpkgs/commit/11fb6504ee2196c35d3c182e0b547e6eb159147f) | `` qrtool: 0.11.3 -> 0.11.4 ``                                                  |
| [`04812261`](https://github.com/NixOS/nixpkgs/commit/04812261f57e4ddc877fc6e5c80174e7fe1e6c5f) | `` alpaca-proxy: init at 2.0.9 ``                                               |
| [`4635f438`](https://github.com/NixOS/nixpkgs/commit/4635f43856b5dbe99c81414f347fecf8340b71eb) | `` maintainers: add 1nv0k32 ``                                                  |
| [`c049585e`](https://github.com/NixOS/nixpkgs/commit/c049585eafa9ad783a5636147bc9f19236a383d7) | `` python312Packages.fastcore: 1.6.1 -> 1.6.2 ``                                |
| [`fb78d2fa`](https://github.com/NixOS/nixpkgs/commit/fb78d2fa03d46f5338c9aa6b6ba305fc595cdab5) | `` python312Packages.grpcio-health-checking: 1.65.1 -> 1.65.4 ``                |
| [`3a719e06`](https://github.com/NixOS/nixpkgs/commit/3a719e06c700c84ec93bfd6c1f4da2f1c8ee21d6) | `` nixos/mediawiki: move to php 8.2 ``                                          |
| [`90cdc2af`](https://github.com/NixOS/nixpkgs/commit/90cdc2afab40aae177e4bafd16f35b3a71a7283b) | `` python312Packages.pypinyin: 0.51.0 -> 0.52.0 ``                              |
| [`160b1737`](https://github.com/NixOS/nixpkgs/commit/160b173705f3f5686a9a2058ec16e8ce1e1229e5) | `` python312Packages.gamble: 0.13 -> 0.14.0 ``                                  |
| [`0b6a95fb`](https://github.com/NixOS/nixpkgs/commit/0b6a95fb6280a14e7994fa9c140de5aa17c8d32c) | `` metals: 1.3.4 -> 1.3.5 ``                                                    |
| [`bf74ddc5`](https://github.com/NixOS/nixpkgs/commit/bf74ddc5f21ac051de69146d46d34c0937ece570) | `` just: 1.32.0 -> 1.34.0 ``                                                    |
| [`cf887aa1`](https://github.com/NixOS/nixpkgs/commit/cf887aa12d08a1adc4e23396591d8aea9d1e8b3e) | `` ktailctl: 0.17.1 -> 0.17.2 ``                                                |
| [`2ae76df4`](https://github.com/NixOS/nixpkgs/commit/2ae76df49e315fb3529eb70cbf3e2b763f53882c) | `` python312Packages.grpcio-reflection: 1.65.1 -> 1.65.4 ``                     |
| [`c78eab1d`](https://github.com/NixOS/nixpkgs/commit/c78eab1d149491c695fc65898c80ae1055ebc24e) | `` python312Packages.grpcio-channelz: 1.65.1 -> 1.65.4 ``                       |
| [`2f0e580a`](https://github.com/NixOS/nixpkgs/commit/2f0e580ad336889ba2c6789f38f177090d97b1a4) | `` python312Packages.grpcio-testing: 1.65.1 -> 1.65.4 ``                        |
| [`2fec6104`](https://github.com/NixOS/nixpkgs/commit/2fec6104fefe6baf4e020e266ddd585969d78192) | `` python312Packages.imread: refactor ``                                        |
| [`27df88c4`](https://github.com/NixOS/nixpkgs/commit/27df88c488a4fbcf642084bcc6641590465f6cd4) | `` python312Packages.neo: refactor ``                                           |
| [`aef47a2d`](https://github.com/NixOS/nixpkgs/commit/aef47a2d1b519dea7d7633fad9eef824b81b3aa0) | `` cosmic-icons: 0-unstable-2024-07-04 -> 0-unstable-2024-08-04 ``              |
| [`387225c2`](https://github.com/NixOS/nixpkgs/commit/387225c2735a2da667e82dcb64955601fbeec02d) | `` metasploit: 6.4.18 -> 6.4.20 ``                                              |
| [`e85e1bc0`](https://github.com/NixOS/nixpkgs/commit/e85e1bc098be4f24554e40adc7a6b35a0957364b) | `` python312Packages.diagrams-as-code: init at 0.0.4 ``                         |
| [`a0a64800`](https://github.com/NixOS/nixpkgs/commit/a0a6480042b517197a77b96b6b12ade26af35f60) | `` vscode-extensions.github.copilot-chat: 0.17.2024062801 -> 0.19.2024073102 `` |
| [`69e6cb01`](https://github.com/NixOS/nixpkgs/commit/69e6cb019d1650d830e0564951cec72125064854) | `` vscode-extensions.github.copilot: 1.219.1019 -> 1.219.1028 ``                |
| [`3e3b4c91`](https://github.com/NixOS/nixpkgs/commit/3e3b4c910c50d30045f0d24684477a309d71e4d6) | `` hmcl: 3.5.8 -> 3.5.9 ``                                                      |
| [`9551c76e`](https://github.com/NixOS/nixpkgs/commit/9551c76ef59922514719db6a6466ccd85bf69def) | `` python312Packages.imread: 0.7.5 -> 0.7.6 ``                                  |
| [`aae29fb6`](https://github.com/NixOS/nixpkgs/commit/aae29fb61395143b66fc6ae65ca331dd2ecf6f5e) | `` python312Packages.neo: 0.13.1 -> 0.13.2 ``                                   |
| [`285ee47a`](https://github.com/NixOS/nixpkgs/commit/285ee47a61618cbb94ecb0521b0f0699197138e6) | `` age-plugin-yubikey: 0.4.0 -> 0.5.0 ``                                        |
| [`2bb68103`](https://github.com/NixOS/nixpkgs/commit/2bb681036a342b1cebfc1ec59bf70fbbc5de9f4b) | `` asm-lsp: 0.7.3 -> 0.7.4 ``                                                   |
| [`e51da07c`](https://github.com/NixOS/nixpkgs/commit/e51da07c01f082367d11c2f16c198e508e8c4389) | `` handlr-regex: 0.10.1 -> 0.11.2 ``                                            |
| [`dd2019b0`](https://github.com/NixOS/nixpkgs/commit/dd2019b0c0d3e2be73e386171886442c1b0fe456) | `` tandem-aligner: move to by-name ``                                           |
| [`a2a6e797`](https://github.com/NixOS/nixpkgs/commit/a2a6e797ac0a5b136b93eb4437fd4f3ce4c787c0) | `` scriv: move to by-name ``                                                    |
| [`444a6ef6`](https://github.com/NixOS/nixpkgs/commit/444a6ef6616838c19a9ac728eccb7f8ef48241bd) | `` latte-integrale: move to by-name ``                                          |
| [`0f05f31b`](https://github.com/NixOS/nixpkgs/commit/0f05f31b4dea7ee3461c162fbe6dde2f5b035027) | `` gh-markdown-preview: move to by-name ``                                      |
| [`5781e6b0`](https://github.com/NixOS/nixpkgs/commit/5781e6b0049bf47e5d46196147842f3fcfa26c72) | `` gh-dash: move to by-name ``                                                  |
| [`9ca37768`](https://github.com/NixOS/nixpkgs/commit/9ca37768272983b28ee60cd4815b3a6fe55c3825) | `` gh-actions-cache: move to by-name ``                                         |
| [`13a894ff`](https://github.com/NixOS/nixpkgs/commit/13a894ff1ced5e49359bff45b46e368b05dfd299) | `` cddl: move to by-name ``                                                     |
| [`52ec421a`](https://github.com/NixOS/nixpkgs/commit/52ec421a000b621f2097e89944f07f1260c760bb) | `` bazecor: move to by-name ``                                                  |
| [`53bdde49`](https://github.com/NixOS/nixpkgs/commit/53bdde4918abe5915e3a13a5e701f866143ac003) | `` ledger-live-desktop: 2.84.0 -> 2.84.1 ``                                     |
| [`11da2254`](https://github.com/NixOS/nixpkgs/commit/11da2254d641e8a6aac5d8eae41bdc5feec7ba3f) | `` python312Packages.rapidfuzz: 3.9.4 -> 3.9.5 ``                               |
| [`7bd0f2e9`](https://github.com/NixOS/nixpkgs/commit/7bd0f2e9bf478c9f9bbe99b38c15273a18f87a14) | `` ngrok: 3.13.0 -> 3.14.0 ``                                                   |
| [`04564a10`](https://github.com/NixOS/nixpkgs/commit/04564a105690cc2e03ec20f771905ca359773d6f) | `` git-machete: 3.26.2 -> 3.26.3 ``                                             |
| [`67a87cc4`](https://github.com/NixOS/nixpkgs/commit/67a87cc4c9bc6173b0261fe8104fabc29b5087f1) | `` libxlsxwriter: 1.1.7 -> 1.1.8 ``                                             |
| [`5dee280b`](https://github.com/NixOS/nixpkgs/commit/5dee280b3d58edcca363e1297176256a79e33c7c) | `` python312Packages.breathe: modernize ``                                      |
| [`a2424528`](https://github.com/NixOS/nixpkgs/commit/a2424528a569987f39d38742454c09d2f4f6aa6f) | `` nixosTests.pixelfed: remove unused function argument ``                      |
| [`96f5069d`](https://github.com/NixOS/nixpkgs/commit/96f5069dd04003ad40c9e08747317336642386d3) | `` planify: 4.9.0 -> 4.10.5 ``                                                  |
| [`31ffcd4e`](https://github.com/NixOS/nixpkgs/commit/31ffcd4e6297c8536f2aa4457fa146ff62c32b99) | `` git-cola: 4.8.0 -> 4.8.1 ``                                                  |
| [`fefc54e7`](https://github.com/NixOS/nixpkgs/commit/fefc54e71e05d788c4a7d5709cc8af46689e9844) | `` mesonlsp: 4.3.1 -> 4.3.2 ``                                                  |
| [`5e763e94`](https://github.com/NixOS/nixpkgs/commit/5e763e941ced878490c6c9f5dccdc346237b360c) | `` networkmanager: 1.48.4 -> 1.48.6 ``                                          |
| [`e9cd65dd`](https://github.com/NixOS/nixpkgs/commit/e9cd65dd16c1b0631d0554a727d9e84a7a69cf67) | `` libserdes: 7.6.2 -> 7.7.0 ``                                                 |
| [`319b2cb3`](https://github.com/NixOS/nixpkgs/commit/319b2cb3aa6a9f97f770d7a00dacf6236b36c97c) | `` b4: 0.14.0 -> 0.14.1 ``                                                      |
| [`959058c2`](https://github.com/NixOS/nixpkgs/commit/959058c2c87978acd350227692151e4a0316c72b) | `` linuxManualConfig: remove "$src is not a directory" logspam ``               |
| [`d97365e0`](https://github.com/NixOS/nixpkgs/commit/d97365e05e847554a7c51146a059a750cc9ceed4) | `` gitea.passthru.data-compressed: switch to compressDrvWeb ``                  |
| [`bbd0655a`](https://github.com/NixOS/nixpkgs/commit/bbd0655ae828b9f1cf39d891b52aa6506394ef46) | `` add compressDrv and compressDrvWeb ``                                        |
| [`6a0b3c2c`](https://github.com/NixOS/nixpkgs/commit/6a0b3c2ccb650f7d4690a9443c37c8b34c484b07) | `` python312Packages.scalene: 1.5.42.2 -> 1.5.43.2 ``                           |
| [`a67c67f2`](https://github.com/NixOS/nixpkgs/commit/a67c67f2371e2f4649fb2839a630846086fee8bd) | `` python312Packages.conda: 24.7.0 -> 24.7.1 ``                                 |
| [`a67c42c7`](https://github.com/NixOS/nixpkgs/commit/a67c42c7585fa71e25750e1d45d4e94f0d4f0aaa) | `` scalene: 1.5.42.2 -> 1.5.43.2 ``                                             |
| [`7519a619`](https://github.com/NixOS/nixpkgs/commit/7519a61915940841a2287be13615b3554d000c24) | `` jmol: 16.2.19 -> 16.2.21 ``                                                  |
| [`0b07b7e4`](https://github.com/NixOS/nixpkgs/commit/0b07b7e4b7a0d6d160e8b1a2296105d1e7a8719e) | `` llvmPackages: fix wasm with common opts ``                                   |
| [`6729e033`](https://github.com/NixOS/nixpkgs/commit/6729e0336d95cf477c3a4d3980fb2755c7c494c9) | `` elixir-ls: 0.21.3 -> 0.23.0 ``                                               |