### PR TITLE
chore(flake/emacs-overlay): `92709054` -> `45405f34`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725037016,
-        "narHash": "sha256-+qsKuZe0zL5nCPyrl+eFCChe+7dUP3w+C9EAoh8eotw=",
+        "lastModified": 1725037990,
+        "narHash": "sha256-7ZwhCJQ8/BvP5UDSOe9PUzrDlDePxfyDrkEYuuZZJJ8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "92709054be3ef3aeddc7a37f1c59b6959530dfac",
+        "rev": "45405f34d10260753298ff244a9b9c36e04b2e11",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`45405f34`](https://github.com/nix-community/emacs-overlay/commit/45405f34d10260753298ff244a9b9c36e04b2e11) | `` Updated emacs `` |