### PR TITLE
chore(flake/nur): `5f95471c` -> `55a22811`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723900824,
-        "narHash": "sha256-53lP0iHfU7mBAEaccRQJn9TpvLACVbszl6eStWmorGE=",
+        "lastModified": 1723905880,
+        "narHash": "sha256-j9xPPY4sVVmdt6n9q4/bH2IHYnzFJ96rWwBUVF9puPM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5f95471c166b00d8e1d11f8954cec22ed8465a15",
+        "rev": "55a2281172b763189cfef53d02e843851cccc51a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`55a22811`](https://github.com/nix-community/NUR/commit/55a2281172b763189cfef53d02e843851cccc51a) | `` automatic update `` |