### PR TITLE
chore(flake/nur): `4fc1aff1` -> `00ca3081`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723711594,
-        "narHash": "sha256-4+MCfFTySwt7P+r+7pmA8sxKH8OeMG6Kp5nIUUxCX0Q=",
+        "lastModified": 1723718829,
+        "narHash": "sha256-B0T9NBMkfVUi0D0AgxC9/lEC5NLhj0HVS5IFpUgA1VY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4fc1aff18faef6b91f31fced51ab81a497bf33ee",
+        "rev": "00ca30815a0cc4881eea66b9461b7acfced1a557",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`00ca3081`](https://github.com/nix-community/NUR/commit/00ca30815a0cc4881eea66b9461b7acfced1a557) | `` automatic update `` |