### PR TITLE
chore(flake/emacs-overlay): `a2e01edc` -> `12e62600`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723626796,
-        "narHash": "sha256-5EsS93frE1YM947ANyPESP8o1XwIl4IOYY8IXyT3oTU=",
+        "lastModified": 1723654825,
+        "narHash": "sha256-+AcqW6tpC3JPeXUsHoD6mExZwysCtOn6zEMHYdwLKpg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a2e01edc18fdc0c31dfe8c3a1796902a4644575a",
+        "rev": "12e6260034f96c64e612efca1482984047fafe5f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`12e62600`](https://github.com/nix-community/emacs-overlay/commit/12e6260034f96c64e612efca1482984047fafe5f) | `` Updated melpa ``  |
| [`928cbbb5`](https://github.com/nix-community/emacs-overlay/commit/928cbbb5a7d0346c861875eb7d2ca57925e3a16b) | `` Updated elpa ``   |
| [`3922fa2c`](https://github.com/nix-community/emacs-overlay/commit/3922fa2cdbf5bf55f874d76167f70f7338f7b603) | `` Updated nongnu `` |
| [`3c335bf8`](https://github.com/nix-community/emacs-overlay/commit/3c335bf80689107105ec6810b43be722fdd186c4) | `` Updated emacs ``  |