### PR TITLE
chore(flake/nur): `002e8397` -> `f9ef5fcb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723881468,
-        "narHash": "sha256-zDWOUgeQadvS7mxBOLe6ok6be+XoUushWxqlJXIPXUs=",
+        "lastModified": 1723895098,
+        "narHash": "sha256-VfV5Ih/qfn2RUxG45O538T9G8sm5WwtAdkPkgzXpJrw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "002e8397e5663981301129fc0e3399a18e9655cf",
+        "rev": "f9ef5fcb4d8cf8c9efe2d266619c0adc569fd0be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f9ef5fcb`](https://github.com/nix-community/NUR/commit/f9ef5fcb4d8cf8c9efe2d266619c0adc569fd0be) | `` automatic update `` |