### PR TITLE
chore(flake/srvos): `a7cc81cd` -> `c5017cb6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -897,11 +897,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723423676,
-        "narHash": "sha256-E+DdXV2cFj77vU35cVNoEEE5YueE075HXiJLXwAxJ0k=",
+        "lastModified": 1723683003,
+        "narHash": "sha256-rzKqGrSMRamqcJJqNSikr1nUCQhtZBdl3XnZuTFiWLU=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "a7cc81cd76c4c07bb7db01b731199ecd4be17305",
+        "rev": "c5017cb68ac667ce63088ac70895387d6f22e6ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`c5017cb6`](https://github.com/nix-community/srvos/commit/c5017cb68ac667ce63088ac70895387d6f22e6ef) | `` dev/private/flake.lock: Update `` |
| [`cc212e8a`](https://github.com/nix-community/srvos/commit/cc212e8a02921bc00ffd46f7c21059ef6447ee25) | `` flake.lock: Update ``             |