### PR TITLE
chore(flake/emacs-overlay): `40712629` -> `76e83593`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1724778758,
-        "narHash": "sha256-t2BztWKuTPncAGBi6FgRZPW0yieikyreK6a42zSf0JI=",
+        "lastModified": 1724807469,
+        "narHash": "sha256-niVuMTx4qitDAPH1jHwXrhJGOGklPkVgaVNmQutZtUw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "40712629565969dd9b8eec73d3b733a437f0bef7",
+        "rev": "76e83593ca1b584f181900b8bc8b95dc163f380c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`76e83593`](https://github.com/nix-community/emacs-overlay/commit/76e83593ca1b584f181900b8bc8b95dc163f380c) | `` Updated elpa ``   |
| [`3b671ddf`](https://github.com/nix-community/emacs-overlay/commit/3b671ddf947fd8708b4cff886daf22a79466c850) | `` Updated nongnu `` |