### PR TITLE
chore(flake/darwin): `ac5694a0` -> `c8d3157d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -88,11 +88,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724561770,
-        "narHash": "sha256-zv8C9RNa86CIpyHwPIVO/k+5TfM8ZbjGwOOpTe1grls=",
+        "lastModified": 1724994893,
+        "narHash": "sha256-yutISDGg6HUaZqCaa54EcsfTwew3vhNtt/FNXBBo44g=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "ac5694a0b855a981e81b4d9f14052e3ff46ca39e",
+        "rev": "c8d3157d1f768e382de5526bb38e74d2245cad04",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                      |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
| [`544db369`](https://github.com/LnL7/nix-darwin/commit/544db3691c98a9bcc56b360cf3cf20bd41257ca3) | `` Add sha256 for DeterminateSystems Nix installer 0.22.0 `` |