### PR TITLE
chore(flake/nur): `339d5219` -> `0b7ccb08`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1724240772,
-        "narHash": "sha256-qexdQP4E2X90wg8V9Mz0B3eYtQWhmxcPrwF7TFvoNTE=",
+        "lastModified": 1724244515,
+        "narHash": "sha256-19D0s6C+IAoSbUoNwGprDylDCluTfStp6WCveEaleM8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "339d5219881cbe5d571a777d3108d96ce678487b",
+        "rev": "0b7ccb08320deb1374ef939bea0b05d7de5f97ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0b7ccb08`](https://github.com/nix-community/NUR/commit/0b7ccb08320deb1374ef939bea0b05d7de5f97ad) | `` automatic update `` |