### PR TITLE
chore(flake/nur): `aff37f63` -> `84e0a72d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723726567,
-        "narHash": "sha256-TD/z334d0wAJRlkJsDf3Q/+AQEndKNRbjGKLYdAzthA=",
+        "lastModified": 1723728459,
+        "narHash": "sha256-/REChCgzN10bqe4Nyd+xPHc8jfFM5YxMJvskSNt8164=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aff37f63807ada07b5179bb9b1c35069786d7fb9",
+        "rev": "84e0a72d1e17aedc43da8fbe38ef654a36211e46",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`84e0a72d`](https://github.com/nix-community/NUR/commit/84e0a72d1e17aedc43da8fbe38ef654a36211e46) | `` automatic update `` |
| [`930f6702`](https://github.com/nix-community/NUR/commit/930f67025461dbd7023c512e488da7830e3e582b) | `` automatic update `` |