### PR TITLE
chore(flake/nix-index-database): `ec78079a` -> `392828aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -571,11 +571,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723352546,
-        "narHash": "sha256-WTIrvp0yV8ODd6lxAq4F7EbrPQv0gscBnyfn559c3k8=",
+        "lastModified": 1723950649,
+        "narHash": "sha256-dHMkGjwwCGj0c2MKyCjRXVBXq2Sz3TWbbM23AS7/5Hc=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "ec78079a904d7d55e81a0468d764d0fffb50ac06",
+        "rev": "392828aafbed62a6ea6ccab13728df2e67481805",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`392828aa`](https://github.com/nix-community/nix-index-database/commit/392828aafbed62a6ea6ccab13728df2e67481805) | `` update generated.nix to release 2024-08-18-025734 `` |
| [`39bc3e8c`](https://github.com/nix-community/nix-index-database/commit/39bc3e8c43432e8f6066cac179b30e3d58b3d4c5) | `` flake.lock: Update ``                                |