### PR TITLE
chore(flake/nur): `0374174d` -> `6aa97f90`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723245523,
-        "narHash": "sha256-0cmDpHSZr9ei/HKlUe3HUi/BFKaT2xqQe4G2HtdDv/s=",
+        "lastModified": 1723258519,
+        "narHash": "sha256-+slzkr7EaXMptdzTievu2E2qqa5PT6WVqQsLBMVjNpc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0374174d5a40d2defd1575979353c9c4f6b17b39",
+        "rev": "6aa97f907d3d5f7dc39d5d28799dde31f3cc9502",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6aa97f90`](https://github.com/nix-community/NUR/commit/6aa97f907d3d5f7dc39d5d28799dde31f3cc9502) | `` automatic update `` |
| [`fcff105b`](https://github.com/nix-community/NUR/commit/fcff105bed3ecf62c170f4c28650e15a887cc9f8) | `` automatic update `` |
| [`4d32950c`](https://github.com/nix-community/NUR/commit/4d32950c6a9c74ae15d82c7fb4e45bfcc56acbf4) | `` automatic update `` |
| [`310a9f5c`](https://github.com/nix-community/NUR/commit/310a9f5ca5fda8056d0886dffcb5ca05ee711fcc) | `` automatic update `` |
| [`ca941fce`](https://github.com/nix-community/NUR/commit/ca941fce500942346e231780670c1ae57b97ae47) | `` automatic update `` |
| [`3049dfd6`](https://github.com/nix-community/NUR/commit/3049dfd6e117bfe27718f94a164eaa741cba1953) | `` automatic update `` |
| [`00e14c47`](https://github.com/nix-community/NUR/commit/00e14c478b32cb46a082280fba94eab8e7895d24) | `` automatic update `` |
| [`1b87f8f7`](https://github.com/nix-community/NUR/commit/1b87f8f707527ec9e4347e3a5874396c0d572c8c) | `` automatic update `` |