### PR TITLE
chore(flake/emacs-overlay): `8a94f9d5` -> `355ea2b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725470024,
-        "narHash": "sha256-i2iWRFWaTCahFz9B2vKqIqpPimL/yn1zX3lZ2EkBzc0=",
+        "lastModified": 1725501717,
+        "narHash": "sha256-4kA9w5HPxCa4sgxmJ7kmNGtV+NU7oMVZ+VBnP/f7B3U=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8a94f9d557f3f8b372f03f18b2e1be3820d7da7f",
+        "rev": "355ea2b7b3a317f9082b30f4d43cc5bee63141f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`355ea2b7`](https://github.com/nix-community/emacs-overlay/commit/355ea2b7b3a317f9082b30f4d43cc5bee63141f2) | `` Updated emacs ``  |
| [`db23857d`](https://github.com/nix-community/emacs-overlay/commit/db23857d4148f49e20bbd76e01fe623564a8ccd2) | `` Updated melpa ``  |
| [`321ab388`](https://github.com/nix-community/emacs-overlay/commit/321ab388f2bf1e9efc8fd729d96f270905addbfa) | `` Updated elpa ``   |
| [`addae6a4`](https://github.com/nix-community/emacs-overlay/commit/addae6a4735e5312c0d23850a560749c19b6d40b) | `` Updated nongnu `` |