### PR TITLE
chore(flake/nur): `905f8fd3` -> `6254de9b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723276431,
-        "narHash": "sha256-s7Ntrj0knxeBbk0qUawGj8H3q3S+NB3aNA/ETR0IK7Y=",
+        "lastModified": 1723285834,
+        "narHash": "sha256-TRULKWp6k+uULQyPSkGVf3cOPzSxjgxctF3jRljoUp4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "905f8fd30478f9a19110cc8bd143dc9cf32f0425",
+        "rev": "6254de9bfb0932ad36b8ac9384f137c18b8690b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6254de9b`](https://github.com/nix-community/NUR/commit/6254de9bfb0932ad36b8ac9384f137c18b8690b2) | `` automatic update `` |
| [`0464b7aa`](https://github.com/nix-community/NUR/commit/0464b7aaa400d98b0b28886e78305a89a3811cf3) | `` automatic update `` |
| [`4bc6e0d9`](https://github.com/nix-community/NUR/commit/4bc6e0d91af751eade4c7752352c276d5bc39ed4) | `` automatic update `` |