### PR TITLE
chore(flake/emacs-overlay): `daae91b8` -> `9d8307d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1724259560,
-        "narHash": "sha256-+fzCsEhWCeHhmujpPBlfJe2Nx1LQgk0kTZIi9LL5k1M=",
+        "lastModified": 1724260428,
+        "narHash": "sha256-JRkb9hBBhLV70DRR/D5FnJBypb1Zs5oUThMh3Rkpbu8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "daae91b88ac87312bdb27a52ac220043c63ef17e",
+        "rev": "9d8307d88a60bc4d6223a391b2fb41cc37e6714c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`9d8307d8`](https://github.com/nix-community/emacs-overlay/commit/9d8307d88a60bc4d6223a391b2fb41cc37e6714c) | `` Updated emacs `` |