### PR TITLE
chore(flake/nur): `37d63785` -> `0feedaeb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723640496,
-        "narHash": "sha256-/j6P/42tHgzvyqdtDgZ2nu8Ddr2EgbSX1rS8kWJt8q4=",
+        "lastModified": 1723654016,
+        "narHash": "sha256-w+YnUCKO+PmG7Y59X5GWDiC4xhYtK0RWSH0wHzBJLFs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "37d63785066f402b8325244b33920f3d6132dbdd",
+        "rev": "0feedaeb18733b83f137961463af71d90c452440",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0feedaeb`](https://github.com/nix-community/NUR/commit/0feedaeb18733b83f137961463af71d90c452440) | `` automatic update `` |
| [`5ac3ad8f`](https://github.com/nix-community/NUR/commit/5ac3ad8f27b04dc9c70d8ccbc3b872097c11ba3d) | `` automatic update `` |