### PR TITLE
chore(flake/emacs-overlay): `e2d49049` -> `e519d6ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1724375351,
-        "narHash": "sha256-1FKw4PfNIdsyh8tVkrYUofvY8lEPGBzNj6okeOYl/Fw=",
+        "lastModified": 1724378545,
+        "narHash": "sha256-XPBXjAeXn9k01QRhx9Z2Pnn3CPuxAV2YOU9dRruRb00=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e2d49049193da5825545ba8c720f02a4eb64e8dc",
+        "rev": "e519d6ceb1aa9635e87db20789602589c7a781e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`e519d6ce`](https://github.com/nix-community/emacs-overlay/commit/e519d6ceb1aa9635e87db20789602589c7a781e0) | `` Updated emacs `` |
| [`46d9f51c`](https://github.com/nix-community/emacs-overlay/commit/46d9f51c7d5dd347d5bb000f0bbb00177b2f25da) | `` Updated melpa `` |