### PR TITLE
chore(flake/nur): `02554469` -> `7cbae72f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723413189,
-        "narHash": "sha256-lTfjQoJgNVnX3nx+7RThpnXPINdfzXnDgXo/gOYmBcc=",
+        "lastModified": 1723416322,
+        "narHash": "sha256-EyZTBv/7wdbkSxPLBmmPNcrOlmW1MQg4zmElINXcHt0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "02554469d7f99056e0b889ce6a8f3857611fd973",
+        "rev": "7cbae72f18bcca0ce2c5e7e57064a8d314a2fe0c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7cbae72f`](https://github.com/nix-community/NUR/commit/7cbae72f18bcca0ce2c5e7e57064a8d314a2fe0c) | `` automatic update `` |
| [`13263f2b`](https://github.com/nix-community/NUR/commit/13263f2b03b1a3cabe37399bbacce4e55fa35ff6) | `` automatic update `` |
| [`8fe15741`](https://github.com/nix-community/NUR/commit/8fe15741c4d3b5f60b05c49d5af7968b47c06c8f) | `` automatic update `` |