### PR TITLE
chore(flake/emacs-overlay): `f396ad6b` -> `bfd58e3c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723686119,
-        "narHash": "sha256-IAqqmbLkL+EhmeD7VAAMRZmay9vSA/MF41RZmFFr/ws=",
+        "lastModified": 1723714552,
+        "narHash": "sha256-Ux0IKC9OUKIFKprfko5s3VpJayRibaY0XM6aDVhPQ04=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f396ad6b3ce6bfa2f3282cba4660df17391fd2a0",
+        "rev": "bfd58e3ccc600bf01bc02d3d7844eb77a1547808",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`bfd58e3c`](https://github.com/nix-community/emacs-overlay/commit/bfd58e3ccc600bf01bc02d3d7844eb77a1547808) | `` Updated emacs ``        |
| [`7e7a29fc`](https://github.com/nix-community/emacs-overlay/commit/7e7a29fc4ca7bbd50ad62c7ac4da3cce79ba1ac2) | `` Updated melpa ``        |
| [`0c527c80`](https://github.com/nix-community/emacs-overlay/commit/0c527c80b18d24ad5b53aae362eac5d9c90f73a8) | `` Updated flake inputs `` |