### PR TITLE
chore(flake/emacs-overlay): `1ac2a8f8` -> `ee905095`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725181040,
-        "narHash": "sha256-2/e9G7c/7VTVWfa+UnXGbOLMf/U0FpA/0QW3thoeQ5s=",
+        "lastModified": 1725209873,
+        "narHash": "sha256-gd8pU7kGS7Udhg2A1rZ2OlYBOKC5wl6h0XeJ4COrC1g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1ac2a8f8ba9d1cbe621d1890dce295716d603daf",
+        "rev": "ee9050954acd3cd7a0c7b5976f6645e43618c59d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`ee905095`](https://github.com/nix-community/emacs-overlay/commit/ee9050954acd3cd7a0c7b5976f6645e43618c59d) | `` Updated melpa ``        |
| [`5bc13ad1`](https://github.com/nix-community/emacs-overlay/commit/5bc13ad142c177b92e4149e0ea00704aa239513e) | `` Updated elpa ``         |
| [`c46c7af3`](https://github.com/nix-community/emacs-overlay/commit/c46c7af331e273e70e6cbd2874d965d1663c138d) | `` Updated nongnu ``       |
| [`2a601aa1`](https://github.com/nix-community/emacs-overlay/commit/2a601aa194ec5524490e682929e2be0949a127aa) | `` Updated flake inputs `` |