### PR TITLE
chore(flake/nur): `597aaf77` -> `91eb7c03`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723003216,
-        "narHash": "sha256-hhxDFHZT1gqZLUC9mD0W4mc/dEZSqXcU3mEGD86g7WQ=",
+        "lastModified": 1723010397,
+        "narHash": "sha256-VWg48uh3mcHSd+2N1sDS5Dz+kagKbs6ZQsj6PDaWT5k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "597aaf77b801671801ffbf6dd46f7d0715bd0198",
+        "rev": "91eb7c0364e6e1dd90c3c1feda6ee9793794461b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`91eb7c03`](https://github.com/nix-community/NUR/commit/91eb7c0364e6e1dd90c3c1feda6ee9793794461b) | `` automatic update `` |
| [`e322551f`](https://github.com/nix-community/NUR/commit/e322551f64635d1b90438367050e7b281a1f8b24) | `` automatic update `` |
| [`88b4b377`](https://github.com/nix-community/NUR/commit/88b4b377a4c010ba483a87d8c638e50eb9152659) | `` automatic update `` |