### PR TITLE
chore(flake/nur): `ea4eb713` -> `25ce6b5c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1724150696,
-        "narHash": "sha256-FXuWhg5wD9uFaG/cBazHjmp1Gmd3rZswjaca8FqHQLU=",
+        "lastModified": 1724158862,
+        "narHash": "sha256-81moQpB1KbsUAL4TVAyel5x/SMgLt+mdNues+S8226c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ea4eb7133060e7f2079f3cc3213c6200eafc7253",
+        "rev": "25ce6b5c373df81b3a9045a629737dda3051e580",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`25ce6b5c`](https://github.com/nix-community/NUR/commit/25ce6b5c373df81b3a9045a629737dda3051e580) | `` automatic update `` |