### PR TITLE
chore(flake/catppuccin): `19a0f144` -> `7e23de35`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1722661201,
-        "narHash": "sha256-2JX3S1hmmUhHuyGyGWnaM4xT0SiaDdVkNzmBrEowwK0=",
+        "lastModified": 1722993668,
+        "narHash": "sha256-JEYvxkXeU2EIuzCcvwoGTvOxvLNa/morO0IMVc2YQ6w=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "19a0f144f0204a12a89243363efb6a493b8cfc83",
+        "rev": "7e23de352f519067ea88db869e9aa14222290a73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                                 |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`7e23de35`](https://github.com/catppuccin/nix/commit/7e23de352f519067ea88db869e9aa14222290a73) | `` feat(home-manager): add support for fuzzel (#75) ``                                  |
| [`512306ae`](https://github.com/catppuccin/nix/commit/512306ae5848d11a9b38afe4680b69e4908648a2) | `` fix(home-manager/hyprland): inherit cursor size, unset hyprcursor env vars (#299) `` |