### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `7f0ff431` -> `52b9927f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -500,11 +500,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1723710831,
-        "narHash": "sha256-O+zWGC5pU5ofXFygKArZuk+LwY3waVC57kfMdjll+g4=",
+        "lastModified": 1723868006,
+        "narHash": "sha256-0YTutDzHqpKYLxKyJxVmA/Zj9z8FbPJbuy5H9EqalQE=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "7f0ff431564632fe192691e408bfc3e27cf66c66",
+        "rev": "52b9927fff3b156df87735a7621099fbfcfab522",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                        |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`52b9927f`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/52b9927fff3b156df87735a7621099fbfcfab522) | `` Never do shallow fetches `` |