### PR TITLE
chore(flake/treefmt): `eebc332d` -> `9fb342d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -977,11 +977,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725269261,
-        "narHash": "sha256-NdxEmL5Ytk0mkVH1bj2FyqWSFbcedZcmpdk0nP0Gq+E=",
+        "lastModified": 1725271838,
+        "narHash": "sha256-VcqxWT0O/gMaeWTTjf1r4MOyG49NaNxW4GHTO3xuThE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "eebc332d1eeba66c46a3c9b8201cf0068dba892e",
+        "rev": "9fb342d14b69aefdf46187f6bb80a4a0d97007cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                    |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`14b9565b`](https://github.com/numtide/treefmt-nix/commit/14b9565b02f77e3c1c89293a05e703942d62fbde) | `` mypy: fix python path not beeing set `` |
| [`65e10308`](https://github.com/numtide/treefmt-nix/commit/65e10308caf73e744c6e408307c9f1887a1fd4c7) | `` feat: update nixpkgs input ``           |