### PR TITLE
chore(flake/nur): `347f710a` -> `d0935c54`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723060083,
-        "narHash": "sha256-uxdKVoT5541dlUbtNsCtklOcVL3SVsrdMNWg8mZMEcQ=",
+        "lastModified": 1723067292,
+        "narHash": "sha256-S9CWur33KkA+zHI4NeInezYV8x6Zft9CI34E28HF3JQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "347f710a16a5bc94d0b4ad9ec422c837cff5f390",
+        "rev": "d0935c541f25a1ae4bd5e32db1e4b4efc4e2076e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d0935c54`](https://github.com/nix-community/NUR/commit/d0935c541f25a1ae4bd5e32db1e4b4efc4e2076e) | `` automatic update `` |