### PR TITLE
chore(flake/srvos): `46a59095` -> `9a04d749`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -897,11 +897,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722473484,
-        "narHash": "sha256-gl0NnSdNwjuAgIHfmGSVx/2jKHNfN5ie8Ex6OTjfczY=",
+        "lastModified": 1722983604,
+        "narHash": "sha256-7Yo5QjEmMHqooWbkXa89T4wVP2aMkoRRgwvIut3pKDs=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "46a59095dc9228a945bf1ee8160b397eb502ad6c",
+        "rev": "9a04d749012b32595b74f56507c1b616809eca37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                   |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`9a04d749`](https://github.com/nix-community/srvos/commit/9a04d749012b32595b74f56507c1b616809eca37) | `` Reapply "ci: remove `max-jobs = 0`" `` |
| [`f8143e66`](https://github.com/nix-community/srvos/commit/f8143e660e90f954400869c9ba3ad3583c6f39ab) | `` dev/private/flake.lock: Update ``      |
| [`aa6613a3`](https://github.com/nix-community/srvos/commit/aa6613a37f2169b6099167766d20027fd0ae1bd9) | `` flake.lock: Update ``                  |
| [`ca4899d7`](https://github.com/nix-community/srvos/commit/ca4899d7a411ac71489c368599d20addb9e842e9) | `` chore(flake): update mkdocs-numtide `` |