### PR TITLE
chore(flake/emacs-overlay): `719fcbc0` -> `4915c4a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723137044,
-        "narHash": "sha256-cvEsedBp7sqKxR/DpQ+G4sR3p/G/tqBwSffBVDtqUow=",
+        "lastModified": 1723165808,
+        "narHash": "sha256-pmD0KRuPxv8a1V2OMdlUZh2HxvOUgqRdVua1tzxR0ow=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "719fcbc0392e846cdd37f230f5cd82bdda58f71c",
+        "rev": "4915c4a157dd6aaac62ede10ea59a4179cb26d14",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`4915c4a1`](https://github.com/nix-community/emacs-overlay/commit/4915c4a157dd6aaac62ede10ea59a4179cb26d14) | `` Updated elpa ``   |
| [`c59e8963`](https://github.com/nix-community/emacs-overlay/commit/c59e8963e74586a72bb0822884943622d72abd45) | `` Updated nongnu `` |