### PR TITLE
chore(flake/emacs-overlay): `3169e5e6` -> `8963f64e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725068821,
-        "narHash": "sha256-UPn9qCMgt9Bk192+1XqRUoMdciE6c1u6vrQMrB/K9Mw=",
+        "lastModified": 1725094718,
+        "narHash": "sha256-N6DoqCMsGZn+0iiPbmW0ge2My7b3dxzJGQ/9FvGtVV0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3169e5e682432a38e768b68e2557dc610ca0a426",
+        "rev": "8963f64ec61eec13f39b1aa425a2e79543a995ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`8963f64e`](https://github.com/nix-community/emacs-overlay/commit/8963f64ec61eec13f39b1aa425a2e79543a995ba) | `` Updated melpa `` |