### PR TITLE
chore(flake/emacs-overlay): `1a0e4480` -> `48fbdaaa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722964308,
-        "narHash": "sha256-EmSqUCbv8uqz5WiE5zk/I443UXUyvyE5K4uD7H1AV1c=",
+        "lastModified": 1722995092,
+        "narHash": "sha256-o9qpu0zYPjw1CZtXvvdxWgaY8MQnCK3+ZGJBNp8mUn4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1a0e4480b35557950f3f427888da596d85fbdbf1",
+        "rev": "48fbdaaa312e0fcbfcf2230ba3067777da5cfb0c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`48fbdaaa`](https://github.com/nix-community/emacs-overlay/commit/48fbdaaa312e0fcbfcf2230ba3067777da5cfb0c) | `` Updated melpa ``  |
| [`06a06134`](https://github.com/nix-community/emacs-overlay/commit/06a061346d80c189652b5e0cc934c7d8daccec01) | `` Updated elpa ``   |
| [`8dcb52e5`](https://github.com/nix-community/emacs-overlay/commit/8dcb52e51154802065d574ef74e9baeaa356a66b) | `` Updated nongnu `` |