### PR TITLE
chore(flake/nur): `8aa95b42` -> `b470c3a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723926497,
-        "narHash": "sha256-sLt2lMpNwjcW0HjU1hbL1SsDcjolJbR/lku4PVw/xu8=",
+        "lastModified": 1723934699,
+        "narHash": "sha256-fIQcPhJ8OCRlmCfedEcK6PI8QFIadP3f+YhcVnNPyRg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8aa95b420ad3c1d292114267d88e870d9f31fcde",
+        "rev": "b470c3a990467cf279735a013759ac85681277c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b470c3a9`](https://github.com/nix-community/NUR/commit/b470c3a990467cf279735a013759ac85681277c8) | `` automatic update `` |
| [`ffaf4109`](https://github.com/nix-community/NUR/commit/ffaf410904d844f7884314c4f5d4ea241301e20d) | `` automatic update `` |