### PR TITLE
chore(flake/emacs-overlay): `73ae2320` -> `51650f60`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723396183,
-        "narHash": "sha256-WqQLm0Omtp45mIHhqUMbdmHrX5oee78DYRZDglxxzOc=",
+        "lastModified": 1723425073,
+        "narHash": "sha256-bLJF/jaZn7cnC8Zr3sEws3/PKrN/bfCBmXfm9M5ZTls=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "73ae2320be79ca277fa5b1c60afe0c6fd1a08519",
+        "rev": "51650f605cdc8e73fa1573d64127ec6f1619ba18",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`51650f60`](https://github.com/nix-community/emacs-overlay/commit/51650f605cdc8e73fa1573d64127ec6f1619ba18) | `` Updated emacs ``  |
| [`f0bcef64`](https://github.com/nix-community/emacs-overlay/commit/f0bcef64b9a27f1de8dbb35d53dda9d4cd7464d2) | `` Updated elpa ``   |
| [`141a020f`](https://github.com/nix-community/emacs-overlay/commit/141a020f73221ba3fc5edf2c0437949827276064) | `` Updated nongnu `` |