### PR TITLE
chore(flake/catppuccin): `3e844a65` -> `fd0902e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1724410422,
-        "narHash": "sha256-2QrZr16l8Fcxlw/URdb0u3a9DJMT5446/TMnQqWIVIw=",
+        "lastModified": 1724415638,
+        "narHash": "sha256-TF8+jAkP/FiliuJmhikdtvdYgEHMz6M5uvwo5eLmzRg=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "3e844a65a400791ff46f721e48f2c6002245d923",
+        "rev": "fd0902e67a84d13a1d6b1a754170e72a26766020",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                        |
| ----------------------------------------------------------------------------------------------- | ------------------------------ |
| [`fd0902e6`](https://github.com/catppuccin/nix/commit/fd0902e67a84d13a1d6b1a754170e72a26766020) | `` docs: add IFD FAQ (#246) `` |