### PR TITLE
chore(flake/nur): `8371879f` -> `27d15481`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722949215,
-        "narHash": "sha256-4Ao2/PWWOrgvEsl62CjaLm+C1zu+UIOn0wgc/wD3vDM=",
+        "lastModified": 1722951671,
+        "narHash": "sha256-4EKAkwPSN7kOWrBglJL172C0JSYau8j/pGlAHsr/MZY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8371879f42fa4f71a16fa281cb4b6a72f5b735a0",
+        "rev": "27d15481046b72fca9ba4712be82ca8453359d67",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`27d15481`](https://github.com/nix-community/NUR/commit/27d15481046b72fca9ba4712be82ca8453359d67) | `` automatic update `` |