### PR TITLE
chore(flake/nix-index-database): `392828aa` -> `fc681ad7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -571,11 +571,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723950649,
-        "narHash": "sha256-dHMkGjwwCGj0c2MKyCjRXVBXq2Sz3TWbbM23AS7/5Hc=",
+        "lastModified": 1724554685,
+        "narHash": "sha256-+FhC3izIlK8BBo0tKvHjKXCBZar685DdRscxLxD67aE=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "392828aafbed62a6ea6ccab13728df2e67481805",
+        "rev": "fc681ad740f0adee9777504accce70a78d3a49b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                  |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`fc681ad7`](https://github.com/nix-community/nix-index-database/commit/fc681ad740f0adee9777504accce70a78d3a49b2) | `` flake.lock: Update `` |