### PR TITLE
chore(flake/nur): `1a7a6602` -> `88c94505`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723188633,
-        "narHash": "sha256-/0Eu/OU2yxm0iXAZBLZpnbiQX2iv3DV6zRsbooj/2sQ=",
+        "lastModified": 1723199600,
+        "narHash": "sha256-GFEIUBtLkZ1a4Pk5RDdO2aFkoQASJ3I7rjry8ad9aF4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1a7a66028df234c6a0ddcf3f24e9da6a07111fb5",
+        "rev": "88c9450556e353bbf98fecab9ee90ea5cfc5edb0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`88c94505`](https://github.com/nix-community/NUR/commit/88c9450556e353bbf98fecab9ee90ea5cfc5edb0) | `` automatic update `` |
| [`5fd46bf6`](https://github.com/nix-community/NUR/commit/5fd46bf6080ac964c170366eab86cf12cef5add8) | `` automatic update `` |
| [`e952b22e`](https://github.com/nix-community/NUR/commit/e952b22e8e0d3f890400a6a80061f7dc6918933d) | `` automatic update `` |
| [`f2e29fb2`](https://github.com/nix-community/NUR/commit/f2e29fb2d48a0ca85cc5b5c33655fe614d859ea1) | `` automatic update `` |