### PR TITLE
chore(flake/treefmt): `3ffd842a` -> `eebc332d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -977,11 +977,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724833132,
-        "narHash": "sha256-F4djBvyNRAXGusJiNYInqR6zIMI3rvlp6WiKwsRISos=",
+        "lastModified": 1725269261,
+        "narHash": "sha256-NdxEmL5Ytk0mkVH1bj2FyqWSFbcedZcmpdk0nP0Gq+E=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "3ffd842a5f50f435d3e603312eefa4790db46af5",
+        "rev": "eebc332d1eeba66c46a3c9b8201cf0068dba892e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                         |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`966dfb4a`](https://github.com/numtide/treefmt-nix/commit/966dfb4afff31af74f5a7a9a34d80f869fb3b4af) | `` mypy: don't set any PYTHONPATH if we don't have a package `` |
| [`c8a2bda8`](https://github.com/numtide/treefmt-nix/commit/c8a2bda80cd465167f4ccc021d91877a84205fe4) | `` mypy: fix include when no module is specified ``             |