### PR TITLE
chore(flake/emacs-overlay): `8aca32cd` -> `ca954064`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725095529,
-        "narHash": "sha256-ibvd9nDtk/bJ/Xa8qMOBKtOsFqlEnLFDvzi9m9wh0zs=",
+        "lastModified": 1725123472,
+        "narHash": "sha256-vGx8OnRnnelLSL3wYj/J4Wsxy9UDMvetgjdwyLIc59Y=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8aca32cde9523f58a2cd3733b891c3c8b494b26f",
+        "rev": "ca9540642850913ce39b90c905f4bdd579660910",
         "type": "github"
       },
       "original": {
@@ -684,11 +684,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1724855419,
-        "narHash": "sha256-WXHSyOF4nBX0cvHN3DfmEMcLOVdKH6tnMk9FQ8wTNRc=",
+        "lastModified": 1725001927,
+        "narHash": "sha256-eV+63gK0Mp7ygCR0Oy4yIYSNcum2VQwnZamHxYTNi+M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ae2fc9e0e42caaf3f068c1bfdc11c71734125e06",
+        "rev": "6e99f2a27d600612004fbd2c3282d614bfee6421",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`ca954064`](https://github.com/nix-community/emacs-overlay/commit/ca9540642850913ce39b90c905f4bdd579660910) | `` Updated melpa ``        |
| [`faae1b85`](https://github.com/nix-community/emacs-overlay/commit/faae1b85f955e2cc3dd4943d9d747151b8fec05a) | `` Updated elpa ``         |
| [`acc702af`](https://github.com/nix-community/emacs-overlay/commit/acc702af5ae924db7557bb36074a373e194dc949) | `` Updated nongnu ``       |
| [`b220a30f`](https://github.com/nix-community/emacs-overlay/commit/b220a30f2a7eedbc3ac50a1c9f8853fd4a9787f9) | `` Updated flake inputs `` |