### PR TITLE
chore(flake/nur): `6254de9b` -> `59baf18b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723285834,
-        "narHash": "sha256-TRULKWp6k+uULQyPSkGVf3cOPzSxjgxctF3jRljoUp4=",
+        "lastModified": 1723301105,
+        "narHash": "sha256-ywTz9cOYtZW6QdJEdvMFjz5OtCeO+t2onVTP7wsHeVE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6254de9bfb0932ad36b8ac9384f137c18b8690b2",
+        "rev": "59baf18b41f0700531db2c0316e859bebf808bfc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`59baf18b`](https://github.com/nix-community/NUR/commit/59baf18b41f0700531db2c0316e859bebf808bfc) | `` automatic update `` |
| [`a309968b`](https://github.com/nix-community/NUR/commit/a309968b9bb49b6a7db22f8e707a9d4f1de44879) | `` automatic update `` |
| [`5087817d`](https://github.com/nix-community/NUR/commit/5087817dda64e63c1835a262e771a427adb75deb) | `` automatic update `` |
| [`b11d19ae`](https://github.com/nix-community/NUR/commit/b11d19aef97d31530b9a118369a706f11c0f2b08) | `` automatic update `` |