### PR TITLE
chore(flake/emacs-overlay): `12e62600` -> `84744bd9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723654825,
-        "narHash": "sha256-+AcqW6tpC3JPeXUsHoD6mExZwysCtOn6zEMHYdwLKpg=",
+        "lastModified": 1723683958,
+        "narHash": "sha256-R33Rluet5kUIh2wAkj7lbSrbkIV3JTCvhz15MVv2pNQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "12e6260034f96c64e612efca1482984047fafe5f",
+        "rev": "84744bd9868534b8d01acca4f464ef8e46758434",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`84744bd9`](https://github.com/nix-community/emacs-overlay/commit/84744bd9868534b8d01acca4f464ef8e46758434) | `` Updated elpa ``   |
| [`09f34c88`](https://github.com/nix-community/emacs-overlay/commit/09f34c88fcb8ea60f8802ffa0efbaa382cad75e5) | `` Updated nongnu `` |