### PR TITLE
chore(flake/nur): `23ac7139` -> `e26c7be5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723689772,
-        "narHash": "sha256-iqreKoz7WVLMU72vcMCFdTsdwJXHB5kKGwSdrivxv2M=",
+        "lastModified": 1723693500,
+        "narHash": "sha256-Mg35DQCl8T3jLyDNtwKJcO57z3TZ65A5TRnZpNSUU2I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "23ac71392704dd300df7a26e65b0ef40b58e3ddc",
+        "rev": "e26c7be568e4e238a1e6ee6c44acdb250458f4a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e26c7be5`](https://github.com/nix-community/NUR/commit/e26c7be568e4e238a1e6ee6c44acdb250458f4a7) | `` automatic update `` |