### PR TITLE
chore(flake/emacs-overlay): `b607b449` -> `ac6e2462`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1724029773,
-        "narHash": "sha256-w38ACMz08GKQ7upsYYuZo3P5Ny/txy33fLDPh4mmNSE=",
+        "lastModified": 1724032823,
+        "narHash": "sha256-H3tX0FEsz8ccciHaD0foNKs3P0Yu52BXLA18vB5r0jc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b607b449257a0df8d1362bd998874cd2f30a432b",
+        "rev": "ac6e2462978c50ddf8c297d95dd1adca7e58d1e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`ac6e2462`](https://github.com/nix-community/emacs-overlay/commit/ac6e2462978c50ddf8c297d95dd1adca7e58d1e1) | `` Updated emacs `` |
| [`5102183b`](https://github.com/nix-community/emacs-overlay/commit/5102183b47bb2cf6699915a1e0a5ea0cc7f140d1) | `` Updated melpa `` |