### PR TITLE
chore(flake/nur): `27d15481` -> `bca4a289`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722951671,
-        "narHash": "sha256-4EKAkwPSN7kOWrBglJL172C0JSYau8j/pGlAHsr/MZY=",
+        "lastModified": 1722959180,
+        "narHash": "sha256-t8gWve5gzFJ7rkRyS7wCVrAshUtiIGxebSFzsacawvs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "27d15481046b72fca9ba4712be82ca8453359d67",
+        "rev": "bca4a289a944eb9aba71e500080945fb464a2c8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bca4a289`](https://github.com/nix-community/NUR/commit/bca4a289a944eb9aba71e500080945fb464a2c8b) | `` automatic update `` |
| [`9e275c94`](https://github.com/nix-community/NUR/commit/9e275c94ecfc1fe5e0e1d910bd309a45be0b1fd2) | `` automatic update `` |
| [`9ad1c39e`](https://github.com/nix-community/NUR/commit/9ad1c39ef821354a1ae5330958799b1ea678c9c6) | `` automatic update `` |