### PR TITLE
chore(flake/nur): `c7cafc10` -> `a321973b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723502021,
-        "narHash": "sha256-UfzHZLj0WkwhrtfVX4qmYLkX8YijXkspM/4J6aE2yGM=",
+        "lastModified": 1723518041,
+        "narHash": "sha256-X37DygsKkL7v83TPxT/YGLHkQT3rUTRjDW6tw/dh0wk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c7cafc107dd9ae3096c0e9b8d4f2ddb7e1bcc370",
+        "rev": "a321973b8862e6a797c7a78b7c4e9289f7198357",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a321973b`](https://github.com/nix-community/NUR/commit/a321973b8862e6a797c7a78b7c4e9289f7198357) | `` automatic update `` |
| [`e000817a`](https://github.com/nix-community/NUR/commit/e000817a2a99f4a63d73a90d9144198f58bb5ba7) | `` automatic update `` |
| [`d5dc2c95`](https://github.com/nix-community/NUR/commit/d5dc2c95a4115525444a0ca451cc5ebb79f43068) | `` automatic update `` |
| [`e27d5a68`](https://github.com/nix-community/NUR/commit/e27d5a683a471fccd9960c8e09a8bfbb8764c4ca) | `` automatic update `` |