### PR TITLE
chore(flake/emacs-overlay): `9973a0ae` -> `011e730e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1724893899,
-        "narHash": "sha256-iD1NOb52MBwQE2+o9rkn+wJCJsp+0dGYQvacUBXMdZY=",
+        "lastModified": 1724896798,
+        "narHash": "sha256-fZ9jm89rluSSSGRrNH6x0jqZedkabmTxBcQZDgVpSEU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9973a0ae63b26b38b682ef0b5673a320f4fe5a1a",
+        "rev": "011e730ea976aeb70a730cf5b01b79643d8da092",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`011e730e`](https://github.com/nix-community/emacs-overlay/commit/011e730ea976aeb70a730cf5b01b79643d8da092) | `` Updated emacs `` |
| [`190dc7b1`](https://github.com/nix-community/emacs-overlay/commit/190dc7b1aaf9b168d7ea2a3d0d3dd962f32d3967) | `` Updated melpa `` |