### PR TITLE
chore(flake/nur): `97b8bccd` -> `19b01562`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723762989,
-        "narHash": "sha256-T4cnHOBoikPxcS05BsEMViuDH1aJAQgOXG1t/NmOb60=",
+        "lastModified": 1723776495,
+        "narHash": "sha256-/KoLMDrzc5JxH2SFKJgpoDsoQtHkoq/BH6rRoG0oV2g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "97b8bccdece23c285eb41f4b2741e1ec25667365",
+        "rev": "19b01562bcc6ff7125ff4829712c95c523a30000",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`19b01562`](https://github.com/nix-community/NUR/commit/19b01562bcc6ff7125ff4829712c95c523a30000) | `` automatic update `` |
| [`74d8507a`](https://github.com/nix-community/NUR/commit/74d8507ac264a3c9b1852e5970fabf7998146b6e) | `` automatic update `` |