### PR TITLE
chore(flake/nur): `919d59cc` -> `315c48e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722973540,
-        "narHash": "sha256-fgdFMMOKhmKZoZVgL+V49TtOY0j+oZrZ9JmbEXzTgAs=",
+        "lastModified": 1722976219,
+        "narHash": "sha256-ggIGbaqOP3N/+aezX3y4K0kbmrsYaJl/8ThC0Jq1it4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "919d59ccb946a81d9ccb879f4cf1638f0d21a2b4",
+        "rev": "315c48e6c9acb95b4af6492015d36ef1b7b99dfc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`315c48e6`](https://github.com/nix-community/NUR/commit/315c48e6c9acb95b4af6492015d36ef1b7b99dfc) | `` automatic update `` |