### PR TITLE
chore(flake/nur): `bca3959c` -> `050f2693`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723781067,
-        "narHash": "sha256-HaitSA+2WiUYET0JZNRN0gR7V4E2bgfpnRYSZ1ZQFN8=",
+        "lastModified": 1723787571,
+        "narHash": "sha256-SgFkJCalTFVlbSgmtXbpIWiC84gvEsStq5c5NQV0Cco=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bca3959c6611ff66940b2af4e36120bdd91030c5",
+        "rev": "050f2693c5f4a2959e4dbfa2682ea7ba1910e2ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`050f2693`](https://github.com/nix-community/NUR/commit/050f2693c5f4a2959e4dbfa2682ea7ba1910e2ee) | `` automatic update `` |