### PR TITLE
chore(flake/emacs-overlay): `51650f60` -> `406b85d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723425073,
-        "narHash": "sha256-bLJF/jaZn7cnC8Zr3sEws3/PKrN/bfCBmXfm9M5ZTls=",
+        "lastModified": 1723427190,
+        "narHash": "sha256-GHemfC5ZoenPENbXOUBgp6ilzUhVNR7tNDxeSTsaAkk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "51650f605cdc8e73fa1573d64127ec6f1619ba18",
+        "rev": "406b85d2b06b4cfab0f0f31b08758fac8e02a691",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`406b85d2`](https://github.com/nix-community/emacs-overlay/commit/406b85d2b06b4cfab0f0f31b08758fac8e02a691) | `` Updated melpa `` |