### PR TITLE
chore(flake/emacs-overlay): `a20a230b` -> `fe8d3b87`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723024089,
-        "narHash": "sha256-PAy2O2jimo1t5iX8ghurqnIO0WmiE4AAdVL46S7SxNY=",
+        "lastModified": 1723050746,
+        "narHash": "sha256-9VwSLorP6M37N58bxwuKTs8LQjb6o//0rIrZ2MlR+4g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a20a230b4051096340ee5415d1a8d66648566810",
+        "rev": "fe8d3b87057c262e2b4aaa0ec0eb6c3bb6bacf31",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`fe8d3b87`](https://github.com/nix-community/emacs-overlay/commit/fe8d3b87057c262e2b4aaa0ec0eb6c3bb6bacf31) | `` Updated emacs ``  |
| [`e048cf67`](https://github.com/nix-community/emacs-overlay/commit/e048cf6775cd7e0d0f4cd17709e90d630ea7988e) | `` Updated melpa ``  |
| [`7e3e428d`](https://github.com/nix-community/emacs-overlay/commit/7e3e428d40015b89e7a529911663195394535882) | `` Updated elpa ``   |
| [`c53e6b75`](https://github.com/nix-community/emacs-overlay/commit/c53e6b75705941f539f77b24488ca2c6000e3198) | `` Updated nongnu `` |