### PR TITLE
chore(flake/emacs-overlay): `45405f34` -> `72077e4b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725037990,
-        "narHash": "sha256-7ZwhCJQ8/BvP5UDSOe9PUzrDlDePxfyDrkEYuuZZJJ8=",
+        "lastModified": 1725066685,
+        "narHash": "sha256-FZeBrNUambaPzTzczGkWd/FH+pM3C4qVZq04Q6BjPSs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "45405f34d10260753298ff244a9b9c36e04b2e11",
+        "rev": "72077e4bba07910b106ec099ec2ece8e5b5736f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`72077e4b`](https://github.com/nix-community/emacs-overlay/commit/72077e4bba07910b106ec099ec2ece8e5b5736f3) | `` Updated elpa ``   |
| [`6e8515fc`](https://github.com/nix-community/emacs-overlay/commit/6e8515fc55c2dc7f65b79aa7c647d318cc7ae760) | `` Updated nongnu `` |