### PR TITLE
chore(flake/git-hooks): `3c977f1c` -> `c7012d0c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -353,11 +353,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1723056346,
-        "narHash": "sha256-YpzywjTAUHRRHcO8zz9x2gYqJ0JmZlcB9+RaUvD89qM=",
+        "lastModified": 1723202784,
+        "narHash": "sha256-qbhjc/NEGaDbyy0ucycubq4N3//gDFFH3DOmp1D3u1Q=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3c977f1c9930f54066c085305b4b2291385e7a73",
+        "rev": "c7012d0c18567c889b948781bc74a501e92275d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                 |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`c2f6ace9`](https://github.com/cachix/git-hooks.nix/commit/c2f6ace9d7f9d583aa0f32eea1ed77f4359c7987) | `` feat: add terraform-validate hook `` |