### PR TITLE
chore(flake/git-hooks): `bfef0ada` -> `1064a45e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -353,11 +353,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1723803910,
-        "narHash": "sha256-yezvUuFiEnCFbGuwj/bQcqg7RykIEqudOy/RBrId0pc=",
+        "lastModified": 1724159077,
+        "narHash": "sha256-AddE0u6WbA5R7uxumw1Ka0oG5dv3cTtN0ppO/M/e0cg=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "bfef0ada09e2c8ac55bbcd0831bd0c9d42e651ba",
+        "rev": "1064a45e81a4e19cda98741b71219d9f4f136900",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                    |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`515d252e`](https://github.com/cachix/git-hooks.nix/commit/515d252eb3c382e0ecc6c8158a6a75f191da3f2a) | `` fix: switch nixfmt to nixfmt-classic `` |