### PR TITLE
chore(flake/emacs-overlay): `2568557a` -> `e3c2692a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723254317,
-        "narHash": "sha256-Ikeu1q/fXLHr7MM1E/P8JTSSiab22A/mzz8yQ/zBi8Q=",
+        "lastModified": 1723280206,
+        "narHash": "sha256-Gz0rzfvUOgGFYnQ1j0sQCFnvym82/ysvCAp8LUmOi1s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2568557a13c8437acfe70164f664c9c0e6d1bb94",
+        "rev": "e3c2692ae5e299dcb27dcb192ba68bab4dc86ab1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`e3c2692a`](https://github.com/nix-community/emacs-overlay/commit/e3c2692ae5e299dcb27dcb192ba68bab4dc86ab1) | `` Updated melpa ``        |
| [`1528fd2d`](https://github.com/nix-community/emacs-overlay/commit/1528fd2d8b6f51e6cf1d367da718570d61c48460) | `` Updated flake inputs `` |