### PR TITLE
chore(flake/srvos): `0c817636` -> `88d4029b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -882,11 +882,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724593676,
-        "narHash": "sha256-WycJuBFIFwDSNZb5KW3Oav0j+otU+y92slpjMFFCp9Y=",
+        "lastModified": 1724633394,
+        "narHash": "sha256-8mlxjIfVFD8XZdge6KQqPmn6Go2MKmfTt7Vzj/mietk=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "0c81763609fd03d5784d53c1de8b8bf7e2dc2515",
+        "rev": "88d4029b6b1feaa6e727d33e2d0b79ff59c33d65",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`88d4029b`](https://github.com/nix-community/srvos/commit/88d4029b6b1feaa6e727d33e2d0b79ff59c33d65) | `` dev/private/flake.lock: Update `` |
| [`76e4a62e`](https://github.com/nix-community/srvos/commit/76e4a62e2e25a20f47d35403941dbefb674e5a7c) | `` flake.lock: Update ``             |