### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `aa972cee` -> `32a8e44a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -500,11 +500,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1723106056,
-        "narHash": "sha256-qzqExC0PiHClztaXrkC7eePFh3nkEfnWwZHCGfbAtNk=",
+        "lastModified": 1723120047,
+        "narHash": "sha256-5rdI23oYWUGAYZ3Vs2jHIkjGKBbt8HshasjvZaccwNw=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "aa972cee6e3c1d8eceec199d9f61fde9224b7f9d",
+        "rev": "32a8e44ae1f044b07a10db7b6ed8c89f9d31a2cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                                         |
| ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`32a8e44a`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/32a8e44ae1f044b07a10db7b6ed8c89f9d31a2cd) | `` Remove obsolete ol-notmuch fetch override `` |