### PR TITLE
chore(flake/nur): `8942c6a9` -> `919d59cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722970094,
-        "narHash": "sha256-NsRpRtx67ZcWz73S2/MN2b84otMC6tZIcXeDl6g7KZU=",
+        "lastModified": 1722973540,
+        "narHash": "sha256-fgdFMMOKhmKZoZVgL+V49TtOY0j+oZrZ9JmbEXzTgAs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8942c6a9fef82d91c18d8f5f34e164bde628d8bc",
+        "rev": "919d59ccb946a81d9ccb879f4cf1638f0d21a2b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`919d59cc`](https://github.com/nix-community/NUR/commit/919d59ccb946a81d9ccb879f4cf1638f0d21a2b4) | `` automatic update `` |