### PR TITLE
chore(flake/srvos): `428941ca` -> `977841b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -882,11 +882,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724918403,
-        "narHash": "sha256-vlmFwOhpKnmKkEgfsFzciAL8+I1tHutuekxGoWggByI=",
+        "lastModified": 1724920817,
+        "narHash": "sha256-qWXS+4M9kHXxG1HgZuv+3gm3KQc1aPdBZUPnLLev8w0=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "428941cab13c7dc778794861c9228c69c6e61226",
+        "rev": "977841b31ddbd3c919f56767a6f85d0615440759",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                             |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`977841b3`](https://github.com/nix-community/srvos/commit/977841b31ddbd3c919f56767a6f85d0615440759) | `` initrd.systemd: disable emergency mode (#481) `` |
| [`2af6c48a`](https://github.com/nix-community/srvos/commit/2af6c48a6e03c451139b4d1f6fd29ff864481916) | `` remove mddoc (#495) ``                           |