### PR TITLE
chore(flake/nur): `f40b06b5` -> `8192c1a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723174965,
-        "narHash": "sha256-sW52wq91+bqITYQFpJBpEg+zcVosY6MSOb1vuaM1Aok=",
+        "lastModified": 1723179073,
+        "narHash": "sha256-s4ytgJABNTUYVZ2/cQiwtdHBUzWhduayFi+L6N9VQW4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f40b06b57eb01142d375eb0de1ec2defa0fd0b77",
+        "rev": "8192c1a0e825f07ee6105e2b39496546f1c4c19a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8192c1a0`](https://github.com/nix-community/NUR/commit/8192c1a0e825f07ee6105e2b39496546f1c4c19a) | `` automatic update `` |
| [`9ac4504c`](https://github.com/nix-community/NUR/commit/9ac4504c836bbf164968c7d12343806b2f734f69) | `` automatic update `` |
| [`19a63ed7`](https://github.com/nix-community/NUR/commit/19a63ed71b7edf323fe5f57ee3f2d9dd43dc5a1a) | `` automatic update `` |