### PR TITLE
chore(flake/emacs-overlay): `b4d9deeb` -> `74354374`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725642841,
-        "narHash": "sha256-FQAvy6QQqEj9GzzS/FhBaQ8St5/BPc1cja9C5iTGg6A=",
+        "lastModified": 1725671463,
+        "narHash": "sha256-+xZpkKrZtWbbrQgIsRMjOdRtxuDi9bgfkKvG0+M3DWM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b4d9deebfbb2010f14e854659f177a4b35e0a531",
+        "rev": "7435437499a03d11725b35a2910088a75ad7cc54",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`74354374`](https://github.com/nix-community/emacs-overlay/commit/7435437499a03d11725b35a2910088a75ad7cc54) | `` Updated elpa ``   |
| [`57727ef4`](https://github.com/nix-community/emacs-overlay/commit/57727ef448f4d57119a708b7d4efc43206620c27) | `` Updated nongnu `` |