### PR TITLE
chore(flake/emacs-overlay): `011e730e` -> `199ade88`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1724896798,
-        "narHash": "sha256-fZ9jm89rluSSSGRrNH6x0jqZedkabmTxBcQZDgVpSEU=",
+        "lastModified": 1724921940,
+        "narHash": "sha256-0KljWFim35K/lpECaj103tlgQ0gl60cMhQL05ZgI5aY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "011e730ea976aeb70a730cf5b01b79643d8da092",
+        "rev": "199ade88c899e69f1089454675f2514161951724",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`199ade88`](https://github.com/nix-community/emacs-overlay/commit/199ade88c899e69f1089454675f2514161951724) | `` Updated melpa ``        |
| [`3b0a0983`](https://github.com/nix-community/emacs-overlay/commit/3b0a0983dfc4565c6f5809c9ba708b36f44d7e0b) | `` Updated flake inputs `` |