### PR TITLE
chore(flake/nur): `9b41374e` -> `43819c51`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723738470,
-        "narHash": "sha256-79TnkrS5degcSDvHZ0itU/SJr+usRVTNUUb1DSNDGu0=",
+        "lastModified": 1723748038,
+        "narHash": "sha256-iY//wtSOdFIyYI8DCL555t1E1QbweJJvtjCSzANeBo4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9b41374e1803cbc897ff8f5be16a2ecfb30bca90",
+        "rev": "43819c5107a11fae5d6063bcd6cdf280cfc6d784",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`43819c51`](https://github.com/nix-community/NUR/commit/43819c5107a11fae5d6063bcd6cdf280cfc6d784) | `` automatic update `` |