### PR TITLE
chore(flake/nur): `7bcbb036` -> `23ac7139`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723664702,
-        "narHash": "sha256-ErRJ3oUHFOzUXoDAzws/h5u7c6dCExETjmm5uIFL/QY=",
+        "lastModified": 1723689772,
+        "narHash": "sha256-iqreKoz7WVLMU72vcMCFdTsdwJXHB5kKGwSdrivxv2M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7bcbb0362c92f230ba4a2c5ad227e04f84fc1ce0",
+        "rev": "23ac71392704dd300df7a26e65b0ef40b58e3ddc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`23ac7139`](https://github.com/nix-community/NUR/commit/23ac71392704dd300df7a26e65b0ef40b58e3ddc) | `` automatic update `` |
| [`9eae8571`](https://github.com/nix-community/NUR/commit/9eae8571d0f224ba660dfbcb7248f63fd333acbe) | `` automatic update `` |
| [`20c7a324`](https://github.com/nix-community/NUR/commit/20c7a3245d736a6da35213ead94955d651b45099) | `` automatic update `` |
| [`833f5651`](https://github.com/nix-community/NUR/commit/833f5651f2daaef5ee4a081362d659af0682fcf2) | `` automatic update `` |