### PR TITLE
chore(flake/srvos): `b8e10788` -> `a6ee5a71`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -882,11 +882,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725040185,
-        "narHash": "sha256-hOv19L8aRprqdm1Jz7T4kT8h/ckdj8BgLtLSNOOj+RE=",
+        "lastModified": 1725238235,
+        "narHash": "sha256-T6K8odVAi3l41REzrVcEblEfQS5gY1aB+0mnwjjdVpg=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "b8e10788e84670049b30dc11d4c5893aedf7b32b",
+        "rev": "a6ee5a7167866cc1a72609e1782d86be1de4acce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`a6ee5a71`](https://github.com/nix-community/srvos/commit/a6ee5a7167866cc1a72609e1782d86be1de4acce) | `` dev/private/flake.lock: Update `` |
| [`5be4cf3a`](https://github.com/nix-community/srvos/commit/5be4cf3aa5359f1862be72942e7c9fa0c5705926) | `` flake.lock: Update ``             |