### PR TITLE
chore(flake/srvos): `0af64f29` -> `0c817636`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -882,11 +882,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724577529,
-        "narHash": "sha256-KCcuMtrfo/kPHxgCyGJOGZwkD2p2H89GHC9t5FXwrxs=",
+        "lastModified": 1724593676,
+        "narHash": "sha256-WycJuBFIFwDSNZb5KW3Oav0j+otU+y92slpjMFFCp9Y=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "0af64f290cfc95bc40f83b436383032b2f177d02",
+        "rev": "0c81763609fd03d5784d53c1de8b8bf7e2dc2515",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                      |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`30eef765`](https://github.com/nix-community/srvos/commit/30eef7653e2b7a5619b4af89a8cc4623b4c2ce24) | `` server: improve feature detection if options.programs.vim.enable exist `` |
| [`36e55dab`](https://github.com/nix-community/srvos/commit/36e55dabfa6bd4340a7cf01266a69717128f34bc) | `` {hetzner-cloud, vultr}: don't conflict with disko ``                      |