### PR TITLE
chore(flake/nur): `ee1bb9cd` -> `7f17320e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722981144,
-        "narHash": "sha256-JX33xSOsMwV8hq6tiEZyPcRwd12wXV1jPPMY0HwqBbk=",
+        "lastModified": 1722983903,
+        "narHash": "sha256-oXkWXGd8KAiDk5m2h14bPAxGacr6rr+1ntamMKIx3Ao=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ee1bb9cdd57a86933f2fa2f6f55f5b1e00fa8458",
+        "rev": "7f17320e32ae086f28142a202fdb5215330f6e7e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7f17320e`](https://github.com/nix-community/NUR/commit/7f17320e32ae086f28142a202fdb5215330f6e7e) | `` automatic update `` |