### PR TITLE
chore(flake/emacs-overlay): `ca954064` -> `6bbe8973`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725123472,
-        "narHash": "sha256-vGx8OnRnnelLSL3wYj/J4Wsxy9UDMvetgjdwyLIc59Y=",
+        "lastModified": 1725124345,
+        "narHash": "sha256-VAZOHWl1NJcmwrtHvVca0O1ivH+vU6SdRPwWcMu+l0Y=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ca9540642850913ce39b90c905f4bdd579660910",
+        "rev": "6bbe8973c0a99ebb54175310f20a0d255f688f90",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`6bbe8973`](https://github.com/nix-community/emacs-overlay/commit/6bbe8973c0a99ebb54175310f20a0d255f688f90) | `` Updated emacs `` |