### PR TITLE
chore(flake/nur): `8511e95d` -> `d508f0f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723364651,
-        "narHash": "sha256-aY+Ckr+3Nx6C4SnRzqKXjYiLj8IVhTiAtKeHyLl/GbU=",
+        "lastModified": 1723373216,
+        "narHash": "sha256-Kw8GUGrdbg+UfjXh7cSCUL+9gLDw3yJfWEzaIR4GT68=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8511e95dfec45e3c770bd2528f5eb90fc8947e75",
+        "rev": "d508f0f8894e51009a0b5201e04866a211788b6b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d508f0f8`](https://github.com/nix-community/NUR/commit/d508f0f8894e51009a0b5201e04866a211788b6b) | `` automatic update `` |