### PR TITLE
chore(flake/nur): `727a0275` -> `f66d403b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723084130,
-        "narHash": "sha256-mTuhe+Z9EqZwuhqGWbnOHmptxabG20kco2RkJYzTLO8=",
+        "lastModified": 1723088722,
+        "narHash": "sha256-DjtWEK3wgIRqFEO7neCZzUYFZyrZFmzOrO1LyiRUi7E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "727a02753b49c64b4554d999f9a20a77a6d10a58",
+        "rev": "f66d403bcb003025dd47cf358dcb706388250b1c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f66d403b`](https://github.com/nix-community/NUR/commit/f66d403bcb003025dd47cf358dcb706388250b1c) | `` automatic update `` |
| [`53d1c4c2`](https://github.com/nix-community/NUR/commit/53d1c4c2570468409958142a3523aedfe3b09956) | `` automatic update `` |