### PR TITLE
chore(flake/nixpkgs): `cb9a96f2` -> `957d95fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -732,11 +732,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1722813957,
-        "narHash": "sha256-IAoYyYnED7P8zrBFMnmp7ydaJfwTnwcnqxUElC1I26Y=",
+        "lastModified": 1722995383,
+        "narHash": "sha256-UzuXo7ZM8ZK0SkWFhHocKkLSGQPHS4JxaE1jvVR4fUo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cb9a96f23c491c081b38eab96d22fa958043c9fa",
+        "rev": "957d95fc8b9bf1eb60d43f8d2eba352b71bbf2be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`a622c107`](https://github.com/NixOS/nixpkgs/commit/a622c107de9f9778874e245102407dcf1c2a4ff6) | `` pretalx: add missing django[argon2] extra ``                           |
| [`a30d7bea`](https://github.com/NixOS/nixpkgs/commit/a30d7bea2c0ef57f64df6b357347bd4da4af9b01) | `` pretix-banktool: init at 1.0.0 ``                                      |
| [`5ee19b6f`](https://github.com/NixOS/nixpkgs/commit/5ee19b6f173a1095dcad7d5b2a98c650d39764b5) | `` octave.buildEnv: fix the eval ``                                       |
| [`b6866e38`](https://github.com/NixOS/nixpkgs/commit/b6866e3882ca1d18562a4514e3659729b6d0ca0b) | `` home-assistant: support permobil component ``                          |
| [`aa618d13`](https://github.com/NixOS/nixpkgs/commit/aa618d13bc5264890366f6d9471998691544a8ce) | `` python312Packages.mypermobil: init at 0.1.8 ``                         |
| [`206b85b4`](https://github.com/NixOS/nixpkgs/commit/206b85b4237f156418549e0d6b0325f4b2d4339b) | `` python312Packages.transitions: 0.9.1 -> 0.9.2 ``                       |
| [`4bcffa6d`](https://github.com/NixOS/nixpkgs/commit/4bcffa6dc3d460b3ab84e6b4298c56dde51da5cc) | `` psst: unstable-2024-05-26 -> unstable-2024-07-29 ``                    |
| [`4f85840d`](https://github.com/NixOS/nixpkgs/commit/4f85840d257160e335e015c3266491ca03d1c52e) | `` gcc: provide build support for gccrs ``                                |
| [`a6555855`](https://github.com/NixOS/nixpkgs/commit/a6555855375c9ac15e66b3ca1e0ec6466b5b5156) | `` cosmic-edit: 0-unstable-2024-04-15 -> 1.0.0-alpha.1 ``                 |
| [`37b38257`](https://github.com/NixOS/nixpkgs/commit/37b3825712e8481fb9036d523f9fbbc2fbb0fa66) | `` cosmic-settings: unstable-2024-02-15 -> 1.0.0-alpha.1 ``               |
| [`a1d122b4`](https://github.com/NixOS/nixpkgs/commit/a1d122b4afa604f9429486b09bfdd6a3f6bc2f84) | `` cosmic-store: unstable-2024-04-15 -> 1.0.0-alpha.1 ``                  |
| [`8f3b8f30`](https://github.com/NixOS/nixpkgs/commit/8f3b8f30f750c3a50dba2b55621e2ecd51deef68) | `` cosmic-term: 0-unstable-2024-04-15 -> 1.0.0-alpha.1 ``                 |
| [`6488c3d4`](https://github.com/NixOS/nixpkgs/commit/6488c3d4388eb951be2aa557263435d11798377e) | `` docs/language-frameworks/python: update python{,2,3}Package aliases `` |
| [`1f620252`](https://github.com/NixOS/nixpkgs/commit/1f620252b7b578a232e65b486d3e2112e1e5d818) | `` taskwarrior3: 3.0.2 -> 3.1.0 ``                                        |
| [`00013f50`](https://github.com/NixOS/nixpkgs/commit/00013f500137892443c6e3a79fc1a3b6ad4882ef) | `` pretalx.plugins.youtube: 2.1.0 -> 2.2.0 ``                             |
| [`61d7da10`](https://github.com/NixOS/nixpkgs/commit/61d7da10e24f01d409c33c2384ad4811cd27dde3) | `` pretalx.plugins.vimeo: 2.2.0 -> 2.3.0 ``                               |
| [`dff5dd7d`](https://github.com/NixOS/nixpkgs/commit/dff5dd7d72e52a818e1fe94e0c3245dd0a7b1b70) | `` pretalx.plugins.venueless: 1.3.0 -> 1.4.0 ``                           |
| [`89e3ce7b`](https://github.com/NixOS/nixpkgs/commit/89e3ce7b75f47769e9dbd5573aa892332d87aa0a) | `` pretalx.plugins.public-voting: 1.5.0 -> 1.6.0 ``                       |
| [`d17feede`](https://github.com/NixOS/nixpkgs/commit/d17feedef7301dca98e7343429c5248f7b7c224e) | `` pretalx.plugins.pages: 1.4.0 -> 1.5.0 ``                               |
| [`d2b7130a`](https://github.com/NixOS/nixpkgs/commit/d2b7130a8eeccad555864206aaed304397f1f0d3) | `` pretalx.plugins.media-ccc-de: 1.2.1 -> 1.3.0 ``                        |
| [`950ae73b`](https://github.com/NixOS/nixpkgs/commit/950ae73b8366703a01f8ce20c53bad395973500f) | `` pretalx.plugins.downstream: 1.2.0 -> 1.3.0 ``                          |
| [`45b32e82`](https://github.com/NixOS/nixpkgs/commit/45b32e82bdf5706a371f2f7f75ebc798881a614d) | `` pretalx: 2024.1.0 -> 2024.2.0 ``                                       |
| [`d1cde1b9`](https://github.com/NixOS/nixpkgs/commit/d1cde1b920d23f351d0760c940726042765644a8) | `` nixos/ananicy: fix typo (#332771) ``                                   |
| [`1cdd1efa`](https://github.com/NixOS/nixpkgs/commit/1cdd1efaf1c86145717a313dd025f9132f7fe793) | `` linuxPackages.nvidiaPackages.beta: 560.28.03 -> 560.31.02 ``           |
| [`1469a6fa`](https://github.com/NixOS/nixpkgs/commit/1469a6fa74273df754cffae5a136f0686ecc6b85) | `` python312Packages.python-rapidjson: 1.18 -> 1.20 ``                    |
| [`d385090a`](https://github.com/NixOS/nixpkgs/commit/d385090a85b8257c985e107cc5a54de092fd39a7) | `` kulala-fmt: 1.1.0 -> 1.2.0 ``                                          |
| [`a9ff0710`](https://github.com/NixOS/nixpkgs/commit/a9ff07109826ac8c58b8a454f94643685095a6b8) | `` python312Packages.python-hcl2: 4.3.4 -> 4.3.5 ``                       |
| [`4c33e4b3`](https://github.com/NixOS/nixpkgs/commit/4c33e4b301d5a6e8d2ce95e5047b6d92f793971d) | `` cosmic-bg: unstable-2023-10-10 -> 1.0.0-alpha.1 ``                     |
| [`040034ca`](https://github.com/NixOS/nixpkgs/commit/040034ca0d3718dde3b35a5be23ffc866376a90b) | `` python312Packages.aioopenexchangerates: 0.4.14 -> 0.4.15 ``            |
| [`2a13929e`](https://github.com/NixOS/nixpkgs/commit/2a13929e1f191b3690dd2f2db13098b04adb9043) | `` postgresqlPackages.timescaledb_toolkit: fix on macos (#332353) ``      |
| [`d1774ec2`](https://github.com/NixOS/nixpkgs/commit/d1774ec21ea2bb62de5c0f646a440bbc7fabd33f) | `` protoc-gen-validate: 1.0.4 -> 1.1.0 ``                                 |
| [`ae4575d2`](https://github.com/NixOS/nixpkgs/commit/ae4575d27bd7f82758f734d78a2b9baba4aa9292) | `` walker: add update script ``                                           |
| [`36467dc5`](https://github.com/NixOS/nixpkgs/commit/36467dc5ab2456d669d9a3e54e1d82b6ed99897c) | `` walker: 0.0.88 -> 0.6.7 ``                                             |
| [`fbf6ab32`](https://github.com/NixOS/nixpkgs/commit/fbf6ab328de212b423341a7ba106436c99e510b4) | `` tdl: 0.17.1 -> 0.17.3 (#331930) ``                                     |
| [`405114d4`](https://github.com/NixOS/nixpkgs/commit/405114d4a08eb57569657254d62346fc0812bca4) | `` anchor: 0.30.0 -> 0.30.1 ``                                            |
| [`0260b66b`](https://github.com/NixOS/nixpkgs/commit/0260b66b956c0eb2be96dc7a8f548f6b7f130e38) | `` marwaita-teal: 20.3 -> 20.3.1 ``                                       |
| [`7e8a4f74`](https://github.com/NixOS/nixpkgs/commit/7e8a4f74895f9fa3de1ee614f418719bb1f5a225) | `` ockam: 0.129.0 -> 0.130.0 ``                                           |
| [`a5466bd5`](https://github.com/NixOS/nixpkgs/commit/a5466bd59105479a9a583af963f3eff1f3745228) | `` wtwitch: migrate to by-name ``                                         |
| [`5bf97d93`](https://github.com/NixOS/nixpkgs/commit/5bf97d939ffe1ca87229a85a8fcafeda547b9bc3) | `` kdePackages: Plasma 6.1.3 -> 6.1.4 ``                                  |
| [`23faf66c`](https://github.com/NixOS/nixpkgs/commit/23faf66c5631b73bbad57c465188f3ac5aa1dbc3) | `` nil: migrate to by-name ``                                             |
| [`6f9b7b68`](https://github.com/NixOS/nixpkgs/commit/6f9b7b68cfdab3bdacc6caff729bca03cfc2f3b9) | `` nil: 2023-08-09 -> 2024-08-06 ``                                       |
| [`834d47d8`](https://github.com/NixOS/nixpkgs/commit/834d47d824143818d41aae89abf4dcc8006354e0) | `` python312Packages.pyturbojpeg: 1.7.3 -> 1.7.5 ``                       |
| [`55f60e89`](https://github.com/NixOS/nixpkgs/commit/55f60e8908dafc63c0e7d52f80620e88001d8eff) | `` python312Packages.print-color: init at 0.4.6 ``                        |
| [`6d46564f`](https://github.com/NixOS/nixpkgs/commit/6d46564f410ea325eea28972832193abf1e953da) | `` python312Packages.pyatv: modernize ``                                  |
| [`2a38dd54`](https://github.com/NixOS/nixpkgs/commit/2a38dd5446a03fb12a90be90a28c3e025055549b) | `` python312Packages.ppk2-api: init at 0.9.2 ``                           |
| [`f915a450`](https://github.com/NixOS/nixpkgs/commit/f915a450baddf49851d1e3f628cdfccb17907e9b) | `` python312Packages.miniaudio: 1.60 -> 1.61 ``                           |
| [`d18755ae`](https://github.com/NixOS/nixpkgs/commit/d18755ae1c94e869553f145ae810f5157ea0fbcf) | `` python312Packages.modbus-tk: init at 1.1.1 ``                          |
| [`b773f192`](https://github.com/NixOS/nixpkgs/commit/b773f192fc0cd04a4fb90af1f6fddc9b0c732f7e) | `` pistol: 0.5.1 -> 0.5.2 ``                                              |
| [`ce30c820`](https://github.com/NixOS/nixpkgs/commit/ce30c820230f2358e69c1e6ffc7aad0efd8f97b1) | `` home-assistant: support emoncms component ``                           |
| [`890c333d`](https://github.com/NixOS/nixpkgs/commit/890c333d2d35db96d24c47a4191c67bb7b3d12f0) | `` python312Packages.pyemoncms: init at 0.1.1 ``                          |
| [`f5054253`](https://github.com/NixOS/nixpkgs/commit/f50542538e071c7106426c62ddfaab22a83fa509) | `` umpire: fix source hash ``                                             |
| [`e9f6e698`](https://github.com/NixOS/nixpkgs/commit/e9f6e698a1f99aa44f7cb6100849d3b56669cffa) | `` home-assistant: support refoss component ``                            |
| [`21fadc35`](https://github.com/NixOS/nixpkgs/commit/21fadc353b2b0c96d2ff1606e415d0d271633035) | `` python312Packages.refoss-ha: init at 1.2.4 ``                          |
| [`07d38933`](https://github.com/NixOS/nixpkgs/commit/07d389332467b0b6e4b7c00a6ceae264c84efa41) | `` python312Packages.mariadb: 1.1.4 -> 1.1.10 ``                          |
| [`64d16c83`](https://github.com/NixOS/nixpkgs/commit/64d16c838302a3ba6594c3081f3d24b8163ccc89) | `` home-assistant: support rocketchat component ``                        |
| [`fa92b69b`](https://github.com/NixOS/nixpkgs/commit/fa92b69b225d034241ef6cd8390c1064eb01331a) | `` python312Packages.rocketchat-api: init at 1.32.0 ``                    |
| [`0c9cb004`](https://github.com/NixOS/nixpkgs/commit/0c9cb0041ba1835fe630d015be292cfc75922761) | `` nixos/misskey: init ``                                                 |
| [`564a6e61`](https://github.com/NixOS/nixpkgs/commit/564a6e61a0e0c6df9eda3baf78071ed59f722248) | `` misskey: init at 2024.5.0 ``                                           |
| [`70cf12a6`](https://github.com/NixOS/nixpkgs/commit/70cf12a6d7a7eb86a0ba05f2ad703cfe76e19c28) | `` maintainers: add feathecutie ``                                        |
| [`9c5ef083`](https://github.com/NixOS/nixpkgs/commit/9c5ef08313eb6837163dd090a98b9923afff4dd7) | `` home-assistant: support splunk component ``                            |
| [`e18f068f`](https://github.com/NixOS/nixpkgs/commit/e18f068f82d412ab4133e10a00842a2e889437d3) | `` python312Packages.hass-splunk: init at 0.1.2 ``                        |
| [`3f953fe8`](https://github.com/NixOS/nixpkgs/commit/3f953fe83d6b0ccbcf601b9a5616c25d3686d626) | `` home-assistant: support stookwijzer component ``                       |
| [`f7985fd5`](https://github.com/NixOS/nixpkgs/commit/f7985fd506795cbf553c9b71d3ac65ee2cec3d11) | `` python312Packages.stookwijzer: init at 1.4.9 ``                        |
| [`ffa83aef`](https://github.com/NixOS/nixpkgs/commit/ffa83aeff3a236abde1e1a8e197fb3427d5ef8cb) | `` python312Packages.greeclimate: 2.0.0 -> 2.1.0 ``                       |
| [`ef676a00`](https://github.com/NixOS/nixpkgs/commit/ef676a00dd21d30f556eda777cf24e2bf184ccc6) | `` argocd: 2.11.7 -> 2.12.0 ``                                            |
| [`f1851ffa`](https://github.com/NixOS/nixpkgs/commit/f1851ffa193963b782878e25203217a0840f92a3) | `` spicedb-zed: 0.19.2 -> 0.20.0 ``                                       |
| [`743e8e20`](https://github.com/NixOS/nixpkgs/commit/743e8e20a07befc5b88319779527c34f63d70723) | `` sniffnet: add libxkbcommon to rpath (#332383) ``                       |
| [`cb36a918`](https://github.com/NixOS/nixpkgs/commit/cb36a91818c89b9a15f70191720ce736597b8a8d) | `` vscode-runner: init at 1.6.1 (#330659) ``                              |
| [`5bbf83ee`](https://github.com/NixOS/nixpkgs/commit/5bbf83eec168e2d37d7c0b2172177a809abf064c) | `` yt-dlp: 2024.8.1 -> 2024.8.6 ``                                        |
| [`99220b7a`](https://github.com/NixOS/nixpkgs/commit/99220b7a17085327d1fab027a0d2e0e0429295be) | `` organicmaps: 2024.07.23-8 -> 2024.07.29-2 ``                           |
| [`65d3877a`](https://github.com/NixOS/nixpkgs/commit/65d3877a977d7f8b099d0967c9e033150937f5a1) | `` cloudlens: init at 0.1.4 (#326310) ``                                  |
| [`345f5939`](https://github.com/NixOS/nixpkgs/commit/345f5939ca4a4b936232188e52ef50a00bb59409) | `` clojure: 1.11.3.1463 -> 1.11.4.1474 ``                                 |
| [`7ac6fb9b`](https://github.com/NixOS/nixpkgs/commit/7ac6fb9b836220e8f323714290fcdc973fde3185) | `` poetryPlugins.poetry-plugin-up: 0.7.1 -> 0.7.2 ``                      |
| [`5826544e`](https://github.com/NixOS/nixpkgs/commit/5826544e2a61574cd6649efed5c7b97fbc46006c) | `` python312Packages.sphinxcontrib-confluencebuilder: refactor ``         |
| [`15e98421`](https://github.com/NixOS/nixpkgs/commit/15e9842154f1ba27645eb86f92dafaeb2a41c3af) | `` open-webui: 0.3.10 -> 0.3.11 ``                                        |
| [`2cab9576`](https://github.com/NixOS/nixpkgs/commit/2cab9576084c5a4a54dbf2ce522c2b1d06252d68) | `` open-webui: add `python-dotenv` dependency ``                          |
| [`e13e593f`](https://github.com/NixOS/nixpkgs/commit/e13e593f1aaedc9898fa2bfdc8aac0f02557490d) | `` dpkg: add CoreServices to fix Darwin build ``                          |
| [`8e8f5b90`](https://github.com/NixOS/nixpkgs/commit/8e8f5b90c5e244759bba905a79d6ba72edc86c61) | `` dpkg: 1.22.6 -> 1.22.10 ``                                             |
| [`9d189075`](https://github.com/NixOS/nixpkgs/commit/9d1890751ead895dbbbd489e2978ed56adabfe5b) | `` python312Packages.pulumi-aws: 6.46.0 -> 6.48.0 ``                      |
| [`4522c84c`](https://github.com/NixOS/nixpkgs/commit/4522c84c4c11c371e88cd79d5abefa5d9e2ab7cb) | `` python312Packages.botocore-stubs: 1.34.153 -> 1.34.154 ``              |
| [`8abe1d5b`](https://github.com/NixOS/nixpkgs/commit/8abe1d5b22f108371c74a928204e2174eb706d36) | `` python312Packages.boto3-stubs: 1.34.153 -> 1.34.154 ``                 |
| [`85a005d9`](https://github.com/NixOS/nixpkgs/commit/85a005d9041c22550f26db2df59aa3ed3aff65f6) | `` python312Packages.tencentcloud-sdk-python: 3.0.1204 -> 3.0.1205 ``     |
| [`8e384f21`](https://github.com/NixOS/nixpkgs/commit/8e384f217d8975d8fb42eda7fdadf81a9dfe8af2) | `` sqlite-vec: init at v0.1.1 ``                                          |
| [`3c282dcb`](https://github.com/NixOS/nixpkgs/commit/3c282dcb850e40041d4aefd8584896634f786488) | `` villain: init at 2.1.0 ``                                              |
| [`9a2efc19`](https://github.com/NixOS/nixpkgs/commit/9a2efc194720dc5a5c6754d1bf4a1ac24f2e56bd) | `` mame: 0.267 -> 0.268 ``                                                |
| [`6a3b421c`](https://github.com/NixOS/nixpkgs/commit/6a3b421ccc351cbf5d8283de8bf760b633fdf986) | `` python312Packages.stripe: 10.4.0 -> 10.6.0 ``                          |
| [`7a6a33d2`](https://github.com/NixOS/nixpkgs/commit/7a6a33d28e68918ee64e3a153362bdfb38f0a088) | `` bearer: 1.45.2 -> 1.46.0 ``                                            |
| [`89a9d23f`](https://github.com/NixOS/nixpkgs/commit/89a9d23f8e726bc187556a231c52245fec35e042) | `` workout-tracker: 1.16.1 -> 1.18.1 ``                                   |
| [`19746f90`](https://github.com/NixOS/nixpkgs/commit/19746f90d9cf9e39a61dfd9a8e33ca683f1c7ec1) | `` python3Packages.paver/nose: remove nose and modernize ``               |
| [`7b31c136`](https://github.com/NixOS/nixpkgs/commit/7b31c13643f9abdff5727515a16608ced7cef81d) | `` wallust: 3.0.0-beta -> 3.0.0 ``                                        |
| [`3ec1eb4f`](https://github.com/NixOS/nixpkgs/commit/3ec1eb4f2c2ccedf2d27180d1bff0acac5caf535) | `` nixos/plasma5: enable xdg.icons ``                                     |
| [`761a8023`](https://github.com/NixOS/nixpkgs/commit/761a8023c41f23f66a3359d4f017b888b4348093) | `` nixos/plasma6: enable xdg.icons ``                                     |
| [`28f19332`](https://github.com/NixOS/nixpkgs/commit/28f193328608e4a3f4bfe65916455e5e446c379d) | `` nixos/wayland-session: enable xdg.icons ``                             |
| [`100d5e4c`](https://github.com/NixOS/nixpkgs/commit/100d5e4c17e51fcb0125dd902e4557698bd57df5) | `` nixos/wayfire: enable xdg.icons ``                                     |
| [`e4582da9`](https://github.com/NixOS/nixpkgs/commit/e4582da985304508de7c1bc7f184c6d875deedb6) | `` nixos/miriway: enable xdg.icons ``                                     |