### PR TITLE
chore(flake/agenix): `3f1dae07` -> `f6291c59`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,11 +16,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722339003,
-        "narHash": "sha256-ZeS51uJI30ehNkcZ4uKqT4ZDARPyqrHADSKAwv5vVCU=",
+        "lastModified": 1723293904,
+        "narHash": "sha256-b+uqzj+Wa6xgMS9aNbX4I+sXeb5biPDi39VgvSFqFvU=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "3f1dae074a12feb7327b4bf43cbac0d124488bb7",
+        "rev": "f6291c5935fdc4e0bef208cfc0dcab7e3f7a1c41",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`e3413992`](https://github.com/ryantm/agenix/commit/e3413992fbc77176f5827949fd3d645288db1223) | `` age-home: Use curly-brackets for XDG_RUNTIME_DIR `` |