### PR TITLE
chore(flake/nur): `91eb7c03` -> `e17bebb3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723010397,
-        "narHash": "sha256-VWg48uh3mcHSd+2N1sDS5Dz+kagKbs6ZQsj6PDaWT5k=",
+        "lastModified": 1723017483,
+        "narHash": "sha256-n1VJ5d0FGAxcFNxVXpnkx9CbbNRKYiNCy2k9jVNUVWU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "91eb7c0364e6e1dd90c3c1feda6ee9793794461b",
+        "rev": "e17bebb3225b8c347a9630c31cd16b48fab6f1e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e17bebb3`](https://github.com/nix-community/NUR/commit/e17bebb3225b8c347a9630c31cd16b48fab6f1e2) | `` automatic update `` |
| [`55e74da2`](https://github.com/nix-community/NUR/commit/55e74da2716e199342453d405452a1a0129b85b2) | `` automatic update `` |
| [`ae27243a`](https://github.com/nix-community/NUR/commit/ae27243a860cc6fedadcbd2e6cfc219953dc849f) | `` automatic update `` |