### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `28e41793` -> `1837ca5d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -500,11 +500,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1724056468,
-        "narHash": "sha256-8jyi6XGR3aHHao/QKuURCSinuadEa654BgGZ36J8E7g=",
+        "lastModified": 1724068684,
+        "narHash": "sha256-mD7BXonDCGjsmozZpHWdtIA7T6cO2Xsm1ypDbqhTjeY=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "28e4179338dc34ed5e768ba9a037632432fd8f12",
+        "rev": "1837ca5d343a7db06b62f2ae647234e21fd3cde9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                          |
| ---------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`1837ca5d`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/1837ca5d343a7db06b62f2ae647234e21fd3cde9) | `` Drop nerd-icons-dired test `` |