### PR TITLE
chore(flake/emacs-overlay): `aad34633` -> `e8c9c507`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723453927,
-        "narHash": "sha256-dXo8MrjqUKkJpHDnpOyt7OYh9nKee56BXnhmNHTZJuI=",
+        "lastModified": 1723481865,
+        "narHash": "sha256-PBiz6u2dwcQzdKFX0Kpsh0WTN0YHSpGZaMbr2ii9yAo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "aad34633f2b567583651ff6b7614026a4b7b58a3",
+        "rev": "e8c9c50731314d192806c46277be0bcac97a4b1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`e8c9c507`](https://github.com/nix-community/emacs-overlay/commit/e8c9c50731314d192806c46277be0bcac97a4b1e) | `` Updated melpa ``  |
| [`9b24a1af`](https://github.com/nix-community/emacs-overlay/commit/9b24a1af7659f8597b57ee7c28f87404826ad9f8) | `` Updated elpa ``   |
| [`3fb3c163`](https://github.com/nix-community/emacs-overlay/commit/3fb3c1632623136fad3cae2d2e5c73e0bca04766) | `` Updated nongnu `` |