### PR TITLE
chore(flake/darwin): `ea319a73` -> `ac5694a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -88,11 +88,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724469941,
-        "narHash": "sha256-+U5152FwmDD9EUOiFi5CFxCK6/yFESyDei9jEIlmUtI=",
+        "lastModified": 1724561770,
+        "narHash": "sha256-zv8C9RNa86CIpyHwPIVO/k+5TfM8ZbjGwOOpTe1grls=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "ea319a737939094b48fda9063fa3201ef2479aac",
+        "rev": "ac5694a0b855a981e81b4d9f14052e3ff46ca39e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------ |
| [`2bd4949a`](https://github.com/LnL7/nix-darwin/commit/2bd4949af3984b1b568f65e68a12a1410d7ba03d) | `` etc: add known hash for DetSys installer 0.20.0+ `` |