### PR TITLE
chore(flake/nur): `b8a4d16b` -> `a5f522a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723609851,
-        "narHash": "sha256-dpRxHgC5RU6iMsVzcKeXZJT1fLOVRvDc7BpMNsXYqsM=",
+        "lastModified": 1723617137,
+        "narHash": "sha256-uV6aRW5Iw72akatE4jJPD1sLwz9Esiz18uj1oNbJVJQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b8a4d16bb0915d6955ceb2caddfa5f309bfb7c4b",
+        "rev": "a5f522a8292a3644f48b40345162a9901b448386",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a5f522a8`](https://github.com/nix-community/NUR/commit/a5f522a8292a3644f48b40345162a9901b448386) | `` automatic update `` |
| [`8cc11e17`](https://github.com/nix-community/NUR/commit/8cc11e1722e986fb5c50f853e812a408254256f8) | `` automatic update `` |