### PR TITLE
chore(flake/nur): `ed676ed3` -> `1d086aa9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1724085534,
-        "narHash": "sha256-RV2N8/kmPGyRSvvLpMT+iD2txkAUnvKwfSuMHHYDsuk=",
+        "lastModified": 1724090444,
+        "narHash": "sha256-dqrPMPstlqrYiQ5QVFci5mONMvUJ3Xov22tbQ3NVeCs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ed676ed3c0199aa228f3fe2884efa5d9d8a4eae4",
+        "rev": "1d086aa9f2c78830ea6b110e338da9b17997c718",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1d086aa9`](https://github.com/nix-community/NUR/commit/1d086aa9f2c78830ea6b110e338da9b17997c718) | `` automatic update `` |