### PR TITLE
chore(flake/sops-nix): `ab2d1ffe` -> `be0eec2d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -877,11 +877,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1723454404,
-        "narHash": "sha256-Zhcf1TMDYb0BxDHKhEKCKFb1qi2vwlX0BgJPwk9Gd3E=",
+        "lastModified": 1723501126,
+        "narHash": "sha256-N9IcHgj/p1+2Pvk8P4Zc1bfrMwld5PcosVA0nL6IGdE=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "ab2d1ffeb5b85da2f6537beb2fe05da54276c261",
+        "rev": "be0eec2d27563590194a9206f551a6f73d52fa34",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                           |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`be0eec2d`](https://github.com/Mic92/sops-nix/commit/be0eec2d27563590194a9206f551a6f73d52fa34) | `` update vendorHash ``                                           |
| [`4802909c`](https://github.com/Mic92/sops-nix/commit/4802909c792ce08b54e0b2265179c69500b5095f) | `` build(deps): bump golang.org/x/crypto from 0.25.0 to 0.26.0 `` |