### PR TITLE
chore(flake/nur): `3ea03a4b` -> `347f710a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723048893,
-        "narHash": "sha256-RsxcL16FBNgx/kQpMtohzbfDduAcjI4UWsBbbTjrUHk=",
+        "lastModified": 1723060083,
+        "narHash": "sha256-uxdKVoT5541dlUbtNsCtklOcVL3SVsrdMNWg8mZMEcQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3ea03a4b815bea41eb4d8250995340cbce144524",
+        "rev": "347f710a16a5bc94d0b4ad9ec422c837cff5f390",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`347f710a`](https://github.com/nix-community/NUR/commit/347f710a16a5bc94d0b4ad9ec422c837cff5f390) | `` automatic update `` |
| [`a2dc0ca1`](https://github.com/nix-community/NUR/commit/a2dc0ca1fe38b3bd0c9cdf17b26a4cdf9b5da5ac) | `` automatic update `` |