### PR TITLE
chore(flake/nur): `7d49736b` -> `69851a97`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1724103901,
-        "narHash": "sha256-yupLp7tv5yu3KvrWQ9mLpCKyVks8RyEvNQVCFToyxdw=",
+        "lastModified": 1724122553,
+        "narHash": "sha256-Rmznjo2DXZySnG9jcK6afMdMsXGw/tTKSdZOfXUuDYw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7d49736b4409f42a795a9129f66e1fc02983221b",
+        "rev": "69851a9766d82a7c238c6f02951595298b2be03a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`69851a97`](https://github.com/nix-community/NUR/commit/69851a9766d82a7c238c6f02951595298b2be03a) | `` automatic update `` |
| [`6c1aee62`](https://github.com/nix-community/NUR/commit/6c1aee62c08749d0ca938c8e158b1d8317a499f6) | `` automatic update `` |