### PR TITLE
chore(flake/emacs-overlay): `0d603cf5` -> `a25c804e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723081474,
-        "narHash": "sha256-/5xHg/jGCtEl0zNorXWt3GLVLp3hMou4UZaPEAX9fAo=",
+        "lastModified": 1723107458,
+        "narHash": "sha256-CnZvmhD1IeCzLh1iyKYsDttbYBdpYKB4TbSAXTkrB+A=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0d603cf53ecdac90f54e546e160876251f4f2c5e",
+        "rev": "a25c804e62e9eb6f79dd2f412e90141b0aa8bfcb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`a25c804e`](https://github.com/nix-community/emacs-overlay/commit/a25c804e62e9eb6f79dd2f412e90141b0aa8bfcb) | `` Updated melpa `` |