### PR TITLE
chore(flake/srvos): `39817ccd` -> `b4e3c643`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -882,11 +882,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725497274,
-        "narHash": "sha256-sGvYBY3q+5pAn4i1Vkb2/ah7NbruonQVIn7DDPRusqE=",
+        "lastModified": 1725628359,
+        "narHash": "sha256-jxdwnF30fdphuh7c9r7oGse2iBWqGQMvk2VLDXp/Yso=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "39817ccdaf8c4a46340a1d3326d59891d6d0b586",
+        "rev": "b4e3c6439571b730022f12840e340f0417e4ee6a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                    |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`139daf46`](https://github.com/nix-community/srvos/commit/139daf46c6e4666abd488328fc1e0f8bf52ebb0d) | `` srvos.flake: use upstream options... `` |