### PR TITLE
chore(flake/nur): `e5405ead` -> `f05ac609`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1724125950,
-        "narHash": "sha256-qZgovskN0ZJiqN+WeJbEHSN/NrebGYvTWapNLOrh3rA=",
+        "lastModified": 1724129587,
+        "narHash": "sha256-kAxIsi7w89jskBNT0Q5zxGQPRW7rvE2bBWrqnfeTV3I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e5405eadce88a9bd92d79f6c6f0c40504937e2ea",
+        "rev": "f05ac60976e18cf12964ce8807d7b688c92e162a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f05ac609`](https://github.com/nix-community/NUR/commit/f05ac60976e18cf12964ce8807d7b688c92e162a) | `` automatic update `` |
| [`751dda87`](https://github.com/nix-community/NUR/commit/751dda87c6b234be9b5ae93c77fe04a125cfd8df) | `` automatic update `` |
| [`1491f1b8`](https://github.com/nix-community/NUR/commit/1491f1b884dc8c9ef1b48f67a04aa13130c4f11f) | `` automatic update `` |