### PR TITLE
chore(flake/home-manager): `471e3eb0` -> `7d569851`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -394,11 +394,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725180166,
-        "narHash": "sha256-fzssXuGR/mCeGbzM1ExaTqDz7QDGta3WA4jJsZyRruo=",
+        "lastModified": 1725627831,
+        "narHash": "sha256-MIaU+T3DIowKvy1esp2owm3EgeyVgWFEoJ5jwAJIyvc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "471e3eb0a114265bcd62d11d58ba8d3421ee68eb",
+        "rev": "7d569851e95e8b360a3d7a2f52c5fc6a597a7657",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                       |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`7d569851`](https://github.com/nix-community/home-manager/commit/7d569851e95e8b360a3d7a2f52c5fc6a597a7657) | `` flake.lock: Update ``                      |
| [`5b95e061`](https://github.com/nix-community/home-manager/commit/5b95e0611b498fac7c8425d1b1bc4cacfd64e7f0) | `` Translate using Weblate (Hungarian) ``     |
| [`b00bdf59`](https://github.com/nix-community/home-manager/commit/b00bdf59c0aa5515a0a8e1773fa19128e7efa181) | `` xdg: add option 'xdg.stateFile' ``         |
| [`03b49187`](https://github.com/nix-community/home-manager/commit/03b49187a2e41f042896a26761ca86ce90cb7f2c) | `` sway: indent sway configuration options `` |
| [`5130249a`](https://github.com/nix-community/home-manager/commit/5130249ab20229480aa732942c9c555a38fb910a) | `` taskwarrior-sync: add package option ``    |