### PR TITLE
chore(flake/srvos): `5a7a27e1` -> `9810f43f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -882,11 +882,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724028469,
-        "narHash": "sha256-vUNNPBErgkbthrGq952uNkP/25J12j0uSAB7jjdrNBo=",
+        "lastModified": 1724287640,
+        "narHash": "sha256-MAjp8fUU6/WambitI/jOVxgjuH3YEfE6A8l4EtonktY=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "5a7a27e18839e3392ac12fcb888d5eb6009ab31b",
+        "rev": "9810f43ff22a10b6f70c38d6085ac6c201b26640",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`9810f43f`](https://github.com/nix-community/srvos/commit/9810f43ff22a10b6f70c38d6085ac6c201b26640) | `` dev/private/flake.lock: Update `` |
| [`d95cab34`](https://github.com/nix-community/srvos/commit/d95cab34d1087f22c05a5cab6d4b9b689a274f63) | `` flake.lock: Update ``             |