### PR TITLE
chore(flake/emacs-overlay): `97e2af44` -> `5d6e7617`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723281132,
-        "narHash": "sha256-DF96+S/XAQdYTM4MkVocS+23LAaSS58Jrlh/qKK1IzE=",
+        "lastModified": 1723308981,
+        "narHash": "sha256-OrwPb3IAcX3Sz/B3170fUI4WyNLidyf38HeG8t6rFtk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "97e2af44f9f4a786996ead0e82e65fea23369609",
+        "rev": "5d6e7617e382a1e5e60103df9164a05e7351be83",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`5d6e7617`](https://github.com/nix-community/emacs-overlay/commit/5d6e7617e382a1e5e60103df9164a05e7351be83) | `` Updated melpa ``  |
| [`8dddc681`](https://github.com/nix-community/emacs-overlay/commit/8dddc6818dce33b9d97d51508c964ca25e845ff7) | `` Updated elpa ``   |
| [`eb6c1c44`](https://github.com/nix-community/emacs-overlay/commit/eb6c1c44a0b90d68dadc2f0dc4c9307d8175280a) | `` Updated nongnu `` |