### PR TITLE
chore(flake/nur): `e8652039` -> `b17b1a5a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723520564,
-        "narHash": "sha256-MRkwiF0b9NB4fIxqMHcJ5079VkoHC4BhV6zKO6pBr38=",
+        "lastModified": 1723521843,
+        "narHash": "sha256-jJKOoupr9f5S2fXONEKMtoim05dE92BLXjlHY7x54Mk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e86520394eb912908a38a5c56d0a4ec7205cc875",
+        "rev": "b17b1a5a8f8cb3d23d7660cdfe2afe53ad18045a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b17b1a5a`](https://github.com/nix-community/NUR/commit/b17b1a5a8f8cb3d23d7660cdfe2afe53ad18045a) | `` automatic update `` |