### PR TITLE
chore(flake/nur): `64c45db6` -> `dc94d48b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723790840,
-        "narHash": "sha256-+B3frYmGnHcbIjvU8/3+rEzshJodBy9A6ZLu0c/QJu0=",
+        "lastModified": 1723795110,
+        "narHash": "sha256-gh/R6p1p2pTaBE9Q3gsIVqFOY5paC1vZBfI35QS3JrM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "64c45db6b2998665cce194350eed7dfc02f009d6",
+        "rev": "dc94d48b66223b9f1fa0db5b4b3ae08bd5d10b78",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dc94d48b`](https://github.com/nix-community/NUR/commit/dc94d48b66223b9f1fa0db5b4b3ae08bd5d10b78) | `` automatic update `` |
| [`ccda5218`](https://github.com/nix-community/NUR/commit/ccda5218a78d1b98239628388607700eafc97f0b) | `` automatic update `` |
| [`7dd00810`](https://github.com/nix-community/NUR/commit/7dd00810e3b0d9f67fad42dce3b9a602d0a9052e) | `` automatic update `` |