### PR TITLE
chore(flake/nur): `6292b376` -> `650e19cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723435450,
-        "narHash": "sha256-2LN4YI0wWDvYZj7hzYxY7NTiyXXcI37kh5G0LJZSj7c=",
+        "lastModified": 1723445320,
+        "narHash": "sha256-yeD890KJQ619ewaNMxYjvOB6Dx8pFaEBjCN+3W4DTY0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6292b376c645574019c76a48a738f34633ca6168",
+        "rev": "650e19ccfc2200e5f04dfd1766d206790ccf57bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`650e19cc`](https://github.com/nix-community/NUR/commit/650e19ccfc2200e5f04dfd1766d206790ccf57bd) | `` automatic update `` |