### PR TITLE
chore(flake/nur): `e26c7be5` -> `09667a60`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723693500,
-        "narHash": "sha256-Mg35DQCl8T3jLyDNtwKJcO57z3TZ65A5TRnZpNSUU2I=",
+        "lastModified": 1723700510,
+        "narHash": "sha256-clXf68ABog0yWrtnBgVk+lIIoEqRn6zjOO03Nd+FdiM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e26c7be568e4e238a1e6ee6c44acdb250458f4a7",
+        "rev": "09667a60026a7ba1db920d8ec24103a109be0592",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`09667a60`](https://github.com/nix-community/NUR/commit/09667a60026a7ba1db920d8ec24103a109be0592) | `` automatic update `` |
| [`983829c8`](https://github.com/nix-community/NUR/commit/983829c8939af35083c183e010889dbde3657d59) | `` automatic update `` |
| [`90caac07`](https://github.com/nix-community/NUR/commit/90caac076e5018f5cc9cf9c68027cfa2d07238de) | `` automatic update `` |
| [`34cb16f0`](https://github.com/nix-community/NUR/commit/34cb16f0c384c4cc47b30722a68724074610e352) | `` automatic update `` |
| [`bf4952df`](https://github.com/nix-community/NUR/commit/bf4952dffe95b193eb8af3cc31394b029fa01990) | `` automatic update `` |
| [`d87772a6`](https://github.com/nix-community/NUR/commit/d87772a6f754308e7f6efb73263317f37345dcd2) | `` automatic update `` |