### PR TITLE
chore(flake/emacs-overlay): `b2cb3623` -> `28c1c399`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1724721028,
-        "narHash": "sha256-o4jOMncWJ2Xhtgb7w0UH1DV2J1hkzI4Qej/bISkH8Yg=",
+        "lastModified": 1724724072,
+        "narHash": "sha256-KeG9u3FVQ7w81Kum1X6M2zqlGs/6QaSvt9EUWfl/QQ0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b2cb3623d2e56d7da2e17ca695b61b895da53100",
+        "rev": "28c1c399c3139a964124b7afef191b83c5b694ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`28c1c399`](https://github.com/nix-community/emacs-overlay/commit/28c1c399c3139a964124b7afef191b83c5b694ec) | `` Updated emacs `` |
| [`f7a3d86f`](https://github.com/nix-community/emacs-overlay/commit/f7a3d86f3ac31d662e9363050a81ae4dbcc7501e) | `` Updated melpa `` |