### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `598ae49a` -> `07299fb3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
     "doomemacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1725080385,
-        "narHash": "sha256-Rp0XUAmyOpPOwpNK8HiFreTZ8sdMjpeFQjzXbAj16r4=",
+        "lastModified": 1725156536,
+        "narHash": "sha256-038TOS3C62ETbB9c4A025gWa8ba2608gPp6SJj5jvXU=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "22fc36dba7078f1b6938b2c06abc82e073ff3688",
+        "rev": "086aed32b2b1f0c9da5bfbaeaa849c4d9c448658",
         "type": "github"
       },
       "original": {
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725068821,
-        "narHash": "sha256-UPn9qCMgt9Bk192+1XqRUoMdciE6c1u6vrQMrB/K9Mw=",
+        "lastModified": 1725181040,
+        "narHash": "sha256-2/e9G7c/7VTVWfa+UnXGbOLMf/U0FpA/0QW3thoeQ5s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3169e5e682432a38e768b68e2557dc610ca0a426",
+        "rev": "1ac2a8f8ba9d1cbe621d1890dce295716d603daf",
         "type": "github"
       },
       "original": {
@@ -500,11 +500,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1725198084,
-        "narHash": "sha256-4t4vYusrjZHTpFXQYYxU+gigTDwGQWK2z+iWevF5iac=",
+        "lastModified": 1725199188,
+        "narHash": "sha256-U9LMGO+xuROQwa5LkUvwcajoQdtbN2PG0xbTMyTD5qk=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "598ae49a4bb4f41d0031ab0c1df392259c5834ec",
+        "rev": "07299fb360ca7dc6241ad3ba731b471d0fd9b59d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`07299fb3`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/07299fb360ca7dc6241ad3ba731b471d0fd9b59d) | `` flake.lock: Update `` |