### PR TITLE
chore(flake/emacs-overlay): `66dea328` -> `5d87c639`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725613122,
-        "narHash": "sha256-paeQa0gqeA9tqAlIopD2yTG+bM/qj+9bCWM0qccB420=",
+        "lastModified": 1725614258,
+        "narHash": "sha256-QhrhRVdcpCxz22rGXjjvuKij3PjMFN/DMlSIKZk9eaM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "66dea328d8d93c607542662d0d110c6ccbd6dc3b",
+        "rev": "5d87c6391f09134b214a85eb3b28ecbebbad7269",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`5d87c639`](https://github.com/nix-community/emacs-overlay/commit/5d87c6391f09134b214a85eb3b28ecbebbad7269) | `` Updated emacs `` |