### PR TITLE
chore(flake/emacs-overlay): `72077e4b` -> `3169e5e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725066685,
-        "narHash": "sha256-FZeBrNUambaPzTzczGkWd/FH+pM3C4qVZq04Q6BjPSs=",
+        "lastModified": 1725068821,
+        "narHash": "sha256-UPn9qCMgt9Bk192+1XqRUoMdciE6c1u6vrQMrB/K9Mw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "72077e4bba07910b106ec099ec2ece8e5b5736f3",
+        "rev": "3169e5e682432a38e768b68e2557dc610ca0a426",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`3169e5e6`](https://github.com/nix-community/emacs-overlay/commit/3169e5e682432a38e768b68e2557dc610ca0a426) | `` Updated melpa `` |