### PR TITLE
chore(flake/emacs-overlay): `3bdfc90a` -> `a930980f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723223605,
-        "narHash": "sha256-gTcJd7LBJkckNrjlHQF6lK+ZbnLOHSv9zMxZUe1TQ2Q=",
+        "lastModified": 1723252167,
+        "narHash": "sha256-wmgjOyLaQksnSH0RfsuMZrxr3U6Lt/3NC2rb9/UE3kM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3bdfc90a8b8b6358dda446e317d3b9c53e247c89",
+        "rev": "a930980f1685668425e0c0a39532051b6a5f1119",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`a930980f`](https://github.com/nix-community/emacs-overlay/commit/a930980f1685668425e0c0a39532051b6a5f1119) | `` Updated elpa ``   |
| [`1375d60f`](https://github.com/nix-community/emacs-overlay/commit/1375d60faaa14d70c30e83e723297fb0ba01418c) | `` Updated emacs ``  |
| [`797ea8b8`](https://github.com/nix-community/emacs-overlay/commit/797ea8b86092a931faa26a72331b63b3c6c47883) | `` Updated nongnu `` |