### PR TITLE
chore(flake/nur): `269b295e` -> `97b8bccd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723761205,
-        "narHash": "sha256-vkH9QBDi/B49//mfXlLnucJXC3yvEURdnjaCJLK1UGQ=",
+        "lastModified": 1723762989,
+        "narHash": "sha256-T4cnHOBoikPxcS05BsEMViuDH1aJAQgOXG1t/NmOb60=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "269b295e0596336cae7a4dfed188d813c39c662b",
+        "rev": "97b8bccdece23c285eb41f4b2741e1ec25667365",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`97b8bccd`](https://github.com/nix-community/NUR/commit/97b8bccdece23c285eb41f4b2741e1ec25667365) | `` automatic update `` |