### PR TITLE
chore(flake/emacs-overlay): `8be02a3d` -> `0f2c4cb3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723366535,
-        "narHash": "sha256-RGWd01yvAD3EpSnBZBc2alATNbWu4O/8QpmG8pMCshg=",
+        "lastModified": 1723395329,
+        "narHash": "sha256-fKIsLjBxf5d4qS3vraLQkZTyhQBdbIZM9gR0cJqYvjE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8be02a3d75b06dd38b1e5765a4a2418abcfe9ad0",
+        "rev": "0f2c4cb31745058644f044fb4976dd41a8307db7",
         "type": "github"
       },
       "original": {
@@ -684,11 +684,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1722987190,
-        "narHash": "sha256-68hmex5efCiM2aZlAAEcQgmFI4ZwWt8a80vOeB/5w3A=",
+        "lastModified": 1723282977,
+        "narHash": "sha256-oTK91aOlA/4IsjNAZGMEBz7Sq1zBS0Ltu4/nIQdYDOg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "21cc704b5e918c5fbf4f9fff22b4ac2681706d90",
+        "rev": "a781ff33ae258bbcfd4ed6e673860c3e923bf2cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`0f2c4cb3`](https://github.com/nix-community/emacs-overlay/commit/0f2c4cb31745058644f044fb4976dd41a8307db7) | `` Updated melpa ``        |
| [`fba162a8`](https://github.com/nix-community/emacs-overlay/commit/fba162a809315d84f1221de9de24ff2ac00187a0) | `` Updated elpa ``         |
| [`2436406b`](https://github.com/nix-community/emacs-overlay/commit/2436406b4efbb9414d92088b4c3a08246db74d7e) | `` Updated nongnu ``       |
| [`6b6c7d8a`](https://github.com/nix-community/emacs-overlay/commit/6b6c7d8a021e2a313af8e7fe77f2078f937fe5a9) | `` Updated flake inputs `` |