### PR TITLE
chore(flake/srvos): `b387f661` -> `6c45a75c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -897,11 +897,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723820613,
-        "narHash": "sha256-STntZkuZdEMb+qqM3dpiHdjoDLixZHepGLmaCFeP4s4=",
+        "lastModified": 1723896521,
+        "narHash": "sha256-yWxfSFKRhRe8gH8PXcFmExJbOxEOGhSiBdhrHcxtNvo=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "b387f661061b60d6de3e21aa37a96bc113b1c3ef",
+        "rev": "6c45a75c604159167ef6f3bcd5658fc7ef649350",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                   |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`1efad919`](https://github.com/nix-community/srvos/commit/1efad919e10376054799dfd7e4f7ac3efd317a3c) | `` nix: don't set nix.optimize.automatic in containers `` |