### PR TITLE
chore(flake/nur): `9f84e9df` -> `8511e95d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723358813,
-        "narHash": "sha256-a0qHrznALyFgpSy71HcW/Rn35+cYTurSEdzbTP+FU3A=",
+        "lastModified": 1723364651,
+        "narHash": "sha256-aY+Ckr+3Nx6C4SnRzqKXjYiLj8IVhTiAtKeHyLl/GbU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9f84e9dfa6e5c4c56fc1e18df3da5a37d7a965e0",
+        "rev": "8511e95dfec45e3c770bd2528f5eb90fc8947e75",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8511e95d`](https://github.com/nix-community/NUR/commit/8511e95dfec45e3c770bd2528f5eb90fc8947e75) | `` automatic update `` |
| [`ea3eb716`](https://github.com/nix-community/NUR/commit/ea3eb7168a68b7496e164849f0d7f58019463a5d) | `` automatic update `` |