### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `44c9f357` -> `8f21f193`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
     "doomemacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1724622355,
-        "narHash": "sha256-ZtrGVJXs/nHbzSdPM/1POIdLPro2kni6lkYXiSaDdlQ=",
+        "lastModified": 1724743498,
+        "narHash": "sha256-GVOacc7wd4/GfmDjq6DsLs4Ko+STIl0WHEBnyxNRzrA=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "c862968f4843fa7c30b9dbca688d8e400729196b",
+        "rev": "a5039c4333aac4d90ae0b4d17f3ff504e26ba4a1",
         "type": "github"
       },
       "original": {
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724662747,
-        "narHash": "sha256-8ehh6fm5C7TRNc3HmTr9KCyi7FqfFR1MqlqdynLKrMA=",
+        "lastModified": 1724724072,
+        "narHash": "sha256-KeG9u3FVQ7w81Kum1X6M2zqlGs/6QaSvt9EUWfl/QQ0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3052bb01d404ee9bd03b040c9ae898febca05b81",
+        "rev": "28c1c399c3139a964124b7afef191b83c5b694ec",
         "type": "github"
       },
       "original": {
@@ -500,11 +500,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1724674329,
-        "narHash": "sha256-AO7hYOw9PSDio2wwOIKmGk0lzm4AdQgyhbFs/FlhO5E=",
+        "lastModified": 1724747706,
+        "narHash": "sha256-xVm/oGmnkMmfLWYYIbSCDlJLjTmYSdDW1IyuEjeD8wo=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "44c9f357f56a79525d148410c240dfc1b1889fc4",
+        "rev": "8f21f19365cbb47f4713dec6a4b47c76b9d9413e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`8f21f193`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/8f21f19365cbb47f4713dec6a4b47c76b9d9413e) | `` flake.lock: Update `` |