### PR TITLE
chore(flake/emacs-overlay): `f53d50f3` -> `aa3997dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723539433,
-        "narHash": "sha256-2h5Z7h4QPYQS64vqbfIbyJ1DaIEUB658l2y6WTUsZPs=",
+        "lastModified": 1723540261,
+        "narHash": "sha256-jniQno8FCotJ0OUSxd43Zl5q0UsKbKvrtATduvrhO2g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f53d50f33151273cdb8cdd899f8de947c6018b06",
+        "rev": "aa3997dd78a00dec18e4d22f6073f78778c75301",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`aa3997dd`](https://github.com/nix-community/emacs-overlay/commit/aa3997dd78a00dec18e4d22f6073f78778c75301) | `` Updated emacs `` |