### PR TITLE
chore(flake/emacs-overlay): `68aae509` -> `4d209acb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722936341,
-        "narHash": "sha256-CG8zrFRt+oQr9SaFALAEopI36wNaqdD/VHRmCUpmXmE=",
+        "lastModified": 1722963425,
+        "narHash": "sha256-waxrc7ecBHeMo7mwbQ6Reg/YRfmObUib2HEqGYUSd3o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "68aae5094b61dad45fb75d67e4a8adcc90c54b55",
+        "rev": "4d209acba3b48dd6b549a34f7a7850e479e9a1f5",
         "type": "github"
       },
       "original": {
@@ -684,11 +684,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1722791413,
-        "narHash": "sha256-rCTrlCWvHzMCNcKxPE3Z/mMK2gDZ+BvvpEVyRM4tKmU=",
+        "lastModified": 1722869614,
+        "narHash": "sha256-7ojM1KSk3mzutD7SkrdSflHXEujPvW1u7QuqWoTLXQU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8b5b6723aca5a51edf075936439d9cd3947b7b2c",
+        "rev": "883180e6550c1723395a3a342f830bfc5c371f6b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`4d209acb`](https://github.com/nix-community/emacs-overlay/commit/4d209acba3b48dd6b549a34f7a7850e479e9a1f5) | `` Updated melpa ``        |
| [`729001bd`](https://github.com/nix-community/emacs-overlay/commit/729001bdfa6be842db28371833d1aecb93324cf8) | `` Updated elpa ``         |
| [`d9c36fe0`](https://github.com/nix-community/emacs-overlay/commit/d9c36fe040d003915246c2c1708e12d2c19fe8d6) | `` Updated flake inputs `` |