### PR TITLE
chore(flake/emacs-overlay): `2ab55649` -> `6b44e96a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725353935,
-        "narHash": "sha256-oM5QnX7a37qruUw+hNVkRU03TF33LcOWm+O5epNOkso=",
+        "lastModified": 1725382747,
+        "narHash": "sha256-94YR44QMq5vNrNpuJyoPEWDVEss8lIlt8J3LhKPr6GY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2ab55649b8375215b978db50efc61064bd4efab8",
+        "rev": "6b44e96a6506afd093cc60b39a2d98e6d74e3a2f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`6b44e96a`](https://github.com/nix-community/emacs-overlay/commit/6b44e96a6506afd093cc60b39a2d98e6d74e3a2f) | `` Updated melpa `` |
| [`3cd65b7f`](https://github.com/nix-community/emacs-overlay/commit/3cd65b7f3c1709933e1d01075108295304ac42bb) | `` Updated elpa ``  |