### PR TITLE
chore(flake/nur): `7bafeb14` -> `9f84e9df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723355629,
-        "narHash": "sha256-/Z25dRkTvjB2CbSD4MN3hbdYQ59MaKuMYKjwkeXhorw=",
+        "lastModified": 1723358813,
+        "narHash": "sha256-a0qHrznALyFgpSy71HcW/Rn35+cYTurSEdzbTP+FU3A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7bafeb14c34848f2faad8ed075d359daefc48e07",
+        "rev": "9f84e9dfa6e5c4c56fc1e18df3da5a37d7a965e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9f84e9df`](https://github.com/nix-community/NUR/commit/9f84e9dfa6e5c4c56fc1e18df3da5a37d7a965e0) | `` automatic update `` |