### PR TITLE
chore(flake/srvos): `95804de6` -> `f3890645`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -897,11 +897,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723044965,
-        "narHash": "sha256-2l5IIANwyaRqixh0ubUQJ2mjn7hW/VwBUYOoG0Ew+as=",
+        "lastModified": 1723077922,
+        "narHash": "sha256-FY5UMtlBCcbMxk+ykmZzYYtm7l/uUKwiMNYbFgqG5yg=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "95804de6d2582c94c70afb7371fce45c59846461",
+        "rev": "f389064525b8330f20106231762f52854490654e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`f3890645`](https://github.com/nix-community/srvos/commit/f389064525b8330f20106231762f52854490654e) | `` dev/private/flake.lock: Update `` |
| [`05a9816c`](https://github.com/nix-community/srvos/commit/05a9816c9a5664881e86c3f09909547866f36979) | `` flake.lock: Update ``             |