### PR TITLE
chore(flake/emacs-overlay): `e519d6ce` -> `06145d70`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1724378545,
-        "narHash": "sha256-XPBXjAeXn9k01QRhx9Z2Pnn3CPuxAV2YOU9dRruRb00=",
+        "lastModified": 1724432259,
+        "narHash": "sha256-U5XBR0OLjIWfmh5R0W0kEUOawdMfm0SY2KXPBTliBEg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e519d6ceb1aa9635e87db20789602589c7a781e0",
+        "rev": "06145d70ae2aad67e0ab8fe7b86f71c3f1fe6e52",
         "type": "github"
       },
       "original": {
@@ -684,11 +684,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1724242322,
-        "narHash": "sha256-HMpK7hNjhEk4z5SFg5UtxEio9OWFocHdaQzCfW1pE7w=",
+        "lastModified": 1724316499,
+        "narHash": "sha256-Qb9MhKBUTCfWg/wqqaxt89Xfi6qTD3XpTzQ9eXi3JmE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "224042e9a3039291f22f4f2ded12af95a616cca0",
+        "rev": "797f7dc49e0bc7fab4b57c021cdf68f595e47841",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`06145d70`](https://github.com/nix-community/emacs-overlay/commit/06145d70ae2aad67e0ab8fe7b86f71c3f1fe6e52) | `` Updated melpa ``        |
| [`011e5ec2`](https://github.com/nix-community/emacs-overlay/commit/011e5ec2d7d83934c8ecfcb4043553d71afe8580) | `` Updated elpa ``         |
| [`be236af2`](https://github.com/nix-community/emacs-overlay/commit/be236af247cc01fb743af02d2ddf95eee37e038c) | `` Updated flake inputs `` |