### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `cfd0a1ad` -> `6d16fb7c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -500,11 +500,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1725093298,
-        "narHash": "sha256-lexUAUi7jgotXmT1v4TnWn2QzESV6sSAoDrzXl/7KMk=",
+        "lastModified": 1725193411,
+        "narHash": "sha256-+AGOxGzGLMkJ6gryZByKPu3Aw1S8gKJEI/RXiEavEsU=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "cfd0a1ad0995efc8ee1149e09445bcde9f9b0a8d",
+        "rev": "6d16fb7c50474f3650a19ccd3e6dc2e3556173f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                                  |
| ---------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`6d16fb7c`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/6d16fb7c50474f3650a19ccd3e6dc2e3556173f9) | `` Drop tree-sitter site-dir renaming `` |