### PR TITLE
chore(flake/nur): `a2a45a36` -> `59ce81db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723451839,
-        "narHash": "sha256-4etPYfCuOj1n9YihCKf/opgRVxqOCvcHBgtAZYO1/S0=",
+        "lastModified": 1723461379,
+        "narHash": "sha256-ceA1i7qNb8Tnq9CitvU/8S9bteBZYG7EoN9GEdP9V44=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a2a45a362192fa32417a014b3174b423a5ea12be",
+        "rev": "59ce81dbfc754ce61933bb0677b531a95ada78dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`59ce81db`](https://github.com/nix-community/NUR/commit/59ce81dbfc754ce61933bb0677b531a95ada78dd) | `` automatic update `` |
| [`948aaf63`](https://github.com/nix-community/NUR/commit/948aaf63fbad8241834eb2cf0e8ffa69b0ca52fe) | `` automatic update `` |
| [`cfaac584`](https://github.com/nix-community/NUR/commit/cfaac58449a977913be5d947b0755969ede22a4a) | `` automatic update `` |