### PR TITLE
chore(flake/emacs-overlay): `9d8307d8` -> `6d6e4169`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1724260428,
-        "narHash": "sha256-JRkb9hBBhLV70DRR/D5FnJBypb1Zs5oUThMh3Rkpbu8=",
+        "lastModified": 1724289010,
+        "narHash": "sha256-dxiSS0NlqjHiyLwmqHhpTXQtBaPXlizZtgeYfawH2Uk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9d8307d88a60bc4d6223a391b2fb41cc37e6714c",
+        "rev": "6d6e416939c4866ba29029eb130c669d586be9bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`6d6e4169`](https://github.com/nix-community/emacs-overlay/commit/6d6e416939c4866ba29029eb130c669d586be9bd) | `` Updated elpa ``   |
| [`515ea143`](https://github.com/nix-community/emacs-overlay/commit/515ea143c92981cc699470a18b1150e4ebb5e4d6) | `` Updated nongnu `` |