### PR TITLE
chore(flake/emacs-overlay): `406b85d2` -> `aad34633`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723427190,
-        "narHash": "sha256-GHemfC5ZoenPENbXOUBgp6ilzUhVNR7tNDxeSTsaAkk=",
+        "lastModified": 1723453927,
+        "narHash": "sha256-dXo8MrjqUKkJpHDnpOyt7OYh9nKee56BXnhmNHTZJuI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "406b85d2b06b4cfab0f0f31b08758fac8e02a691",
+        "rev": "aad34633f2b567583651ff6b7614026a4b7b58a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`aad34633`](https://github.com/nix-community/emacs-overlay/commit/aad34633f2b567583651ff6b7614026a4b7b58a3) | `` Updated emacs `` |
| [`d4cae4d9`](https://github.com/nix-community/emacs-overlay/commit/d4cae4d9ac38b0d7d5ccd61d57bed8aad9c752f0) | `` Updated melpa `` |