### PR TITLE
chore(flake/nur): `e357b847` -> `31427278`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723867047,
-        "narHash": "sha256-/JIaGY3uYpjOdspuNQ/qh4ysFujd/JPBrzElcfbJdlU=",
+        "lastModified": 1723867448,
+        "narHash": "sha256-heW9iIx+2FFIYGTEV7zBy7wS0Hb5eHW+/xxSRKnA1Yk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e357b847cda2a994db243a8389a6aebcc6457d55",
+        "rev": "314272782b9c4f4e837409ffd4f0dd749eaaf28e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`31427278`](https://github.com/nix-community/NUR/commit/314272782b9c4f4e837409ffd4f0dd749eaaf28e) | `` automatic update `` |