### PR TITLE
chore(flake/nur): `82de4979` -> `72b07c6f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723027680,
-        "narHash": "sha256-rtzjhh86Z4LMjGHUw18FG66d92HIC7/u7CF4AxK+FI8=",
+        "lastModified": 1723035278,
+        "narHash": "sha256-2L15kk3w0EAuyHsC7wjIl2s8J31b0UuYt5xJiT57fqg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "82de49791ccfc0b945a6da570e22a787241596c4",
+        "rev": "72b07c6f9c755e11ca51fdb3761504f93893bbd5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`72b07c6f`](https://github.com/nix-community/NUR/commit/72b07c6f9c755e11ca51fdb3761504f93893bbd5) | `` automatic update `` |
| [`1909116a`](https://github.com/nix-community/NUR/commit/1909116ad05fc6ab287af67160532d95f9316dcd) | `` automatic update `` |
| [`67ac6fe5`](https://github.com/nix-community/NUR/commit/67ac6fe5d3dbe9bf0e0551ea083b1e02cb660071) | `` automatic update `` |
| [`a461e486`](https://github.com/nix-community/NUR/commit/a461e486b28d5e76280723376bef91faf4f4a886) | `` automatic update `` |
| [`8404a4ce`](https://github.com/nix-community/NUR/commit/8404a4ce0458a20c464fe76e4a8cdc3849bca747) | `` automatic update `` |