### PR TITLE
chore(flake/nur): `55a22811` -> `ee09cd60`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723905880,
-        "narHash": "sha256-j9xPPY4sVVmdt6n9q4/bH2IHYnzFJ96rWwBUVF9puPM=",
+        "lastModified": 1723920956,
+        "narHash": "sha256-lDJs5iHz9L6aRNY9tLaewQTu48xNNczIGtnKc34spwc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "55a2281172b763189cfef53d02e843851cccc51a",
+        "rev": "ee09cd604a871210536053db7f4ebfbe4a272714",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ee09cd60`](https://github.com/nix-community/NUR/commit/ee09cd604a871210536053db7f4ebfbe4a272714) | `` automatic update `` |
| [`b8464432`](https://github.com/nix-community/NUR/commit/b8464432860810d2dc9119081586acfaaf2ae37a) | `` automatic update `` |
| [`2ce83222`](https://github.com/nix-community/NUR/commit/2ce832220c093b55c023b43931bc39e26af55f1c) | `` automatic update `` |
| [`357cdf40`](https://github.com/nix-community/NUR/commit/357cdf40637f1ea4aa386fabef913023f88a118b) | `` automatic update `` |