### PR TITLE
chore(flake/nur): `18702583` -> `9b67a63f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723128305,
-        "narHash": "sha256-J9XTRGCSkz4lV/ofjr38KUb20IgfuxB1e6iZcSYZ2dE=",
+        "lastModified": 1723142956,
+        "narHash": "sha256-RbhgnkTyKg3byRRJCc9LDL3KG77Z7pqBuzVl2CeY2GA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "18702583c7f9e7c309e3c801ea3a25a184852fd9",
+        "rev": "9b67a63fb6299db726a43a68458b21fafb89adf7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9b67a63f`](https://github.com/nix-community/NUR/commit/9b67a63fb6299db726a43a68458b21fafb89adf7) | `` automatic update `` |
| [`da0a121e`](https://github.com/nix-community/NUR/commit/da0a121ed070ac23851f41d20551c03267254ba7) | `` automatic update `` |