### PR TITLE
chore(flake/nur): `09667a60` -> `4fc1aff1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723700510,
-        "narHash": "sha256-clXf68ABog0yWrtnBgVk+lIIoEqRn6zjOO03Nd+FdiM=",
+        "lastModified": 1723711594,
+        "narHash": "sha256-4+MCfFTySwt7P+r+7pmA8sxKH8OeMG6Kp5nIUUxCX0Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "09667a60026a7ba1db920d8ec24103a109be0592",
+        "rev": "4fc1aff18faef6b91f31fced51ab81a497bf33ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4fc1aff1`](https://github.com/nix-community/NUR/commit/4fc1aff18faef6b91f31fced51ab81a497bf33ee) | `` automatic update `` |
| [`4e8eca87`](https://github.com/nix-community/NUR/commit/4e8eca8729026d62258146706bd40ec237b4fa86) | `` automatic update `` |