### PR TITLE
chore(flake/nur): `494fb371` -> `754a2813`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723554177,
-        "narHash": "sha256-c874Bx8Hi6NGEt+PZQ88tgay2eyZ9Zly6rDHFhKFRJk=",
+        "lastModified": 1723564068,
+        "narHash": "sha256-n9oNE84eg7ZCZ86ARKoAwJZRVNHWHhyGGfhg4olJB7k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "494fb37109715b5e3498c6a85532d5be16bdf10e",
+        "rev": "754a2813625424a088d514a2da7f0d51a25c2834",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`754a2813`](https://github.com/nix-community/NUR/commit/754a2813625424a088d514a2da7f0d51a25c2834) | `` automatic update `` |