### PR TITLE
chore(flake/impermanence): `467e24bd` -> `03fe473c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -409,11 +409,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1724143219,
-        "narHash": "sha256-31OWIrsNKXMaSQFC+wzIl6OZZIflzNM90Q+JIH8zB7w=",
+        "lastModified": 1724146542,
+        "narHash": "sha256-MLxtqDtu+y/4UDhXX5pFypX9/qbH54TDP6Z90oFzd/A=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "467e24bd041e16a9752de7700d067b2efb9329c9",
+        "rev": "03fe473c731cda2900bae9894b8dfc68e3492db5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`03fe473c`](https://github.com/nix-community/impermanence/commit/03fe473c731cda2900bae9894b8dfc68e3492db5) | `` nixos: Formatting fixes ``              |
| [`785dd659`](https://github.com/nix-community/impermanence/commit/785dd6597b4fdc7f9f3b96a8f351be611ed56757) | `` nixos: Add option to toggle warnings `` |