### PR TITLE
chore(flake/nixpkgs): `12228ff1` -> `ad416d06`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -732,11 +732,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1725103162,
-        "narHash": "sha256-Ym04C5+qovuQDYL/rKWSR+WESseQBbNAe5DsXNx5trY=",
+        "lastModified": 1725432240,
+        "narHash": "sha256-+yj+xgsfZaErbfYM3T+QvEE2hU7UuE+Jf0fJCJ8uPS0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "12228ff1752d7b7624a54e9c1af4b222b3c1073b",
+        "rev": "ad416d066ca1222956472ab7d0555a6946746a80",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`534f68ff`](https://github.com/NixOS/nixpkgs/commit/534f68ff00c8b4ac716b5d959bd69edffa9da830) | `` uv: 0.4.3 -> 0.4.4 ``                                                                    |
| [`da35f19d`](https://github.com/NixOS/nixpkgs/commit/da35f19d64a6a596049835ceadce5b17f99cbca9) | `` dnscontrol: 4.12.5 -> 4.13.0 ``                                                          |
| [`7e2831e2`](https://github.com/NixOS/nixpkgs/commit/7e2831e2ba846afa719dfb4e1cce49169e4a5af0) | `` artalk: 2.8.7 -> 2.9.0 ``                                                                |
| [`54aa628c`](https://github.com/NixOS/nixpkgs/commit/54aa628cf671b3e3276b21efa59a0206f1b0c196) | `` disko: 1.6.1 -> 1.7.0 ``                                                                 |
| [`ecedb931`](https://github.com/NixOS/nixpkgs/commit/ecedb9315aa1fe6a3340f0264ed6a7b6fe689ebf) | `` buildMozillaMach: apply cbindgen patches for 128.1.x ``                                  |
| [`82988f7e`](https://github.com/NixOS/nixpkgs/commit/82988f7ed5473fc38872837cbe8ff7f974c1a97e) | `` simple-dlna-browser: remove loveisgrief from maintainers ``                              |
| [`1f7e8091`](https://github.com/NixOS/nixpkgs/commit/1f7e8091666d506cec7a1384cbbc5f018f2174cb) | `` buildMozillaMach: update patches ``                                                      |
| [`0523d786`](https://github.com/NixOS/nixpkgs/commit/0523d7864b4cedf14656b46dcc5bfc2154d7d8b4) | `` duckstation: Fix build on aarch64-linux ``                                               |
| [`878a46e7`](https://github.com/NixOS/nixpkgs/commit/878a46e7a7bb637a5d616ea8a410e84ad54bae81) | `` python312Packages.renault-api: 0.2.6 -> 0.2.7 ``                                         |
| [`d37c3e56`](https://github.com/NixOS/nixpkgs/commit/d37c3e56ecebf57a8145d15677680d83eded81fe) | `` python312Packages.aioshelly: run tests ``                                                |
| [`57d72fb5`](https://github.com/NixOS/nixpkgs/commit/57d72fb55410914df620f12b2ff6c164d034b6f2) | `` python312Packages.aioshelly: 11.4.1 -> 11.4.2 ``                                         |
| [`26a7a872`](https://github.com/NixOS/nixpkgs/commit/26a7a872936ae87a9c59747a658c44d466772249) | `` avahi: remove config.avahi ``                                                            |
| [`aec0d148`](https://github.com/NixOS/nixpkgs/commit/aec0d148347db6e2c5a8affa648c12253ed3e5ac) | `` treewide: Fix or remove some markdown links ``                                           |
| [`583270c8`](https://github.com/NixOS/nixpkgs/commit/583270c8efbf87a8808a60d85ac2be625a6e66d7) | `` ryujinx: disable parallel building ``                                                    |
| [`4b61c573`](https://github.com/NixOS/nixpkgs/commit/4b61c573e2ba83babdc7e288458bc1fca51f1680) | `` nexusmods-app: disable parallel building ``                                              |
| [`699b1823`](https://github.com/NixOS/nixpkgs/commit/699b182349e62582ce230c5b75a14ee2782ce50a) | `` recyclarr: disable parallel building ``                                                  |
| [`cc45e694`](https://github.com/NixOS/nixpkgs/commit/cc45e69475dedd3e97192ceef4d744a2ecfd967d) | `` .github: continue finessing the text and names for nixpkgs-vet ``                        |
| [`89cbfde9`](https://github.com/NixOS/nixpkgs/commit/89cbfde96de175f6134b6605d9d52fd38e2b3f6d) | `` nixpkgs-vet: update CI, docs, and release to 0.1.4 ``                                    |
| [`40c5077a`](https://github.com/NixOS/nixpkgs/commit/40c5077a7adef4b06cad27b6206ed87716343f2c) | `` conduwuit: init at 0.4.6 ``                                                              |
| [`9656e3f8`](https://github.com/NixOS/nixpkgs/commit/9656e3f8008102a5c7bda86503ed8037d0bda628) | `` gitlab-runner: remove bachp as maintainer ``                                             |
| [`458e48eb`](https://github.com/NixOS/nixpkgs/commit/458e48eb518f2d5a43a6214922c7a765a2d7936b) | `` openshift: remove bachp as maintainer ``                                                 |
| [`2d33d5c7`](https://github.com/NixOS/nixpkgs/commit/2d33d5c7783ee46320d7776ff33dac5b3887d523) | `` buildDotnetModule: inherit enableParallelBuilding ``                                     |
| [`ff8952ad`](https://github.com/NixOS/nixpkgs/commit/ff8952add32eefab31c0361554396372dc667adf) | `` nextcloud*Packages: update apps ``                                                       |
| [`cda22422`](https://github.com/NixOS/nixpkgs/commit/cda2242214c48d1facf258f6b5ee04830b444175) | `` nextcloud29: 29.0.5 -> 29.0.6 ``                                                         |
| [`a5317c33`](https://github.com/NixOS/nixpkgs/commit/a5317c333836e433cb10547fe907c402ec77c77e) | `` thc-hydra: --replace -> --replace-fail ``                                                |
| [`37586a74`](https://github.com/NixOS/nixpkgs/commit/37586a74824369de2d0f36c4062f1a63b410ec2e) | `` thc-hydra: add samba to enable smb2 support ``                                           |
| [`eb93347a`](https://github.com/NixOS/nixpkgs/commit/eb93347a3b01fc9917f8445816adac8f984f2b6c) | `` emacsPackages.cask: 0.8.8 -> 0.9.0 ``                                                    |
| [`ceda2ff1`](https://github.com/NixOS/nixpkgs/commit/ceda2ff16366bdb23b5da5bddb663f3980927e95) | `` python312Packages.prefixed: 0.8.0 -> 0.9.0 ``                                            |
| [`78bf14b8`](https://github.com/NixOS/nixpkgs/commit/78bf14b807bb77ff478df3c06f6847826c28a047) | `` emacsPackages.cask: use melpaBuild ``                                                    |
| [`a76f741b`](https://github.com/NixOS/nixpkgs/commit/a76f741b31c62bd060d9b68856937eb5e35ae994) | `` signalbackup-tools: 20240816 -> 20240830 ``                                              |
| [`c67a2a4e`](https://github.com/NixOS/nixpkgs/commit/c67a2a4ec66ddb81eae12fdb0cc807d3e4dfc9eb) | `` ssh-openpgp-auth: update comment to refer to nixpkgs-vet ``                              |
| [`2c2d7a0f`](https://github.com/NixOS/nixpkgs/commit/2c2d7a0f07e070e8fafd55e40ff9e05b9528a88f) | `` python312Packages.publicsuffixlist: 1.0.2.20240724 -> 1.0.2.20240903 ``                  |
| [`dca7537c`](https://github.com/NixOS/nixpkgs/commit/dca7537c8f958d58ec98b69cdfec3adfae0cca2e) | `` ungoogled-chromium: 128.0.6613.113-1 -> 128.0.6613.119-1 ``                              |
| [`c0a3113a`](https://github.com/NixOS/nixpkgs/commit/c0a3113afeb9b73ef43bbb114b5e1f41871fe6f8) | `` chromium,chromedriver: 128.0.6613.113 -> 128.0.6613.119 ``                               |
| [`96ea1569`](https://github.com/NixOS/nixpkgs/commit/96ea156926944fe009def871f11a5ad21e8c9fe9) | `` chromium: match release blog entry titles case-insensitive in `get-commit-message.py` `` |
| [`ed02e380`](https://github.com/NixOS/nixpkgs/commit/ed02e38086bbe8954d977c6ef3cfa628bc5755ed) | `` python312Packages.oelint-parser: 3.5.5 -> 4.0.0 ``                                       |
| [`f01da3d3`](https://github.com/NixOS/nixpkgs/commit/f01da3d33ba1f0a24d619ff89661c7f3b0670416) | `` python312Packages.nocasedict: 2.0.3 -> 2.0.4 ``                                          |
| [`fbffac3a`](https://github.com/NixOS/nixpkgs/commit/fbffac3af16e058aa804b0af89d45977851070c8) | `` zet: fix build ``                                                                        |
| [`df8e3b15`](https://github.com/NixOS/nixpkgs/commit/df8e3b1546635ebd9f31ed3ac3b1f03aba2c4b2d) | `` rust-script: 0.34.0 -> 0.35.0 ``                                                         |
| [`b2a450be`](https://github.com/NixOS/nixpkgs/commit/b2a450bebb6bfba10b2e8f52f80fcecb865d5568) | `` firefox-esr-115-unwrapped: 115.14.0esr -> 115.15.0esr ``                                 |
| [`b553f338`](https://github.com/NixOS/nixpkgs/commit/b553f338163999d5d656a7517bc9c08ce1564a6d) | `` firefox-esr-128-unwrapped: 128.1.0esr -> 128.2.0esr ``                                   |
| [`1513714d`](https://github.com/NixOS/nixpkgs/commit/1513714dd6ebb66ce8342f37701f9eb95445bd86) | `` firefox-bin-unwrapped: 129.0.2 -> 130.0 ``                                               |
| [`f258df8d`](https://github.com/NixOS/nixpkgs/commit/f258df8d6fd55b6d3f67f2268199d17ec968f1bb) | `` firefox-unwrapped: 129.0.2 -> 130.0 ``                                                   |
| [`4e0ca3fb`](https://github.com/NixOS/nixpkgs/commit/4e0ca3fbfeffa67ffc28ce71454c2447fc362b21) | `` python312Packages.nocaselist: 2.0.2 -> 2.0.3 ``                                          |
| [`4be51023`](https://github.com/NixOS/nixpkgs/commit/4be51023c545b2cb2a0dbaaa697fb88e6bce818a) | `` josm: 19160 → 19207 ``                                                                   |
| [`12b2f7e6`](https://github.com/NixOS/nixpkgs/commit/12b2f7e6dae28cf48f4f29178282d1e98e6ab0f5) | `` python312Packages.nats-py: 2.8.0 -> 2.9.0 ``                                             |
| [`9cdf2347`](https://github.com/NixOS/nixpkgs/commit/9cdf2347ee0817ac01dfd44b5dfb55f3916a9667) | `` python312Packages.msgraph-core: 1.1.2 -> 1.1.3 ``                                        |
| [`bf198520`](https://github.com/NixOS/nixpkgs/commit/bf19852090b1f9d86a91ebe8f864a1a467f44ff5) | `` python312Packages.ms-active-directory: 1.13.0 -> 1.14.0 ``                               |
| [`45ba4560`](https://github.com/NixOS/nixpkgs/commit/45ba4560cfb8100f6549527a8a22185aa62b1aa8) | `` python312Packages.mkdocstrings: 0.25.2 -> 0.26.0 ``                                      |
| [`015c3f56`](https://github.com/NixOS/nixpkgs/commit/015c3f56b33111dd7dcc49fc7e4e62367064671b) | `` python312Packages.lxmf: 0.4.4 -> 0.4.5 ``                                                |
| [`387fbb7a`](https://github.com/NixOS/nixpkgs/commit/387fbb7a4bdff0cf99e0a2fd9d5e761d10655dd9) | `` libunwind: use default LLVM on riscv32-linux ``                                          |
| [`473bba08`](https://github.com/NixOS/nixpkgs/commit/473bba08fe1445b7f7faa4f39be63563fc13159a) | `` dbip-country-lite: 2024-08 -> 2024-09 ``                                                 |
| [`df119bf0`](https://github.com/NixOS/nixpkgs/commit/df119bf05be0152ab0a88cc17f42a8017e5c47de) | `` ada: 2.9.1 -> 2.9.2 ``                                                                   |
| [`c4bc8a9a`](https://github.com/NixOS/nixpkgs/commit/c4bc8a9af631e15f91ed1f7360df93a25d8fc121) | `` cargo-cyclonedx: 0.5.4 -> 0.5.5 ``                                                       |
| [`494549b8`](https://github.com/NixOS/nixpkgs/commit/494549b8aeeb60694e620ba934f8afc80a90bfc2) | `` pulumi: fix withPackages invocation (#331660) ``                                         |
| [`105933cf`](https://github.com/NixOS/nixpkgs/commit/105933cf4f0f0ebeb49a3e047de843de7570e9e3) | `` pkgs/build-support/rust: fix warning-related eval issue ``                               |
| [`561eb736`](https://github.com/NixOS/nixpkgs/commit/561eb736d06a38aae04a884c354bf272873bbc44) | `` botan: enable building statically ``                                                     |
| [`170e3336`](https://github.com/NixOS/nixpkgs/commit/170e33364456a79bbcb460ca7ee0d54c790be010) | `` botan: refactor configureFlags into botanConfigureFlags ``                               |
| [`d6248902`](https://github.com/NixOS/nixpkgs/commit/d62489026da072b7732c47daa711c2e1f27471b7) | `` botan: move to finalAttrs ``                                                             |
| [`3287db25`](https://github.com/NixOS/nixpkgs/commit/3287db25962155bc39dfcccb09dce65298b43bb1) | `` faiss: mark as broken on Darwin ``                                                       |
| [`bf595360`](https://github.com/NixOS/nixpkgs/commit/bf595360e47746d65ed240f40b8e23d9f2eb485c) | `` goose: 3.21.1 -> 3.22.0 ``                                                               |
| [`5d313d9a`](https://github.com/NixOS/nixpkgs/commit/5d313d9a5d7c7e6acfd9b6d67893bb0c9f48b8ab) | `` libspiro: 20221101 -> 20240902 ``                                                        |
| [`2f937eeb`](https://github.com/NixOS/nixpkgs/commit/2f937eebfe087314dc1081d7015fe5d7a8aca56e) | `` geesefs: 0.41.1 -> 0.41.2 ``                                                             |
| [`8b4061fd`](https://github.com/NixOS/nixpkgs/commit/8b4061fd60ccc3b3f44b73faa7c983eacf7a6f7b) | `` skia: make use of gnFlags ``                                                             |
| [`0436990d`](https://github.com/NixOS/nixpkgs/commit/0436990db5df100bdd2a845af04fe78532a7eb55) | `` power-profiles-daemon: add updateScript ``                                               |
| [`122e267f`](https://github.com/NixOS/nixpkgs/commit/122e267f17bed0da20ecbd9767cad29521987ae9) | `` power-profiles-daemon: use finalAttrs ``                                                 |
| [`916f08fa`](https://github.com/NixOS/nixpkgs/commit/916f08fab3ca9fb8dd99aa0a96a7c6edd2c011ef) | `` power-profiles-daemon: move to pkgs/by-name ``                                           |
| [`7d2350b7`](https://github.com/NixOS/nixpkgs/commit/7d2350b795e7a9e2fe45a8c290be3f0d329799be) | `` power-profiles-daemon: reformat with nixfmt ``                                           |
| [`0e905f6b`](https://github.com/NixOS/nixpkgs/commit/0e905f6bc12528d7e3ead3d4263530d7f13597cb) | `` aider-chat: 0.53.0 -> 0.54.0 ``                                                          |
| [`677e5fc9`](https://github.com/NixOS/nixpkgs/commit/677e5fc90bf5ee0984e3da2908bb80e0f3413f61) | `` vscode-extensions.ms-toolsai.datawrangler: 0.29.6 -> 1.7.2 ``                            |
| [`67e42aa0`](https://github.com/NixOS/nixpkgs/commit/67e42aa053985b4cd19953e81aae975751c7f01d) | `` mkosi: add msanft as maintainer ``                                                       |
| [`12f6399c`](https://github.com/NixOS/nixpkgs/commit/12f6399c1e6dc2159b5df63d80183908190e7629) | `` mkosi: format ``                                                                         |
| [`edd502ff`](https://github.com/NixOS/nixpkgs/commit/edd502ffd9b3593865cb613e65f41859c308ca06) | `` mkosi: 22 -> 24.3-unstable-2024-08-28 ``                                                 |
| [`69fdcd4a`](https://github.com/NixOS/nixpkgs/commit/69fdcd4af5efcb10c76be98bb7c9b21583cfd02a) | `` md-tui: add anas to maintainers ``                                                       |
| [`f2e14433`](https://github.com/NixOS/nixpkgs/commit/f2e14433d7f07ef9b6e027f5339490bcca6d565d) | `` mdt: remove (duplicate of md-tui) ``                                                     |
| [`34e17483`](https://github.com/NixOS/nixpkgs/commit/34e1748391b028788b14a30740309e1739293c77) | `` zfs: fix maybe getting wrong kernel in latestCompatibleLinuxPackages ``                  |
| [`e847adaa`](https://github.com/NixOS/nixpkgs/commit/e847adaa30613d5cd19b6c69f9739348f3f75a7e) | `` ghdl: enable builds on "x86_64-darwin" (#335975) ``                                      |
| [`0cdec497`](https://github.com/NixOS/nixpkgs/commit/0cdec497e1ed9a54e3042105e2d41cc8865f56d9) | `` nqp: no auto update ``                                                                   |
| [`2cb1c91f`](https://github.com/NixOS/nixpkgs/commit/2cb1c91f1049f698d49a04f330e50ec4ca22e14b) | `` moarvm: no auto update ``                                                                |
| [`d2447c30`](https://github.com/NixOS/nixpkgs/commit/d2447c306eddb78a3d1bda91355fe365a9a11a55) | `` rakudo: no auto update ``                                                                |
| [`837414b5`](https://github.com/NixOS/nixpkgs/commit/837414b563001b3f9c3a5adbfa9d77bb0be895df) | `` python312Packages.ocrmypdf: 16.4.3 -> 16.5.0 ``                                          |
| [`42d4d73b`](https://github.com/NixOS/nixpkgs/commit/42d4d73b7e6f9112fa709dc3d499e3eff6cf8cab) | `` python312Packages.orange-canvas-core: mark as broken on darwin ``                        |
| [`bc9dacde`](https://github.com/NixOS/nixpkgs/commit/bc9dacde24956f300faaa7a7cecc57ff4ff0cb77) | `` php82Extensions.soap: fix tests ``                                                       |
| [`f1bd8d4a`](https://github.com/NixOS/nixpkgs/commit/f1bd8d4ac65edc76c2ace1fe5e330fa0a71b305f) | `` sageWithDoc: 10.3 -> 10.4 ``                                                             |
| [`d45655d9`](https://github.com/NixOS/nixpkgs/commit/d45655d9e52e297c8fa4999dd10a058e021016c8) | `` python312Packages.testcontainers: 4.8.0 -> 4.8.1 ``                                      |
| [`d37b21ab`](https://github.com/NixOS/nixpkgs/commit/d37b21abc312a4375fd3941c5a0b176c37ece61f) | `` citrix_workspace: remove myself from maintainer's list ``                                |
| [`52f210ec`](https://github.com/NixOS/nixpkgs/commit/52f210ec74e23f79e587f61c13ad7f23df7d9f6f) | `` pyspread: 2.2.3 -> 2.3 ``                                                                |
| [`f5901c9e`](https://github.com/NixOS/nixpkgs/commit/f5901c9e8b9884a5503d56d7845fad4370f044c4) | `` uxn: 1.0-unstable-2024-08-25 -> 1.0-unstable-2024-08-29 ``                               |