### PR TITLE
chore(flake/nur): `c4d9c79c` -> `7d49736b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1724099379,
-        "narHash": "sha256-JN3ESiKxZFnRk2C4208JxAfqb+J3ivzImKfdpRpLjWQ=",
+        "lastModified": 1724103901,
+        "narHash": "sha256-yupLp7tv5yu3KvrWQ9mLpCKyVks8RyEvNQVCFToyxdw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c4d9c79cfd8be1c89a989dc0f9ec6bc6ae6b5da0",
+        "rev": "7d49736b4409f42a795a9129f66e1fc02983221b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7d49736b`](https://github.com/nix-community/NUR/commit/7d49736b4409f42a795a9129f66e1fc02983221b) | `` automatic update `` |