### PR TITLE
chore(flake/nixpkgs): `c374d94f` -> `d0e1602d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -732,11 +732,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1724224976,
-        "narHash": "sha256-Z/ELQhrSd7bMzTO8r7NZgi9g5emh+aRKoCdaAv5fiO0=",
+        "lastModified": 1724479785,
+        "narHash": "sha256-pP3Azj5d6M5nmG68Fu4JqZmdGt4S4vqI5f8te+E/FTw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c374d94f1536013ca8e92341b540eba4c22f9c62",
+        "rev": "d0e1602ddde669d5beb01aec49d71a51937ed7be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`0b6fa5ee`](https://github.com/NixOS/nixpkgs/commit/0b6fa5ee40c14df33494d4ed9da1251e872fb0c2) | `` virtualisation.oci-containers: Add new `imageStream` option (#335430) ``    |
| [`fcfb3a11`](https://github.com/NixOS/nixpkgs/commit/fcfb3a1106c37d2dc55322b1f01d6d8a8f97d71f) | `` gcalcli: normalize source ``                                                |
| [`9fb8100e`](https://github.com/NixOS/nixpkgs/commit/9fb8100e85ab2783a13a2d77b194be0aa496958b) | `` python312Packages.keyrings-alt: 5.0.1 -> 5.0.2 ``                           |
| [`5b914f70`](https://github.com/NixOS/nixpkgs/commit/5b914f70e9faf3b8a32c1c291ee9435262c4c92a) | `` music-assistant: 2.2.0 -> 2.2.2 ``                                          |
| [`a2f47ce5`](https://github.com/NixOS/nixpkgs/commit/a2f47ce51ce3b17fcdcb5e5142c8e82069814978) | `` gdm-settings: fix eval ``                                                   |
| [`b918f69b`](https://github.com/NixOS/nixpkgs/commit/b918f69b5dca4359d0c982e59e27249b3b3dde79) | `` xdg-dbus-proxy: 0.1.5 -> 0.1.6 ``                                           |
| [`fc086f12`](https://github.com/NixOS/nixpkgs/commit/fc086f122c34e8937bc127bcea948a75983d8a82) | `` mailctl: remove ``                                                          |
| [`62fa341d`](https://github.com/NixOS/nixpkgs/commit/62fa341dba29aae3e253f571992eb109cb2c57fa) | `` oama: init at 0.14 ``                                                       |
| [`9816ee4d`](https://github.com/NixOS/nixpkgs/commit/9816ee4d4b43b3f9cbcffd1c48a9a1c58b7e6f69) | `` python312Packages.pyopengltk: init at 0.0.4 ``                              |
| [`92b9791a`](https://github.com/NixOS/nixpkgs/commit/92b9791a221fba30cff6b2f1da72dbd7d504d5e2) | `` cosmic-randr: unstable-2023-12-12 -> 1.0.0-alpha.1 (#335404) ``             |
| [`2fb12e99`](https://github.com/NixOS/nixpkgs/commit/2fb12e9970702a64070961279586fd1cc9b04086) | `` cosmic-greeter: unstable-2023-11-08 -> 1.0.0-alpha.1 (#335386) ``           |
| [`a735878b`](https://github.com/NixOS/nixpkgs/commit/a735878ba0b494a2e2569371387b9e4b56d6d3fd) | `` cosmic-osd: unstable-2023-11-15 -> 1.0.0-alpha.1 (#335379) ``               |
| [`c74138d2`](https://github.com/NixOS/nixpkgs/commit/c74138d2164a3983fd3e4e8b05d42a19ccb41f36) | `` python312Packages.kde-material-you-colors: init at 1.9.3 ``                 |
| [`bfa2e1c0`](https://github.com/NixOS/nixpkgs/commit/bfa2e1c04013d080da671b69d895eedd83625178) | `` python312Packages.pytibber: 0.30.0 -> 0.30.1 ``                             |
| [`892775d3`](https://github.com/NixOS/nixpkgs/commit/892775d387954581932d320dd3af432382c6351f) | `` python312Packages.safety: 3.2.5 -> 3.2.6 ``                                 |
| [`defe5158`](https://github.com/NixOS/nixpkgs/commit/defe51584aa1390187a35044b8b78277b2730344) | `` python312Packages.safety-schemas: 0.0.3 -> 0.0.5 ``                         |
| [`02f40d42`](https://github.com/NixOS/nixpkgs/commit/02f40d422cef71c7699bae5ac3c06fc6bdeb0a87) | `` gcalcli: enable tests ``                                                    |
| [`0ae051ff`](https://github.com/NixOS/nixpkgs/commit/0ae051ffcdce8cd89c3402d033add7ef96f9dd5d) | `` gcalcli: format with nixfmt-rfc-style ``                                    |
| [`70b7e539`](https://github.com/NixOS/nixpkgs/commit/70b7e53986407a234008f389da5ee15b5283e388) | `` python312Packages.pyquil: 4.14.1 -> 4.14.2 ``                               |
| [`30ca6491`](https://github.com/NixOS/nixpkgs/commit/30ca6491712b813398b7a885c0dadba1e4c89db7) | `` python312Packages.qcs-sdk-python: 0.19.2 -> 0.19.3 ``                       |
| [`810afbd5`](https://github.com/NixOS/nixpkgs/commit/810afbd5dd63130ed0685f9f00573076072ab51d) | `` distgen: 1.17 -> 1.18 ``                                                    |
| [`661c4b03`](https://github.com/NixOS/nixpkgs/commit/661c4b039fd3c9ada66d362a9f813d88304089ac) | `` python312Packages.jaraco-path: 3.7.0 -> 3.7.1 ``                            |
| [`ecf7f38c`](https://github.com/NixOS/nixpkgs/commit/ecf7f38cecf56fd7b388fbe931025189d37f87f3) | `` home-assistant: support epic_games_store component ``                       |
| [`017aa7d3`](https://github.com/NixOS/nixpkgs/commit/017aa7d34e52ffb8d4a97160d4f91669a999f0d1) | `` python312Packages.epicstore-api: init at 0.1.8 ``                           |
| [`6abcae97`](https://github.com/NixOS/nixpkgs/commit/6abcae971c19a8edd7f8ed49c2339a1b3ebbf341) | `` python3Packages.pytouchlinesl: remove nix-update-script ``                  |
| [`e4c97299`](https://github.com/NixOS/nixpkgs/commit/e4c972991a234571834cddd33e4b282ec4f9aad0) | `` spicedb: 1.35.2 -> 1.35.3 ``                                                |
| [`e5abda70`](https://github.com/NixOS/nixpkgs/commit/e5abda703a3a8c962e7db3bb290749f80f84411d) | `` python312Packages.python-linkplay: 0.0.8 -> 0.0.9 ``                        |
| [`069f7de1`](https://github.com/NixOS/nixpkgs/commit/069f7de1e790f0e4826609e3d2e0224360af4dfa) | `` olm: add more information to `knownVulnerabilities` ``                      |
| [`9b4f2d30`](https://github.com/NixOS/nixpkgs/commit/9b4f2d304628d320f6f90540edda45b24361dac6) | `` python312Packages.bthome-ble: 3.9.3 -> 3.10.0 ``                            |
| [`f66ce6a5`](https://github.com/NixOS/nixpkgs/commit/f66ce6a56f28f62623fd02f1ce94335892bd4a27) | `` tauon: sort arguments by usage order ``                                     |
| [`b24f9173`](https://github.com/NixOS/nixpkgs/commit/b24f9173e6b78a9a65704e049e6eefe47fa90fa2) | `` tauon: remove unused depedencies and fix runtime dependency ``              |
| [`a2fcb4e0`](https://github.com/NixOS/nixpkgs/commit/a2fcb4e05cde503620449cda5f38ed893781c31c) | `` tauon: update substituteInPlace patches ``                                  |
| [`51afc33a`](https://github.com/NixOS/nixpkgs/commit/51afc33a17280bb5f0758981ad244ecb43417010) | `` tauon: fix build error ``                                                   |
| [`6815fd88`](https://github.com/NixOS/nixpkgs/commit/6815fd88e71a63f9b6aced293089f961adf7a3db) | `` oterm: 0.2.9 -> 0.4.2 ``                                                    |
| [`2f33e999`](https://github.com/NixOS/nixpkgs/commit/2f33e99955478dfc6529698764f94454f46d32e1) | `` lgogdownloader: 3.14 -> 3.15 ``                                             |
| [`8aef2b45`](https://github.com/NixOS/nixpkgs/commit/8aef2b450b13ab2de98fcd776e0de4f05ae2881e) | `` cargo-dist: 0.21.0 -> 0.21.1 ``                                             |
| [`f2bc50c3`](https://github.com/NixOS/nixpkgs/commit/f2bc50c38228002e796cbc257db6e19a88c78460) | `` python312Packages.langgraph-cli: 0.1.50 -> 0.1.51 ``                        |
| [`b7426eaa`](https://github.com/NixOS/nixpkgs/commit/b7426eaac4a3fe13ad32cc0b9b3b105c4511980e) | `` pantheon.switchboard-plug-a11y: Drop ``                                     |
| [`321dc68b`](https://github.com/NixOS/nixpkgs/commit/321dc68bc9b17bd3a559716594c3ef22d2fc6ce4) | `` kubernetes-helmPlugins.helm-mapkubeapis: 0.5.0 -> 0.5.1 ``                  |
| [`965065bc`](https://github.com/NixOS/nixpkgs/commit/965065bc2a3f03c14b4f0e52deb5a5ff1e14aea7) | `` pantheon.wingpanel-indicator-a11y: Don't ship by default ``                 |
| [`380e272b`](https://github.com/NixOS/nixpkgs/commit/380e272be17ed762c5a6a5d4783c31ddd4fce7a6) | `` pmbootstrap: fix darwin build ``                                            |
| [`434db069`](https://github.com/NixOS/nixpkgs/commit/434db0692644d36c787902d0df64fdfa862aefe9) | `` linuxPackages.nvidiaPackages.vulkan_beta: 550.40.67 -> 550.40.70 ``         |
| [`954fa1cd`](https://github.com/NixOS/nixpkgs/commit/954fa1cda6a2f6fbd0e7a56146727051ecc67abc) | `` onboard: Fix crashes at startup ``                                          |
| [`e0064776`](https://github.com/NixOS/nixpkgs/commit/e00647762f42e71d5c0f7733619012a04291c902) | `` cronie: init at 1.7.2 ``                                                    |
| [`ee206c81`](https://github.com/NixOS/nixpkgs/commit/ee206c813fdc87959e69729e3131485a10dc3a69) | `` isc-cron: adopt and wash ``                                                 |
| [`74ffb29e`](https://github.com/NixOS/nixpkgs/commit/74ffb29e9035ace93e5281b550eeda2a410d7d85) | `` isc-cron: migrate to by-name ``                                             |
| [`b19f51a6`](https://github.com/NixOS/nixpkgs/commit/b19f51a6ddc91e5ef69c580916ce344ab82125d6) | `` mongodb-compass: 1.43.5 -> 1.43.6 ``                                        |
| [`6bd1d28e`](https://github.com/NixOS/nixpkgs/commit/6bd1d28e3fdcc7e0e465bc5ea3e0bf87afd14f34) | `` aws-iam-authenticator: 0.6.23 -> 0.6.25 ``                                  |
| [`47bf11fe`](https://github.com/NixOS/nixpkgs/commit/47bf11fef9efbfb22f081e39640a1cbf0754ba85) | `` gum: 0.14.3 -> 0.14.4 ``                                                    |
| [`935b2068`](https://github.com/NixOS/nixpkgs/commit/935b20686a85b84b97d536b4bcad308dc6d6171a) | `` freshrss: 1.24.1 -> 1.24.2 ``                                               |
| [`606b49a3`](https://github.com/NixOS/nixpkgs/commit/606b49a30362190dc4ab6d29b7d8562e4ab8af4d) | `` python3Packages.pytouchlinesl: init at 0.1.0 ``                             |
| [`1e94c136`](https://github.com/NixOS/nixpkgs/commit/1e94c1360778246a3d1ca15c120be058da72c2bf) | `` jetbrains.plugins: update ``                                                |
| [`bf9408f9`](https://github.com/NixOS/nixpkgs/commit/bf9408f91adc050ddf7a83b4a44608ce18eb7512) | `` jetbrains: 2024.2 -> 2024.2.0.1 ``                                          |
| [`ddd8d7b3`](https://github.com/NixOS/nixpkgs/commit/ddd8d7b3e02e69826d6108ee88c0d3979dd84bc0) | `` jetbrains.plugins: update ``                                                |
| [`2620b98e`](https://github.com/NixOS/nixpkgs/commit/2620b98e02ba839f168d0d4f5dc53df007b225f5) | `` jetbrains: 2024.1.7 -> 2024.2.1 ``                                          |
| [`5ed7d4c9`](https://github.com/NixOS/nixpkgs/commit/5ed7d4c9a3fefad046e3e6fda2b2c8098d1e9639) | `` jetbrains: Select best available launcher and wrap in all cases ``          |
| [`d4f311a3`](https://github.com/NixOS/nixpkgs/commit/d4f311a338a1f29c0c2e117f378193cc51470ace) | `` jetbrains.plugins: github-copilot: Use correct agent path ``                |
| [`b66e43f2`](https://github.com/NixOS/nixpkgs/commit/b66e43f26c000e467c369d3d6aa2b9fa835cfb6e) | `` jetbrains.plugins: update ``                                                |
| [`edce7221`](https://github.com/NixOS/nixpkgs/commit/edce7221c35b1bcbb03f3f21d8d845b3d862449e) | `` jetbrains: 2023.3 Public Preview -> 2024.2 ``                               |
| [`5780c70e`](https://github.com/NixOS/nixpkgs/commit/5780c70ee27b511f49140dbcb3b2739de4ca27ef) | `` use native launchers ``                                                     |
| [`efde3531`](https://github.com/NixOS/nixpkgs/commit/efde353175592870884fc9897de78b3a4026a6ec) | `` jetbrains.plugins: update ``                                                |
| [`a94d08e2`](https://github.com/NixOS/nixpkgs/commit/a94d08e236faf957085442e4d7bb56926820dea4) | `` jetbrains: 2023.3.1 -> 2024.2.1 ``                                          |
| [`4fe688d7`](https://github.com/NixOS/nixpkgs/commit/4fe688d7008d69051972713e4926de0f0f428cf0) | `` pantheon.wingpanel-indicator-session: Drop ``                               |
| [`2af84786`](https://github.com/NixOS/nixpkgs/commit/2af847864f303d38001aebc0a9edaf7f6bf9938e) | `` pantheon.wingpanel-quick-settings: init at 1.0.0 ``                         |
| [`e3e17841`](https://github.com/NixOS/nixpkgs/commit/e3e17841f539c1c900da45014e5ba38937115f51) | `` pantheon.wingpanel: Backport QuickSettings support ``                       |
| [`dfc226bf`](https://github.com/NixOS/nixpkgs/commit/dfc226bfb1561b8538e365a7f1a5b62bcae19294) | `` nixos/pantheon: Enable switcheroo support ``                                |
| [`f117b2c1`](https://github.com/NixOS/nixpkgs/commit/f117b2c132026d0b96e5f9ae737751eab817fc93) | `` gpu-screen-recorder: nixfmt, add meta.mainProgram (#336769) ``              |
| [`175de87d`](https://github.com/NixOS/nixpkgs/commit/175de87d1c9da7d3fdac63a71e8235e5c05b9310) | `` ungoogled-chromium: 127.0.6533.119-2 -> 128.0.6613.84-1 ``                  |
| [`18b12fec`](https://github.com/NixOS/nixpkgs/commit/18b12fec2a57a708e7217d919bcd7adb3097d54e) | `` chromium,chromedriver: 127.0.6533.119 -> 128.0.6613.84 ``                   |
| [`9cb4c038`](https://github.com/NixOS/nixpkgs/commit/9cb4c03866f6b7f9086498eada63fdbb2f47975d) | `` pantheon.wingpanel-indicator-sound: 7.0.0 -> 8.0.0 ``                       |
| [`77805c3f`](https://github.com/NixOS/nixpkgs/commit/77805c3f4064dd9d6c42545add7d33102ffcb0ef) | `` ovn-lts: 24.03.2 -> 24.03.3 ``                                              |
| [`a5b6432d`](https://github.com/NixOS/nixpkgs/commit/a5b6432dc8ccac8cbc2dbfb0fb3ccb3cce46ff8f) | `` movim: 0.26 → 0.27.1 ``                                                     |
| [`3c1fa0d0`](https://github.com/NixOS/nixpkgs/commit/3c1fa0d0e3ec2594c2be17f9e68efa845a85c05f) | `` pantheon.wingpanel-indicator-power: 6.2.1 -> 8.0.0 ``                       |
| [`97464b21`](https://github.com/NixOS/nixpkgs/commit/97464b21a242e554e699feafe5522edd186406fc) | `` grapejuice: remove ``                                                       |
| [`2277579c`](https://github.com/NixOS/nixpkgs/commit/2277579c3884c0fe5929c4e35e3de41dd0bcdd92) | `` vinegar: remove ``                                                          |
| [`5f153f6d`](https://github.com/NixOS/nixpkgs/commit/5f153f6db406e1bd2afd334df31537ca636e99b7) | `` pantheon.wingpanel-indicator-notifications: 7.1.0 -> 7.1.1 ``               |
| [`43f8c88e`](https://github.com/NixOS/nixpkgs/commit/43f8c88e9c5e46c83862e1dd1a36e7f14af7ba50) | `` nixos/pantheon: Ship elementary-bluetooth-daemon by default ``              |
| [`1ec06b18`](https://github.com/NixOS/nixpkgs/commit/1ec06b188feef60145d472c7305a9bed5606f16d) | `` pantheon.wingpanel-indicator-bluetooth: 7.0.1 -> 8.0.0 ``                   |
| [`1ff7e280`](https://github.com/NixOS/nixpkgs/commit/1ff7e28086233e3ddf0be3a24d046eb148c987d8) | `` pantheon.elementary-session-settings: 6.0.0-unstable-2024-03-29 -> 8.0.0 `` |
| [`fd59b0e4`](https://github.com/NixOS/nixpkgs/commit/fd59b0e417d78fac763529fa639a6e9cb6c522fa) | `` ansible: 2.17.1 -> 2.17.3 ``                                                |
| [`f58856a8`](https://github.com/NixOS/nixpkgs/commit/f58856a85b016db435157524b2f264b3d9940592) | `` moq: 0.3.4 -> 0.4.0 ``                                                      |
| [`e12cd327`](https://github.com/NixOS/nixpkgs/commit/e12cd3270365bb4624f16e9b3bc0b08918b21e83) | `` jumppad: 0.13.1 -> 0.13.2 ``                                                |
| [`3dc62fe3`](https://github.com/NixOS/nixpkgs/commit/3dc62fe36a4763595acac1f398d170e511a5e9a5) | `` dummyhttp: 1.0.3 -> 1.1.0 ``                                                |
| [`b833f7bd`](https://github.com/NixOS/nixpkgs/commit/b833f7bd61530c0685bf204cfa0555e74a493497) | `` fd: 10.1.0 -> 10.2.0 ``                                                     |
| [`d01560ac`](https://github.com/NixOS/nixpkgs/commit/d01560ac29c32a2bfe3cf3284cc3a6569f75c855) | `` cshatag: 2.1.0 -> 2.2.0 ``                                                  |
| [`ec85ff93`](https://github.com/NixOS/nixpkgs/commit/ec85ff9346731bdb47705ac2067a7488c3de3923) | `` compose2nix: 0.2.1 -> 0.2.2 ``                                              |
| [`29c13e2d`](https://github.com/NixOS/nixpkgs/commit/29c13e2d0c49541ed01d6c373bfbc6654a7ae57b) | `` viber: fix fetchurl hash ``                                                 |
| [`c4bd4f44`](https://github.com/NixOS/nixpkgs/commit/c4bd4f447142fbd6ebdebb0c036288710465832d) | `` deepin.deepin-clone: remove ``                                              |
| [`4b0b32e5`](https://github.com/NixOS/nixpkgs/commit/4b0b32e5f5dded9fdfbc3a7578690c8643d62c7f) | `` mongodb-ce: fix darwin build ``                                             |
| [`5e6a89a3`](https://github.com/NixOS/nixpkgs/commit/5e6a89a3a3ac5856372f539d36fdf12b7bf07fff) | `` glanceclient: 4.6.0 -> 4.7.0 ``                                             |
| [`64ee32d0`](https://github.com/NixOS/nixpkgs/commit/64ee32d0b2406d4658410b51898211519de0cd2c) | `` python312Packages.mkdocs-material: 9.5.31 -> 9.5.33 ``                      |
| [`2c61ec85`](https://github.com/NixOS/nixpkgs/commit/2c61ec858716cbe025a1b37268efba307ad05bd7) | `` cosmic-randr: remove env substituteInPlace ``                               |
| [`5b36ae93`](https://github.com/NixOS/nixpkgs/commit/5b36ae93b0aac5c84e367aa29b1c65ae8d56e197) | `` vimPlugins.nvim-dap-rr: init at 2024-07-10 ``                               |
| [`26c89d06`](https://github.com/NixOS/nixpkgs/commit/26c89d068edd79499173442edddccd30ae72cdfc) | `` python3Packages.cpyparsing: 2.4.7.2.3.3 -> 2.4.7.2.4.0 ``                   |
| [`86cf5022`](https://github.com/NixOS/nixpkgs/commit/86cf5022c44a0760ef3278ea2f3967a472369d26) | `` please: 0.5.4 -> 0.5.5 ``                                                   |
| [`0a1f4c46`](https://github.com/NixOS/nixpkgs/commit/0a1f4c46f4545433fa92d57c43254793908475bd) | `` jsonnet-bundler: 0.5.1 -> 0.6.0 ``                                          |
| [`7d71f22b`](https://github.com/NixOS/nixpkgs/commit/7d71f22b5f7254453641e8d8e288281eeaa45d48) | `` python312Packages.unearth: 0.17.0 -> 0.17.1 ``                              |