### PR TITLE
chore(flake/nur): `27f59822` -> `3b925b1a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723096977,
-        "narHash": "sha256-/OFbSpsjIl+b5ECPKz7anD/Q8EGFCOIjG9w9NIV61Gk=",
+        "lastModified": 1723117599,
+        "narHash": "sha256-gYbX1k6Bqy8EQ/IxAqTTnDE192Sqpwn5CBY2Ouj0KEU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "27f59822c315763c64b55fb12f862a54df79b929",
+        "rev": "3b925b1a914602741b8e36ddb5e6eee50af210a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3b925b1a`](https://github.com/nix-community/NUR/commit/3b925b1a914602741b8e36ddb5e6eee50af210a1) | `` automatic update `` |
| [`7e1daf74`](https://github.com/nix-community/NUR/commit/7e1daf74a827931ebd5b173f1cffd07e9a0fdcb7) | `` automatic update `` |
| [`ed6ebd69`](https://github.com/nix-community/NUR/commit/ed6ebd69a68e291023e8c6d27c8b59984cfc745e) | `` automatic update `` |
| [`24bd913c`](https://github.com/nix-community/NUR/commit/24bd913ce8ecc66e9f75e2c5ac7af6068781fe73) | `` automatic update `` |
| [`7a152a27`](https://github.com/nix-community/NUR/commit/7a152a27c430f6998cbeb69b561cd0a64f063214) | `` automatic update `` |
| [`ac3d0fa5`](https://github.com/nix-community/NUR/commit/ac3d0fa5650c3e645cb257378a0736c2b5115bb0) | `` automatic update `` |
| [`18bd8b19`](https://github.com/nix-community/NUR/commit/18bd8b19541f9815b883d279311ac0a746b6df4a) | `` automatic update `` |
| [`cb8ccf5c`](https://github.com/nix-community/NUR/commit/cb8ccf5c1c988720cb3bc06233ba1d2f9d288301) | `` automatic update `` |