### PR TITLE
chore(flake/emacs-overlay): `083d5626` -> `fa52ed43`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723828499,
-        "narHash": "sha256-Op3Z6wlbBhTFNwT6p2HQSMzdc46cfgo2P7P1eblGfE0=",
+        "lastModified": 1723856879,
+        "narHash": "sha256-QeIHStW7aYLQAzotnNXzl4By9J1M2PMJy/3GFBS1d+A=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "083d562644c3efa57b0e11b9bf902d2bb70bfbd0",
+        "rev": "fa52ed43781e7174f69e4072f37dec3730c01f3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`fa52ed43`](https://github.com/nix-community/emacs-overlay/commit/fa52ed43781e7174f69e4072f37dec3730c01f3e) | `` Updated emacs ``  |
| [`812df766`](https://github.com/nix-community/emacs-overlay/commit/812df766a75b6e3b6a6b0852c86bb6def40d205b) | `` Updated elpa ``   |
| [`2fe43aca`](https://github.com/nix-community/emacs-overlay/commit/2fe43aca0a7b2c4bc395bde028173ca37a6b6904) | `` Updated nongnu `` |