### PR TITLE
chore(flake/nur): `84e0a72d` -> `e4764b20`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723728459,
-        "narHash": "sha256-/REChCgzN10bqe4Nyd+xPHc8jfFM5YxMJvskSNt8164=",
+        "lastModified": 1723736856,
+        "narHash": "sha256-95ZdzpqK4odVlpaUELOgPTVb6VQDwyUwaxS8tZRTUpU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "84e0a72d1e17aedc43da8fbe38ef654a36211e46",
+        "rev": "e4764b20f661ba1e6ae5c465e6aac015bf69c07a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e4764b20`](https://github.com/nix-community/NUR/commit/e4764b20f661ba1e6ae5c465e6aac015bf69c07a) | `` automatic update `` |
| [`657eb09d`](https://github.com/nix-community/NUR/commit/657eb09d4389643f0622783457d8c815b3839f78) | `` automatic update `` |