### PR TITLE
chore(flake/emacs-overlay): `a633f437` -> `709f6f16`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1724691683,
-        "narHash": "sha256-kmCwts4RUK+/LHaavd+2jPUroyOEF/SYU6QOe6rOL7o=",
+        "lastModified": 1724692493,
+        "narHash": "sha256-fQtQMW50ZoSw4a8SQ+x+8hUD8+r/Lbd58VqmV7jiXxc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a633f4375024504d2a5d485f971ce7c9af987248",
+        "rev": "709f6f16db78e31d37f1db7f2a3f58715d3c1746",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`709f6f16`](https://github.com/nix-community/emacs-overlay/commit/709f6f16db78e31d37f1db7f2a3f58715d3c1746) | `` Updated emacs `` |