### PR TITLE
chore(flake/nixpkgs): `957d95fc` -> `5e0ca229`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -732,11 +732,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1722995383,
-        "narHash": "sha256-UzuXo7ZM8ZK0SkWFhHocKkLSGQPHS4JxaE1jvVR4fUo=",
+        "lastModified": 1723175592,
+        "narHash": "sha256-M0xJ3FbDUc4fRZ84dPGx5VvgFsOzds77KiBMW/mMTnI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "957d95fc8b9bf1eb60d43f8d2eba352b71bbf2be",
+        "rev": "5e0ca22929f3342b19569b21b2f3462f053e497b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`246eb482`](https://github.com/NixOS/nixpkgs/commit/246eb48269c783a22af8e46093cf4be015a41668) | `` ruff: 0.5.6 -> 0.5.7 ``                                                        |
| [`6bd4b696`](https://github.com/NixOS/nixpkgs/commit/6bd4b696665cf05599f78036923d3270712cdf2c) | `` typstyle: 0.11.30 -> 0.11.31 ``                                                |
| [`24ff5d47`](https://github.com/NixOS/nixpkgs/commit/24ff5d472bc90ec22dee818a255499384d4e0cac) | `` hyprlandPlugins.hypr-dynamic-cursors: fix library path ``                      |
| [`1287f061`](https://github.com/NixOS/nixpkgs/commit/1287f061558a300710dd432b35f2bfc76193eb24) | `` ocamlPackages.janestreet: 0.16 -> 0.17 (#329201) ``                            |
| [`c2a6b2e9`](https://github.com/NixOS/nixpkgs/commit/c2a6b2e909f2464907f215083f025225dd0218ca) | `` julia: fix build by adding zlib to buildInputs ``                              |
| [`13b41a1e`](https://github.com/NixOS/nixpkgs/commit/13b41a1ed13a596337c4eca08e257822f076ae76) | `` xen: fix meta.longDescription ``                                               |
| [`7d7fc690`](https://github.com/NixOS/nixpkgs/commit/7d7fc6900462858a9311dce474b632eb3c9ba45d) | `` xen: build full html documentation ``                                          |
| [`e073c332`](https://github.com/NixOS/nixpkgs/commit/e073c3321b83b8878e2991664b9796617d7787c7) | `` xen: package documentation fixes ``                                            |
| [`1a3bbfb6`](https://github.com/NixOS/nixpkgs/commit/1a3bbfb6f9f6a518774ec2b0b67671b218862f2e) | `` vscode: 1.92.0 -> 1.92.1 ``                                                    |
| [`2df5e19f`](https://github.com/NixOS/nixpkgs/commit/2df5e19ff34a7541d900958a2b52674fd3890d73) | `` mtail: 3.0.7 -> 3.0.8 ``                                                       |
| [`280cc69c`](https://github.com/NixOS/nixpkgs/commit/280cc69cd69987a90e22efacca3e82e6a9f48119) | `` python312Packages.pytest-spec: 3.2.0-unstable-2023-06-04 -> 4.0.0 ``           |
| [`f3903d65`](https://github.com/NixOS/nixpkgs/commit/f3903d65fcc8c4858402b017588e4138ee160f46) | `` github-runner: 2.317.0 -> 2.319.0 ``                                           |
| [`8ccab48f`](https://github.com/NixOS/nixpkgs/commit/8ccab48f1c8aa2da2a032aa979ce2475c78a0d69) | `` gitlab-shell: rename bin/{install, check} to gitlab-shell-{install, check} ``  |
| [`3e8666bc`](https://github.com/NixOS/nixpkgs/commit/3e8666bce952916df704e390989641705b193ab1) | `` nixos/redis: remove outdated info in enable option ``                          |
| [`5c8f9b09`](https://github.com/NixOS/nixpkgs/commit/5c8f9b09765594dda011547c566f8fe7e806f45e) | `` vault-unseal: 0.5.1 -> 0.6.0 ``                                                |
| [`93b6400f`](https://github.com/NixOS/nixpkgs/commit/93b6400ff55782bdcdc68df89168fe498ae6494a) | `` nixos/chromium: Make programs.chromium.enable install chromium ``              |
| [`36e77237`](https://github.com/NixOS/nixpkgs/commit/36e77237bb9ab1e060c360ac1f8bd14efa52a6a1) | `` mdbook-graphviz: 0.2.0 -> 0.2.1 ``                                             |
| [`4779222d`](https://github.com/NixOS/nixpkgs/commit/4779222d620dedbde1282ac0e84acc9a240bdeb7) | `` ooniprobe-cli: 3.22.0 -> 3.23.0 ``                                             |
| [`297ca91a`](https://github.com/NixOS/nixpkgs/commit/297ca91a94ceb594f8c40ad73d25329421072f35) | `` erg: 0.6.40 -> 0.6.41 ``                                                       |
| [`c23aa12f`](https://github.com/NixOS/nixpkgs/commit/c23aa12f82f3e4d423898ec5f75ab7ae4a10f45b) | `` ocamlPackages.alcotest: 1.7.0 → 1.8.0 ``                                       |
| [`d73d7026`](https://github.com/NixOS/nixpkgs/commit/d73d70261f6b0472f759b498b9e7af640ba8963c) | `` kolla: init at 18.1.0 ``                                                       |
| [`d7f5a4cc`](https://github.com/NixOS/nixpkgs/commit/d7f5a4cce37ab3043913b30b593f868968893480) | `` klipper: 0.12.0-unstable-2024-07-05 -> 0.12.0-unstable-2024-08-03 (#327843) `` |
| [`0901ba6e`](https://github.com/NixOS/nixpkgs/commit/0901ba6e722446336f0fb627843705b7d0dbfcf5) | `` python312Packages.catkin-pkg: 0.5.2 -> 1.0.0 ``                                |
| [`fcaf39b0`](https://github.com/NixOS/nixpkgs/commit/fcaf39b0e7c456b469a50eb4ebc36a41687f08bf) | `` ollama: 0.3.1 -> 0.3.4 ``                                                      |
| [`700b1e63`](https://github.com/NixOS/nixpkgs/commit/700b1e637c32f50ae7013d7bfd42de967a128547) | `` ffsubsync: fix build by adding a Python 3.12 patch ``                          |
| [`1ca92c56`](https://github.com/NixOS/nixpkgs/commit/1ca92c5641fae066b6c21b54c1051fd458dbde2a) | `` ffsubsync: nixfmt ``                                                           |
| [`cead2ccd`](https://github.com/NixOS/nixpkgs/commit/cead2ccdc6a780605d571894890efd09d706820d) | `` python31{1,2}Packages.subliminal: 2.1.0 -> 2.2.1; unbreak ``                   |
| [`8c07271c`](https://github.com/NixOS/nixpkgs/commit/8c07271c4f49457ed665fb81a087381db80b199e) | `` python31{1,2}Packages.subliminal: reformat expression a bit ``                 |
| [`a7c7290b`](https://github.com/NixOS/nixpkgs/commit/a7c7290b039af68454d7797ee7427ae1d2629d79) | `` python31{1,2}Packages.pysubs2: 1.6.1 -> 1.7.3 ``                               |
| [`aed0db11`](https://github.com/NixOS/nixpkgs/commit/aed0db11bae06e49307dbae34ac8367d41a37296) | `` python31{1,2}Packages.enzyme: 0.4.1 -> 0.5.2 ``                                |
| [`1a95fb36`](https://github.com/NixOS/nixpkgs/commit/1a95fb3696f55c276ba268a83edc0a48606cc1e7) | `` home-assistant: pin aioazuredevops at 2.1.1 ``                                 |
| [`6ae0e1ab`](https://github.com/NixOS/nixpkgs/commit/6ae0e1abae33a0e9ced277c8d91012dd2113e8dc) | `` python312Packages.aioazuredevops: fix pythonImportsCheck ``                    |
| [`a6f76888`](https://github.com/NixOS/nixpkgs/commit/a6f768881a04bfb124a89bc4941d8559dc3f3336) | `` treefmt2: 2.0.3 -> 2.0.4 (#333200) ``                                          |
| [`21835c89`](https://github.com/NixOS/nixpkgs/commit/21835c891e60535a5d091ddec140894bef4aa18c) | `` SDL2: add some reverse deps to passthru.tests ``                               |
| [`2ea785c8`](https://github.com/NixOS/nixpkgs/commit/2ea785c809aa6cc4c628880c69778600fd239deb) | `` alacritty-theme: 0-unstable-2024-07-25 -> 0-unstable-2024-07-31 ``             |
| [`73dfd956`](https://github.com/NixOS/nixpkgs/commit/73dfd95684abc42dae7ccd691b15893a3ec0810c) | `` alpaca: 1.0.5 -> 1.0.6 ``                                                      |
| [`2e9f870b`](https://github.com/NixOS/nixpkgs/commit/2e9f870bf8e019bf8e18c607187a839023caa7e5) | `` nwg-panel: 0.9.36 -> 0.9.37 ``                                                 |
| [`4b30e1a0`](https://github.com/NixOS/nixpkgs/commit/4b30e1a0d97baf749e14d8d253c19cc8fbfbbba3) | `` nixfmt-rfc-style: 2024-07-12 -> 2024-08-08 ``                                  |
| [`87c9101c`](https://github.com/NixOS/nixpkgs/commit/87c9101c5afbb141afee5da60596129a85da5ca1) | `` osmo-sip-connector: 1.6.3 -> 1.7.0 ``                                          |
| [`52aa54e5`](https://github.com/NixOS/nixpkgs/commit/52aa54e5af18c9071fd932d474dcff1aacf35793) | `` python312Packages.zha: 0.0.27 -> 0.0.28 ``                                     |
| [`8b2fe41b`](https://github.com/NixOS/nixpkgs/commit/8b2fe41bcfb5e7149694a38fe72eb58984a14933) | `` python312Packages.courlan: update disabled ``                                  |
| [`7c257212`](https://github.com/NixOS/nixpkgs/commit/7c2572123a7dcd4a7e7a3030b33c51d03cee8256) | `` argc: 1.19.0 -> 1.20.0 ``                                                      |
| [`ba49422c`](https://github.com/NixOS/nixpkgs/commit/ba49422c39b3cd79cf51788e00a2d40f49388959) | `` Revert "python312Packages.dns-lexicon: 3.16.1 -> 3.17.0" ``                    |
| [`6de8cff7`](https://github.com/NixOS/nixpkgs/commit/6de8cff79f01bf79e4a26d0ff1d9cdfc73c8c1cf) | `` pupdate: 3.11.0 -> 3.11.1 ``                                                   |
| [`9e964541`](https://github.com/NixOS/nixpkgs/commit/9e964541b2d887a79406260bf82466568d1d592d) | `` tippecanoe: 2.57.0 -> 2.58.0 ``                                                |
| [`dd34f476`](https://github.com/NixOS/nixpkgs/commit/dd34f4762385ec5d6f8d8a29a6584c96743d2b85) | `` python312Packages.pylitterbot: 2023.5.1 -> 2023.5.1 ``                         |
| [`85973290`](https://github.com/NixOS/nixpkgs/commit/85973290194bb102d5ea5735974e21d3a6406564) | `` python312Packages.ruff-api: 0.0.6 -> 0.0.7 ``                                  |
| [`90c03278`](https://github.com/NixOS/nixpkgs/commit/90c03278260c5991c03dfdbcaff2f71a5672e77c) | `` python312Packages.reolink-aio: 0.9.6 -> 0.9.7 ``                               |
| [`de2aa4a8`](https://github.com/NixOS/nixpkgs/commit/de2aa4a86e361f1f07889a6ccaa0b85cfcaf613e) | `` python312Packages.pyexploitdb: 0.2.28 -> 0.2.29 ``                             |
| [`066bc5ae`](https://github.com/NixOS/nixpkgs/commit/066bc5ae64c49df04221f66b58739202e89f13f8) | `` python312Packages.lxml-html-clean: 0.1.1 -> 0.2.0 ``                           |
| [`4ea1dc70`](https://github.com/NixOS/nixpkgs/commit/4ea1dc70cafa4d0cf34efb7a058da6aaa5ec7362) | `` python312Packages.lacuscore: 1.10.8 -> 1.10.9 ``                               |
| [`124c55da`](https://github.com/NixOS/nixpkgs/commit/124c55dae808153cfbbabf495f1033ee6af16a55) | `` python312Packages.playwrightcapture: 1.25.9 -> 1.25.10 ``                      |
| [`338d216b`](https://github.com/NixOS/nixpkgs/commit/338d216b9cc4681ec57500ddf388ebe0183b5c54) | `` python312Packages.botocore-stubs: 1.34.155 -> 1.34.156 ``                      |
| [`2142bead`](https://github.com/NixOS/nixpkgs/commit/2142beada7339e7e10a8a4b36b5bd5de40a6e704) | `` python312Packages.boto3-stubs: 1.34.155 -> 1.34.156 ``                         |
| [`bb7da4d4`](https://github.com/NixOS/nixpkgs/commit/bb7da4d474ef9edc2f48319ee33db291006e1aec) | `` home-assistant-custom-lovelace-modules.android-tv-card: 3.9.3 -> 3.9.4 ``      |
| [`f6cef9ad`](https://github.com/NixOS/nixpkgs/commit/f6cef9ad481071b4edf39b733e7d38a9c1c0dd15) | `` pylyzer: 0.0.56 -> 0.0.57 ``                                                   |
| [`c630011d`](https://github.com/NixOS/nixpkgs/commit/c630011db528613ea06fa921ad66214da44c6e3f) | `` optimism: 1.8.0 -> 1.9.0 ``                                                    |
| [`58aa8b40`](https://github.com/NixOS/nixpkgs/commit/58aa8b40e7b8f15846a2023517f231c21318ac60) | `` ginkgo: 2.19.1 -> 2.20.0 ``                                                    |
| [`d1183e44`](https://github.com/NixOS/nixpkgs/commit/d1183e440a78f25ddc3da2ef71bd4bd5739d985b) | `` sd-mux-ctrl: update homepage ``                                                |
| [`a0dd2b89`](https://github.com/NixOS/nixpkgs/commit/a0dd2b89647a3c2f8ba45f360664de892c85ad79) | `` mold: 2.32.1 -> 2.33.0 ``                                                      |
| [`32206ddb`](https://github.com/NixOS/nixpkgs/commit/32206ddb02d2f3bd6d36bd74fcf7cb6af07bbf31) | `` syncthingtray-minimal: 1.5.5 -> 1.6.0 ``                                       |
| [`a8e5d638`](https://github.com/NixOS/nixpkgs/commit/a8e5d6388b4ca907078e1d81e63235e02882e654) | `` rbw: 1.11.1 -> 1.12.1 ``                                                       |
| [`5a51773c`](https://github.com/NixOS/nixpkgs/commit/5a51773c34ce1a116830126e2f25a8f4fbe4562c) | `` python312Packages.django-modeltranslation: 0.19.5 -> 0.19.6 ``                 |
| [`b36668d2`](https://github.com/NixOS/nixpkgs/commit/b36668d24ab40a2332eb3981b21d8fb05bd0ec7e) | `` python312Packages.meraki: 1.48.0 -> 1.49.0 ``                                  |
| [`9e5890af`](https://github.com/NixOS/nixpkgs/commit/9e5890af880607d5ae1a555c0ec0724e2a2eee19) | `` sd-mux-ctrl: move to pkgs/by-name ``                                           |
| [`11a8d12b`](https://github.com/NixOS/nixpkgs/commit/11a8d12b3d9cddd1eeed71de027a7b64969710ff) | `` python312Packages.polyswarm-api: 3.8.0 -> 3.9.0 ``                             |
| [`505258a6`](https://github.com/NixOS/nixpkgs/commit/505258a616954d1e5ce9f53df56ded93bbc92a9c) | `` jumppad: 0.12.1 -> 0.13.0 ``                                                   |
| [`e574a549`](https://github.com/NixOS/nixpkgs/commit/e574a549ab5c22d9d0405d2aed1ab4edeed5ad2e) | `` devenv: rm test binaries ``                                                    |
| [`f134d858`](https://github.com/NixOS/nixpkgs/commit/f134d8581068a4938283c696acbbb83e992b50ca) | `` libsForQt5.qtutilities: 6.14.1 -> 6.14.2 ``                                    |
| [`7da778d9`](https://github.com/NixOS/nixpkgs/commit/7da778d98a5042abe8a252b7fdf423cef6abbb36) | `` kdePackages.qtutilities: 6.14.1 -> 6.14.2 ``                                   |
| [`846f4e6a`](https://github.com/NixOS/nixpkgs/commit/846f4e6a6cf71df18e5ff0cfa74a5c0cd6d97fe4) | `` cobalt: 0.19.5 -> 0.19.6 ``                                                    |
| [`111534ce`](https://github.com/NixOS/nixpkgs/commit/111534ce35c36060803b810e1d6929385f46ccea) | `` jujutsu: 0.19.0 -> 0.20.0 ``                                                   |
| [`6e37f5e6`](https://github.com/NixOS/nixpkgs/commit/6e37f5e6d4861f7310248ff7bd5c25286924dd8d) | `` yosys: 0.43 -> 0.44 ``                                                         |
| [`8671daf3`](https://github.com/NixOS/nixpkgs/commit/8671daf3d2c394485dd459979a23b92e362b6f9e) | `` cpp-utilities: 5.25.0 -> 5.26.0 ``                                             |
| [`4cd3b78b`](https://github.com/NixOS/nixpkgs/commit/4cd3b78b821a8cb86a9de728491b43607bd967a6) | `` c2fmzq: 0.4.21 -> 0.4.22 ``                                                    |
| [`619966cf`](https://github.com/NixOS/nixpkgs/commit/619966cf7324e53f76a326e0f7f9fe86ff78c63f) | `` chezmoi: 2.51.0 -> 2.52.0 ``                                                   |
| [`562171c5`](https://github.com/NixOS/nixpkgs/commit/562171c53ab9a6b5c763ef8d2464d5bdf350ba3c) | `` sd-mux-ctrl: add shell completions ``                                          |
| [`326e5ea8`](https://github.com/NixOS/nixpkgs/commit/326e5ea8edca6d73af0669fb791e5609fae89d4c) | `` safeeyes: libappindicator-gtk3 is no longer a buildInput ``                    |
| [`2740c987`](https://github.com/NixOS/nixpkgs/commit/2740c9877942f9e499ad6ec4b4d3ae981cdf53c4) | `` sd-mux-ctrl: add newam as a maintainer ``                                      |
| [`f20eeca6`](https://github.com/NixOS/nixpkgs/commit/f20eeca6dfa51fcb6c9a9f9f351f92b739ed32ba) | `` ugrep: 6.3.0 -> 6.4.0 ``                                                       |
| [`f4928961`](https://github.com/NixOS/nixpkgs/commit/f4928961863fa5a4568b10306e4aaf40a26206ca) | `` python312Packages.incomfort-client: 0.6.3 -> 0.6.3-1 ``                        |
| [`408250c6`](https://github.com/NixOS/nixpkgs/commit/408250c6875ba41e1d4b91b4e239b4d53e6eb29a) | `` python312Packages.pylutron: 0.2.13 -> 0.2.15 ``                                |
| [`5cdcd1a2`](https://github.com/NixOS/nixpkgs/commit/5cdcd1a2051bb0013cc3e1e8f2bac4f7493f8235) | `` ipopt: enable mumps & spral ``                                                 |
| [`73f6b8ac`](https://github.com/NixOS/nixpkgs/commit/73f6b8ac942f8caa72f81142c57bc256227ffe42) | `` pinocchio: add casadiSupport ``                                                |
| [`7c9c23c5`](https://github.com/NixOS/nixpkgs/commit/7c9c23c5970ff42028195b70a58ba79168df6514) | `` casadi: init at 3.6.5 ``                                                       |
| [`e006f848`](https://github.com/NixOS/nixpkgs/commit/e006f8483ebec4170f15431df4fcb2d04970efc3) | `` spral: init at 2024.05.08 ``                                                   |
| [`05fb9b07`](https://github.com/NixOS/nixpkgs/commit/05fb9b070f5eede965f8b6e867a7ace0eef824ad) | `` mumps: init at 5.7.3 ``                                                        |
| [`37d24895`](https://github.com/NixOS/nixpkgs/commit/37d248957367e6995d1a02b55c59b745b734ed46) | `` castero: disable more tests to fix build ``                                    |
| [`d97ef61f`](https://github.com/NixOS/nixpkgs/commit/d97ef61f12e05ff04fe5da2fcd5be752cc3a503c) | `` dqlite: 1.16.6 -> 1.16.7 ``                                                    |
| [`9434ea8e`](https://github.com/NixOS/nixpkgs/commit/9434ea8e0f874f56a8c45a14a585f53adc019ea3) | `` python312Packages.tencentcloud-sdk-python: 3.0.1206 -> 3.0.1207 ``             |
| [`0025cb41`](https://github.com/NixOS/nixpkgs/commit/0025cb4199b27b8a5ee7462ab2b7bfc79d45797d) | `` python311Packages.angr: 9.2.113 -> 9.2.114 ``                                  |
| [`442a9c99`](https://github.com/NixOS/nixpkgs/commit/442a9c995a218327bfb78dac538689c607fac9ea) | `` python312Packages.claripy: 9.2.113 -> 9.2.114 ``                               |
| [`7788dbb2`](https://github.com/NixOS/nixpkgs/commit/7788dbb2e53677e9f4029960d909108b3dcc007a) | `` scotch: also install libesmumps for mumps ``                                   |
| [`38f97d09`](https://github.com/NixOS/nixpkgs/commit/38f97d09b303d523098764f8b8b77f79871aeaa1) | `` fatrop: init at 0.0.1 ``                                                       |
| [`f7ea2a5f`](https://github.com/NixOS/nixpkgs/commit/f7ea2a5f25a5ecde786acfcaa747c7cb58ee1d14) | `` hpipm: init at 0.1.3 ``                                                        |
| [`640f5d61`](https://github.com/NixOS/nixpkgs/commit/640f5d612bebe755f2a69992fff7d23a8d2a8fd5) | `` blasfeo: init at 0.1.3 ``                                                      |
| [`af6c0545`](https://github.com/NixOS/nixpkgs/commit/af6c05456c406430736eb4de5dd8c4aaac9f5c82) | `` osqp: fix cmake export ``                                                      |
| [`2064b01d`](https://github.com/NixOS/nixpkgs/commit/2064b01da307387d0546511157dd023d3b3c0017) | `` sleqp: init at 1.0.2 ``                                                        |
| [`59573a15`](https://github.com/NixOS/nixpkgs/commit/59573a150243af7582b277e1c972d5f1e885bb48) | `` trlib: init at 0.4 ``                                                          |
| [`1c48fcff`](https://github.com/NixOS/nixpkgs/commit/1c48fcff9c43a00a965e044df8fe226a1a4f781d) | `` superscs: init at 1.3.2 ``                                                     |
| [`c2a7d214`](https://github.com/NixOS/nixpkgs/commit/c2a7d214e23e535aa51c3eb7fb7b074faf27ad40) | `` python312Packages.cle: 9.2.113 -> 9.2.114 ``                                   |
| [`8b807a89`](https://github.com/NixOS/nixpkgs/commit/8b807a89ffbe4e9059af10ea1c13e7bb42f9c953) | `` proxsuite: init at 0.6.6 ``                                                    |
| [`2c635049`](https://github.com/NixOS/nixpkgs/commit/2c63504912e048fb07f89b79c5a7d4acd211988a) | `` python312Packages.pyvex: 9.2.113 -> 9.2.114 ``                                 |
| [`a464a32d`](https://github.com/NixOS/nixpkgs/commit/a464a32dda7f42bde36d94685311861f63427ab9) | `` python312Packages.ailment: 9.2.113 -> 9.2.114 ``                               |
| [`ba394ddd`](https://github.com/NixOS/nixpkgs/commit/ba394ddd960045edc0d5d7f06cc89e31c32c706f) | `` python312Packages.archinfo: 9.2.113 -> 9.2.114 ``                              |
| [`1990b25d`](https://github.com/NixOS/nixpkgs/commit/1990b25dd12ff253b9593afb714115ffaf028680) | `` python312Packages.aiobiketrax: 1.3.0 -> 1.3.1 ``                               |
| [`889cfb69`](https://github.com/NixOS/nixpkgs/commit/889cfb698a124dcf2cfbbedcc7714f34e9c06e03) | `` python312Packages.pubnub: update license ``                                    |
| [`a887b4e1`](https://github.com/NixOS/nixpkgs/commit/a887b4e1ecdb6afdad295cbfe7b2d4852c88bf28) | `` anytype: 0.41.1 -> 0.42.3 ``                                                   |
| [`b57fafb5`](https://github.com/NixOS/nixpkgs/commit/b57fafb5f9ff9eef472c8c3557a8970e28b3eef4) | `` osmo-sgsn: 1.11.1 -> 1.12.0 ``                                                 |
| [`8272535a`](https://github.com/NixOS/nixpkgs/commit/8272535aeedb8e354f94419425df47ccfac7c2b9) | `` osmo-ggsn: 1.11.0 -> 1.12.0 ``                                                 |
| [`0a540e6f`](https://github.com/NixOS/nixpkgs/commit/0a540e6fc5d567341e6aef7aa53a48418c7c5d38) | `` osmo-msc: 1.11.1 -> 1.12.0 ``                                                  |
| [`e469377a`](https://github.com/NixOS/nixpkgs/commit/e469377acc8898b592ab74337b4badb0ab3a820e) | `` osmo-hlr: 1.7.0 -> 1.8.0 ``                                                    |
| [`796d1b3e`](https://github.com/NixOS/nixpkgs/commit/796d1b3e85d77f6c49c313d27dfcd2569b13c4d2) | `` xwayland: 24.1.1 -> 24.1.2 ``                                                  |
| [`0479ce8e`](https://github.com/NixOS/nixpkgs/commit/0479ce8ee0c2fcb3d56d3309fcae609718d7ad1e) | `` osmo-bsc: 1.11.1 -> 1.12.1 ``                                                  |
| [`9c14c3f0`](https://github.com/NixOS/nixpkgs/commit/9c14c3f03af207fd2c53aa5dd26ebf12c498d5df) | `` osmo-mgw: 1.12.2 -> 1.13.0 ``                                                  |
| [`8bae7de7`](https://github.com/NixOS/nixpkgs/commit/8bae7de716aad6cca2b455a57bcaf6d7202026a6) | `` osmo-pcu: 1.4.0 -> 1.5.0 ``                                                    |
| [`842e5233`](https://github.com/NixOS/nixpkgs/commit/842e5233176b294f18e272dc4bdda2e94547f45d) | `` python312Packages.nbdev: 2.3.26 -> 2.3.27 ``                                   |
| [`3442f981`](https://github.com/NixOS/nixpkgs/commit/3442f981413d8bb29fd62c6414dc8fc849a3bc47) | `` osmo-bts: 1.7.2 -> 1.8.0 ``                                                    |