### PR TITLE
chore(flake/nur): `9ba744a2` -> `20b1fc40`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723534475,
-        "narHash": "sha256-YJwSdRctvR2uEds62c/DUZg+qucchQ/JH1pi9DsI5nM=",
+        "lastModified": 1723549487,
+        "narHash": "sha256-65NYBcYUx0DjL7TGlesle5PdtJVfOCPnv5zvsgB/dRw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ba744a28615d55d2cca30e5f96ad691066e22b6",
+        "rev": "20b1fc4032363116a880dc64e3fa96f8a24d4e64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`20b1fc40`](https://github.com/nix-community/NUR/commit/20b1fc4032363116a880dc64e3fa96f8a24d4e64) | `` automatic update `` |
| [`ef211499`](https://github.com/nix-community/NUR/commit/ef2114993069b79eddfbe2fb3b1981fffd357bc9) | `` automatic update `` |
| [`7df50126`](https://github.com/nix-community/NUR/commit/7df50126eb1153c563673fdde8433f807ff8613c) | `` automatic update `` |
| [`e661a7d0`](https://github.com/nix-community/NUR/commit/e661a7d0d90ddde499b2d777e0ec50b5427ea132) | `` automatic update `` |
| [`f84d1727`](https://github.com/nix-community/NUR/commit/f84d17278b3886bd716a71006a21b811db456e3d) | `` automatic update `` |