### PR TITLE
chore(flake/nur): `95c40262` -> `8003eded`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1724057243,
-        "narHash": "sha256-2vpUacUEJ+vC+xeUv/ytyQfRY9Tl5oSus5h3SCTGL/Y=",
+        "lastModified": 1724071666,
+        "narHash": "sha256-qydcL3kvgokoHx5hQTMm87d521eg0lqHf/6FgOuMG1g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "95c40262c6bb22100dea3be6de4fe3716be554ca",
+        "rev": "8003eded0f705c72b47221b5ee05599ae9f370fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                             |
| -------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`8003eded`](https://github.com/nix-community/NUR/commit/8003eded0f705c72b47221b5ee05599ae9f370fb) | `` automatic update ``              |
| [`9eb034ea`](https://github.com/nix-community/NUR/commit/9eb034eac5f6fc788d3877bccafc3c89b3383f38) | `` automatic update ``              |
| [`217fcb6a`](https://github.com/nix-community/NUR/commit/217fcb6a1ef7260cc723d47a9bdca7a93f751ec7) | `` automatic update ``              |
| [`f3366e8b`](https://github.com/nix-community/NUR/commit/f3366e8b9eff7f9c08d1a44887fefcfe3dac365e) | `` add zzzsyyy/flakes repository `` |
| [`0efc8295`](https://github.com/nix-community/NUR/commit/0efc829574140db617152ec847d1800b2b3ca208) | `` automatic update ``              |
| [`e27cfa95`](https://github.com/nix-community/NUR/commit/e27cfa9541c1581639bebf1ed29f3560d0bd0d07) | `` automatic update ``              |