### PR TITLE
chore(flake/nur): `c26b11c4` -> `597aaf77`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722995604,
-        "narHash": "sha256-Et6gzlth9iaO7QGTOrEnRZ+a7TtiykXE22VeQQJXJ68=",
+        "lastModified": 1723003216,
+        "narHash": "sha256-hhxDFHZT1gqZLUC9mD0W4mc/dEZSqXcU3mEGD86g7WQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c26b11c4bd3e03d9bed563abb5d40eee87e5bf74",
+        "rev": "597aaf77b801671801ffbf6dd46f7d0715bd0198",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`597aaf77`](https://github.com/nix-community/NUR/commit/597aaf77b801671801ffbf6dd46f7d0715bd0198) | `` automatic update `` |
| [`db486fcf`](https://github.com/nix-community/NUR/commit/db486fcf0f69a78506415fa38aa48cec4ba8fea6) | `` automatic update `` |
| [`6a855016`](https://github.com/nix-community/NUR/commit/6a855016485d73074727b221566d8345786d34b4) | `` automatic update `` |
| [`bc75a7f3`](https://github.com/nix-community/NUR/commit/bc75a7f325bda4b0286b564f5beb57e9bec1ba33) | `` automatic update `` |