### PR TITLE
chore(flake/emacs-overlay): `22d7f296` -> `d1f6dc57`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725153732,
-        "narHash": "sha256-OjIdDbdxW7wad7kk8gU4PfAIdmcuAB4eeEQImTps+L4=",
+        "lastModified": 1725156753,
+        "narHash": "sha256-nWJE0JqTzP6yTCmBl/DbYaVhVjyudFAjgrH4epKTJTY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "22d7f296028354d7b3d485940f90a6b2b94d8bdd",
+        "rev": "d1f6dc57f8ac04cafa2eb7926373a016b215e862",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`d1f6dc57`](https://github.com/nix-community/emacs-overlay/commit/d1f6dc57f8ac04cafa2eb7926373a016b215e862) | `` Updated emacs `` |
| [`7281c8b0`](https://github.com/nix-community/emacs-overlay/commit/7281c8b0dd831fad24e4ee551e8d911dcad46a6d) | `` Updated melpa `` |