### PR TITLE
chore(flake/git-hooks): `c7012d0c` -> `bfef0ada`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -353,11 +353,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1723202784,
-        "narHash": "sha256-qbhjc/NEGaDbyy0ucycubq4N3//gDFFH3DOmp1D3u1Q=",
+        "lastModified": 1723803910,
+        "narHash": "sha256-yezvUuFiEnCFbGuwj/bQcqg7RykIEqudOy/RBrId0pc=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "c7012d0c18567c889b948781bc74a501e92275d1",
+        "rev": "bfef0ada09e2c8ac55bbcd0831bd0c9d42e651ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                             |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`bfef0ada`](https://github.com/cachix/git-hooks.nix/commit/bfef0ada09e2c8ac55bbcd0831bd0c9d42e651ba) | `` chore: update renovate config `` |
| [`a98a24e4`](https://github.com/cachix/git-hooks.nix/commit/a98a24e48dddd9c0f2b351f7906df41e2f0c77ec) | `` chore: update renovate config `` |