### PR TITLE
chore(flake/emacs-overlay): `e8c9c507` -> `463ee3b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723481865,
-        "narHash": "sha256-PBiz6u2dwcQzdKFX0Kpsh0WTN0YHSpGZaMbr2ii9yAo=",
+        "lastModified": 1723482913,
+        "narHash": "sha256-wzIUWp672DHcFYhfKBxzfs4nSlm6W34tOmTOlFwwETE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e8c9c50731314d192806c46277be0bcac97a4b1e",
+        "rev": "463ee3b4d1c63385c58d7742d33dbe6bdc8fd2a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`463ee3b4`](https://github.com/nix-community/emacs-overlay/commit/463ee3b4d1c63385c58d7742d33dbe6bdc8fd2a1) | `` Updated emacs `` |