### PR TITLE
chore(flake/catppuccin): `55205677` -> `32326f7b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1723691425,
-        "narHash": "sha256-F25VvHFMaqr26b7goaVWspXaK6XTRFz8RnILV+9OPkk=",
+        "lastModified": 1724020531,
+        "narHash": "sha256-C40a2i2dB+d2xoFlE1dfw5kU2y6g16pUx29qDftXvMw=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "552056779a136092eb6358c573d925630172fc30",
+        "rev": "32326f7b9be0eaeb3c8d71de563a93cfb8f63700",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`32326f7b`](https://github.com/catppuccin/nix/commit/32326f7b9be0eaeb3c8d71de563a93cfb8f63700) | `` chore(home-manager/tmux): follow upstream spelling change (#315) `` |
| [`3c3196c8`](https://github.com/catppuccin/nix/commit/3c3196c8c75c58e4d96457dfd4f4e6dbaff4a5f1) | `` chore(modules): update ports (#307) ``                              |