### PR TITLE
chore(flake/nur): `da7b293a` -> `727a0275`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723074332,
-        "narHash": "sha256-G3gIvVOXzAoowRJrRevBiX8ze8tWIaRygIA776P+TVs=",
+        "lastModified": 1723084130,
+        "narHash": "sha256-mTuhe+Z9EqZwuhqGWbnOHmptxabG20kco2RkJYzTLO8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "da7b293a9e4c97328fa852fa44e1b74664b5c111",
+        "rev": "727a02753b49c64b4554d999f9a20a77a6d10a58",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`727a0275`](https://github.com/nix-community/NUR/commit/727a02753b49c64b4554d999f9a20a77a6d10a58) | `` automatic update `` |
| [`3e895053`](https://github.com/nix-community/NUR/commit/3e8950537af264663bf01bfffb707666eaf82198) | `` automatic update `` |