### PR TITLE
chore(flake/nur): `39c71b34` -> `b8a4d16b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723604170,
-        "narHash": "sha256-uZlW9bLT4qszWWi+pg3179quFup3+cRwveiWU+fYoAQ=",
+        "lastModified": 1723609851,
+        "narHash": "sha256-dpRxHgC5RU6iMsVzcKeXZJT1fLOVRvDc7BpMNsXYqsM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "39c71b34de19911dd13cd970d41d147ee480cc11",
+        "rev": "b8a4d16bb0915d6955ceb2caddfa5f309bfb7c4b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b8a4d16b`](https://github.com/nix-community/NUR/commit/b8a4d16bb0915d6955ceb2caddfa5f309bfb7c4b) | `` automatic update `` |
| [`8200aa36`](https://github.com/nix-community/NUR/commit/8200aa360759a1f4da5a3b9f2f0821582e1fe621) | `` automatic update `` |
| [`c16eca75`](https://github.com/nix-community/NUR/commit/c16eca75d2b7c1cd6c155207ebaced358057817c) | `` automatic update `` |
| [`f2557ee1`](https://github.com/nix-community/NUR/commit/f2557ee1306848960d2bc966e04820fc43085c95) | `` automatic update `` |
| [`0aa36428`](https://github.com/nix-community/NUR/commit/0aa36428066275a451dc16db09ae4f2791c7a709) | `` automatic update `` |
| [`a8540475`](https://github.com/nix-community/NUR/commit/a8540475b5de2cf6d9373b28b3346795ba4dd5e4) | `` automatic update `` |