### PR TITLE
chore(flake/nur): `8635a022` -> `fba87298`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723959581,
-        "narHash": "sha256-5aLv+r8HY0MNGdq3tB1OOY2R93oRuFT0NJvpg/4jyrk=",
+        "lastModified": 1723962718,
+        "narHash": "sha256-T/rHajzjKbwcxQf4Mz2m/lS7tZygOY+FuSOoQvSqNl0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8635a022d528532bac6f40a4a44b0a015c25a7fd",
+        "rev": "fba872986d73bad37218643f8a43108e0a6bd7be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fba87298`](https://github.com/nix-community/NUR/commit/fba872986d73bad37218643f8a43108e0a6bd7be) | `` automatic update `` |