### PR TITLE
chore(flake/nur): `0ed1f855` -> `bca3959c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723780027,
-        "narHash": "sha256-/eHXLdQFQOB8UDIgWQnkfk/IZYTNq7WNA7wrSYZG9iU=",
+        "lastModified": 1723781067,
+        "narHash": "sha256-HaitSA+2WiUYET0JZNRN0gR7V4E2bgfpnRYSZ1ZQFN8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0ed1f855c74c321450263bc729097353d66fdd74",
+        "rev": "bca3959c6611ff66940b2af4e36120bdd91030c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bca3959c`](https://github.com/nix-community/NUR/commit/bca3959c6611ff66940b2af4e36120bdd91030c5) | `` automatic update `` |