### PR TITLE
chore(flake/srvos): `7a53c57f` -> `207bc438`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -882,11 +882,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724668936,
-        "narHash": "sha256-d0NsQXqCFQ218amt+TJ1xRuTJhx0Q7uE8UNbcN2M/XE=",
+        "lastModified": 1724824961,
+        "narHash": "sha256-rekY47LKsruBMeKB3hgnsTdRKwyEGGakTY9PSlQ5jww=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "7a53c57fb8034aa753513b14b0ac6ae5d8e76476",
+        "rev": "207bc438961f179b2c4ff46b0b881eb5ee0922c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                         |
| ---------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`03e7726f`](https://github.com/nix-community/srvos/commit/03e7726f7a4248be2a72d12e0e9ea15ee22747d1) | `` chore: drop mdmonitor-fix `` |