### PR TITLE
chore(flake/nixos-hardware): `f7e31ff8` -> `ba7bb376`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -611,11 +611,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1725388496,
-        "narHash": "sha256-X7ClCNPP0dVmE8x5FN9Pt/UDCDHPR/cCZit4aEWo9gg=",
+        "lastModified": 1725436345,
+        "narHash": "sha256-sWfTgSJ3Wq/L7jEZHiU82NaBjpMMmBR1y+MSvx88WeE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "f7e31ff8efd7d450c3a9c6379963f333f32889a8",
+        "rev": "ba7bb3761c960793001ed153a333e543345f34cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`19fba44e`](https://github.com/NixOS/nixos-hardware/commit/19fba44ecefcedab6cc3c299074732c0764a7a98) | `` lenovo-legion-16ach6h: Add nvidia architecture ``           |
| [`a5e2826f`](https://github.com/NixOS/nixos-hardware/commit/a5e2826fc2b75cb6f1ac012fa3dd80602817ef67) | `` Set mkDefault for enabling bluetooth. ``                    |
| [`aa3739f4`](https://github.com/NixOS/nixos-hardware/commit/aa3739f4ab414b2b0b212cf235d0682f14de3d4a) | `` asus-zephyrus-gu603h: Add nvidia architecture ``            |
| [`249f33df`](https://github.com/NixOS/nixos-hardware/commit/249f33df8be84218d090626749fe567cff3c572b) | `` asus-zephyrus-ga503: Add nvidia architecture ``             |
| [`a38b5d12`](https://github.com/NixOS/nixos-hardware/commit/a38b5d1286083d25541f165fd42443d8bb7383c5) | `` asus-zephyrus-ga502: Add nvidia architecture ``             |
| [`5c04dd45`](https://github.com/NixOS/nixos-hardware/commit/5c04dd453beb0244a686d7c543e97aed71a20258) | `` asus-zephyrus-ga402x: Add nvidia architecture ``            |
| [`45e5bcc7`](https://github.com/NixOS/nixos-hardware/commit/45e5bcc7d5453058a6b0011ad807b28b26ebc4eb) | `` asus-zephyrus-ga401: Add nvidia architecture ``             |
| [`537992d8`](https://github.com/NixOS/nixos-hardware/commit/537992d88433c9a0f7949d633ae958829f602ca1) | `` asus-rog-strix-g733qs: Add nvidia architecture ``           |
| [`9b17be34`](https://github.com/NixOS/nixos-hardware/commit/9b17be344e79376e9c5a3a5593fcc640ef3130c4) | `` asus-rog-strix-g713ie: Add nvidia architecture ``           |
| [`910e61b2`](https://github.com/NixOS/nixos-hardware/commit/910e61b27da79ac4a0c56ef68336c85586cbf273) | `` asus-rog-strix-g513im: Add nvidia architecture ``           |
| [`59894d5e`](https://github.com/NixOS/nixos-hardware/commit/59894d5e56ba7fd0fc5d34b4d2b397106fe3f060) | `` asus-fa507rm: Add nvidia architecture ``                    |
| [`b978e8c9`](https://github.com/NixOS/nixos-hardware/commit/b978e8c9038834197e7f0516dba325d037ee1cd8) | `` Add GPD Win Mini 2024 to the configuration list. (#1099) `` |