### PR TITLE
chore(flake/srvos): `6c45a75c` -> `5a7a27e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -897,11 +897,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723896521,
-        "narHash": "sha256-yWxfSFKRhRe8gH8PXcFmExJbOxEOGhSiBdhrHcxtNvo=",
+        "lastModified": 1724028469,
+        "narHash": "sha256-vUNNPBErgkbthrGq952uNkP/25J12j0uSAB7jjdrNBo=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "6c45a75c604159167ef6f3bcd5658fc7ef649350",
+        "rev": "5a7a27e18839e3392ac12fcb888d5eb6009ab31b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`5a7a27e1`](https://github.com/nix-community/srvos/commit/5a7a27e18839e3392ac12fcb888d5eb6009ab31b) | `` dev/private/flake.lock: Update `` |
| [`8800b61b`](https://github.com/nix-community/srvos/commit/8800b61bd2108b9bd436c524424c4ff25ea9a0aa) | `` flake.lock: Update ``             |