### PR TITLE
chore(flake/srvos): `f3890645` -> `a7cc81cd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -897,11 +897,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723077922,
-        "narHash": "sha256-FY5UMtlBCcbMxk+ykmZzYYtm7l/uUKwiMNYbFgqG5yg=",
+        "lastModified": 1723423676,
+        "narHash": "sha256-E+DdXV2cFj77vU35cVNoEEE5YueE075HXiJLXwAxJ0k=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "f389064525b8330f20106231762f52854490654e",
+        "rev": "a7cc81cd76c4c07bb7db01b731199ecd4be17305",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`a7cc81cd`](https://github.com/nix-community/srvos/commit/a7cc81cd76c4c07bb7db01b731199ecd4be17305) | `` dev/private/flake.lock: Update `` |
| [`9fdf87d4`](https://github.com/nix-community/srvos/commit/9fdf87d406ec2e72b76340885ba859ceb401b8d0) | `` flake.lock: Update ``             |