### PR TITLE
chore(flake/nixos-hardware): `b09c4643` -> `1c84c314`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -611,11 +611,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1724067415,
-        "narHash": "sha256-WJBAEFXAtA41RMpK8mvw0cQ62CJkNMBtzcEeNIJV7b0=",
+        "lastModified": 1724495652,
+        "narHash": "sha256-Q/sAhwemnZqAsSadjTNqTkoLN2xPouPdU1oLJ3Tjlhg=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "b09c46430ffcf18d575acf5c339b38ac4e1db5d2",
+        "rev": "1c84c314db42dd40ed6cf9293b9451ec2e7ebee4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                             |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`1c84c314`](https://github.com/NixOS/nixos-hardware/commit/1c84c314db42dd40ed6cf9293b9451ec2e7ebee4) | `` 16ach6h: Use the hardware.display module ``      |
| [`d3600fc2`](https://github.com/NixOS/nixos-hardware/commit/d3600fc29620a5fba432f3180ca9c7a84e3f8889) | `` xps13-9380: enable fwupd ``                      |
| [`59bcb4c4`](https://github.com/NixOS/nixos-hardware/commit/59bcb4c4e19bf4edfa95a14a58776a67d0171ce0) | `` lenovo/p14s/intel: init with gen3 ``             |
| [`83dfb513`](https://github.com/NixOS/nixos-hardware/commit/83dfb513067529148cec3ce406b0583484d2056d) | `` fix: intelgpu.loadInInitrd now does something `` |