### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `4b2c4217` -> `d40cdbc4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
     "doomemacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1725253858,
-        "narHash": "sha256-xyuDa2bBKLs4ZzaOsXYlOULRhRXYh4glpLQ0vRErOH4=",
+        "lastModified": 1725350669,
+        "narHash": "sha256-VolWh2VkVydYmOhmALxODhDgUIpIFt3iY7lFGFyHJFQ=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "d6bc2b0f19e51fa57e57c38f622b8c91fdddf0c0",
+        "rev": "559e5b6a966fa82bf8322f89d78a00ef4181812a",
         "type": "github"
       },
       "original": {
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725242597,
-        "narHash": "sha256-qfkeho6+vMNy7kf5jdSqiyPbOZUTlV/JoOu/T1bEdxE=",
+        "lastModified": 1725328944,
+        "narHash": "sha256-fbL2p6brL2uvXBI/SyyaWtqXqn+qox3ZZI96CxkID3Y=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "32f1e40cbf5c4866d2a2bf518b19fe0acf4c892e",
+        "rev": "dd2bea615a05ddba399f76115bd57037c38278a7",
         "type": "github"
       },
       "original": {
@@ -500,11 +500,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1725266209,
-        "narHash": "sha256-vbfE0FXpMFKwBCWMFBN0uJWhSg9BcdGuQiCsNIFXY64=",
+        "lastModified": 1725352578,
+        "narHash": "sha256-XsgZF4QguD52u5kyt+jWfns2V/VHCjNd6A3XfCaWflk=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "4b2c42171f5e7dcf3a957f83621d25c46f5c7cb2",
+        "rev": "d40cdbc4fb62bcf750232cf281fdc5a11f5de78d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`d40cdbc4`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/d40cdbc4fb62bcf750232cf281fdc5a11f5de78d) | `` flake.lock: Update `` |