### PR TITLE
chore(flake/emacs-overlay): `e3c2692a` -> `97e2af44`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723280206,
-        "narHash": "sha256-Gz0rzfvUOgGFYnQ1j0sQCFnvym82/ysvCAp8LUmOi1s=",
+        "lastModified": 1723281132,
+        "narHash": "sha256-DF96+S/XAQdYTM4MkVocS+23LAaSS58Jrlh/qKK1IzE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e3c2692ae5e299dcb27dcb192ba68bab4dc86ab1",
+        "rev": "97e2af44f9f4a786996ead0e82e65fea23369609",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`97e2af44`](https://github.com/nix-community/emacs-overlay/commit/97e2af44f9f4a786996ead0e82e65fea23369609) | `` Updated emacs `` |