### PR TITLE
chore(flake/nur): `d0935c54` -> `f1a0b2a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723067292,
-        "narHash": "sha256-S9CWur33KkA+zHI4NeInezYV8x6Zft9CI34E28HF3JQ=",
+        "lastModified": 1723070393,
+        "narHash": "sha256-YHIckrhqPiE2fd8eibXNtxa314PwZUXcohTY0CevzYw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d0935c541f25a1ae4bd5e32db1e4b4efc4e2076e",
+        "rev": "f1a0b2a1e5d3be0c9b03a335eddfa94a244227c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f1a0b2a1`](https://github.com/nix-community/NUR/commit/f1a0b2a1e5d3be0c9b03a335eddfa94a244227c2) | `` automatic update `` |