### PR TITLE
chore(flake/nur): `86d7af52` -> `0374174d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723242662,
-        "narHash": "sha256-TSqqX02lspcDPzwdz2OxJC/d/ei+K/oW1pPpSHo2KVQ=",
+        "lastModified": 1723245523,
+        "narHash": "sha256-0cmDpHSZr9ei/HKlUe3HUi/BFKaT2xqQe4G2HtdDv/s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "86d7af527765221a4e43f7c3a4ce2da7b1e4fad4",
+        "rev": "0374174d5a40d2defd1575979353c9c4f6b17b39",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0374174d`](https://github.com/nix-community/NUR/commit/0374174d5a40d2defd1575979353c9c4f6b17b39) | `` automatic update `` |