### PR TITLE
chore(flake/nur): `4ba8abc6` -> `8635a022`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723955500,
-        "narHash": "sha256-gIfQ0/pMSdQNh2TZm5J1FPgYqTjKADGR/CuVhm7bYhc=",
+        "lastModified": 1723959581,
+        "narHash": "sha256-5aLv+r8HY0MNGdq3tB1OOY2R93oRuFT0NJvpg/4jyrk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ba8abc655ccf3b432c2c4235a80364325f3ea8d",
+        "rev": "8635a022d528532bac6f40a4a44b0a015c25a7fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8635a022`](https://github.com/nix-community/NUR/commit/8635a022d528532bac6f40a4a44b0a015c25a7fd) | `` automatic update `` |