### PR TITLE
chore(flake/nur): `25ce6b5c` -> `0b86d564`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1724158862,
-        "narHash": "sha256-81moQpB1KbsUAL4TVAyel5x/SMgLt+mdNues+S8226c=",
+        "lastModified": 1724159175,
+        "narHash": "sha256-3z9wRL+h+gTVFtecCUGrRaW6nvPPAtBCIDE9KAmZj7c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "25ce6b5c373df81b3a9045a629737dda3051e580",
+        "rev": "0b86d5643d99e3982471f0d79e553871c6f35396",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0b86d564`](https://github.com/nix-community/NUR/commit/0b86d5643d99e3982471f0d79e553871c6f35396) | `` automatic update `` |