### PR TITLE
chore(flake/emacs-overlay): `3052bb01` -> `a633f437`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1724662747,
-        "narHash": "sha256-8ehh6fm5C7TRNc3HmTr9KCyi7FqfFR1MqlqdynLKrMA=",
+        "lastModified": 1724691683,
+        "narHash": "sha256-kmCwts4RUK+/LHaavd+2jPUroyOEF/SYU6QOe6rOL7o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3052bb01d404ee9bd03b040c9ae898febca05b81",
+        "rev": "a633f4375024504d2a5d485f971ce7c9af987248",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`a633f437`](https://github.com/nix-community/emacs-overlay/commit/a633f4375024504d2a5d485f971ce7c9af987248) | `` Updated melpa ``        |
| [`d282abe5`](https://github.com/nix-community/emacs-overlay/commit/d282abe57699b13cc8da18fadb0900f6592fc0ab) | `` Updated elpa ``         |
| [`2c166e27`](https://github.com/nix-community/emacs-overlay/commit/2c166e2729fa6e7907abe9d309a58fff67295183) | `` Updated nongnu ``       |
| [`899069ba`](https://github.com/nix-community/emacs-overlay/commit/899069bad48b633d0da92e2e0d64add207283ed8) | `` Updated flake inputs `` |