### PR TITLE
chore(flake/srvos): `9a04d749` -> `95804de6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -897,11 +897,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722983604,
-        "narHash": "sha256-7Yo5QjEmMHqooWbkXa89T4wVP2aMkoRRgwvIut3pKDs=",
+        "lastModified": 1723044965,
+        "narHash": "sha256-2l5IIANwyaRqixh0ubUQJ2mjn7hW/VwBUYOoG0Ew+as=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "9a04d749012b32595b74f56507c1b616809eca37",
+        "rev": "95804de6d2582c94c70afb7371fce45c59846461",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                           |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`95804de6`](https://github.com/nix-community/srvos/commit/95804de6d2582c94c70afb7371fce45c59846461) | `` feat(docs): Add links to module docs (#479) `` |