### PR TITLE
chore(flake/emacs-overlay): `535e21a9` -> `747634bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723773516,
-        "narHash": "sha256-LCgLnmuLBHSXoLhhSB1Lg5iLwnxoyts15twqs6tjkdc=",
+        "lastModified": 1723798669,
+        "narHash": "sha256-t0kHoGLpuQsOAQZk6dTyqAndc9/Cz1J9IhNrCYcCgbE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "535e21a91760db70f655492c6dc696a806726470",
+        "rev": "747634bb5f7f6cdc2f76b037707c7b6779f4b5d8",
         "type": "github"
       },
       "original": {
@@ -684,11 +684,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1723556749,
-        "narHash": "sha256-+CHVZnTnIYRLYsARInHYoWkujzcRkLY/gXm3s5bE52o=",
+        "lastModified": 1723688146,
+        "narHash": "sha256-sqLwJcHYeWLOeP/XoLwAtYjr01TISlkOfz+NG82pbdg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4a92571f9207810b559c9eac203d1f4d79830073",
+        "rev": "c3d4ac725177c030b1e289015989da2ad9d56af0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`747634bb`](https://github.com/nix-community/emacs-overlay/commit/747634bb5f7f6cdc2f76b037707c7b6779f4b5d8) | `` Updated melpa ``        |
| [`bcb0bbba`](https://github.com/nix-community/emacs-overlay/commit/bcb0bbba64286cdf35be2a975efaeb10ab274dee) | `` Updated flake inputs `` |