### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `a860a2fe` -> `764953de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
     "doomemacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1724213886,
-        "narHash": "sha256-ivQks1ITxJxlLSsH3ScAOYzYgWFZg0HvaYUlqE3corg=",
+        "lastModified": 1724266403,
+        "narHash": "sha256-3ri3m6QBSCDtZK2CW0SRAnhpspDAbeuqVCXZFF7pqow=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "f3e9920e802bb19cd77a463af944dd3fabe3ef90",
+        "rev": "dbcd30820bccc79680ad83f8a09cdc1614027c5a",
         "type": "github"
       },
       "original": {
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724228539,
-        "narHash": "sha256-WEPcaV2OyB76QutedmTOSYbtCFsy3XQm7Wvago1Ps+4=",
+        "lastModified": 1724314704,
+        "narHash": "sha256-y1dyY44XrluD07ZVykIfY8YLUb904rBySl3eWrLWqpY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "37db8016026a43b5f3d16ec4b949792d6b6bce4a",
+        "rev": "75c12ab00289f28750067608de1dd8e3022cffaf",
         "type": "github"
       },
       "original": {
@@ -500,11 +500,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1724247015,
-        "narHash": "sha256-avAw+bJt57mj0SJ05V43aI1XX6OMIEKhNRC9lRVZJ3w=",
+        "lastModified": 1724315638,
+        "narHash": "sha256-A0rJ1gaWfgEdgJZZCw+5jDkGYeASsZNAeRm4vU3aYUA=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "a860a2fec866f0b22504d04b4bb0df8f8255b64a",
+        "rev": "764953de630c3bf15bd34349dc9360398ab8f501",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`764953de`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/764953de630c3bf15bd34349dc9360398ab8f501) | `` flake.lock: Update `` |