### PR TITLE
chore(flake/nur): `377a1356` -> `a599bbff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723168435,
-        "narHash": "sha256-BYmkIw2N/rLwgUmoXN2olDsjL2dEkWBqJNIlRIhqNSo=",
+        "lastModified": 1723171767,
+        "narHash": "sha256-VsmaFJ5teijXKD1d+Uem+b6PTNl42pUdxzHaM5xz6Xs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "377a1356b36a619e7fa58c763fe7b2efc66e0fe7",
+        "rev": "a599bbffd130bfab8663cd134f5c599758b830d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a599bbff`](https://github.com/nix-community/NUR/commit/a599bbffd130bfab8663cd134f5c599758b830d3) | `` automatic update `` |
| [`0ab5c205`](https://github.com/nix-community/NUR/commit/0ab5c205af3a577b906180d6267b377de1f71787) | `` automatic update `` |