### PR TITLE
chore(flake/emacs-overlay): `d1f6dc57` -> `1ac2a8f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725156753,
-        "narHash": "sha256-nWJE0JqTzP6yTCmBl/DbYaVhVjyudFAjgrH4epKTJTY=",
+        "lastModified": 1725181040,
+        "narHash": "sha256-2/e9G7c/7VTVWfa+UnXGbOLMf/U0FpA/0QW3thoeQ5s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d1f6dc57f8ac04cafa2eb7926373a016b215e862",
+        "rev": "1ac2a8f8ba9d1cbe621d1890dce295716d603daf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`1ac2a8f8`](https://github.com/nix-community/emacs-overlay/commit/1ac2a8f8ba9d1cbe621d1890dce295716d603daf) | `` Updated melpa `` |