### PR TITLE
chore(flake/nur): `4b5ae362` -> `27fff3e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723815900,
-        "narHash": "sha256-USeM2VAo6DDN8yq6Ve02+ZQB8bqqSBqBfOfkuOmtzUE=",
+        "lastModified": 1723825553,
+        "narHash": "sha256-M7w/KcMfA4iQE9dJrCRk/vbBBH2fbuJEeiu1pod7HwI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4b5ae3627ff2bbe71adc1502f1321fcbb52006da",
+        "rev": "27fff3e7e6d489968a48a2348b712ffaaf04b50b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`27fff3e7`](https://github.com/nix-community/NUR/commit/27fff3e7e6d489968a48a2348b712ffaaf04b50b) | `` automatic update `` |
| [`f353bf60`](https://github.com/nix-community/NUR/commit/f353bf606c89d4d738dfc34eac069f5c15c5c1a6) | `` automatic update `` |
| [`31888fa6`](https://github.com/nix-community/NUR/commit/31888fa6958dee0e1d9bc4d62ef5d892efc68cd4) | `` automatic update `` |