### PR TITLE
chore(flake/nur): `c7ba591c` -> `c780827a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723578304,
-        "narHash": "sha256-p/G1yrUyJ84lh0JpBHXMwNuHWLKLLKSpdIufPJljvY4=",
+        "lastModified": 1723588302,
+        "narHash": "sha256-W6DOAEA8rh6ucmbtaY3+6LJYjcRo8lNPd0QWV6c97W4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c7ba591cead34c21172cca76f1aabcb130c40508",
+        "rev": "c780827a7878d1b490a589fc289fd6de7b5d84b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c780827a`](https://github.com/nix-community/NUR/commit/c780827a7878d1b490a589fc289fd6de7b5d84b3) | `` automatic update `` |
| [`e36bc569`](https://github.com/nix-community/NUR/commit/e36bc569a3652499909486b983ef97d319ee7271) | `` automatic update `` |