### PR TITLE
chore(flake/treefmt): `c9f97032` -> `349de7bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -992,11 +992,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723402464,
-        "narHash": "sha256-xjunKUFQs9D7u0TpVoXhrRYb4tbVkutRoFUHj0lEydE=",
+        "lastModified": 1723454642,
+        "narHash": "sha256-S0Gvsenh0II7EAaoc9158ZB4vYyuycvMGKGxIbERNAM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "c9f97032be6816fa234f24803b8ae79dc7753a91",
+        "rev": "349de7bc435bdff37785c2466f054ed1766173be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                     |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`349de7bc`](https://github.com/numtide/treefmt-nix/commit/349de7bc435bdff37785c2466f054ed1766173be) | `` fix: unset PRJ_ROOT to prevent impure behavior (#220) `` |
| [`f28662bc`](https://github.com/numtide/treefmt-nix/commit/f28662bca45de748787024a72930450a13115fe4) | `` {shellcheck,shfmt}: include `*.envrc.*` files (#221) ``  |