### PR TITLE
chore(flake/nur): `8fff9cd2` -> `9287117f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723467741,
-        "narHash": "sha256-cLjB5JeHNBbe51JW18I0kk8gmj8aIctr2++AaxqN2Cg=",
+        "lastModified": 1723488528,
+        "narHash": "sha256-QO0kJGN1PhnnyXn5E34zcJMCKKxRJ+hzSIm5zkjy4ws=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8fff9cd2c702f18d4a9020dc9e5186a028761769",
+        "rev": "9287117f3d873e92b93858d7770b5cb91069e1dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9287117f`](https://github.com/nix-community/NUR/commit/9287117f3d873e92b93858d7770b5cb91069e1dd) | `` automatic update `` |
| [`a4f1c6cf`](https://github.com/nix-community/NUR/commit/a4f1c6cf98a629c082edc90fd84be7cc4525e244) | `` automatic update `` |