### PR TITLE
chore(flake/nur): `7f17320e` -> `c26b11c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722983903,
-        "narHash": "sha256-oXkWXGd8KAiDk5m2h14bPAxGacr6rr+1ntamMKIx3Ao=",
+        "lastModified": 1722995604,
+        "narHash": "sha256-Et6gzlth9iaO7QGTOrEnRZ+a7TtiykXE22VeQQJXJ68=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7f17320e32ae086f28142a202fdb5215330f6e7e",
+        "rev": "c26b11c4bd3e03d9bed563abb5d40eee87e5bf74",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c26b11c4`](https://github.com/nix-community/NUR/commit/c26b11c4bd3e03d9bed563abb5d40eee87e5bf74) | `` automatic update `` |