### PR TITLE
chore(flake/srvos): `88d4029b` -> `7a53c57f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -882,11 +882,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724633394,
-        "narHash": "sha256-8mlxjIfVFD8XZdge6KQqPmn6Go2MKmfTt7Vzj/mietk=",
+        "lastModified": 1724668936,
+        "narHash": "sha256-d0NsQXqCFQ218amt+TJ1xRuTJhx0Q7uE8UNbcN2M/XE=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "88d4029b6b1feaa6e727d33e2d0b79ff59c33d65",
+        "rev": "7a53c57fb8034aa753513b14b0ac6ae5d8e76476",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                      |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`7a53c57f`](https://github.com/nix-community/srvos/commit/7a53c57fb8034aa753513b14b0ac6ae5d8e76476) | `` fix(nix-remote-builder): allow more connections (#490) `` |