### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `c8e3c381` -> `50439675`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723341846,
-        "narHash": "sha256-ZLQwk39U2ByDd8ZlsFOQN8wBRbjFtglCRgIHWDVG2RI=",
+        "lastModified": 1723427190,
+        "narHash": "sha256-GHemfC5ZoenPENbXOUBgp6ilzUhVNR7tNDxeSTsaAkk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "516c442503ca7f744d46d30b77b2ca11f35f1e3e",
+        "rev": "406b85d2b06b4cfab0f0f31b08758fac8e02a691",
         "type": "github"
       },
       "original": {
@@ -500,11 +500,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1723365095,
-        "narHash": "sha256-2230LsHCU86sqVP2ND/w5A3JPH1eiikzrIPKVd0ZQho=",
+        "lastModified": 1723451722,
+        "narHash": "sha256-hnp590P+pbnWuiXBq+cyCFUz1r3/xJLJ6BbUcLBKLBI=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "c8e3c381a6cb4e12768f23265f3af65902d872a2",
+        "rev": "50439675ebc8b6df32c3bc33c951a25a95f0981a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`50439675`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/50439675ebc8b6df32c3bc33c951a25a95f0981a) | `` flake.lock: Update `` |