### PR TITLE
chore(flake/srvos): `207bc438` -> `1374d06d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -882,11 +882,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724824961,
-        "narHash": "sha256-rekY47LKsruBMeKB3hgnsTdRKwyEGGakTY9PSlQ5jww=",
+        "lastModified": 1724892475,
+        "narHash": "sha256-wj/1NiNk0cBuYzAXWIQJU6re7ZjaEma6y38RR7SSan0=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "207bc438961f179b2c4ff46b0b881eb5ee0922c5",
+        "rev": "1374d06d151a28d589296436c7c3d3de4ccc065d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`1374d06d`](https://github.com/nix-community/srvos/commit/1374d06d151a28d589296436c7c3d3de4ccc065d) | `` dev/private/flake.lock: Update `` |
| [`d972147a`](https://github.com/nix-community/srvos/commit/d972147a3f61163a6e244b63bcb9129ab98deb94) | `` flake.lock: Update ``             |