### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `32a8e44a` -> `354fb873`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
     "doomemacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1722963733,
-        "narHash": "sha256-+ilEZAPcx1zjtnJQfYVQt7gDaqxgj7UiAbXwRQ3SN1M=",
+        "lastModified": 1723152418,
+        "narHash": "sha256-YyDi0S+f18x1LYNroj5yfxcbCzllAQvVGkXDgyzPdbY=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "2c17f719657c46ea37e4846289e951c83409a514",
+        "rev": "7f3412e3174d3f5bb721a140f67be3a5a055e31d",
         "type": "github"
       },
       "original": {
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723081474,
-        "narHash": "sha256-/5xHg/jGCtEl0zNorXWt3GLVLp3hMou4UZaPEAX9fAo=",
+        "lastModified": 1723167917,
+        "narHash": "sha256-JA7dMKYML+F/SKhsaXPYagVb/GWO68vsQyn2m2fI/j8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0d603cf53ecdac90f54e546e160876251f4f2c5e",
+        "rev": "59682436402b2e69e2f88285485a4b40c1211067",
         "type": "github"
       },
       "original": {
@@ -500,11 +500,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1723120047,
-        "narHash": "sha256-5rdI23oYWUGAYZ3Vs2jHIkjGKBbt8HshasjvZaccwNw=",
+        "lastModified": 1723192441,
+        "narHash": "sha256-XM16tLbSbHwd3ffR0FDd6xsIY8yCe2q6WKL4rC4OZvs=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "32a8e44ae1f044b07a10db7b6ed8c89f9d31a2cd",
+        "rev": "354fb873eefe55d99d5dfc9355378794bd155411",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`354fb873`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/354fb873eefe55d99d5dfc9355378794bd155411) | `` flake.lock: Update `` |