### PR TITLE
chore(flake/nur): `110866de` -> `7672f0d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723380405,
-        "narHash": "sha256-r2TX7+d1ABS3X04kmbicfpV96yXUVLIZGC6FR55VwhA=",
+        "lastModified": 1723408862,
+        "narHash": "sha256-0cK4/YozxKTtZJqr74Lndah9bQpOlZZpXGkoCnLznJQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "110866de6b9a3981751d3d4cf9f7b978610b30f1",
+        "rev": "7672f0d495501eadcdb21cf77a5ecc88a48a66c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7672f0d4`](https://github.com/nix-community/NUR/commit/7672f0d495501eadcdb21cf77a5ecc88a48a66c8) | `` automatic update `` |
| [`34fa3e15`](https://github.com/nix-community/NUR/commit/34fa3e15b5bd5539177d960cf8c7487eabb9f1c7) | `` automatic update `` |
| [`b1d085b2`](https://github.com/nix-community/NUR/commit/b1d085b2eff3686c60e8da197569662e6555ef33) | `` automatic update `` |
| [`300d0d96`](https://github.com/nix-community/NUR/commit/300d0d9687ce7b672ada107a764705558375e7bf) | `` automatic update `` |