### PR TITLE
chore(flake/nur): `f8446cad` -> `18702583`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723122031,
-        "narHash": "sha256-/4TfA1C1Osw4LeIUOftJS4Ub8eInofwzdEV/GZHH/zs=",
+        "lastModified": 1723128305,
+        "narHash": "sha256-J9XTRGCSkz4lV/ofjr38KUb20IgfuxB1e6iZcSYZ2dE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f8446cad6221ef38f9a5e989d0836e5c2743c009",
+        "rev": "18702583c7f9e7c309e3c801ea3a25a184852fd9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`18702583`](https://github.com/nix-community/NUR/commit/18702583c7f9e7c309e3c801ea3a25a184852fd9) | `` automatic update `` |
| [`a39850a4`](https://github.com/nix-community/NUR/commit/a39850a40d1d85db104086bb000c3f3c20252141) | `` automatic update `` |