### PR TITLE
chore(flake/nur): `050f2693` -> `64c45db6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723787571,
-        "narHash": "sha256-SgFkJCalTFVlbSgmtXbpIWiC84gvEsStq5c5NQV0Cco=",
+        "lastModified": 1723790840,
+        "narHash": "sha256-+B3frYmGnHcbIjvU8/3+rEzshJodBy9A6ZLu0c/QJu0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "050f2693c5f4a2959e4dbfa2682ea7ba1910e2ee",
+        "rev": "64c45db6b2998665cce194350eed7dfc02f009d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`64c45db6`](https://github.com/nix-community/NUR/commit/64c45db6b2998665cce194350eed7dfc02f009d6) | `` automatic update `` |
| [`843b9fe4`](https://github.com/nix-community/NUR/commit/843b9fe49d1670949445a995335540506a0c49fa) | `` automatic update `` |