### PR TITLE
chore(flake/nix-index-database): `f65c9d6e` -> `e333d62b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -571,11 +571,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724555399,
-        "narHash": "sha256-OVX8nA446AcVvUzI2QXF0unkWb27u1CJpqeW02CCKWE=",
+        "lastModified": 1724576102,
+        "narHash": "sha256-uM7n5nNL6fmA0bwMJBNll11f4cMWOFa2Ni6F5KeIldM=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "f65c9d6efae4ee39f4341aaed073cf2d56fb0ecb",
+        "rev": "e333d62b70b179da1dd78d94315e8a390f2d12e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                |
| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`e333d62b`](https://github.com/nix-community/nix-index-database/commit/e333d62b70b179da1dd78d94315e8a390f2d12e5) | `` README: mention nix-darwin usage `` |