### PR TITLE
chore(flake/nur): `ee09cd60` -> `8aa95b42`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723920956,
-        "narHash": "sha256-lDJs5iHz9L6aRNY9tLaewQTu48xNNczIGtnKc34spwc=",
+        "lastModified": 1723926497,
+        "narHash": "sha256-sLt2lMpNwjcW0HjU1hbL1SsDcjolJbR/lku4PVw/xu8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ee09cd604a871210536053db7f4ebfbe4a272714",
+        "rev": "8aa95b420ad3c1d292114267d88e870d9f31fcde",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8aa95b42`](https://github.com/nix-community/NUR/commit/8aa95b420ad3c1d292114267d88e870d9f31fcde) | `` automatic update `` |