### PR TITLE
chore(flake/nur): `8192c1a0` -> `93a6eb95`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723179073,
-        "narHash": "sha256-s4ytgJABNTUYVZ2/cQiwtdHBUzWhduayFi+L6N9VQW4=",
+        "lastModified": 1723182316,
+        "narHash": "sha256-X4sGnUGPZMTV/PYBLXe92uOZkj9NQoocIlG3B+ObzJ8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8192c1a0e825f07ee6105e2b39496546f1c4c19a",
+        "rev": "93a6eb95f8cb4eb7e60d69d3954ac384b89fb074",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`93a6eb95`](https://github.com/nix-community/NUR/commit/93a6eb95f8cb4eb7e60d69d3954ac384b89fb074) | `` automatic update `` |