### PR TITLE
chore(flake/nur): `fd42f83c` -> `754c9ccd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723229499,
-        "narHash": "sha256-LlcgmzEVDUa5pA1x50nYp1QRUUmTqZvHmwZAIj6Xqus=",
+        "lastModified": 1723236310,
+        "narHash": "sha256-+vIUekDyN8ZE+saHzfHY14rPC9fcHZbxezs8tywMocM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fd42f83c561adde6bcc9e352f4bb8644081c411b",
+        "rev": "754c9ccddf3694bbcc3d02ae341fe5e184dfc168",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`754c9ccd`](https://github.com/nix-community/NUR/commit/754c9ccddf3694bbcc3d02ae341fe5e184dfc168) | `` automatic update `` |
| [`677f9a42`](https://github.com/nix-community/NUR/commit/677f9a4272495e4cb13785bce324b89df1e56509) | `` automatic update `` |
| [`3eac2c1b`](https://github.com/nix-community/NUR/commit/3eac2c1b62671b8cf68a415606912c8fe3f8b299) | `` automatic update `` |
| [`1f4e4b2e`](https://github.com/nix-community/NUR/commit/1f4e4b2e3d5eacd96effbbadb06c8d6de985fd9f) | `` automatic update `` |