### PR TITLE
chore(flake/emacs-overlay): `3b4f8179` -> `083d5626`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723799695,
-        "narHash": "sha256-8W/xxCpwQC9LOnwUO0Q7aGAF463ozaxcwQ6/toqtz0M=",
+        "lastModified": 1723828499,
+        "narHash": "sha256-Op3Z6wlbBhTFNwT6p2HQSMzdc46cfgo2P7P1eblGfE0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3b4f8179de2b4950540d70161854e43fe1010eae",
+        "rev": "083d562644c3efa57b0e11b9bf902d2bb70bfbd0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`083d5626`](https://github.com/nix-community/emacs-overlay/commit/083d562644c3efa57b0e11b9bf902d2bb70bfbd0) | `` Updated emacs ``  |
| [`88948124`](https://github.com/nix-community/emacs-overlay/commit/8894812488e2c1f34e6e1dbcda726b5bc040e6d1) | `` Updated melpa ``  |
| [`c8dbec6a`](https://github.com/nix-community/emacs-overlay/commit/c8dbec6a0b96c0c32134d85e9165e746b68ddee4) | `` Updated elpa ``   |
| [`857cc166`](https://github.com/nix-community/emacs-overlay/commit/857cc166e4e91a1fd5b0db388505898c26785304) | `` Updated nongnu `` |