### PR TITLE
chore(flake/nixos-hardware): `14c33316` -> `107bb46e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -611,11 +611,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1722332872,
-        "narHash": "sha256-2xLM4sc5QBfi0U/AANJAW21Bj4ZX479MHPMPkB+eKBU=",
+        "lastModified": 1723149858,
+        "narHash": "sha256-3u51s7jdhavmEL1ggtd8wqrTH2clTy5yaZmhLvAXTqc=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "14c333162ba53c02853add87a0000cbd7aa230c2",
+        "rev": "107bb46eef1f05e86fc485ee8af9b637e5157988",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`107bb46e`](https://github.com/NixOS/nixos-hardware/commit/107bb46eef1f05e86fc485ee8af9b637e5157988) | `` surface: linux 6.9.12 -> 6.10.3 ``                      |
| [`e6d16f1b`](https://github.com/NixOS/nixos-hardware/commit/e6d16f1b6b4a3ab6f717f62965a8c1d23e6a502e) | `` surface: linux-surface arch-6.9.9-1 -> arch-6.10.3-1 `` |