### PR TITLE
chore(flake/nur): `754c9ccd` -> `2d5ab2b9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723236310,
-        "narHash": "sha256-+vIUekDyN8ZE+saHzfHY14rPC9fcHZbxezs8tywMocM=",
+        "lastModified": 1723239984,
+        "narHash": "sha256-5fXz8xYt90QPv89sU2JIRFI4Ty3oe1kJZvDURtufewI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "754c9ccddf3694bbcc3d02ae341fe5e184dfc168",
+        "rev": "2d5ab2b97f7c4aeb84c903e0eca91a808e13f6e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2d5ab2b9`](https://github.com/nix-community/NUR/commit/2d5ab2b97f7c4aeb84c903e0eca91a808e13f6e8) | `` automatic update `` |