### PR TITLE
chore(flake/nur): `36a0288f` -> `8aee730a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722931126,
-        "narHash": "sha256-kHtLrwlv18yBw382BylYyxuKPTtm5tvlrRn/FRMsYqw=",
+        "lastModified": 1722934043,
+        "narHash": "sha256-x0ENypK+dOo3JDcd0czNORLaEikIcp+iNPhhIG4CZtI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "36a0288f44efcb9013f89d4adc39ef2246982968",
+        "rev": "8aee730aaaf99ba00e8d84c9383ebb9b6fc67cc4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8aee730a`](https://github.com/nix-community/NUR/commit/8aee730aaaf99ba00e8d84c9383ebb9b6fc67cc4) | `` automatic update `` |