### PR TITLE
chore(flake/emacs-overlay): `0780b827` -> `12d91d19`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1724490633,
-        "narHash": "sha256-Ok9pSW0ge++fbNDu6pac9tJaTSIfxaTyjl8Xvl2tCf4=",
+        "lastModified": 1724518527,
+        "narHash": "sha256-kyXDfsh5nJzgOU1bZXAj43yQNdanjRwvwNUAzeX4/Gs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0780b82798307b08982e766e039f7a1680fadfe8",
+        "rev": "12d91d1951ee5541436a6970556d21a8e5f4f3ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`12d91d19`](https://github.com/nix-community/emacs-overlay/commit/12d91d1951ee5541436a6970556d21a8e5f4f3ca) | `` Updated melpa ``  |
| [`943df04c`](https://github.com/nix-community/emacs-overlay/commit/943df04c834c0e0ff07565fc3eaab51fd881d81f) | `` Updated elpa ``   |
| [`a1a70d50`](https://github.com/nix-community/emacs-overlay/commit/a1a70d5067afaf9167850efc62b124f5da9b5b64) | `` Updated nongnu `` |