### PR TITLE
chore(flake/emacs-overlay): `d945c2ba` -> `f15cba42`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1724577031,
-        "narHash": "sha256-C3ufe7meLX9zNEOawPKdIpfmFQ+D5d2oqQ3iQMFdva4=",
+        "lastModified": 1724604953,
+        "narHash": "sha256-TTi12+OSn1HUao75J5z45u1S+Yutqz2XCV16kVMXgko=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d945c2ba0421e0c1b239b5882f2c0725fe8cfba1",
+        "rev": "f15cba422c1f3dba4f388c8a042e92afe9be824a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`f15cba42`](https://github.com/nix-community/emacs-overlay/commit/f15cba422c1f3dba4f388c8a042e92afe9be824a) | `` Updated melpa ``  |
| [`f95296dc`](https://github.com/nix-community/emacs-overlay/commit/f95296dceac522efc2f9ad2b0f14b602210e55a8) | `` Updated elpa ``   |
| [`f04e49f5`](https://github.com/nix-community/emacs-overlay/commit/f04e49f576af07b1093d9889e1215ab9f0eaca48) | `` Updated nongnu `` |