### PR TITLE
chore(flake/emacs-overlay): `b569d3ae` -> `ad0373d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1724433242,
-        "narHash": "sha256-/rX20nvm6EKtmsyJS4DoazcYPyRNKJ1oMSS1yhAce/w=",
+        "lastModified": 1724461667,
+        "narHash": "sha256-DP8ug+p89YZ1kzv0c7tU82xoRGri10FPWfLYisVfLK4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b569d3ae7d60c901a19944b00440c3a11e4da48a",
+        "rev": "ad0373d03bd3f3e9e88332628cf258ca65983e57",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message            |
| ------------------------------------------------------------------------------------------------------------ | ------------------ |
| [`ad0373d0`](https://github.com/nix-community/emacs-overlay/commit/ad0373d03bd3f3e9e88332628cf258ca65983e57) | `` Updated elpa `` |