### PR TITLE
chore(flake/nur): `72b07c6f` -> `2ee33d83`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723035278,
-        "narHash": "sha256-2L15kk3w0EAuyHsC7wjIl2s8J31b0UuYt5xJiT57fqg=",
+        "lastModified": 1723036652,
+        "narHash": "sha256-YIKo7vD/wkItzqIzg7u9bxYPhPwKhJbRbFcENuT0p68=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "72b07c6f9c755e11ca51fdb3761504f93893bbd5",
+        "rev": "2ee33d83d919b2375ebeeee175fab2af02dff92f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2ee33d83`](https://github.com/nix-community/NUR/commit/2ee33d83d919b2375ebeeee175fab2af02dff92f) | `` automatic update `` |