### PR TITLE
chore(flake/emacs-overlay): `caa97943` -> `8d081308`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725440322,
-        "narHash": "sha256-vRl/KT12yahy35wMw+yEvtSBtwTMZvWNfMMN9vs3w7A=",
+        "lastModified": 1725469132,
+        "narHash": "sha256-eS+12y/ux3VVKmDZGEqsEKcheuIIYoNOSRnQmttbyWw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "caa979438d279b0daf0e0aee38e5102f5d40ace2",
+        "rev": "8d081308bf9c1bc53e77be677e28767f7df7cdd0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`8d081308`](https://github.com/nix-community/emacs-overlay/commit/8d081308bf9c1bc53e77be677e28767f7df7cdd0) | `` Updated melpa ``  |
| [`04c4b688`](https://github.com/nix-community/emacs-overlay/commit/04c4b6880dac53c766c3dd9c42f54d76171b7f93) | `` Updated elpa ``   |
| [`d9a26422`](https://github.com/nix-community/emacs-overlay/commit/d9a2642269cf8a4b145d98906fb5b7a1b4bdeb41) | `` Updated nongnu `` |