### PR TITLE
chore(flake/emacs-overlay): `8dd2e6a5` -> `0547cd35`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723597543,
-        "narHash": "sha256-iCH3XzX1uDJGLtnXzP5yAFiID7oeTdqV7gyunPLtskQ=",
+        "lastModified": 1723625917,
+        "narHash": "sha256-RvyS6uiRo9dhXl8Tm+hVA+OKTfVPeportih3MlDpJuw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8dd2e6a5281ec2be00c2115ad0b2483be8db9d4b",
+        "rev": "0547cd35dec4cbe988eb83bf6c2f676dced94fe5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`0547cd35`](https://github.com/nix-community/emacs-overlay/commit/0547cd35dec4cbe988eb83bf6c2f676dced94fe5) | `` Updated melpa ``  |
| [`c71cb74c`](https://github.com/nix-community/emacs-overlay/commit/c71cb74ccd98d6b9987822cd8e52c80a2aa0e8f1) | `` Updated elpa ``   |
| [`442e4090`](https://github.com/nix-community/emacs-overlay/commit/442e4090a2f155ff5e7b3cce66a2f2245797034c) | `` Updated nongnu `` |