### PR TITLE
chore(flake/emacs-overlay): `49261a89` -> `92709054`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725005981,
-        "narHash": "sha256-ezhDP4Q14peqH9FFdUTS4THS6+7kcLZuAlYrVc8fODE=",
+        "lastModified": 1725037016,
+        "narHash": "sha256-+qsKuZe0zL5nCPyrl+eFCChe+7dUP3w+C9EAoh8eotw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "49261a899cc9c11a465c243d9dcebc54d3b91fdb",
+        "rev": "92709054be3ef3aeddc7a37f1c59b6959530dfac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`92709054`](https://github.com/nix-community/emacs-overlay/commit/92709054be3ef3aeddc7a37f1c59b6959530dfac) | `` Updated melpa `` |
| [`4d3bcfc2`](https://github.com/nix-community/emacs-overlay/commit/4d3bcfc264afcd04617945191cdca0c13becc463) | `` Updated elpa ``  |