### PR TITLE
chore(flake/emacs-overlay): `8d081308` -> `8a94f9d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725469132,
-        "narHash": "sha256-eS+12y/ux3VVKmDZGEqsEKcheuIIYoNOSRnQmttbyWw=",
+        "lastModified": 1725470024,
+        "narHash": "sha256-i2iWRFWaTCahFz9B2vKqIqpPimL/yn1zX3lZ2EkBzc0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8d081308bf9c1bc53e77be677e28767f7df7cdd0",
+        "rev": "8a94f9d557f3f8b372f03f18b2e1be3820d7da7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`8a94f9d5`](https://github.com/nix-community/emacs-overlay/commit/8a94f9d557f3f8b372f03f18b2e1be3820d7da7f) | `` Updated emacs `` |