### PR TITLE
chore(flake/nur): `20b1fc40` -> `494fb371`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723549487,
-        "narHash": "sha256-65NYBcYUx0DjL7TGlesle5PdtJVfOCPnv5zvsgB/dRw=",
+        "lastModified": 1723554177,
+        "narHash": "sha256-c874Bx8Hi6NGEt+PZQ88tgay2eyZ9Zly6rDHFhKFRJk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "20b1fc4032363116a880dc64e3fa96f8a24d4e64",
+        "rev": "494fb37109715b5e3498c6a85532d5be16bdf10e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`494fb371`](https://github.com/nix-community/NUR/commit/494fb37109715b5e3498c6a85532d5be16bdf10e) | `` automatic update `` |