### PR TITLE
chore(flake/emacs-overlay): `ae062765` -> `0780b827`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1724463858,
-        "narHash": "sha256-VOZSEuWgdjrLKvn/WprrkHofJKOh9xWknibAWIkQftE=",
+        "lastModified": 1724490633,
+        "narHash": "sha256-Ok9pSW0ge++fbNDu6pac9tJaTSIfxaTyjl8Xvl2tCf4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ae06276558dc3500804032c7d5457095f17561b7",
+        "rev": "0780b82798307b08982e766e039f7a1680fadfe8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`0780b827`](https://github.com/nix-community/emacs-overlay/commit/0780b82798307b08982e766e039f7a1680fadfe8) | `` Updated emacs `` |
| [`b9785eef`](https://github.com/nix-community/emacs-overlay/commit/b9785eef40edb93ed3e353f63ad69f25a320557c) | `` Updated melpa `` |