### PR TITLE
chore(flake/nur): `e4764b20` -> `9b41374e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723736856,
-        "narHash": "sha256-95ZdzpqK4odVlpaUELOgPTVb6VQDwyUwaxS8tZRTUpU=",
+        "lastModified": 1723738470,
+        "narHash": "sha256-79TnkrS5degcSDvHZ0itU/SJr+usRVTNUUb1DSNDGu0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e4764b20f661ba1e6ae5c465e6aac015bf69c07a",
+        "rev": "9b41374e1803cbc897ff8f5be16a2ecfb30bca90",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9b41374e`](https://github.com/nix-community/NUR/commit/9b41374e1803cbc897ff8f5be16a2ecfb30bca90) | `` automatic update `` |