### PR TITLE
chore(flake/nixos-hardware): `95c3dfe6` -> `f7e31ff8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -611,11 +611,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1724878143,
-        "narHash": "sha256-UjpKo92iZ25M05kgSOw/Ti6VZwpgdlOa73zHj8OcaDk=",
+        "lastModified": 1725388496,
+        "narHash": "sha256-X7ClCNPP0dVmE8x5FN9Pt/UDCDHPR/cCZit4aEWo9gg=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "95c3dfe6ef2e96ddc1ccdd7194e3cda02ca9a8ef",
+        "rev": "f7e31ff8efd7d450c3a9c6379963f333f32889a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                               |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
| [`12acfdef`](https://github.com/NixOS/nixos-hardware/commit/12acfdefc1d352a382f5e875fc9a6c48ab989e08) | `` dell-xps-17-9700: Add nvidia architecture ``                                                       |
| [`dec757bf`](https://github.com/NixOS/nixos-hardware/commit/dec757bf4ebd310df00b19e54daa6ef1b241ec21) | `` dell-xps-15-9560: Add nvidia architecture ``                                                       |
| [`9f9cf89d`](https://github.com/NixOS/nixos-hardware/commit/9f9cf89d3370df3ffc307e77ca881b9a4dd76095) | `` dell-xps-15-9550: Add nvidia architecture ``                                                       |
| [`30584336`](https://github.com/NixOS/nixos-hardware/commit/30584336012b279813bf842ad27acf77fef33ae9) | `` dell-xps-15-9520: Add nvidia architecture ``                                                       |
| [`c75b52ac`](https://github.com/NixOS/nixos-hardware/commit/c75b52ace8305b2d64b16ec45335545a15062031) | `` dell-xps-15-9510: Add nvidia architecture ``                                                       |
| [`32979d22`](https://github.com/NixOS/nixos-hardware/commit/32979d223a3747f4a2683774db0d6cdfe6d1bf1a) | `` dell-xps-15-9500: Add nvidia architecture ``                                                       |
| [`b1ee64a4`](https://github.com/NixOS/nixos-hardware/commit/b1ee64a4eae363724f064a1e1536dd27a80c9e9b) | `` dell-g3-3779: Add nvidia architecture ``                                                           |
| [`6d6022fa`](https://github.com/NixOS/nixos-hardware/commit/6d6022faac1c3d2995c3ca47fac0b5a29b2380ed) | `` tests: Update flake.lock ``                                                                        |
| [`366ddc33`](https://github.com/NixOS/nixos-hardware/commit/366ddc33ff1b93d95ef3809d12ce0fba74c8d316) | `` flake.nix: don't expose nvidia modules ``                                                         |
| [`ca005ac1`](https://github.com/NixOS/nixos-hardware/commit/ca005ac1e8392f1da8bb06f64b84dfee226f543a) | `` fix: spelling errors ``                                                                            |
| [`04567f4e`](https://github.com/NixOS/nixos-hardware/commit/04567f4ebcc9d4f90a7f527713ec7a3cd51e9cab) | `` fix: Update NVIDIA GPU configurations to use mkOverride ``                                         |
| [`5cbf7922`](https://github.com/NixOS/nixos-hardware/commit/5cbf79226baf922b3a4b64edc46b642ca0e10fb7) | `` feat: Add support for NVIDIA microarchitecture to xps 7590 and 9570 ``                             |
| [`4ac71504`](https://github.com/NixOS/nixos-hardware/commit/4ac71504155c4ac80d2f37bc0401c9b3aa75fadb) | `` feat: Add configurations for nvidia microarchitectures with configs for the open source drivers `` |
| [`24bc1f98`](https://github.com/NixOS/nixos-hardware/commit/24bc1f98d8db75306bceb82cdb345a1189bc2064) | `` lenovo: fix unstable wifi on Yoga laptops ``                                                       |