### PR TITLE
chore(flake/nur): `dc6d7986` -> `37d63785`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723632306,
-        "narHash": "sha256-WzILwMkbQ4S1ks1g5AzeHNTIWj5AcJ6PwQDUnHNWmM8=",
+        "lastModified": 1723640496,
+        "narHash": "sha256-/j6P/42tHgzvyqdtDgZ2nu8Ddr2EgbSX1rS8kWJt8q4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dc6d7986f1d0a0d03f1a270e22352181f074e70a",
+        "rev": "37d63785066f402b8325244b33920f3d6132dbdd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`37d63785`](https://github.com/nix-community/NUR/commit/37d63785066f402b8325244b33920f3d6132dbdd) | `` automatic update `` |