### PR TITLE
chore(flake/nur): `901c567b` -> `ed676ed3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1724082075,
-        "narHash": "sha256-16XkBxbzDW2xBn7hq2E+h8RQfBVTWBMDCPxpye+X6oY=",
+        "lastModified": 1724085534,
+        "narHash": "sha256-RV2N8/kmPGyRSvvLpMT+iD2txkAUnvKwfSuMHHYDsuk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "901c567b80ee1ea4777dba66111b32f10e1ebcf2",
+        "rev": "ed676ed3c0199aa228f3fe2884efa5d9d8a4eae4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ed676ed3`](https://github.com/nix-community/NUR/commit/ed676ed3c0199aa228f3fe2884efa5d9d8a4eae4) | `` automatic update `` |