### PR TITLE
chore(flake/emacs-overlay): `2dc18fd0` -> `bde8f177`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723885890,
-        "narHash": "sha256-MNREOblaa/DcYkM2Az57JC+auv023k+93biSDP6tiGY=",
+        "lastModified": 1723913891,
+        "narHash": "sha256-0e9LdES+4d4zsxWPaRniybpuArZUG1elbHFVIZC2GfA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2dc18fd0621276a03b36e509d9271155d6e5ee19",
+        "rev": "bde8f17728d51394fa78605cf3cd2493b8e6475b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`bde8f177`](https://github.com/nix-community/emacs-overlay/commit/bde8f17728d51394fa78605cf3cd2493b8e6475b) | `` Updated melpa ``  |
| [`a1d264a4`](https://github.com/nix-community/emacs-overlay/commit/a1d264a46c1f782adb72fb7c4996d0cde2570223) | `` Updated elpa ``   |
| [`1eb41e1b`](https://github.com/nix-community/emacs-overlay/commit/1eb41e1bd466beb7611cddadb8378e602cc24945) | `` Updated nongnu `` |