### PR TITLE
chore(flake/git-hooks): `c8a54057` -> `1cd12de6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -353,11 +353,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1724440431,
-        "narHash": "sha256-9etXEOUtzeMgqg1u0wp+EdwG7RpmrAZ2yX516bMj2aE=",
+        "lastModified": 1724763886,
+        "narHash": "sha256-SzBtZs5z+YGM50oyt67R78qLhxG/wG5/SlVRsCF5kRc=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "c8a54057aae480c56e28ef3e14e4960628ac495b",
+        "rev": "1cd12de659fab215624c630c37d1c62aa2b7824e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`55b98216`](https://github.com/cachix/git-hooks.nix/commit/55b98216505b209b09499cfa39b34a3d63bc9ca3) | `` feat: register gc root for the generated .pre-commit-config.yaml `` |