### PR TITLE
chore(flake/nur): `67458d41` -> `c4d9c79c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1724096795,
-        "narHash": "sha256-CuxtEo3rpFtil5zDNbnlufBiHtEtAjIvFbMx6RCut3I=",
+        "lastModified": 1724099379,
+        "narHash": "sha256-JN3ESiKxZFnRk2C4208JxAfqb+J3ivzImKfdpRpLjWQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "67458d4148e0f04d520a5ace007d3281e4898899",
+        "rev": "c4d9c79cfd8be1c89a989dc0f9ec6bc6ae6b5da0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c4d9c79c`](https://github.com/nix-community/NUR/commit/c4d9c79cfd8be1c89a989dc0f9ec6bc6ae6b5da0) | `` automatic update `` |