### PR TITLE
chore(flake/nur): `697ec3fa` -> `c7ba591c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723574392,
-        "narHash": "sha256-VK4ytRNd3+vNlIBjqkJX/yYZhzFAYA1srdIbvHnVgqI=",
+        "lastModified": 1723578304,
+        "narHash": "sha256-p/G1yrUyJ84lh0JpBHXMwNuHWLKLLKSpdIufPJljvY4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "697ec3fa425a6a06f951198f235b24af63c2a4a4",
+        "rev": "c7ba591cead34c21172cca76f1aabcb130c40508",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c7ba591c`](https://github.com/nix-community/NUR/commit/c7ba591cead34c21172cca76f1aabcb130c40508) | `` automatic update `` |