### PR TITLE
chore(flake/nur): `8aee730a` -> `4f0cf621`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722934043,
-        "narHash": "sha256-x0ENypK+dOo3JDcd0czNORLaEikIcp+iNPhhIG4CZtI=",
+        "lastModified": 1722936537,
+        "narHash": "sha256-Ux0Ko4h7mSTbU4y7t5d7bovxtpJ+iByEomDvAPg/JUQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8aee730aaaf99ba00e8d84c9383ebb9b6fc67cc4",
+        "rev": "4f0cf621f5753d763dfac977f150c98ed9ed202e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4f0cf621`](https://github.com/nix-community/NUR/commit/4f0cf621f5753d763dfac977f150c98ed9ed202e) | `` automatic update `` |