### PR TITLE
chore(flake/impermanence): `9de98e03` -> `467e24bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -409,11 +409,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1724098307,
-        "narHash": "sha256-7SKGkqrXPLRD0jbs9IOnUhmjJZv2wawrlkgtzF0tMrw=",
+        "lastModified": 1724143219,
+        "narHash": "sha256-31OWIrsNKXMaSQFC+wzIl6OZZIflzNM90Q+JIH8zB7w=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "9de98e038ae91e15ea725700386044309b340299",
+        "rev": "467e24bd041e16a9752de7700d067b2efb9329c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                      |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`467e24bd`](https://github.com/nix-community/impermanence/commit/467e24bd041e16a9752de7700d067b2efb9329c9) | `` nixos: Make the /var/lib/nixos assertion a warning and include parents `` |