### PR TITLE
chore(flake/nur): `a5f522a8` -> `91baabfd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723617137,
-        "narHash": "sha256-uV6aRW5Iw72akatE4jJPD1sLwz9Esiz18uj1oNbJVJQ=",
+        "lastModified": 1723622234,
+        "narHash": "sha256-VA61FDbGrlWbQDBLVVTXAQFpN/zt1rvQwPJBiUeto1Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a5f522a8292a3644f48b40345162a9901b448386",
+        "rev": "91baabfd02313e20047a64e6fd34a7d16bc0f1bf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`91baabfd`](https://github.com/nix-community/NUR/commit/91baabfd02313e20047a64e6fd34a7d16bc0f1bf) | `` automatic update `` |