### PR TITLE
chore(flake/nix-on-droid): `248cc080` -> `5d88ff25`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -596,11 +596,11 @@
         "nmd": "nmd"
       },
       "locked": {
-        "lastModified": 1721670745,
-        "narHash": "sha256-rjTQ14dqQ90EaHQy4g/mGylrJ1aZJYc3wCXc4A3GHJg=",
+        "lastModified": 1725658585,
+        "narHash": "sha256-P29z4Gt89n5ps1U7+qmIrj0BuRXGZQSIaOe2+tsPgfw=",
         "owner": "t184256",
         "repo": "nix-on-droid",
-        "rev": "248cc0806120fac9214f503dee0eaf0f47740dd0",
+        "rev": "5d88ff2519e4952f8d22472b52c531bb5f1635fc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`5d88ff25`](https://github.com/nix-community/nix-on-droid/commit/5d88ff2519e4952f8d22472b52c531bb5f1635fc) | `` tests/emulator/poke_around: test setting user.shell `` |
| [`21629b43`](https://github.com/nix-community/nix-on-droid/commit/21629b43fd29d8c743b14c15c3a919a03dc5fe71) | `` Check if the selected shell is a directory ``          |