### PR TITLE
chore(flake/nur): `31427278` -> `606fea4f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723867448,
-        "narHash": "sha256-heW9iIx+2FFIYGTEV7zBy7wS0Hb5eHW+/xxSRKnA1Yk=",
+        "lastModified": 1723877460,
+        "narHash": "sha256-M7f9vYq0+0xh2T24y6xaYfHtrja4E6m1lgjmZx3LQII=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "314272782b9c4f4e837409ffd4f0dd749eaaf28e",
+        "rev": "606fea4f20ac6e386dfcedcdfd82b271ee0ecd1b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`606fea4f`](https://github.com/nix-community/NUR/commit/606fea4f20ac6e386dfcedcdfd82b271ee0ecd1b) | `` automatic update `` |