### PR TITLE
chore(flake/nixpkgs): `a58bc8ad` -> `c3aa7b89`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -732,11 +732,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1723362943,
-        "narHash": "sha256-dFZRVSgmJkyM0bkPpaYRtG/kRMRTorUIDj8BxoOt1T4=",
+        "lastModified": 1723637854,
+        "narHash": "sha256-med8+5DSWa2UnOqtdICndjDAEjxr5D7zaIiK4pn0Q7c=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a58bc8ad779655e790115244571758e8de055e3d",
+        "rev": "c3aa7b8938b17aebd2deecf7be0636000d62a2b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                      |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`0cb2fd7c`](https://github.com/NixOS/nixpkgs/commit/0cb2fd7c59fed0cd82ef858cbcbdb552b9a33465) | `` wiki-tui: format with nixfmt ``                                                           |
| [`818e0e5b`](https://github.com/NixOS/nixpkgs/commit/818e0e5ba2bfbe3406bc4ff01efbbcbc8667f3a7) | `` wiki-tui: fix compilation with rust 1.80 ``                                               |
| [`1bd503aa`](https://github.com/NixOS/nixpkgs/commit/1bd503aa21f99634e551fa624d8a1a14ccdf5afc) | `` josh: 23.12.04 -> 24.08.14 ``                                                             |
| [`c27c804e`](https://github.com/NixOS/nixpkgs/commit/c27c804e4c8639c7bb584acdb137b771dc838486) | `` spotifyd: 0.3.5-unstable-2024-07-10 -> 0.3.5-unstable-2024-08-13 ``                       |
| [`486a1234`](https://github.com/NixOS/nixpkgs/commit/486a12344095eb65c6971054787e2ad91cd41cd4) | `` symbolicator: 23.11.2 -> 24.7.1 ``                                                        |
| [`e639bd45`](https://github.com/NixOS/nixpkgs/commit/e639bd4516c09f0c80576aa9af3ec064444e6697) | `` bugstalker: 0.1.4 -> 0.2.2 ``                                                             |
| [`e38e5d30`](https://github.com/NixOS/nixpkgs/commit/e38e5d3038ef73ea57663e983fc397ae72a5c1f6) | `` fedimint: 0.3.3 -> 0.4.1 ``                                                               |
| [`83929642`](https://github.com/NixOS/nixpkgs/commit/8392964211c45d1da5734d8fccd3a1a0d1499b13) | `` cloud-hypervisor: backport patch to fix UB ``                                             |
| [`ef0ba818`](https://github.com/NixOS/nixpkgs/commit/ef0ba81875aee32e13257f72f8eb57f9a188d5f6) | `` foot: 1.18.0 -> 1.18.1 ``                                                                 |
| [`e77cba10`](https://github.com/NixOS/nixpkgs/commit/e77cba10828eb47dad1b22765a6734ac1c9ba59e) | `` foot: disable -Werror ``                                                                  |
| [`e1e4197e`](https://github.com/NixOS/nixpkgs/commit/e1e4197e1fd0bc3363ddddcee35874f6368a18c2) | `` foot: 1.17.2 -> 1.18.0 ``                                                                 |
| [`a93c62a0`](https://github.com/NixOS/nixpkgs/commit/a93c62a08d8893d31abcdff7b3ea31a45c274fb1) | `` dvc: fix build ``                                                                         |
| [`36ea3951`](https://github.com/NixOS/nixpkgs/commit/36ea39511ba50576b6f58a29f37efc2e93cb3de5) | `` frankenphp: 1.2.3 -> 1.2.4 ``                                                             |
| [`405d72d3`](https://github.com/NixOS/nixpkgs/commit/405d72d3b3c30403fb2fa7304c323e3d4cf80e90) | `` efivar: 38 -> 39 (#295673) ``                                                             |
| [`f7145582`](https://github.com/NixOS/nixpkgs/commit/f71455822a4c7dcb84111a2257275deb50674f78) | `` linuxPackages*.v4l2loopback: 0.12.7-unstable-2024-02-12 -> 0.13.2 ``                      |
| [`5ef32027`](https://github.com/NixOS/nixpkgs/commit/5ef32027f286fb32fb747d26734b7fb50d920c83) | `` coqPackages.interval: 4.10.0 → 4.11.0 ``                                                  |
| [`235b3177`](https://github.com/NixOS/nixpkgs/commit/235b3177f089ecb6162d5d15294221a814acdfe5) | `` ockam: 0.130.0 -> 0.132.0 ``                                                              |
| [`4f18893d`](https://github.com/NixOS/nixpkgs/commit/4f18893d4f6e6b9558e78c2ee48f14c28f0dc4ce) | `` gossip: move hash to last attribute ``                                                    |
| [`8ec0b4d9`](https://github.com/NixOS/nixpkgs/commit/8ec0b4d96311d7b24705710831d30d3e83e79950) | `` gossip: use tag directly ``                                                               |
| [`b4163123`](https://github.com/NixOS/nixpkgs/commit/b41631231e4ad1721fb4c06cbc2b499797769814) | `` gossip: 0.9 -> 0.11.3 ``                                                                  |
| [`f684bb85`](https://github.com/NixOS/nixpkgs/commit/f684bb85472d242a2751e60fb97d1deae844471d) | `` vimPlugins.vim-clap: 0.54 -> 0.54-unstable-2024-08-11 ``                                  |
| [`c846d93d`](https://github.com/NixOS/nixpkgs/commit/c846d93d74fb76233f8938a5b851998a48c18536) | `` dopamine: 3.0.0-preview.29 -> 3.0.0-preview.31 ``                                         |
| [`1d28ed3c`](https://github.com/NixOS/nixpkgs/commit/1d28ed3c3ad38590ff4d9cd99cd25b9339a498e8) | `` nix-melt: fix build for rust 1.80 ``                                                      |
| [`187f4f07`](https://github.com/NixOS/nixpkgs/commit/187f4f0739fa9f32ca6ef05c9239509abca68c3a) | `` mozillavpn: 2.21.0 → 2.23.1 ``                                                            |
| [`fa03a539`](https://github.com/NixOS/nixpkgs/commit/fa03a53979328cc9080b1b388f727d0897d942e1) | `` mozillavpn: Use finalAttrs ``                                                             |
| [`d8b4be37`](https://github.com/NixOS/nixpkgs/commit/d8b4be3797ad4a21fafcadfd6cd30413205e9b63) | `` mozillavpn: Reformat with nixfmt-rfc-style ``                                             |
| [`7a1adfd1`](https://github.com/NixOS/nixpkgs/commit/7a1adfd1ce99c13468b0e52b033716d777bee2b0) | `` python312Packages.lacuscore: 1.10.9 -> 1.10.10 ``                                         |
| [`bccd4daa`](https://github.com/NixOS/nixpkgs/commit/bccd4daa473f3a1af92d6239a261a839d6f12dc7) | `` golangci-lint: 1.59.1 -> 1.60.1 ``                                                        |
| [`e1822b63`](https://github.com/NixOS/nixpkgs/commit/e1822b634ce439bd0b22873324f13f57dca8bba9) | `` nix-init: 0.3.0 -> 0.3.1 ``                                                               |
| [`def8f476`](https://github.com/NixOS/nixpkgs/commit/def8f4761fc948ba4b5805116eac61ec6a992659) | `` php83Packages.phan: 5.4.4 -> 5.4.5 ``                                                     |
| [`6c8f9e06`](https://github.com/NixOS/nixpkgs/commit/6c8f9e06ccc395735a790309a01110da2610b34b) | `` poetryPlugins.poetry-plugin-up: 0.7.2 -> 0.7.3 ``                                         |
| [`e4e19575`](https://github.com/NixOS/nixpkgs/commit/e4e19575c80a9226331f95781db0061b5c516141) | `` filterpath: 1.0.1 -> 1.0.2 ``                                                             |
| [`cf4f89ec`](https://github.com/NixOS/nixpkgs/commit/cf4f89ec3f6e7f45ca0e3a2f9f45493088952868) | `` go_1_23: 1.23rc2 -> 1.23.0 ``                                                             |
| [`0637303c`](https://github.com/NixOS/nixpkgs/commit/0637303ca87a14a475c873c9ff9825c0987d7d8f) | `` Revert "Merge pull request #330017 from Mic92/boot-counting" ``                           |
| [`e7c47c70`](https://github.com/NixOS/nixpkgs/commit/e7c47c701bdd2a1ff057abf9c0c29b790c69a2f5) | `` aiosonic: init at 0.20.1 ``                                                               |
| [`5f343173`](https://github.com/NixOS/nixpkgs/commit/5f3431731ac8ced81c9e2f7203f04536c2d5db8e) | `` onecache: init at 0.7.0 ``                                                                |
| [`92d69dd2`](https://github.com/NixOS/nixpkgs/commit/92d69dd2be6393e8bc75dfca066dd11fb99b110d) | `` charmcraft: 3.1.1 -> 3.1.2 ``                                                             |
| [`ac9202cf`](https://github.com/NixOS/nixpkgs/commit/ac9202cf3e92d08d6c45f8d8af94baae149a6528) | `` bearer: 1.46.0 -> 1.46.1 ``                                                               |
| [`b78bd2f9`](https://github.com/NixOS/nixpkgs/commit/b78bd2f9120b2e21b8556c45ee20ddb49942fc67) | `` Revert "Merge pull request #333952 from r-vdp/specialisation-name-regex" ``               |
| [`bed19bdf`](https://github.com/NixOS/nixpkgs/commit/bed19bdf39b3a13ecaba4286ba69634584f0b556) | `` fetchPypiLegacy: Pass cacert to enable TLS verification when username/password is used `` |
| [`92026d85`](https://github.com/NixOS/nixpkgs/commit/92026d8506bba8d195d5685153c4b7e6b0de4d25) | `` nix-eval-jobs: 2.23.0 -> 2.24.0 ``                                                        |
| [`d7e9ead3`](https://github.com/NixOS/nixpkgs/commit/d7e9ead319b7abff55e9a48879b14d18ae032360) | `` nixVersions.nix_2_24: 2.24.1 -> 2.24.2 ``                                                 |
| [`ea1ab74d`](https://github.com/NixOS/nixpkgs/commit/ea1ab74d35c04835578384c1b5d145ba750dcb70) | `` terraform-providers.spacelift: init at v1.14.0 ``                                         |
| [`482a2638`](https://github.com/NixOS/nixpkgs/commit/482a26382fc8ad6392ad406ebb7a916aa2d1ebd6) | `` fetchPypiLegacy: pass NETRC via impureEnvVars if inPureEval ``                            |
| [`3f185803`](https://github.com/NixOS/nixpkgs/commit/3f185803049c37ff80f386a84f3dc1be4f428221) | `` python312Packages.mitogen: 0.3.8 -> 0.3.9 ``                                              |
| [`f7aaf3ae`](https://github.com/NixOS/nixpkgs/commit/f7aaf3ae2aeae4ee46e5fa8c931a07740d2eabc7) | `` python312Packages.sentry-sdk_2: 2.12.0 -> 2.13.0 ``                                       |
| [`f6788b61`](https://github.com/NixOS/nixpkgs/commit/f6788b61651082cd163a2cc3c114f59e7429a218) | `` nixos/miniflux: make admin provisioning optional ``                                       |
| [`4e5f0455`](https://github.com/NixOS/nixpkgs/commit/4e5f0455c35f4add01a16bc7ba5f2ad290ae7ac4) | `` python312Packages.mongoengine: drop nose dependency ``                                    |
| [`8f416800`](https://github.com/NixOS/nixpkgs/commit/8f416800f6e1dbccfda2006771a9f9cd430e2aff) | `` python312Packages.apsw: 3.46.0.1 -> 3.46.1.0 ``                                           |
| [`488701ce`](https://github.com/NixOS/nixpkgs/commit/488701cec18a13fe658104b85f4a7bcc98146231) | `` goperf: 0-unstable-2024-07-07 -> 0-unstable-2024-08-06 ``                                 |
| [`0209986e`](https://github.com/NixOS/nixpkgs/commit/0209986e495e9f19dbdbcefe747defc55a6e8cc0) | `` yubioath-flutter: 6.4.0 -> 7.0.1 ``                                                       |
| [`8a2609dd`](https://github.com/NixOS/nixpkgs/commit/8a2609dd2d990832b2de72e3eed54e39312ba2ac) | `` sploitscan: 0.10.4 -> 0.10.5 ``                                                           |
| [`2fa258a5`](https://github.com/NixOS/nixpkgs/commit/2fa258a52fa66cee4fd4531e02e765a51261f104) | `` go-tools: 2023.1.7 -> 2024.1 ``                                                           |
| [`190557b1`](https://github.com/NixOS/nixpkgs/commit/190557b19ec80af209cb7dfb13db8681ac5171f4) | `` honk: 1.3.1 -> 1.4.1 ``                                                                   |
| [`c07ae91b`](https://github.com/NixOS/nixpkgs/commit/c07ae91b46217693ae1f5079e3cc2f4d7004aabf) | `` proxsuite: disable a failing test on aarch64-linux ``                                     |
| [`e7e3cdf5`](https://github.com/NixOS/nixpkgs/commit/e7e3cdf5e373805d59c56f56f7f8cec18636f8be) | `` onnxruntime: pin abseil-cpp_202401 ``                                                     |
| [`355530f3`](https://github.com/NixOS/nixpkgs/commit/355530f35a053bc20143467836649bddf981a6eb) | `` abseil-cpp_202401: reinit ``                                                              |
| [`d553b0b4`](https://github.com/NixOS/nixpkgs/commit/d553b0b45bc1d97122bed2d51f4fb7bb8a5613c2) | `` element-desktop: 1.11.73 -> 1.11.74 ``                                                    |
| [`b4074d89`](https://github.com/NixOS/nixpkgs/commit/b4074d89a63e3871a7b6b3f7dbd6d04d2ac111df) | `` signaturepdf: add missing lib/ directory to result ``                                     |
| [`098a7874`](https://github.com/NixOS/nixpkgs/commit/098a7874e21c64c118c100801f6b189b49fa6f1b) | `` casadi: always set PYTHON_PREFIX, using `placeholder "out"`. ``                           |
| [`ea92738f`](https://github.com/NixOS/nixpkgs/commit/ea92738f92ef4bc3359e824a9670deb63db9ec57) | `` paraview: 5.12.0 -> 5.12.1 ``                                                             |
| [`a8f5edc3`](https://github.com/NixOS/nixpkgs/commit/a8f5edc39c753953dd88a1fb560d16f6379cc140) | `` paraview: apply nixfmt ``                                                                 |
| [`3b1bd551`](https://github.com/NixOS/nixpkgs/commit/3b1bd55109b8797b93389a6351dd50033fe31f2d) | `` python312Packages.qdrant-client: 1.10.1 -> 1.11.0 ``                                      |
| [`60a11682`](https://github.com/NixOS/nixpkgs/commit/60a11682d186b38aa62814d130babf2e8ec8095c) | `` python312Packages.cpe: 1.2.1 -> 1.3.0 ``                                                  |
| [`6cd3a589`](https://github.com/NixOS/nixpkgs/commit/6cd3a589ddf78dd6345ae79b6247b4831302e847) | `` python312Packages.pubnub: 8.0.0 -> 8.1.0 ``                                               |
| [`a3b45b9f`](https://github.com/NixOS/nixpkgs/commit/a3b45b9fe93e16b37f78d3d00ae9152f97a946a6) | `` casadi: set meta.platforms ``                                                             |
| [`4b956095`](https://github.com/NixOS/nixpkgs/commit/4b95609540b6174dcd3a06139fc77740b57a379d) | `` python312Packages.google-nest-sdm: 4.0.5 -> 4.0.6 ``                                      |
| [`5808295c`](https://github.com/NixOS/nixpkgs/commit/5808295c866b6dbe1375f6514843b467a2118851) | `` python312Packages.fyta-cli: 0.5.0 -> 0.5.1 ``                                             |
| [`8b15b3f8`](https://github.com/NixOS/nixpkgs/commit/8b15b3f84a044abb11c25837ae558c15edd0e4db) | `` open62541: 1.4.2 -> 1.4.4 ``                                                              |
| [`e30a879e`](https://github.com/NixOS/nixpkgs/commit/e30a879e01d206e09d220f9321a96f1c84c6ba0d) | `` hop-cli: remove pkg ``                                                                    |
| [`b58932b9`](https://github.com/NixOS/nixpkgs/commit/b58932b9446e55e60253c0aab526face17bf9870) | `` namespace-cli: 0.0.388 -> 0.0.389 ``                                                      |
| [`eb51ddc8`](https://github.com/NixOS/nixpkgs/commit/eb51ddc8827ecb7af5fe0ec14b119144af9aae5f) | `` polkadot: fix compilation with rust 1.80 ``                                               |