### PR TITLE
chore(flake/nur): `4f0cf621` -> `8371879f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722936537,
-        "narHash": "sha256-Ux0Ko4h7mSTbU4y7t5d7bovxtpJ+iByEomDvAPg/JUQ=",
+        "lastModified": 1722949215,
+        "narHash": "sha256-4Ao2/PWWOrgvEsl62CjaLm+C1zu+UIOn0wgc/wD3vDM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4f0cf621f5753d763dfac977f150c98ed9ed202e",
+        "rev": "8371879f42fa4f71a16fa281cb4b6a72f5b735a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8371879f`](https://github.com/nix-community/NUR/commit/8371879f42fa4f71a16fa281cb4b6a72f5b735a0) | `` automatic update `` |
| [`addaf31c`](https://github.com/nix-community/NUR/commit/addaf31cf82a1c17f71918f7f4b668d34ccbfee0) | `` automatic update `` |