### PR TITLE
chore(flake/emacs-overlay): `fa52ed43` -> `5b263d57`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723856879,
-        "narHash": "sha256-QeIHStW7aYLQAzotnNXzl4By9J1M2PMJy/3GFBS1d+A=",
+        "lastModified": 1723858959,
+        "narHash": "sha256-mc2U9vzgGk52dzy3QXaD6iZSDuqO19YpLzwTot0XMSo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fa52ed43781e7174f69e4072f37dec3730c01f3e",
+        "rev": "5b263d5788c503a83399c2b54ba87e46fb96b418",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`5b263d57`](https://github.com/nix-community/emacs-overlay/commit/5b263d5788c503a83399c2b54ba87e46fb96b418) | `` Updated melpa `` |