### PR TITLE
chore(flake/emacs-overlay): `f5ad3310` -> `b4d9deeb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725641963,
-        "narHash": "sha256-PoPIJ+4jGllhPW9dApqhuQqbwlOp60hx/UwP8IXwmDs=",
+        "lastModified": 1725642841,
+        "narHash": "sha256-FQAvy6QQqEj9GzzS/FhBaQ8St5/BPc1cja9C5iTGg6A=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f5ad33100d118b07d9db1c52eeda075714cd3546",
+        "rev": "b4d9deebfbb2010f14e854659f177a4b35e0a531",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`b4d9deeb`](https://github.com/nix-community/emacs-overlay/commit/b4d9deebfbb2010f14e854659f177a4b35e0a531) | `` Updated emacs `` |