### PR TITLE
chore(flake/nur): `315c48e6` -> `ee1bb9cd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722976219,
-        "narHash": "sha256-ggIGbaqOP3N/+aezX3y4K0kbmrsYaJl/8ThC0Jq1it4=",
+        "lastModified": 1722981144,
+        "narHash": "sha256-JX33xSOsMwV8hq6tiEZyPcRwd12wXV1jPPMY0HwqBbk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "315c48e6c9acb95b4af6492015d36ef1b7b99dfc",
+        "rev": "ee1bb9cdd57a86933f2fa2f6f55f5b1e00fa8458",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ee1bb9cd`](https://github.com/nix-community/NUR/commit/ee1bb9cdd57a86933f2fa2f6f55f5b1e00fa8458) | `` automatic update `` |