### PR TITLE
chore(flake/emacs-overlay): `c051c42e` -> `68aae509`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722909529,
-        "narHash": "sha256-GNSbAD9a4zzd7Ir9qgeY9wbeqywh4vvqQz6iFw2/4HU=",
+        "lastModified": 1722936341,
+        "narHash": "sha256-CG8zrFRt+oQr9SaFALAEopI36wNaqdD/VHRmCUpmXmE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c051c42e3325ac62e9bf83e72e3868db1e5f2e64",
+        "rev": "68aae5094b61dad45fb75d67e4a8adcc90c54b55",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`68aae509`](https://github.com/nix-community/emacs-overlay/commit/68aae5094b61dad45fb75d67e4a8adcc90c54b55) | `` Updated emacs ``        |
| [`c64683db`](https://github.com/nix-community/emacs-overlay/commit/c64683db9939ee81ad836528d77d366498c66c92) | `` Updated melpa ``        |
| [`991746cb`](https://github.com/nix-community/emacs-overlay/commit/991746cb534d11cab851c1902a4206f8007361a4) | `` Updated flake inputs `` |