### PR TITLE
chore(flake/srvos): `977841b3` -> `b8e10788`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -882,11 +882,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724920817,
-        "narHash": "sha256-qWXS+4M9kHXxG1HgZuv+3gm3KQc1aPdBZUPnLLev8w0=",
+        "lastModified": 1725040185,
+        "narHash": "sha256-hOv19L8aRprqdm1Jz7T4kT8h/ckdj8BgLtLSNOOj+RE=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "977841b31ddbd3c919f56767a6f85d0615440759",
+        "rev": "b8e10788e84670049b30dc11d4c5893aedf7b32b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                       |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`b8e10788`](https://github.com/nix-community/srvos/commit/b8e10788e84670049b30dc11d4c5893aedf7b32b) | `` break(nix): disable nix channels (#466) `` |