### PR TITLE
chore(flake/sops-nix): `5db5921e` -> `d9d78152`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -862,11 +862,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1725201042,
-        "narHash": "sha256-lj5pxOwidP0W//E7IvyhbhXrnEUW99I07+QpERnzTS4=",
+        "lastModified": 1725540166,
+        "narHash": "sha256-htc9rsTMSAY5ek+DB3tpntdD/es0eam2hJgO92bWSys=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "5db5921e40ae382d6716dce591ea23b0a39d96f7",
+        "rev": "d9d781523a1463965cd1e1333a306e70d9feff07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                |
| ----------------------------------------------------------------------------------------------- | ---------------------- |
| [`d9d78152`](https://github.com/Mic92/sops-nix/commit/d9d781523a1463965cd1e1333a306e70d9feff07) | `` Support userborn `` |