### PR TITLE
chore(flake/nur): `467c5cf6` -> `3ea03a4b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723041933,
-        "narHash": "sha256-/QhpaNTdmkFuEtZ3OTWKEBOlP4TajqMUSOm00RBE7Es=",
+        "lastModified": 1723048893,
+        "narHash": "sha256-RsxcL16FBNgx/kQpMtohzbfDduAcjI4UWsBbbTjrUHk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "467c5cf6cd150216ff4f04b486aa71b7441e956a",
+        "rev": "3ea03a4b815bea41eb4d8250995340cbce144524",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3ea03a4b`](https://github.com/nix-community/NUR/commit/3ea03a4b815bea41eb4d8250995340cbce144524) | `` automatic update `` |