### PR TITLE
chore(flake/nur): `6fa6d154` -> `c9caa27b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723333488,
-        "narHash": "sha256-doh2p9FBCa6ZKn1b6huobhL4JIj6WbpmljMt7s+XV9I=",
+        "lastModified": 1723348823,
+        "narHash": "sha256-+dXyf4zteDBg6T+AFLeDiTpd7ZQvKhH3w4cSZOLHjPc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6fa6d1546dfc0b15f8ba384b80b8f03c81d9471a",
+        "rev": "c9caa27ba0fd79f9f7c1f803df162b67a01cd83a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                            |
| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`c9caa27b`](https://github.com/nix-community/NUR/commit/c9caa27ba0fd79f9f7c1f803df162b67a01cd83a) | `` bin/nur: update shebang to include python3Packages.distutils `` |
| [`11c787f9`](https://github.com/nix-community/NUR/commit/11c787f9576874b561ef6dc31f68ba8adc60bb19) | `` automatic update ``                                             |
| [`638e850b`](https://github.com/nix-community/NUR/commit/638e850bd503b43214c8e39a838c625f011d9b10) | `` automatic update ``                                             |
| [`6a7afd04`](https://github.com/nix-community/NUR/commit/6a7afd04259930b6a3b83819e7184868a9260d17) | `` automatic update ``                                             |
| [`f6527eac`](https://github.com/nix-community/NUR/commit/f6527eaceb0d1c762c811fd4e5c2b51682eb7369) | `` automatic update ``                                             |