### PR TITLE
chore(flake/nur): `69851a97` -> `e5405ead`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1724122553,
-        "narHash": "sha256-Rmznjo2DXZySnG9jcK6afMdMsXGw/tTKSdZOfXUuDYw=",
+        "lastModified": 1724125950,
+        "narHash": "sha256-qZgovskN0ZJiqN+WeJbEHSN/NrebGYvTWapNLOrh3rA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "69851a9766d82a7c238c6f02951595298b2be03a",
+        "rev": "e5405eadce88a9bd92d79f6c6f0c40504937e2ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e5405ead`](https://github.com/nix-community/NUR/commit/e5405eadce88a9bd92d79f6c6f0c40504937e2ea) | `` automatic update `` |
| [`57f11b97`](https://github.com/nix-community/NUR/commit/57f11b979f0e6fec4da138333dc3de49b49e8d8e) | `` automatic update `` |