### PR TITLE
chore(flake/nur): `0f9d17ba` -> `5dea43cd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723268720,
-        "narHash": "sha256-mPdehKZCp14+QnG72CEoHFMMVS1d6LyJe22J66EfI3o=",
+        "lastModified": 1723270775,
+        "narHash": "sha256-fVYCQ1s6he573+tmv97iG+9iMtzg03W2vGFfwi+U/KE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0f9d17ba385fe124d3591d9b8fd99a04aac850b8",
+        "rev": "5dea43cd92cc98d4dfe5a8f21a97cca27b9e4901",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5dea43cd`](https://github.com/nix-community/NUR/commit/5dea43cd92cc98d4dfe5a8f21a97cca27b9e4901) | `` automatic update `` |