### PR TITLE
chore(flake/emacs-overlay): `5d6e7617` -> `548db807`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723308981,
-        "narHash": "sha256-OrwPb3IAcX3Sz/B3170fUI4WyNLidyf38HeG8t6rFtk=",
+        "lastModified": 1723338854,
+        "narHash": "sha256-PLkSNwd072KPZhwKd6aiMpOMqSuyoAUInBCbkqh4MVI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5d6e7617e382a1e5e60103df9164a05e7351be83",
+        "rev": "548db80761853bba29fb6289727a6319b27cc0eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`548db807`](https://github.com/nix-community/emacs-overlay/commit/548db80761853bba29fb6289727a6319b27cc0eb) | `` Updated elpa ``   |
| [`6b3fd267`](https://github.com/nix-community/emacs-overlay/commit/6b3fd267d5f4d54b1498f5dee2c32661f3f90613) | `` Updated nongnu `` |