### PR TITLE
chore(flake/nur): `adee26fc` -> `a19d5331`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723992327,
-        "narHash": "sha256-w0DhauBqGC7zBlsm0i0IXVvhBGqBvsJPGnc5b9jffvA=",
+        "lastModified": 1724006181,
+        "narHash": "sha256-iv99eBazOPW/qr6axVH1CefGINFuNTXtrCL1MB8d62c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "adee26fc0c486560152c814b963ae27851eef658",
+        "rev": "a19d533182fdd7783135ad918f70d13143884aa1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a19d5331`](https://github.com/nix-community/NUR/commit/a19d533182fdd7783135ad918f70d13143884aa1) | `` automatic update `` |