### PR TITLE
chore(flake/flake-parts): `1e6fc322` -> `4f37dc19`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -243,11 +243,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1725011404,
-        "narHash": "sha256-EBDxPawECn+UA3zCk2RqVmuvXcGBQadgl/INHhDshJA=",
+        "lastModified": 1725015982,
+        "narHash": "sha256-1WXS/BBKZUcWlfeZL7U8ujuCdlLktImbpmJgN9zsZXM=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "1e6fc322ada6d6c62f33b9cf0be850c3a97e31cd",
+        "rev": "4f37dc19b47b50512008f38858734f8fa8a4e0cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                             |
| -------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`1728089f`](https://github.com/hercules-ci/flake-parts/commit/1728089f3e8a28df678f60cc52cff4219ade477d) | `` flakeModules.partitions: Improve and fix docs `` |