### PR TITLE
chore(flake/flake-parts): `8471fe90` -> `1e6fc322`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -243,11 +243,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1722555600,
-        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "lastModified": 1725011404,
+        "narHash": "sha256-EBDxPawECn+UA3zCk2RqVmuvXcGBQadgl/INHhDshJA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "rev": "1e6fc322ada6d6c62f33b9cf0be850c3a97e31cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                    |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`1957ef2c`](https://github.com/hercules-ci/flake-parts/commit/1957ef2c4ba04e213c59380a19e46c9fcee38d0e) | `` Dogfood flakeModules.partitions ``      |
| [`0d5122e8`](https://github.com/hercules-ci/flake-parts/commit/0d5122e84c0d7606363f89f0924245317c2fe3a0) | `` Add flakeModules.partitions ``          |
| [`c07ef7e5`](https://github.com/hercules-ci/flake-parts/commit/c07ef7e578fbb1a2e964615e0faee1949371cd22) | `` Dogfood lib.mkFlake ``                  |
| [`3ea68936`](https://github.com/hercules-ci/flake-parts/commit/3ea689365998db56cc4c84aa4de4ddd15d550baa) | `` refact: Add let binding to flake.nix `` |