### PR TITLE
chore(flake/emacs-overlay): `74354374` -> `0442d57f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725671463,
-        "narHash": "sha256-+xZpkKrZtWbbrQgIsRMjOdRtxuDi9bgfkKvG0+M3DWM=",
+        "lastModified": 1725674458,
+        "narHash": "sha256-AeemHTjtU56bXUCXJ4CrEJmIOfXfALkIR8Ix+AVlclg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7435437499a03d11725b35a2910088a75ad7cc54",
+        "rev": "0442d57ffa83985ec2ffaec95db9c0fe742f5182",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`0442d57f`](https://github.com/nix-community/emacs-overlay/commit/0442d57ffa83985ec2ffaec95db9c0fe742f5182) | `` Updated emacs `` |
| [`127ea0a2`](https://github.com/nix-community/emacs-overlay/commit/127ea0a204ce87110d625a28c59a46708b6684e0) | `` Updated melpa `` |