### PR TITLE
chore(flake/emacs-overlay): `f97fc32d` -> `3387f280`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1724318074,
-        "narHash": "sha256-ZoV3H/kFChy3wwPLHz+87cc6vve0sGufuyni27Z4lBU=",
+        "lastModified": 1724345840,
+        "narHash": "sha256-mrY09tKUadcE4yWf81vbr7rmtaXxRxHdTa0iqFuGZaA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f97fc32d98cd25d40830543e95dc7cd66ef9ac63",
+        "rev": "3387f28077f6891063b2428eb71858974546aa13",
         "type": "github"
       },
       "original": {
@@ -684,11 +684,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1724098845,
-        "narHash": "sha256-D5HwjQw/02fuXbR4LCTo64koglP2j99hkDR79/3yLOE=",
+        "lastModified": 1724242322,
+        "narHash": "sha256-HMpK7hNjhEk4z5SFg5UtxEio9OWFocHdaQzCfW1pE7w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f1bad50880bae73ff2d82fafc22010b4fc097a9c",
+        "rev": "224042e9a3039291f22f4f2ded12af95a616cca0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`3387f280`](https://github.com/nix-community/emacs-overlay/commit/3387f28077f6891063b2428eb71858974546aa13) | `` Updated melpa ``        |
| [`74f02299`](https://github.com/nix-community/emacs-overlay/commit/74f022991e5310eeb5179e8eb969591714f0b24a) | `` Updated elpa ``         |
| [`c4de0daa`](https://github.com/nix-community/emacs-overlay/commit/c4de0daa8d91f44418332e2b57c9219339003296) | `` Updated nongnu ``       |
| [`11677931`](https://github.com/nix-community/emacs-overlay/commit/11677931e3ee57dfd557d0e6cc44343f8d2608e8) | `` Updated flake inputs `` |