### PR TITLE
chore(flake/nur): `8d3ce52c` -> `0e825dc2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1724183132,
-        "narHash": "sha256-NuoFFsNrPM1ub56SELd7XlA2uUDl+Vc1U2Msgq0A78c=",
+        "lastModified": 1724191013,
+        "narHash": "sha256-o6uDc8oQ3lxyKnHMV0ha3HEAGJMeKp67Jjd0OF1SsAc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8d3ce52c3e4b7e9c52650ead6d64101f9818c921",
+        "rev": "0e825dc2d84025c34c75058fed4300588343dbe9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0e825dc2`](https://github.com/nix-community/NUR/commit/0e825dc2d84025c34c75058fed4300588343dbe9) | `` automatic update `` |
| [`1d7ad0db`](https://github.com/nix-community/NUR/commit/1d7ad0db0a2770b635bc8d584f59de9e63065f74) | `` automatic update `` |