### PR TITLE
chore(flake/nur): `f66d403b` -> `374507bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723088722,
-        "narHash": "sha256-DjtWEK3wgIRqFEO7neCZzUYFZyrZFmzOrO1LyiRUi7E=",
+        "lastModified": 1723091578,
+        "narHash": "sha256-VGA9zNECu99Kw+QYh8eXVuOjqXezq5fkrDaLhO2SwWM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f66d403bcb003025dd47cf358dcb706388250b1c",
+        "rev": "374507bc5ce4cf2865f583ab770e2dad611a764d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`374507bc`](https://github.com/nix-community/NUR/commit/374507bc5ce4cf2865f583ab770e2dad611a764d) | `` automatic update `` |
| [`6231099f`](https://github.com/nix-community/NUR/commit/6231099f6d539aca600ec93f677fffbe51c39ab0) | `` automatic update `` |