### PR TITLE
chore(flake/nur): `91baabfd` -> `dc6d7986`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723622234,
-        "narHash": "sha256-VA61FDbGrlWbQDBLVVTXAQFpN/zt1rvQwPJBiUeto1Y=",
+        "lastModified": 1723632306,
+        "narHash": "sha256-WzILwMkbQ4S1ks1g5AzeHNTIWj5AcJ6PwQDUnHNWmM8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "91baabfd02313e20047a64e6fd34a7d16bc0f1bf",
+        "rev": "dc6d7986f1d0a0d03f1a270e22352181f074e70a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dc6d7986`](https://github.com/nix-community/NUR/commit/dc6d7986f1d0a0d03f1a270e22352181f074e70a) | `` automatic update `` |
| [`0b0870e3`](https://github.com/nix-community/NUR/commit/0b0870e3e233a353fb83b543b38512a8733a9baa) | `` automatic update `` |
| [`c93a98ed`](https://github.com/nix-community/NUR/commit/c93a98ed00d5f52b500e38f27dd18bdd3e291eae) | `` automatic update `` |
| [`857d3a05`](https://github.com/nix-community/NUR/commit/857d3a051a3249402a9e6a0b510e297ed3208ba9) | `` automatic update `` |