### PR TITLE
chore(flake/nur): `4f8a3901` -> `fc45ce5f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723946204,
-        "narHash": "sha256-LqQE11+KUcNes+WpFUb1+INu6n4xV+T4uKAiFid83iQ=",
+        "lastModified": 1723953534,
+        "narHash": "sha256-CZaKobHd3+HuIwgmX0iWQy+BFVz7h7RCRTm1gESjV44=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4f8a3901451df31ded2be1bd95b5f5d6624fdecb",
+        "rev": "fc45ce5fba9405c6f6510c00af87a837cada317f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fc45ce5f`](https://github.com/nix-community/NUR/commit/fc45ce5fba9405c6f6510c00af87a837cada317f) | `` automatic update `` |
| [`0849b11a`](https://github.com/nix-community/NUR/commit/0849b11a1cebab4027ad4d2e74f6c1532b1f42e3) | `` automatic update `` |
| [`0757a5c4`](https://github.com/nix-community/NUR/commit/0757a5c43a50b729a45e967505aa9d431716b0c5) | `` automatic update `` |
| [`eefd7f64`](https://github.com/nix-community/NUR/commit/eefd7f643ffeb25543019d48952e66ddae3da583) | `` automatic update `` |