### PR TITLE
chore(flake/nur): `e03cacc3` -> `24471a48`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1724039602,
-        "narHash": "sha256-gggFnk6lSnK1FIl9Q22uwy1xiY2d1Q8WbE3JUNGIegg=",
+        "lastModified": 1724040334,
+        "narHash": "sha256-Ia4gRRmhFn4oJ4SJKJPDNPomsRRFWU+bqCK7yuiLW4E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e03cacc3f19508311dbc1e8c58520d2c63701d57",
+        "rev": "24471a48600e18669d13d24c9640b9859357d2cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`24471a48`](https://github.com/nix-community/NUR/commit/24471a48600e18669d13d24c9640b9859357d2cf) | `` automatic update `` |