### PR TITLE
chore(flake/nur): `c780827a` -> `83571d8c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723588302,
-        "narHash": "sha256-W6DOAEA8rh6ucmbtaY3+6LJYjcRo8lNPd0QWV6c97W4=",
+        "lastModified": 1723601429,
+        "narHash": "sha256-SWZwTy53sjudJn+bNLDkqgEOYUv/3Ou/PjoHj2Ff5fk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c780827a7878d1b490a589fc289fd6de7b5d84b3",
+        "rev": "83571d8caf24cfbeebf6088388e9b72b62ac1def",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`83571d8c`](https://github.com/nix-community/NUR/commit/83571d8caf24cfbeebf6088388e9b72b62ac1def) | `` automatic update `` |
| [`2d0c0fcd`](https://github.com/nix-community/NUR/commit/2d0c0fcdbb46634101b39a3544a8173720969168) | `` automatic update `` |