### PR TITLE
chore(flake/nur): `a8c59fb3` -> `36a0288f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722923094,
-        "narHash": "sha256-+WdMDwfdhnRFxlHR0BLqxA3Y55h9GJIH7lYscpV7COI=",
+        "lastModified": 1722931126,
+        "narHash": "sha256-kHtLrwlv18yBw382BylYyxuKPTtm5tvlrRn/FRMsYqw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a8c59fb337460c3b7e8132146ff027f613877c72",
+        "rev": "36a0288f44efcb9013f89d4adc39ef2246982968",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`36a0288f`](https://github.com/nix-community/NUR/commit/36a0288f44efcb9013f89d4adc39ef2246982968) | `` automatic update `` |
| [`17d1ac0a`](https://github.com/nix-community/NUR/commit/17d1ac0a926cbca73c5e556683df16bd2e83b697) | `` automatic update `` |
| [`8d43df99`](https://github.com/nix-community/NUR/commit/8d43df9916996fed8eeff0aa87deac7105f0e22f) | `` automatic update `` |