### PR TITLE
chore(flake/emacs-overlay): `d153d9f1` -> `ceedca8a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1724086605,
-        "narHash": "sha256-kZm8GJfEt8Na5JyNfjXCIUKiMOAbWDNsCejh2OeF7r8=",
+        "lastModified": 1724116118,
+        "narHash": "sha256-eZnS3Qc7qvYEGVscetS2Lf7rR7VO7ztBI1IUU3W9CPg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d153d9f118d71fa8f4d3204639b4fd32d793ab57",
+        "rev": "ceedca8a2911251076c33b52464850646173d401",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`ceedca8a`](https://github.com/nix-community/emacs-overlay/commit/ceedca8a2911251076c33b52464850646173d401) | `` Updated elpa ``         |
| [`3e4af547`](https://github.com/nix-community/emacs-overlay/commit/3e4af547dc749364760bb5a45ec1b2a0a8be8037) | `` Updated nongnu ``       |
| [`f364a854`](https://github.com/nix-community/emacs-overlay/commit/f364a8542a98343e54b5e2598f2479ba06b5ea5c) | `` Updated flake inputs `` |