### PR TITLE
chore(flake/emacs-overlay): `cf12eee4` -> `32f1e40c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725239593,
-        "narHash": "sha256-4smTnt5ow3RvymR2Gds2N6wvZIzyqD6fBj8Jjg0ntXE=",
+        "lastModified": 1725242597,
+        "narHash": "sha256-qfkeho6+vMNy7kf5jdSqiyPbOZUTlV/JoOu/T1bEdxE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cf12eee4a4a45b6a2e2af6dbf50963d7329c3a98",
+        "rev": "32f1e40cbf5c4866d2a2bf518b19fe0acf4c892e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`32f1e40c`](https://github.com/nix-community/emacs-overlay/commit/32f1e40cbf5c4866d2a2bf518b19fe0acf4c892e) | `` Updated emacs `` |
| [`511d11f7`](https://github.com/nix-community/emacs-overlay/commit/511d11f7c95bf4576ad79879e7b3e71738f02d89) | `` Updated melpa `` |