### PR TITLE
chore(flake/nur): `43819c51` -> `aef1c2b0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723748038,
-        "narHash": "sha256-iY//wtSOdFIyYI8DCL555t1E1QbweJJvtjCSzANeBo4=",
+        "lastModified": 1723751217,
+        "narHash": "sha256-yVMt/4gk91OfLbog4nTT07Q+hyQWHo8Dxcwv0jc+vn0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "43819c5107a11fae5d6063bcd6cdf280cfc6d784",
+        "rev": "aef1c2b0ae78a7e96a54cfa43fd182a38c622aaa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`aef1c2b0`](https://github.com/nix-community/NUR/commit/aef1c2b0ae78a7e96a54cfa43fd182a38c622aaa) | `` automatic update `` |