### PR TITLE
chore(flake/nur): `a321973b` -> `e8652039`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723518041,
-        "narHash": "sha256-X37DygsKkL7v83TPxT/YGLHkQT3rUTRjDW6tw/dh0wk=",
+        "lastModified": 1723520564,
+        "narHash": "sha256-MRkwiF0b9NB4fIxqMHcJ5079VkoHC4BhV6zKO6pBr38=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a321973b8862e6a797c7a78b7c4e9289f7198357",
+        "rev": "e86520394eb912908a38a5c56d0a4ec7205cc875",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e8652039`](https://github.com/nix-community/NUR/commit/e86520394eb912908a38a5c56d0a4ec7205cc875) | `` automatic update `` |