### PR TITLE
chore(flake/nur): `081f0c3e` -> `fd42f83c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723221530,
-        "narHash": "sha256-Rjp1MrNLXbDr4iDk9u+ySMwZxutxLobkgRB8lWa8bMg=",
+        "lastModified": 1723229499,
+        "narHash": "sha256-LlcgmzEVDUa5pA1x50nYp1QRUUmTqZvHmwZAIj6Xqus=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "081f0c3e9f5fb30d33ecc12cdf711b5985e7beca",
+        "rev": "fd42f83c561adde6bcc9e352f4bb8644081c411b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fd42f83c`](https://github.com/nix-community/NUR/commit/fd42f83c561adde6bcc9e352f4bb8644081c411b) | `` automatic update `` |
| [`5310d9f8`](https://github.com/nix-community/NUR/commit/5310d9f8ff8cc236af929bc597606629e6886717) | `` automatic update `` |