### PR TITLE
chore(flake/nur): `93a6eb95` -> `1a7a6602`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723182316,
-        "narHash": "sha256-X4sGnUGPZMTV/PYBLXe92uOZkj9NQoocIlG3B+ObzJ8=",
+        "lastModified": 1723188633,
+        "narHash": "sha256-/0Eu/OU2yxm0iXAZBLZpnbiQX2iv3DV6zRsbooj/2sQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "93a6eb95f8cb4eb7e60d69d3954ac384b89fb074",
+        "rev": "1a7a66028df234c6a0ddcf3f24e9da6a07111fb5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1a7a6602`](https://github.com/nix-community/NUR/commit/1a7a66028df234c6a0ddcf3f24e9da6a07111fb5) | `` automatic update `` |
| [`8d13e343`](https://github.com/nix-community/NUR/commit/8d13e343f784f89162001e6d9f597e594724f2e1) | `` automatic update `` |
| [`d5914abe`](https://github.com/nix-community/NUR/commit/d5914abed7b09cbb32a491911dbac6de646b1490) | `` automatic update `` |
| [`bbc2d92f`](https://github.com/nix-community/NUR/commit/bbc2d92f580f093613ac259382700faaaf5fdf53) | `` automatic update `` |