### PR TITLE
chore(flake/emacs-overlay): `92c05dd6` -> `381e4aa2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723568237,
-        "narHash": "sha256-2iv6ITbPhnZQGMmelEY3T+4Bm9RUwjG9J0LEdLrP7as=",
+        "lastModified": 1723569059,
+        "narHash": "sha256-1oVparM3qQRKoDrACqwer65c1cYV3hjc0+dZQ9MjFlk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "92c05dd6f84856ef9b434ce876c62eea2ac5c03f",
+        "rev": "381e4aa28c0ecf265ed207ea14b0d10275eb651f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`381e4aa2`](https://github.com/nix-community/emacs-overlay/commit/381e4aa28c0ecf265ed207ea14b0d10275eb651f) | `` Updated emacs `` |