### PR TITLE
chore(flake/nur): `b17b1a5a` -> `a5d98727`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723521843,
-        "narHash": "sha256-jJKOoupr9f5S2fXONEKMtoim05dE92BLXjlHY7x54Mk=",
+        "lastModified": 1723528339,
+        "narHash": "sha256-eYivJjsUREndFgGPbIIAQQ1+PIz7IHddNFO/wC5PwGw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b17b1a5a8f8cb3d23d7660cdfe2afe53ad18045a",
+        "rev": "a5d98727b0dce6656d526278681360050e6d3693",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a5d98727`](https://github.com/nix-community/NUR/commit/a5d98727b0dce6656d526278681360050e6d3693) | `` automatic update `` |