### PR TITLE
chore(flake/nur): `c9caa27b` -> `7bafeb14`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723348823,
-        "narHash": "sha256-+dXyf4zteDBg6T+AFLeDiTpd7ZQvKhH3w4cSZOLHjPc=",
+        "lastModified": 1723355629,
+        "narHash": "sha256-/Z25dRkTvjB2CbSD4MN3hbdYQ59MaKuMYKjwkeXhorw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c9caa27ba0fd79f9f7c1f803df162b67a01cd83a",
+        "rev": "7bafeb14c34848f2faad8ed075d359daefc48e07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                         |
| -------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`7bafeb14`](https://github.com/nix-community/NUR/commit/7bafeb14c34848f2faad8ed075d359daefc48e07) | `` automatic update ``          |
| [`06eddcbc`](https://github.com/nix-community/NUR/commit/06eddcbc4d9cc759ee3d5eb0c293b805f79b861c) | `` automatic update ``          |
| [`252eced1`](https://github.com/nix-community/NUR/commit/252eced16a1b90e46c91abf47089889413dbd734) | `` add mich-adams repository `` |
| [`096fb9ba`](https://github.com/nix-community/NUR/commit/096fb9ba8d8f37eabf232bc394707bbf14043b3f) | `` automatic update ``          |
| [`12f61663`](https://github.com/nix-community/NUR/commit/12f61663cff0fafbd36516021d78bd312d4e2c03) | `` add j4ger repository ``      |
| [`9b219a97`](https://github.com/nix-community/NUR/commit/9b219a978c04817980f8298f0d5935c61f065c2d) | `` automatic update ``          |
| [`8d587bae`](https://github.com/nix-community/NUR/commit/8d587baeb98b38402fb75e80fb2e3b2237e2d5be) | `` add NotBalds repository ``   |
| [`6eff14cd`](https://github.com/nix-community/NUR/commit/6eff14cd12764955d6edb134517f8db07104dfae) | `` automatic update ``          |
| [`cb9956b3`](https://github.com/nix-community/NUR/commit/cb9956b37de23e4822ba45ae40e34ae3fcf16a81) | `` add definfo repository ``    |
| [`b192190d`](https://github.com/nix-community/NUR/commit/b192190d32db78f7bcfa8cf56c872bb086eae05a) | `` automatic update ``          |
| [`171f0f22`](https://github.com/nix-community/NUR/commit/171f0f22a677486191906ab293a47313b5fa6adc) | `` add mrene repository ``      |