### PR TITLE
chore(flake/nur): `3b925b1a` -> `f8446cad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723117599,
-        "narHash": "sha256-gYbX1k6Bqy8EQ/IxAqTTnDE192Sqpwn5CBY2Ouj0KEU=",
+        "lastModified": 1723122031,
+        "narHash": "sha256-/4TfA1C1Osw4LeIUOftJS4Ub8eInofwzdEV/GZHH/zs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3b925b1a914602741b8e36ddb5e6eee50af210a1",
+        "rev": "f8446cad6221ef38f9a5e989d0836e5c2743c009",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f8446cad`](https://github.com/nix-community/NUR/commit/f8446cad6221ef38f9a5e989d0836e5c2743c009) | `` automatic update `` |
| [`7cfed96a`](https://github.com/nix-community/NUR/commit/7cfed96a9799f77d4e2650d9db64a5ca9eb58619) | `` automatic update `` |
| [`565d337b`](https://github.com/nix-community/NUR/commit/565d337b49cb856c44f67463c39b85e1612e4454) | `` automatic update `` |