### PR TITLE
chore(flake/home-manager): `40ddec2f` -> `b18f3ebc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -394,11 +394,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724412552,
-        "narHash": "sha256-e5t8dwb9VkQD6CUtZKYcEmraBMTHda94HF7ws62224M=",
+        "lastModified": 1724412708,
+        "narHash": "sha256-tLr1k+UZLVumyqXRU8E5lBtLjsvHSy8e2NiamfkjpYg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "40ddec2f8a71d9fb92735f0553dc81a8825596c4",
+        "rev": "b18f3ebc4029c22d437e3424014c8597a8b459a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`b18f3ebc`](https://github.com/nix-community/home-manager/commit/b18f3ebc4029c22d437e3424014c8597a8b459a0) | `` systemd: fully deprecate legacy switcher `` |
| [`25c12f07`](https://github.com/nix-community/home-manager/commit/25c12f07366fb98008326cc3910d4231ccf889e9) | `` tests: fix escaping of wait command ``      |