### PR TITLE
chore(flake/nur): `b470c3a9` -> `4f8a3901`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723934699,
-        "narHash": "sha256-fIQcPhJ8OCRlmCfedEcK6PI8QFIadP3f+YhcVnNPyRg=",
+        "lastModified": 1723946204,
+        "narHash": "sha256-LqQE11+KUcNes+WpFUb1+INu6n4xV+T4uKAiFid83iQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b470c3a990467cf279735a013759ac85681277c8",
+        "rev": "4f8a3901451df31ded2be1bd95b5f5d6624fdecb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4f8a3901`](https://github.com/nix-community/NUR/commit/4f8a3901451df31ded2be1bd95b5f5d6624fdecb) | `` automatic update `` |
| [`13b96f87`](https://github.com/nix-community/NUR/commit/13b96f87683bbe9d908d8de918aa5745f7bc27db) | `` automatic update `` |