### PR TITLE
chore(flake/flake-parts): `4f37dc19` -> `af510d4a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -243,11 +243,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1725015982,
-        "narHash": "sha256-1WXS/BBKZUcWlfeZL7U8ujuCdlLktImbpmJgN9zsZXM=",
+        "lastModified": 1725024810,
+        "narHash": "sha256-ODYRm8zHfLTH3soTFWE452ydPYz2iTvr9T8ftDMUQ3E=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "4f37dc19b47b50512008f38858734f8fa8a4e0cc",
+        "rev": "af510d4a62d071ea13925ce41c95e3dec816c01d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                       |
| -------------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`f112e301`](https://github.com/hercules-ci/flake-parts/commit/f112e301b33a8c0fbe7f65eac7a793e2dd8d3bf6) | `` Fix test ``                |
| [`358ab837`](https://github.com/hercules-ci/flake-parts/commit/358ab8370e9726e60c16cb299c8138228fb0301e) | `` reference to Nix manual `` |
| [`309636f1`](https://github.com/hercules-ci/flake-parts/commit/309636f1b058eb305c974882967577225a3ee29a) | `` correct typo ``            |
| [`4a41226e`](https://github.com/hercules-ci/flake-parts/commit/4a41226e755f18ff9cd0d3914698c680ee0b804c) | `` apps: Add `meta` option `` |