### PR TITLE
chore(flake/emacs-overlay): `fd627331` -> `30226406`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725527726,
-        "narHash": "sha256-pXpTBPxSW8Dss8F9gtVNS5P9G9LEEEXq3e7h8OvhMa4=",
+        "lastModified": 1725555506,
+        "narHash": "sha256-9HIRqIPSHNMu9dfNrSkmatRtXKxmiddm/VXFvFFhSz4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fd627331988189a021b2d766f8699c91a6eb79fa",
+        "rev": "302264062ca73851e9306b70daeed6d9f1ae3ff9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`30226406`](https://github.com/nix-community/emacs-overlay/commit/302264062ca73851e9306b70daeed6d9f1ae3ff9) | `` Updated melpa ``        |
| [`0f3c92cd`](https://github.com/nix-community/emacs-overlay/commit/0f3c92cdcfc668cbb77fd6295067b2d7c0c1aacf) | `` Updated elpa ``         |
| [`317d03dc`](https://github.com/nix-community/emacs-overlay/commit/317d03dca082b3bf2d563e098454c077a19cc82a) | `` Updated nongnu ``       |
| [`9cec4279`](https://github.com/nix-community/emacs-overlay/commit/9cec427916653a42b96e1b81c642bc9cbee64ce6) | `` Updated flake inputs `` |