### PR TITLE
chore(flake/emacs-overlay): `86e302cd` -> `e3e088ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1724605786,
-        "narHash": "sha256-775X03n4D7cRhwDyFlbKd+CUsDeDvjM9DSArcohJx3c=",
+        "lastModified": 1724637687,
+        "narHash": "sha256-L/g0Lcmr8gcmR3zvWf7ZyOPHKW0R6DMUSuKlU8CZw/w=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "86e302cd5f144f7bc4bb7a4d52536c92831c4c57",
+        "rev": "e3e088ef4b4b187a54445f5767047a8257893093",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`e3e088ef`](https://github.com/nix-community/emacs-overlay/commit/e3e088ef4b4b187a54445f5767047a8257893093) | `` Updated emacs ``  |
| [`915783ed`](https://github.com/nix-community/emacs-overlay/commit/915783ed540951d87bd320b1e2f2d8ec930be375) | `` Updated melpa ``  |
| [`54f25978`](https://github.com/nix-community/emacs-overlay/commit/54f25978c01029a03e2163a6d928cb8de09f1e1b) | `` Updated elpa ``   |
| [`1852ff42`](https://github.com/nix-community/emacs-overlay/commit/1852ff42eaa15648376a480750e3194d57ead9c3) | `` Updated nongnu `` |