### PR TITLE
chore(flake/emacs-overlay): `b5a54319` -> `d153d9f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1724055554,
-        "narHash": "sha256-qg/+f8DxrhW53m8F2Ak5nVmQznZRDYV2BvS6LTM7qRI=",
+        "lastModified": 1724086605,
+        "narHash": "sha256-kZm8GJfEt8Na5JyNfjXCIUKiMOAbWDNsCejh2OeF7r8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b5a543194c6156e121a974a8710c52476c0e30d4",
+        "rev": "d153d9f118d71fa8f4d3204639b4fd32d793ab57",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`d153d9f1`](https://github.com/nix-community/emacs-overlay/commit/d153d9f118d71fa8f4d3204639b4fd32d793ab57) | `` Updated melpa ``  |
| [`c38ab8ab`](https://github.com/nix-community/emacs-overlay/commit/c38ab8ab3a08f09f2e4b35c792f70a70159f72f0) | `` Updated elpa ``   |
| [`da6dff8b`](https://github.com/nix-community/emacs-overlay/commit/da6dff8bff20b1e11a84b98cb7d57ebc4fbe94b0) | `` Updated nongnu `` |