### PR TITLE
chore(flake/nur): `fc45ce5f` -> `4ba8abc6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723953534,
-        "narHash": "sha256-CZaKobHd3+HuIwgmX0iWQy+BFVz7h7RCRTm1gESjV44=",
+        "lastModified": 1723955500,
+        "narHash": "sha256-gIfQ0/pMSdQNh2TZm5J1FPgYqTjKADGR/CuVhm7bYhc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fc45ce5fba9405c6f6510c00af87a837cada317f",
+        "rev": "4ba8abc655ccf3b432c2c4235a80364325f3ea8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4ba8abc6`](https://github.com/nix-community/NUR/commit/4ba8abc655ccf3b432c2c4235a80364325f3ea8d) | `` automatic update `` |
| [`390e10d4`](https://github.com/nix-community/NUR/commit/390e10d457d2cb6850f91868a2c50e46c953f2f8) | `` automatic update `` |