### PR TITLE
chore(flake/emacs-overlay): `2f7c7275` -> `fa117fc7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725267572,
-        "narHash": "sha256-s5+GUIs8OewO1McYn3bhMz31Q+Xl0WRxUTKp+lPZLno=",
+        "lastModified": 1725296367,
+        "narHash": "sha256-a+aVMTHHflfUgyoBIpHHVmJfcDkvxH0haIrCONZDF/M=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2f7c7275d542f59760bd307e5805572cee65ae37",
+        "rev": "fa117fc7f6ad4f7466e305608c72688947da5b5d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`fa117fc7`](https://github.com/nix-community/emacs-overlay/commit/fa117fc7f6ad4f7466e305608c72688947da5b5d) | `` Updated melpa ``  |
| [`5a20ac36`](https://github.com/nix-community/emacs-overlay/commit/5a20ac36515bace80929c9246e69172359bfaca5) | `` Updated elpa ``   |
| [`070df6b0`](https://github.com/nix-community/emacs-overlay/commit/070df6b044b05cd340491b0c088b3ebc27cd925b) | `` Updated nongnu `` |