### PR TITLE
chore(flake/emacs-overlay): `8937306d` -> `df0173fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723108268,
-        "narHash": "sha256-CcJbD2SKUr2KikR3dNXkGwskSRwL0po3r5vfSOSw6C4=",
+        "lastModified": 1723136200,
+        "narHash": "sha256-jXtwXlF1Y8rnmDFjCJrjbEJaEUWiQrHyaUhFoTEa4To=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8937306d2635d87bd83d472ab617ea3fad75f227",
+        "rev": "df0173fad06b6db686dab80ea97cb6c698e8f115",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`df0173fa`](https://github.com/nix-community/emacs-overlay/commit/df0173fad06b6db686dab80ea97cb6c698e8f115) | `` Updated melpa ``  |
| [`dd824a8d`](https://github.com/nix-community/emacs-overlay/commit/dd824a8da6c3ed4d0a5a9ce494a6ef14d649646d) | `` Updated elpa ``   |
| [`88aa0b90`](https://github.com/nix-community/emacs-overlay/commit/88aa0b90f3d27721ec0fac83ce836fecdccccaad) | `` Updated nongnu `` |