### PR TITLE
chore(flake/emacs-overlay): `aa3997dd` -> `92c05dd6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723540261,
-        "narHash": "sha256-jniQno8FCotJ0OUSxd43Zl5q0UsKbKvrtATduvrhO2g=",
+        "lastModified": 1723568237,
+        "narHash": "sha256-2iv6ITbPhnZQGMmelEY3T+4Bm9RUwjG9J0LEdLrP7as=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "aa3997dd78a00dec18e4d22f6073f78778c75301",
+        "rev": "92c05dd6f84856ef9b434ce876c62eea2ac5c03f",
         "type": "github"
       },
       "original": {
@@ -684,11 +684,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1723282977,
-        "narHash": "sha256-oTK91aOlA/4IsjNAZGMEBz7Sq1zBS0Ltu4/nIQdYDOg=",
+        "lastModified": 1723400035,
+        "narHash": "sha256-WoKZDlBEdMhP+hjquBAh0BhUJbcH2+U8g2mHOr1mv8I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a781ff33ae258bbcfd4ed6e673860c3e923bf2cc",
+        "rev": "a731b45590a5169542990c36ffcde6cebd9a3356",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`92c05dd6`](https://github.com/nix-community/emacs-overlay/commit/92c05dd6f84856ef9b434ce876c62eea2ac5c03f) | `` Updated melpa ``        |
| [`2455e57b`](https://github.com/nix-community/emacs-overlay/commit/2455e57b0cf3242cc495d9831044529a50936722) | `` Updated elpa ``         |
| [`5b945043`](https://github.com/nix-community/emacs-overlay/commit/5b9450433aff68564c2e7c11bb4de967a7cbdf20) | `` Updated nongnu ``       |
| [`e66167c0`](https://github.com/nix-community/emacs-overlay/commit/e66167c05e56e79750446cfcd5d1237da7f55a02) | `` Updated flake inputs `` |