### PR TITLE
chore(flake/nur): `374507bc` -> `27f59822`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723091578,
-        "narHash": "sha256-VGA9zNECu99Kw+QYh8eXVuOjqXezq5fkrDaLhO2SwWM=",
+        "lastModified": 1723096977,
+        "narHash": "sha256-/OFbSpsjIl+b5ECPKz7anD/Q8EGFCOIjG9w9NIV61Gk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "374507bc5ce4cf2865f583ab770e2dad611a764d",
+        "rev": "27f59822c315763c64b55fb12f862a54df79b929",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`27f59822`](https://github.com/nix-community/NUR/commit/27f59822c315763c64b55fb12f862a54df79b929) | `` automatic update `` |