### PR TITLE
chore(flake/nur): `fba87298` -> `575ee4dc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723962718,
-        "narHash": "sha256-T/rHajzjKbwcxQf4Mz2m/lS7tZygOY+FuSOoQvSqNl0=",
+        "lastModified": 1723976478,
+        "narHash": "sha256-eF815/buOMQlX2XbtNgN3GtA9bwv4psLbckU9iTBsxs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fba872986d73bad37218643f8a43108e0a6bd7be",
+        "rev": "575ee4dc4dc7c031663bdcfe2e8779abacc80d0a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`575ee4dc`](https://github.com/nix-community/NUR/commit/575ee4dc4dc7c031663bdcfe2e8779abacc80d0a) | `` automatic update `` |