### PR TITLE
chore(flake/nur): `7672f0d4` -> `02554469`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723408862,
-        "narHash": "sha256-0cK4/YozxKTtZJqr74Lndah9bQpOlZZpXGkoCnLznJQ=",
+        "lastModified": 1723413189,
+        "narHash": "sha256-lTfjQoJgNVnX3nx+7RThpnXPINdfzXnDgXo/gOYmBcc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7672f0d495501eadcdb21cf77a5ecc88a48a66c8",
+        "rev": "02554469d7f99056e0b889ce6a8f3857611fd973",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`02554469`](https://github.com/nix-community/NUR/commit/02554469d7f99056e0b889ce6a8f3857611fd973) | `` automatic update `` |
| [`da0fd3c5`](https://github.com/nix-community/NUR/commit/da0fd3c5e43c4ad44279d9dbc2d15c0c133531d7) | `` automatic update `` |