### PR TITLE
chore(flake/nur): `e755d34f` -> `4b5ae362`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723803150,
-        "narHash": "sha256-v9c1hPZ6YvAf75WR4sHaTDyUUCfVKiY+uZKJzNRk0gg=",
+        "lastModified": 1723815900,
+        "narHash": "sha256-USeM2VAo6DDN8yq6Ve02+ZQB8bqqSBqBfOfkuOmtzUE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e755d34fc42be029b37fc50716d143b8fd4b85b1",
+        "rev": "4b5ae3627ff2bbe71adc1502f1321fcbb52006da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4b5ae362`](https://github.com/nix-community/NUR/commit/4b5ae3627ff2bbe71adc1502f1321fcbb52006da) | `` automatic update `` |
| [`6c2b6943`](https://github.com/nix-community/NUR/commit/6c2b694306a22adb677a0f438067aa1cb9b795fe) | `` automatic update `` |
| [`d643eccb`](https://github.com/nix-community/NUR/commit/d643eccbbf7869977efe6bc479ee009de9c71b02) | `` automatic update `` |
| [`4b95fad5`](https://github.com/nix-community/NUR/commit/4b95fad522865dfe1d79dc37c29cb14bd5b6ffc6) | `` automatic update `` |