### PR TITLE
chore(flake/nur): `0feedaeb` -> `7bcbb036`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723654016,
-        "narHash": "sha256-w+YnUCKO+PmG7Y59X5GWDiC4xhYtK0RWSH0wHzBJLFs=",
+        "lastModified": 1723664702,
+        "narHash": "sha256-ErRJ3oUHFOzUXoDAzws/h5u7c6dCExETjmm5uIFL/QY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0feedaeb18733b83f137961463af71d90c452440",
+        "rev": "7bcbb0362c92f230ba4a2c5ad227e04f84fc1ce0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7bcbb036`](https://github.com/nix-community/NUR/commit/7bcbb0362c92f230ba4a2c5ad227e04f84fc1ce0) | `` automatic update `` |
| [`efe9bf91`](https://github.com/nix-community/NUR/commit/efe9bf917fc80a2162ec45fd150a3174a3c76f4c) | `` automatic update `` |
| [`900ffbf9`](https://github.com/nix-community/NUR/commit/900ffbf9a642f9a2b7d87f0c0a26245138567dc0) | `` automatic update `` |