### PR TITLE
chore(flake/treefmt): `4a6d7dcc` -> `1d077395`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -992,11 +992,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723656612,
-        "narHash": "sha256-6Sx+/VhRPLR+kRf6rnNUFMQ66DUz1DMYajixYUe+CUU=",
+        "lastModified": 1723808491,
+        "narHash": "sha256-rhis3qNuGmJmYC/okT7Dkc4M8CeUuRCSvW6kC2f3hBc=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "4a6d7dccf80a1aa2d04cfaa88d9e5511542a2486",
+        "rev": "1d07739554fdc4f8481068f1b11d6ab4c1a4167a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                          |
| ---------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`7d94c09b`](https://github.com/numtide/treefmt-nix/commit/7d94c09bdbd4aa8f659d8aea10a17976896225fc) | `` feat: update nixpkgs input `` |