### PR TITLE
chore(flake/nur): `606fea4f` -> `002e8397`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723877460,
-        "narHash": "sha256-M7f9vYq0+0xh2T24y6xaYfHtrja4E6m1lgjmZx3LQII=",
+        "lastModified": 1723881468,
+        "narHash": "sha256-zDWOUgeQadvS7mxBOLe6ok6be+XoUushWxqlJXIPXUs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "606fea4f20ac6e386dfcedcdfd82b271ee0ecd1b",
+        "rev": "002e8397e5663981301129fc0e3399a18e9655cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`002e8397`](https://github.com/nix-community/NUR/commit/002e8397e5663981301129fc0e3399a18e9655cf) | `` automatic update `` |
| [`e04f6b59`](https://github.com/nix-community/NUR/commit/e04f6b59507958fbb84b24a7e9018486080fe2c1) | `` automatic update `` |