### PR TITLE
chore(flake/darwin): `a8968d88` -> `ea319a73`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -88,11 +88,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724299755,
-        "narHash": "sha256-P5zMA17kD9tqiqMuNXwupkM7buM3gMNtoZ1VuJTRDE4=",
+        "lastModified": 1724469941,
+        "narHash": "sha256-+U5152FwmDD9EUOiFi5CFxCK6/yFESyDei9jEIlmUtI=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "a8968d88e5a537b0491f68ce910749cd870bdbef",
+        "rev": "ea319a737939094b48fda9063fa3201ef2479aac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                 |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
| [`2861a042`](https://github.com/LnL7/nix-darwin/commit/2861a0421bd289aadb16378d9892ce0a3537f5a9) | `` Use flake based command for uninstaller in README `` |