### PR TITLE
chore(flake/nur): `f91e2cc7` -> `cf00972a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723419898,
-        "narHash": "sha256-fUxZlPPZAYzHvqg4O8snIYVtqR17YCnEEMHKNL+sY4g=",
+        "lastModified": 1723434153,
+        "narHash": "sha256-PfH9by7ZcTNhasovh/aoKc0Uco/CdwT1+FLTZvPOv7k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f91e2cc78335cd634c103576f2b2e826d93bb291",
+        "rev": "cf00972a752f8c7f0a843b2e72aeaf944e5e1e2a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cf00972a`](https://github.com/nix-community/NUR/commit/cf00972a752f8c7f0a843b2e72aeaf944e5e1e2a) | `` automatic update `` |
| [`b8e83bfc`](https://github.com/nix-community/NUR/commit/b8e83bfc04f25cdc5be1d6e1abb5a06c3f398eac) | `` automatic update `` |
| [`9bca1e1b`](https://github.com/nix-community/NUR/commit/9bca1e1b49bccb1af85b98de9f468011833f7ef8) | `` automatic update `` |