### PR TITLE
chore(flake/nix-index-database): `fc681ad7` -> `f65c9d6e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -571,11 +571,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724554685,
-        "narHash": "sha256-+FhC3izIlK8BBo0tKvHjKXCBZar685DdRscxLxD67aE=",
+        "lastModified": 1724555399,
+        "narHash": "sha256-OVX8nA446AcVvUzI2QXF0unkWb27u1CJpqeW02CCKWE=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "fc681ad740f0adee9777504accce70a78d3a49b2",
+        "rev": "f65c9d6efae4ee39f4341aaed073cf2d56fb0ecb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`f65c9d6e`](https://github.com/nix-community/nix-index-database/commit/f65c9d6efae4ee39f4341aaed073cf2d56fb0ecb) | `` update generated.nix to release 2024-08-25-025816 `` |