### PR TITLE
chore(flake/emacs-overlay): `df0173fa` -> `719fcbc0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723136200,
-        "narHash": "sha256-jXtwXlF1Y8rnmDFjCJrjbEJaEUWiQrHyaUhFoTEa4To=",
+        "lastModified": 1723137044,
+        "narHash": "sha256-cvEsedBp7sqKxR/DpQ+G4sR3p/G/tqBwSffBVDtqUow=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "df0173fad06b6db686dab80ea97cb6c698e8f115",
+        "rev": "719fcbc0392e846cdd37f230f5cd82bdda58f71c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`719fcbc0`](https://github.com/nix-community/emacs-overlay/commit/719fcbc0392e846cdd37f230f5cd82bdda58f71c) | `` Updated emacs `` |