### PR TITLE
chore(flake/emacs-overlay): `28c1c399` -> `e614da0a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1724724072,
-        "narHash": "sha256-KeG9u3FVQ7w81Kum1X6M2zqlGs/6QaSvt9EUWfl/QQ0=",
+        "lastModified": 1724777847,
+        "narHash": "sha256-dzWLIKbNZCmERYflvyOVTBFivER6Kezedc0clkU62cQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "28c1c399c3139a964124b7afef191b83c5b694ec",
+        "rev": "e614da0a87240a3d88ea5ae3f4c75e0e10f41373",
         "type": "github"
       },
       "original": {
@@ -684,11 +684,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1724316499,
-        "narHash": "sha256-Qb9MhKBUTCfWg/wqqaxt89Xfi6qTD3XpTzQ9eXi3JmE=",
+        "lastModified": 1724531977,
+        "narHash": "sha256-XROVLf9ti4rrNCFLr+DmXRZtPjCQTW4cYy59owTEmxk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "797f7dc49e0bc7fab4b57c021cdf68f595e47841",
+        "rev": "2527da1ef492c495d5391f3bcf9c1dd9f4514e32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`e614da0a`](https://github.com/nix-community/emacs-overlay/commit/e614da0a87240a3d88ea5ae3f4c75e0e10f41373) | `` Updated melpa ``        |
| [`50010ea7`](https://github.com/nix-community/emacs-overlay/commit/50010ea7cd65efdf1ee448ae8c0791402ffd47c5) | `` Updated elpa ``         |
| [`b19075bb`](https://github.com/nix-community/emacs-overlay/commit/b19075bb87c0fec472dc9b4720096ce1735da1aa) | `` Updated nongnu ``       |
| [`277861c3`](https://github.com/nix-community/emacs-overlay/commit/277861c302ef06cc912c86dd790990c6a14b105d) | `` Updated flake inputs `` |