### PR TITLE
chore(flake/nur): `647b6650` -> `a8c59fb3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722918018,
-        "narHash": "sha256-SQ9cHHQK5dCfwA1wDaxTEtLfvIp/r4gTQDu5X7YLL34=",
+        "lastModified": 1722923094,
+        "narHash": "sha256-+WdMDwfdhnRFxlHR0BLqxA3Y55h9GJIH7lYscpV7COI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "647b6650052d9384149d631f44b88aa0bf64ddf7",
+        "rev": "a8c59fb337460c3b7e8132146ff027f613877c72",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a8c59fb3`](https://github.com/nix-community/NUR/commit/a8c59fb337460c3b7e8132146ff027f613877c72) | `` automatic update `` |
| [`01c95d61`](https://github.com/nix-community/NUR/commit/01c95d61fc11b97a374fda8607bc089136e80878) | `` automatic update `` |
| [`8e9bb8de`](https://github.com/nix-community/NUR/commit/8e9bb8de393bff11193da86b3d0763e392d1bff4) | `` automatic update `` |
| [`cb91cfc6`](https://github.com/nix-community/NUR/commit/cb91cfc6ecf60316cf2537c6dd169338adffc627) | `` automatic update `` |