### PR TITLE
chore(flake/srvos): `a6ee5a71` -> `28192679`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -882,11 +882,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725238235,
-        "narHash": "sha256-T6K8odVAi3l41REzrVcEblEfQS5gY1aB+0mnwjjdVpg=",
+        "lastModified": 1725362121,
+        "narHash": "sha256-LSN5hmeiRa77mVyret2sMeaEd9fPy805Aa1USKbTD3w=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "a6ee5a7167866cc1a72609e1782d86be1de4acce",
+        "rev": "2819267964a457cb10e78a0f74750acc8dc78371",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                           |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`a65bd00f`](https://github.com/nix-community/srvos/commit/a65bd00f57daedc8f33e53f9401c32505d553128) | `` feat(srvos.flake): export the flake further `` |
| [`93668c19`](https://github.com/nix-community/srvos/commit/93668c19870e53de89bba21d8f5f496e254225f5) | `` diff: add enable option ``                     |