### PR TITLE
chore(flake/srvos): `9810f43f` -> `0af64f29`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -882,11 +882,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724287640,
-        "narHash": "sha256-MAjp8fUU6/WambitI/jOVxgjuH3YEfE6A8l4EtonktY=",
+        "lastModified": 1724577529,
+        "narHash": "sha256-KCcuMtrfo/kPHxgCyGJOGZwkD2p2H89GHC9t5FXwrxs=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "9810f43ff22a10b6f70c38d6085ac6c201b26640",
+        "rev": "0af64f290cfc95bc40f83b436383032b2f177d02",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                        |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`88ac302b`](https://github.com/nix-community/srvos/commit/88ac302bac4c90946a57268860a10adba05da5c1) | `` dev/private/flake.lock: Update ``           |
| [`e8d5cd72`](https://github.com/nix-community/srvos/commit/e8d5cd72ac36e767680536badf763a71c5e478be) | `` dev/private/flake: add nixpkgs-dev input `` |