### PR TITLE
chore(flake/nur): `401628ec` -> `e357b847`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723849682,
-        "narHash": "sha256-uu7U8afWM5+fpg3ox073GcrCHFXNE5mLg6IpfG2Vr3E=",
+        "lastModified": 1723867047,
+        "narHash": "sha256-/JIaGY3uYpjOdspuNQ/qh4ysFujd/JPBrzElcfbJdlU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "401628ec50d326030e81aa44a37adf8ca876b72a",
+        "rev": "e357b847cda2a994db243a8389a6aebcc6457d55",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e357b847`](https://github.com/nix-community/NUR/commit/e357b847cda2a994db243a8389a6aebcc6457d55) | `` automatic update `` |
| [`d3ccb21e`](https://github.com/nix-community/NUR/commit/d3ccb21ef1b7d23a4fc67930c943260417a4ab85) | `` automatic update `` |
| [`5fe231ee`](https://github.com/nix-community/NUR/commit/5fe231eec9b5a39ef8e0af39a64c24a8775f9df8) | `` automatic update `` |
| [`b43ecc46`](https://github.com/nix-community/NUR/commit/b43ecc46a848d0107b17091e2cd74cb442e28885) | `` automatic update `` |