### PR TITLE
chore(flake/catppuccin): `8886a68e` -> `3e844a65`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1724156255,
-        "narHash": "sha256-rpUCeS/QZwQdJmDrvCm0hRi8bFvQNQKAnIMK5ZDBfpM=",
+        "lastModified": 1724410422,
+        "narHash": "sha256-2QrZr16l8Fcxlw/URdb0u3a9DJMT5446/TMnQqWIVIw=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "8886a68edadb1d93c7101337f995ffce4b410ff2",
+        "rev": "3e844a65a400791ff46f721e48f2c6002245d923",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                        |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`3e844a65`](https://github.com/catppuccin/nix/commit/3e844a65a400791ff46f721e48f2c6002245d923) | `` style: format 0047cf5 ``                                    |
| [`0047cf58`](https://github.com/catppuccin/nix/commit/0047cf5816313075f5a141daea73532525dbb5df) | `` fix(home-manager/k9s): support darwin without XDG (#311) `` |