### PR TITLE
chore(flake/srvos): `c5017cb6` -> `b387f661`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -897,11 +897,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723683003,
-        "narHash": "sha256-rzKqGrSMRamqcJJqNSikr1nUCQhtZBdl3XnZuTFiWLU=",
+        "lastModified": 1723820613,
+        "narHash": "sha256-STntZkuZdEMb+qqM3dpiHdjoDLixZHepGLmaCFeP4s4=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "c5017cb68ac667ce63088ac70895387d6f22e6ef",
+        "rev": "b387f661061b60d6de3e21aa37a96bc113b1c3ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                 |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`b387f661`](https://github.com/nix-community/srvos/commit/b387f661061b60d6de3e21aa37a96bc113b1c3ef) | `` fix: set lower prio on networking.hostName (#484) `` |