### PR TITLE
chore(flake/nur): `2d5ab2b9` -> `86d7af52`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723239984,
-        "narHash": "sha256-5fXz8xYt90QPv89sU2JIRFI4Ty3oe1kJZvDURtufewI=",
+        "lastModified": 1723242662,
+        "narHash": "sha256-TSqqX02lspcDPzwdz2OxJC/d/ei+K/oW1pPpSHo2KVQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2d5ab2b97f7c4aeb84c903e0eca91a808e13f6e8",
+        "rev": "86d7af527765221a4e43f7c3a4ce2da7b1e4fad4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`86d7af52`](https://github.com/nix-community/NUR/commit/86d7af527765221a4e43f7c3a4ce2da7b1e4fad4) | `` automatic update `` |