### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `67cc18bf` -> `aa972cee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723024089,
-        "narHash": "sha256-PAy2O2jimo1t5iX8ghurqnIO0WmiE4AAdVL46S7SxNY=",
+        "lastModified": 1723081474,
+        "narHash": "sha256-/5xHg/jGCtEl0zNorXWt3GLVLp3hMou4UZaPEAX9fAo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a20a230b4051096340ee5415d1a8d66648566810",
+        "rev": "0d603cf53ecdac90f54e546e160876251f4f2c5e",
         "type": "github"
       },
       "original": {
@@ -500,11 +500,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1723040548,
-        "narHash": "sha256-HUKpAaHCCKCz6vyXXsTQwFPEkWBDQxVzmcKLNDWFoFQ=",
+        "lastModified": 1723106056,
+        "narHash": "sha256-qzqExC0PiHClztaXrkC7eePFh3nkEfnWwZHCGfbAtNk=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "67cc18bff685aa411e00b2d1908a899db0cd101a",
+        "rev": "aa972cee6e3c1d8eceec199d9f61fde9224b7f9d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`aa972cee`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/aa972cee6e3c1d8eceec199d9f61fde9224b7f9d) | `` flake.lock: Update `` |