### PR TITLE
chore(flake/nur): `e58b60dd` -> `8c7136cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1724010377,
-        "narHash": "sha256-b0F0EKc+kpOoR+u1F7ZdXP757sOG0CYnFTsdbJIerP0=",
+        "lastModified": 1724012881,
+        "narHash": "sha256-lqn4UX+tvtwOmBZ2Dxh6euXKNcXGEYqPolEdjtONDVY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e58b60dd8b3fe89363986b15dcea3ca43c77b41d",
+        "rev": "8c7136cb22fd96cde881225863b450df75876ebc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8c7136cb`](https://github.com/nix-community/NUR/commit/8c7136cb22fd96cde881225863b450df75876ebc) | `` automatic update `` |