### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `15141ade` -> `cfd0a1ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
     "doomemacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1724999223,
-        "narHash": "sha256-K8I3liug8DHfzV0jS3U/yPFrXIGpxOw/HoIVpVX2dwc=",
+        "lastModified": 1725080385,
+        "narHash": "sha256-Rp0XUAmyOpPOwpNK8HiFreTZ8sdMjpeFQjzXbAj16r4=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "7197ee65c7cd1a8291266a3514583406e1ab1f18",
+        "rev": "22fc36dba7078f1b6938b2c06abc82e073ff3688",
         "type": "github"
       },
       "original": {
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725005981,
-        "narHash": "sha256-ezhDP4Q14peqH9FFdUTS4THS6+7kcLZuAlYrVc8fODE=",
+        "lastModified": 1725068821,
+        "narHash": "sha256-UPn9qCMgt9Bk192+1XqRUoMdciE6c1u6vrQMrB/K9Mw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "49261a899cc9c11a465c243d9dcebc54d3b91fdb",
+        "rev": "3169e5e682432a38e768b68e2557dc610ca0a426",
         "type": "github"
       },
       "original": {
@@ -500,11 +500,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1725006937,
-        "narHash": "sha256-kH7jbgSjxzLejNMmJCcm9hZm3mWCI9HvcU9V35XoXhw=",
+        "lastModified": 1725093298,
+        "narHash": "sha256-lexUAUi7jgotXmT1v4TnWn2QzESV6sSAoDrzXl/7KMk=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "15141ade487985a0cdeb0fb6500b432a260c9fd8",
+        "rev": "cfd0a1ad0995efc8ee1149e09445bcde9f9b0a8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`cfd0a1ad`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/cfd0a1ad0995efc8ee1149e09445bcde9f9b0a8d) | `` flake.lock: Update `` |