### PR TITLE
chore(flake/srvos): `b4e3c643` -> `c15adcd6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -882,11 +882,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725628359,
-        "narHash": "sha256-jxdwnF30fdphuh7c9r7oGse2iBWqGQMvk2VLDXp/Yso=",
+        "lastModified": 1725708209,
+        "narHash": "sha256-Dur8ZkiskNeQxjivdp7Jtmz9ZFTi6q0w34+P6WTRyv0=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "b4e3c6439571b730022f12840e340f0417e4ee6a",
+        "rev": "c15adcd6056c0e218669e62affb3e27654d18181",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                               |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`c15adcd6`](https://github.com/nix-community/srvos/commit/c15adcd6056c0e218669e62affb3e27654d18181) | `` server: disable command-not-found, freedesktop xdg files (#501) `` |