### PR TITLE
chore(flake/nixos-hardware): `c54cf53e` -> `b09c4643`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -611,11 +611,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1723310128,
-        "narHash": "sha256-IiH8jG6PpR4h9TxSGMYh+2/gQiJW9MwehFvheSb5rPc=",
+        "lastModified": 1724067415,
+        "narHash": "sha256-WJBAEFXAtA41RMpK8mvw0cQ62CJkNMBtzcEeNIJV7b0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "c54cf53e022b0b3c1d3b8207aa0f9b194c24f0cf",
+        "rev": "b09c46430ffcf18d575acf5c339b38ac4e1db5d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`b09c4643`](https://github.com/NixOS/nixos-hardware/commit/b09c46430ffcf18d575acf5c339b38ac4e1db5d2) | `` Add Dell Latitude 5490 ``                               |
| [`feefc78f`](https://github.com/NixOS/nixos-hardware/commit/feefc78fbc4b205485eda0c1d9202c8f9288778a) | `` surface: linux 6.10.3 -> 6.10.5 ``                      |
| [`15c3e009`](https://github.com/NixOS/nixos-hardware/commit/15c3e00913f854e9a1e7d2df522fc5c00495e04c) | `` mergify: merge in batches of 5 ``                       |
| [`b887ec29`](https://github.com/NixOS/nixos-hardware/commit/b887ec296a95682e689a36065ae64c24d999d843) | `` fix: update fix to a closer version which fixes this `` |
| [`70e7e3fa`](https://github.com/NixOS/nixos-hardware/commit/70e7e3fa140d55efc43e78379ae09d8872d8dc7f) | `` update mergify ``                                       |
| [`a3efd466`](https://github.com/NixOS/nixos-hardware/commit/a3efd46620a6b9f60a82b66f22c1c363223d60d4) | `` apple/imac/18-2: fix gpu import path ``                 |
| [`15c8c47f`](https://github.com/NixOS/nixos-hardware/commit/15c8c47fe2a5f6c72f8327ed6a43c99e4a924d82) | `` kobol/helios4: fix eval ``                              |
| [`04a366f2`](https://github.com/NixOS/nixos-hardware/commit/04a366f28cd492eda94d07fcf67b3cc99f4ef6cf) | `` fix ci and make it reproducible ``                      |