### PR TITLE
chore(flake/nur): `8c7136cb` -> `e03cacc3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1724012881,
-        "narHash": "sha256-lqn4UX+tvtwOmBZ2Dxh6euXKNcXGEYqPolEdjtONDVY=",
+        "lastModified": 1724039602,
+        "narHash": "sha256-gggFnk6lSnK1FIl9Q22uwy1xiY2d1Q8WbE3JUNGIegg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8c7136cb22fd96cde881225863b450df75876ebc",
+        "rev": "e03cacc3f19508311dbc1e8c58520d2c63701d57",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e03cacc3`](https://github.com/nix-community/NUR/commit/e03cacc3f19508311dbc1e8c58520d2c63701d57) | `` automatic update `` |
| [`e6dac467`](https://github.com/nix-community/NUR/commit/e6dac4671797c6a98dbd609b58af9a1c9b1fdccc) | `` automatic update `` |
| [`1322a95f`](https://github.com/nix-community/NUR/commit/1322a95f0abb60b1c58dee8281555aa92366854c) | `` automatic update `` |
| [`613ff083`](https://github.com/nix-community/NUR/commit/613ff0835b3f0bd59bd00be961cd54acaf00be9a) | `` automatic update `` |