### PR TITLE
chore(flake/emacs-overlay): `fe8d3b87` -> `0d603cf5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723050746,
-        "narHash": "sha256-9VwSLorP6M37N58bxwuKTs8LQjb6o//0rIrZ2MlR+4g=",
+        "lastModified": 1723081474,
+        "narHash": "sha256-/5xHg/jGCtEl0zNorXWt3GLVLp3hMou4UZaPEAX9fAo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fe8d3b87057c262e2b4aaa0ec0eb6c3bb6bacf31",
+        "rev": "0d603cf53ecdac90f54e546e160876251f4f2c5e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`0d603cf5`](https://github.com/nix-community/emacs-overlay/commit/0d603cf53ecdac90f54e546e160876251f4f2c5e) | `` Updated melpa ``  |
| [`c76660e7`](https://github.com/nix-community/emacs-overlay/commit/c76660e716c458ee4b4f117fad99fafd25007edb) | `` Updated elpa ``   |
| [`9e64aabf`](https://github.com/nix-community/emacs-overlay/commit/9e64aabf90258a2ee0c3feb20a69236433d83017) | `` Updated nongnu `` |