### PR TITLE
chore(flake/nur): `bca4a289` -> `8942c6a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722959180,
-        "narHash": "sha256-t8gWve5gzFJ7rkRyS7wCVrAshUtiIGxebSFzsacawvs=",
+        "lastModified": 1722970094,
+        "narHash": "sha256-NsRpRtx67ZcWz73S2/MN2b84otMC6tZIcXeDl6g7KZU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bca4a289a944eb9aba71e500080945fb464a2c8b",
+        "rev": "8942c6a9fef82d91c18d8f5f34e164bde628d8bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8942c6a9`](https://github.com/nix-community/NUR/commit/8942c6a9fef82d91c18d8f5f34e164bde628d8bc) | `` automatic update `` |
| [`53890dce`](https://github.com/nix-community/NUR/commit/53890dce0d75f604734289bea72835f7975fee82) | `` automatic update `` |
| [`a9a00bc3`](https://github.com/nix-community/NUR/commit/a9a00bc38734f053d434ee3797ec637b4429d0d7) | `` automatic update `` |