### PR TITLE
chore(flake/impermanence): `23c1f063` -> `9de98e03`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -409,11 +409,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1719091691,
-        "narHash": "sha256-AxaLX5cBEcGtE02PeGsfscSb/fWMnyS7zMWBXQWDKbE=",
+        "lastModified": 1724098307,
+        "narHash": "sha256-7SKGkqrXPLRD0jbs9IOnUhmjJZv2wawrlkgtzF0tMrw=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "23c1f06316b67cb5dabdfe2973da3785cfe9c34a",
+        "rev": "9de98e038ae91e15ea725700386044309b340299",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`213f8050`](https://github.com/nix-community/impermanence/commit/213f8050c9e9ddd8382224f962bf46f1ce5ac54f) | `` nixos: Add assertion for persisting UIDs/GIDs `` |