### PR TITLE
chore(flake/nur): `dc94d48b` -> `e755d34f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723795110,
-        "narHash": "sha256-gh/R6p1p2pTaBE9Q3gsIVqFOY5paC1vZBfI35QS3JrM=",
+        "lastModified": 1723803150,
+        "narHash": "sha256-v9c1hPZ6YvAf75WR4sHaTDyUUCfVKiY+uZKJzNRk0gg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dc94d48b66223b9f1fa0db5b4b3ae08bd5d10b78",
+        "rev": "e755d34fc42be029b37fc50716d143b8fd4b85b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e755d34f`](https://github.com/nix-community/NUR/commit/e755d34fc42be029b37fc50716d143b8fd4b85b1) | `` automatic update `` |
| [`129a5860`](https://github.com/nix-community/NUR/commit/129a58609adfba26860f66d0d7ab5c3337aa9e76) | `` automatic update `` |
| [`c90dd253`](https://github.com/nix-community/NUR/commit/c90dd25354b9d33c027473f99eeac10db72b1c70) | `` automatic update `` |
| [`6091a416`](https://github.com/nix-community/NUR/commit/6091a4164206d90a6cf2b8c07046490c482b5686) | `` automatic update `` |
| [`54276aa4`](https://github.com/nix-community/NUR/commit/54276aa4ce9596362520ba1f6dc13c4663850e91) | `` automatic update `` |