### PR TITLE
chore(flake/emacs-overlay): `463ee3b4` -> `83f1d71d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723482913,
-        "narHash": "sha256-wzIUWp672DHcFYhfKBxzfs4nSlm6W34tOmTOlFwwETE=",
+        "lastModified": 1723511402,
+        "narHash": "sha256-SBmFZKehLSF07OqR849Ai+nYs8L6RXoOTugiCkal2og=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "463ee3b4d1c63385c58d7742d33dbe6bdc8fd2a1",
+        "rev": "83f1d71d1486e4af3e84483293da9b37b0402964",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`83f1d71d`](https://github.com/nix-community/emacs-overlay/commit/83f1d71d1486e4af3e84483293da9b37b0402964) | `` Updated elpa ``   |
| [`34aa99ed`](https://github.com/nix-community/emacs-overlay/commit/34aa99ed7c4cf36c93de4966850afc814ab5664e) | `` Updated nongnu `` |