### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `db0d51a8` -> `28e41793`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
     "doomemacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1723672919,
-        "narHash": "sha256-UqlyRORsIc0AgcE4C2HjuiESkQdoKvO7tRyDWF31Wik=",
+        "lastModified": 1724048105,
+        "narHash": "sha256-/6PAjSbF3G3IrbfkWCwY1LHpH9i9ck2gcV9155MhBoY=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "173842cceaefdb175dd0163ceb11bedd22093bf8",
+        "rev": "ddfb0cc3cc4326e72efb6db84c95eeb1401c7fc2",
         "type": "github"
       },
       "original": {
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723709928,
-        "narHash": "sha256-VZk6VbVaic73BsChdWeBjGxLPNfjt9fcLyYEmmLOILo=",
+        "lastModified": 1724055554,
+        "narHash": "sha256-qg/+f8DxrhW53m8F2Ak5nVmQznZRDYV2BvS6LTM7qRI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0c527c80b18d24ad5b53aae362eac5d9c90f73a8",
+        "rev": "b5a543194c6156e121a974a8710c52476c0e30d4",
         "type": "github"
       },
       "original": {
@@ -500,11 +500,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1723880039,
-        "narHash": "sha256-pS5PUcLvwoRVQdRz84cPQKEH0SbSZIYKrehBuJ/FlnE=",
+        "lastModified": 1724056468,
+        "narHash": "sha256-8jyi6XGR3aHHao/QKuURCSinuadEa654BgGZ36J8E7g=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "db0d51a864c119594dc0ef400fd2819758efc4a2",
+        "rev": "28e4179338dc34ed5e768ba9a037632432fd8f12",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`28e41793`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/28e4179338dc34ed5e768ba9a037632432fd8f12) | `` flake.lock: Update `` |