### PR TITLE
chore(flake/srvos): `1374d06d` -> `428941ca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -882,11 +882,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724892475,
-        "narHash": "sha256-wj/1NiNk0cBuYzAXWIQJU6re7ZjaEma6y38RR7SSan0=",
+        "lastModified": 1724918403,
+        "narHash": "sha256-vlmFwOhpKnmKkEgfsFzciAL8+I1tHutuekxGoWggByI=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "1374d06d151a28d589296436c7c3d3de4ccc065d",
+        "rev": "428941cab13c7dc778794861c9228c69c6e61226",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                        |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`ebcf3f2f`](https://github.com/nix-community/srvos/commit/ebcf3f2fdb5692168238df4d3dad145b1787ebd7) | `` feat(server): restrict boot entries to 5 `` |