### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `6d16fb7c` -> `598ae49a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -500,11 +500,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1725193411,
-        "narHash": "sha256-+AGOxGzGLMkJ6gryZByKPu3Aw1S8gKJEI/RXiEavEsU=",
+        "lastModified": 1725198084,
+        "narHash": "sha256-4t4vYusrjZHTpFXQYYxU+gigTDwGQWK2z+iWevF5iac=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "6d16fb7c50474f3650a19ccd3e6dc2e3556173f9",
+        "rev": "598ae49a4bb4f41d0031ab0c1df392259c5834ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                                                 |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`598ae49a`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/598ae49a4bb4f41d0031ab0c1df392259c5834ec) | `` Explicitly create autoloads file for trivialBuild `` |