### PR TITLE
chore(flake/nur): `aef1c2b0` -> `be8fc33e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723751217,
-        "narHash": "sha256-yVMt/4gk91OfLbog4nTT07Q+hyQWHo8Dxcwv0jc+vn0=",
+        "lastModified": 1723755277,
+        "narHash": "sha256-CG3tf+EwOXTYFfGSYyJjSnWQTpVW7+1ptz0ySf6KGPc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aef1c2b0ae78a7e96a54cfa43fd182a38c622aaa",
+        "rev": "be8fc33ecbf051d900d23f0f42a8ff7a305f586f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`be8fc33e`](https://github.com/nix-community/NUR/commit/be8fc33ecbf051d900d23f0f42a8ff7a305f586f) | `` automatic update `` |