### PR TITLE
chore(flake/srvos): `28192679` -> `39817ccd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -882,11 +882,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725362121,
-        "narHash": "sha256-LSN5hmeiRa77mVyret2sMeaEd9fPy805Aa1USKbTD3w=",
+        "lastModified": 1725497274,
+        "narHash": "sha256-sGvYBY3q+5pAn4i1Vkb2/ah7NbruonQVIn7DDPRusqE=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "2819267964a457cb10e78a0f74750acc8dc78371",
+        "rev": "39817ccdaf8c4a46340a1d3326d59891d6d0b586",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`39817ccd`](https://github.com/nix-community/srvos/commit/39817ccdaf8c4a46340a1d3326d59891d6d0b586) | `` dev/private/flake.lock: Update `` |
| [`69b4ac24`](https://github.com/nix-community/srvos/commit/69b4ac246bdc60b215e4fb4e4a68061697782225) | `` flake.lock: Update ``             |