### PR TITLE
chore(flake/emacs-overlay): `c34c8d77` -> `3db40512`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723946515,
-        "narHash": "sha256-b/OHNTfJl16JSLpGMDSoiGliqc13MmUUEu78GqS++Sg=",
+        "lastModified": 1724000115,
+        "narHash": "sha256-jle8O4KP2vuQyAEkrR34WyC0gAncWXTPoWzb3yHnI5o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c34c8d77f326f42d43d5912c33e8802a96d29cd0",
+        "rev": "3db405127bfaea6458d5d8efdab0f97a72377a0d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                 |
| ------------------------------------------------------------------------------------------------------------ | ----------------------- |
| [`3db40512`](https://github.com/nix-community/emacs-overlay/commit/3db405127bfaea6458d5d8efdab0f97a72377a0d) | `` Updated melpa ``     |
| [`ed21ef42`](https://github.com/nix-community/emacs-overlay/commit/ed21ef421c345eafbaf656dffeb44bbb6e891154) | `` Updated elpa ``      |
| [`ad08090d`](https://github.com/nix-community/emacs-overlay/commit/ad08090d3f0ef28bcbb7b989d0491402cff4f745) | `` Updated nongnu ``    |
| [`eda7ebd2`](https://github.com/nix-community/emacs-overlay/commit/eda7ebd2ea4134dd2b428e9e25f30239c7194f66) | `` Updated fromElisp `` |