### PR TITLE
chore(flake/catppuccin): `7e23de35` -> `66f4ea17`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1722993668,
-        "narHash": "sha256-JEYvxkXeU2EIuzCcvwoGTvOxvLNa/morO0IMVc2YQ6w=",
+        "lastModified": 1722997334,
+        "narHash": "sha256-vE5FcKVQ3E0txJKt5w3vOlfcN1XoTAlxK9PnQ/CJavA=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "7e23de352f519067ea88db869e9aa14222290a73",
+        "rev": "66f4ea170093b62f319f41cebd2337a51b225c5a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                           |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`66f4ea17`](https://github.com/catppuccin/nix/commit/66f4ea170093b62f319f41cebd2337a51b225c5a) | `` fix(home-manager/lazygit): avoid IFD (#304) `` |
| [`dfef742d`](https://github.com/catppuccin/nix/commit/dfef742dd2156969c96f196d2bd478056340322a) | `` chore: update dev flake inputs (#287) ``       |
| [`f1ccaad4`](https://github.com/catppuccin/nix/commit/f1ccaad444ef97c84c59215e3858ed7a95fa7bff) | `` fix(home-manager/mpv): avoid IFD (#303) ``     |
| [`afe2c4c8`](https://github.com/catppuccin/nix/commit/afe2c4c8651c137c44ec45c5e01948979cb77bc7) | `` fix(home-manager/tofi): avoid IFD (#301) ``    |
| [`38df8bf4`](https://github.com/catppuccin/nix/commit/38df8bf46f0a88e11490de438100207a48040a9c) | `` fix(home-manager/foot): avoid IFD (#300) ``    |
| [`41d51d7f`](https://github.com/catppuccin/nix/commit/41d51d7f0459f95ab354b81ecbd49cc413a8d49d) | `` fix(home-manager/zathura): avoid IFD (#298) `` |