### PR TITLE
chore(flake/nix-index-database): `e333d62b` -> `32058e91`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -571,11 +571,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724576102,
-        "narHash": "sha256-uM7n5nNL6fmA0bwMJBNll11f4cMWOFa2Ni6F5KeIldM=",
+        "lastModified": 1725161148,
+        "narHash": "sha256-WfAHq3Ag3vLNFfWxKHjFBFdPI6JIideWFJod9mx1eoo=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "e333d62b70b179da1dd78d94315e8a390f2d12e5",
+        "rev": "32058e9138248874773630c846563b1a78ee7a5b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`32058e91`](https://github.com/nix-community/nix-index-database/commit/32058e9138248874773630c846563b1a78ee7a5b) | `` update generated.nix to release 2024-09-01-031416 `` |
| [`78ccfbc4`](https://github.com/nix-community/nix-index-database/commit/78ccfbc4a41fa8461b23aa1a999f9c3ced1882c9) | `` flake.lock: Update ``                                |