### PR TITLE
chore(flake/nur): `754a2813` -> `697ec3fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723564068,
-        "narHash": "sha256-n9oNE84eg7ZCZ86ARKoAwJZRVNHWHhyGGfhg4olJB7k=",
+        "lastModified": 1723574392,
+        "narHash": "sha256-VK4ytRNd3+vNlIBjqkJX/yYZhzFAYA1srdIbvHnVgqI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "754a2813625424a088d514a2da7f0d51a25c2834",
+        "rev": "697ec3fa425a6a06f951198f235b24af63c2a4a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`697ec3fa`](https://github.com/nix-community/NUR/commit/697ec3fa425a6a06f951198f235b24af63c2a4a4) | `` automatic update `` |
| [`e6177712`](https://github.com/nix-community/NUR/commit/e6177712b31189686407abbda3e186356dfb0094) | `` automatic update `` |