### PR TITLE
chore(flake/home-manager): `b3d5ea65` -> `086f619d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -394,11 +394,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723015306,
-        "narHash": "sha256-jQnFEtH20/OsDPpx71ntZzGdRlpXhUENSQCGTjn//NA=",
+        "lastModified": 1723399884,
+        "narHash": "sha256-97wn0ihhGqfMb8WcUgzzkM/TuAxce2Gd20A8oiruju4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b3d5ea65d88d67d4ec578ed11d4d2d51e3de525e",
+        "rev": "086f619dd991a4d355c07837448244029fc2d9ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`086f619d`](https://github.com/nix-community/home-manager/commit/086f619dd991a4d355c07837448244029fc2d9ab) | `` flake.lock: Update ``                |
| [`8b7cdfce`](https://github.com/nix-community/home-manager/commit/8b7cdfceaf877086fba641bad4607f5db4c4002a) | `` Translate using Weblate (Catalan) `` |