### PR TITLE
chore(flake/emacs-overlay): `bde8f177` -> `cd1f4c41`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723913891,
-        "narHash": "sha256-0e9LdES+4d4zsxWPaRniybpuArZUG1elbHFVIZC2GfA=",
+        "lastModified": 1723914756,
+        "narHash": "sha256-yZEqw0FTnN4/m6ha+seuYH7UUIGP+Kl83tPCnLCA3BY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bde8f17728d51394fa78605cf3cd2493b8e6475b",
+        "rev": "cd1f4c419ab3f3dd981de94fd1dda5a450dbcadf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`cd1f4c41`](https://github.com/nix-community/emacs-overlay/commit/cd1f4c419ab3f3dd981de94fd1dda5a450dbcadf) | `` Updated emacs `` |