### PR TITLE
chore(flake/nur): `cf00972a` -> `6292b376`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723434153,
-        "narHash": "sha256-PfH9by7ZcTNhasovh/aoKc0Uco/CdwT1+FLTZvPOv7k=",
+        "lastModified": 1723435450,
+        "narHash": "sha256-2LN4YI0wWDvYZj7hzYxY7NTiyXXcI37kh5G0LJZSj7c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cf00972a752f8c7f0a843b2e72aeaf944e5e1e2a",
+        "rev": "6292b376c645574019c76a48a738f34633ca6168",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6292b376`](https://github.com/nix-community/NUR/commit/6292b376c645574019c76a48a738f34633ca6168) | `` automatic update `` |