### PR TITLE
chore(flake/nixos-hardware): `107bb46e` -> `c54cf53e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -611,11 +611,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1723149858,
-        "narHash": "sha256-3u51s7jdhavmEL1ggtd8wqrTH2clTy5yaZmhLvAXTqc=",
+        "lastModified": 1723310128,
+        "narHash": "sha256-IiH8jG6PpR4h9TxSGMYh+2/gQiJW9MwehFvheSb5rPc=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "107bb46eef1f05e86fc485ee8af9b637e5157988",
+        "rev": "c54cf53e022b0b3c1d3b8207aa0f9b194c24f0cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                                                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
| [`c54cf53e`](https://github.com/NixOS/nixos-hardware/commit/c54cf53e022b0b3c1d3b8207aa0f9b194c24f0cf) | `` Tidy-up idents ``                                                                                                                                    |
| [`569b23fd`](https://github.com/NixOS/nixos-hardware/commit/569b23fd8271ec562652295bf67e7378cca6570e) | `` Simplify the diff, by moving the (mkIf ...) for the keyboard.autosuspend.enable option to within the associated services.udev.extraRules attr-set `` |
| [`6f38f857`](https://github.com/NixOS/nixos-hardware/commit/6f38f8576c0dd1cc76f158e56793323f9c7df773) | `` Test the kernel version, rather than the NixOS release version ``                                                                                    |
| [`d1966ef8`](https://github.com/NixOS/nixos-hardware/commit/d1966ef874040b83d654ab9c896430f3017a9ec1) | `` Clarify doc-comments ``                                                                                                                              |
| [`ddebede9`](https://github.com/NixOS/nixos-hardware/commit/ddebede97439b73e1ba746c0ce68b999bcbb49c0) | `` On ASUS Zephyrus GA402X, make enabling auto-suspend on the keyboard optional ``                                                                      |
| [`dfe45103`](https://github.com/NixOS/nixos-hardware/commit/dfe45103b691b66a9f5b22cbec99d32ee31e0a52) | `` lenovo/legion/16arha7: fix kernel check for speaker patch ``                                                                                         |
| [`72b83c83`](https://github.com/NixOS/nixos-hardware/commit/72b83c838d756b6d019017cfafd645b314f85097) | `` asus-fx506hm: use nvidia-open by default ``                                                                                                          |
| [`6ed55216`](https://github.com/NixOS/nixos-hardware/commit/6ed5521636c7b40b800a014f26f0eaaa210c2e30) | `` thinkpad-t14-gen1: add a kernel param for touchpad to work properly ``                                                                               |
| [`f568ffb6`](https://github.com/NixOS/nixos-hardware/commit/f568ffb601d39e3aedae86b056b4cb8e9cb590a8) | `` apple/t2: bump kernel to 6.10.3 ``                                                                                                                   |