### PR TITLE
chore(flake/emacs-overlay): `f560efb1` -> `c34c8d77`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723943585,
-        "narHash": "sha256-/Hii4Pjm0AHcb7nc2ZxRo8d2e51SllaCZmQMErLm45E=",
+        "lastModified": 1723946515,
+        "narHash": "sha256-b/OHNTfJl16JSLpGMDSoiGliqc13MmUUEu78GqS++Sg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f560efb1e208748c2bbccce0459a860b2ef62bdc",
+        "rev": "c34c8d77f326f42d43d5912c33e8802a96d29cd0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`c34c8d77`](https://github.com/nix-community/emacs-overlay/commit/c34c8d77f326f42d43d5912c33e8802a96d29cd0) | `` Updated emacs `` |
| [`47c6dc70`](https://github.com/nix-community/emacs-overlay/commit/47c6dc70ea802686fcb513928be6465ec6400839) | `` Updated melpa `` |