### PR TITLE
chore(flake/nixpkgs): `ad416d06` -> `574d1eac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -732,11 +732,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1725432240,
-        "narHash": "sha256-+yj+xgsfZaErbfYM3T+QvEE2hU7UuE+Jf0fJCJ8uPS0=",
+        "lastModified": 1725634671,
+        "narHash": "sha256-v3rIhsJBOMLR8e/RNWxr828tB+WywYIoajrZKFM+0Gg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ad416d066ca1222956472ab7d0555a6946746a80",
+        "rev": "574d1eac1c200690e27b8eb4e24887f8df7ac27c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                       |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`87c8bf47`](https://github.com/NixOS/nixpkgs/commit/87c8bf47ee4ae706a7144719c2a409fb006150eb) | `` kubernetes-helmPlugins.helm-diff: 3.9.9 -> 3.9.10 ``                                       |
| [`6350c71d`](https://github.com/NixOS/nixpkgs/commit/6350c71d9bea84b0562df8d24956bc1079d53169) | `` music-player: format ``                                                                    |
| [`1af6eaf9`](https://github.com/NixOS/nixpkgs/commit/1af6eaf93c0b0e78e16e13d8823e3c00f4af93e5) | `` music-player: 0.2.0-alpha.14 -> unstable-2024-08-24 ``                                     |
| [`d3609033`](https://github.com/NixOS/nixpkgs/commit/d3609033f3933e2faccd543cce4ab995fef286da) | `` simplex-chat-desktop: 6.0.3 -> 6.0.4 ``                                                    |
| [`fb6971a2`](https://github.com/NixOS/nixpkgs/commit/fb6971a27001aae45487b4960da184d063d27cfa) | `` snscrape: add patch to fix find_module deprecation ``                                      |
| [`d4838fd5`](https://github.com/NixOS/nixpkgs/commit/d4838fd5efae125120270a6ff126dfe6338d9ab9) | `` Revert "nixos/all-tests: skip hibernate test for now" ``                                   |
| [`44e71aef`](https://github.com/NixOS/nixpkgs/commit/44e71aeffd80af202714aa63b3ac2fbf51f232c7) | `` vimPlugins.ranger-nvim: fix wrong patching ``                                              |
| [`91b7e41f`](https://github.com/NixOS/nixpkgs/commit/91b7e41f61df616d076092ec8e82b6ef01dc7c6a) | `` nixos/tests/containers-imperative: add Perl library that is now missing due to stc-ng ``   |
| [`7d34adda`](https://github.com/NixOS/nixpkgs/commit/7d34adda138185351f1672ed708dc8929ba39ac5) | `` nixos/tests/installer: add some Perl libraries that are now missing due to stc-ng ``       |
| [`e4b8a0a2`](https://github.com/NixOS/nixpkgs/commit/e4b8a0a243d917d78935e6c479a5005e7c52063f) | `` switch-to-configuration-ng: move sources to a subdirectory to avoid fileset shenanigans `` |
| [`e7d5deb1`](https://github.com/NixOS/nixpkgs/commit/e7d5deb19f812fd0bac0c4147603ab2394c942c2) | `` nixos/tests/dex-oidc: fix build ``                                                         |
| [`a52dac7c`](https://github.com/NixOS/nixpkgs/commit/a52dac7c2ffe3b4e4d329991cf5c4e83ba026ea3) | `` desed: init at master ``                                                                   |
| [`6889824f`](https://github.com/NixOS/nixpkgs/commit/6889824f226c24504d78e6dd97b929a417bc3fd9) | `` open-webui: 0.3.18 -> 0.3.19 ``                                                            |
| [`3c58c8c8`](https://github.com/NixOS/nixpkgs/commit/3c58c8c8a86fcd112d7493be889af065d6e91e69) | `` androidStudioPackages.beta: 2024.1.2.11 -> 2024.2.1.6 ``                                   |
| [`cc6e93a6`](https://github.com/NixOS/nixpkgs/commit/cc6e93a6178bee76311e20ef3621f2254028469e) | `` nixos/release-small: also gate on simpleUefiSystemdBoot test on x86_64 ``                  |
| [`925d85f1`](https://github.com/NixOS/nixpkgs/commit/925d85f1f67a34b419b701800a3d4e5ce2ab05a5) | `` cargo-mobile2: 0.15.1 -> 0.17.0 ``                                                         |
| [`c3aeb4f6`](https://github.com/NixOS/nixpkgs/commit/c3aeb4f6489d64286de2fe7b989af7cd9d3d0d56) | `` v2ray-domain-list-community: 20240829063032 -> 20240905162746 ``                           |
| [`616b3459`](https://github.com/NixOS/nixpkgs/commit/616b34597ae2ebc2bace5b72d59a37015cdaa8f0) | `` nixos/release-small: actually remove minimal installer ISOs ``                             |
| [`862911fd`](https://github.com/NixOS/nixpkgs/commit/862911fd227110e16739fe5cebe710cb29d28942) | `` nixos/release-small: remove minimal installer ISOs ``                                      |
| [`fccd84a0`](https://github.com/NixOS/nixpkgs/commit/fccd84a04522aaa8fa65b0a09395a498bd1ed11d) | `` twitch-chat-downloader: update client_id ``                                                |
| [`a5cfd68c`](https://github.com/NixOS/nixpkgs/commit/a5cfd68cb1924b961be5cf2d86d9ac6cbe58fa5b) | `` nixos/doc/perlless: remove outdated warning ``                                             |
| [`866a8e22`](https://github.com/NixOS/nixpkgs/commit/866a8e220c20d46cfd25417dd2645de44464d5d2) | `` nixos/perlless: remove redundant `system.switch.enableNg` ``                               |
| [`73f34448`](https://github.com/NixOS/nixpkgs/commit/73f34448ca92e639620fa2ec9b9b0e092f4de443) | `` nixos/tests/switch-test: simplify `enableNg` setting ``                                    |
| [`56dea6da`](https://github.com/NixOS/nixpkgs/commit/56dea6da87acccf04f94374ef464a0359ee5883d) | `` nixos: switch to `switch-to-configuration-ng` by default ``                                |
| [`63c1a4d6`](https://github.com/NixOS/nixpkgs/commit/63c1a4d62c3073a127f176d68508d3572527bb30) | `` androidStudioPackages.canary: 2024.2.1.4 -> 2024.2.1.5 ``                                  |
| [`f0d9cf51`](https://github.com/NixOS/nixpkgs/commit/f0d9cf51c03511d9d3e9890afe6392461bb86d9f) | `` pmtiles: add geospatial team as maintainer ``                                              |
| [`4da4c9c5`](https://github.com/NixOS/nixpkgs/commit/4da4c9c55b0fce1b078f881b5345ac7f80ca620e) | `` qq: 3.2.12-2024.8.19 -> 3.2.12-2024.9.2 ``                                                 |
| [`3732e946`](https://github.com/NixOS/nixpkgs/commit/3732e94603adee495be0bc455fb3b5e38893398a) | `` maintainers: remove kierdavis ``                                                           |
| [`d4bfb852`](https://github.com/NixOS/nixpkgs/commit/d4bfb852a93b8cb85b778c959609430956d3c089) | `` nh: 3.5.21 -> 3.5.25 ``                                                                    |
| [`c264bc68`](https://github.com/NixOS/nixpkgs/commit/c264bc681c7833ac1223f879956179de8a0cfb67) | `` home-assistant-custom-lovelace-modules.universal-remote-card: 4.0.0 -> 4.0.1 ``            |
| [`ce6176e9`](https://github.com/NixOS/nixpkgs/commit/ce6176e9c422b86bc6aeac02c7c33295a9dfd014) | `` python312Packages.cohere: 5.9.0 -> 5.9.1 ``                                                |
| [`1d5377ff`](https://github.com/NixOS/nixpkgs/commit/1d5377fffd39a0851fd5ef9de212669a24099d97) | `` music-player: migrate to by-name ``                                                        |
| [`115a8ef0`](https://github.com/NixOS/nixpkgs/commit/115a8ef037f549f4663943306fdbbd3864170c9c) | `` files-cli: 2.13.128 -> 2.13.133 ``                                                         |
| [`9dca8ad0`](https://github.com/NixOS/nixpkgs/commit/9dca8ad0d237264948f5150bc34ede9dcaee7aa5) | `` llama-cpp: 3645 -> 3672 ``                                                                 |
| [`80f8973a`](https://github.com/NixOS/nixpkgs/commit/80f8973af826e178a255992fd334d4a04054ba10) | `` github-runner: remove newam from maintainers ``                                            |
| [`6b1425c6`](https://github.com/NixOS/nixpkgs/commit/6b1425c64b5ba96ab697451cc42b1cfb454f89e3) | `` gamescope: 3.15.2 -> 3.15.5 ``                                                             |
| [`a0a77227`](https://github.com/NixOS/nixpkgs/commit/a0a77227b5a10e0a5b5b4200cc3628c1d514767d) | `` stripe-cli: 1.21.3 -> 1.21.5 ``                                                            |
| [`2da9e105`](https://github.com/NixOS/nixpkgs/commit/2da9e1050719a857728cd947d8ec0949d5fa3522) | `` tippecanoe: 2.60.0 -> 2.62.0 ``                                                            |
| [`b0a5797c`](https://github.com/NixOS/nixpkgs/commit/b0a5797c24b35d67cfb447818435c854e935dfcb) | `` wizer: 7.0.4 -> 7.0.5 ``                                                                   |
| [`0e0665d1`](https://github.com/NixOS/nixpkgs/commit/0e0665d1e0a05ade073ff23e54b6e389c928af20) | `` go_1_23: 1.23.0 -> 1.23.1 ``                                                               |
| [`fd9fd8a7`](https://github.com/NixOS/nixpkgs/commit/fd9fd8a7e1c04d1a0d9edfa66dbebea931190272) | `` python312Packages.meshtastic: 2.4.0 -> 2.4.1 ``                                            |
| [`61cfeab4`](https://github.com/NixOS/nixpkgs/commit/61cfeab4dda7703ae972db2269acde35b238582a) | `` x265: fix cross-compiling to armv7 ``                                                      |
| [`30f35b15`](https://github.com/NixOS/nixpkgs/commit/30f35b1560f5079053a8714a61d3dfb566e2dc34) | `` python312Packages.craft-cli: 2.6.0 -> 2.7.0 ``                                             |
| [`b9732794`](https://github.com/NixOS/nixpkgs/commit/b9732794c275a1756e09b04d246bd709e101903d) | `` emilua: add lucasew as maintainer ``                                                       |
| [`c83a915d`](https://github.com/NixOS/nixpkgs/commit/c83a915d4724255a1e29918a856db55ec68bd7a4) | `` okteto: 2.30.2 -> 2.31.0 ``                                                                |
| [`6cb162ec`](https://github.com/NixOS/nixpkgs/commit/6cb162ece8aae073ccc68d0f03088f51af4445bb) | `` emiluaPlugins: recurseIntoAttrs ``                                                         |
| [`0c3ff997`](https://github.com/NixOS/nixpkgs/commit/0c3ff997a79dc371c05288ec7e1a126d76749101) | `` nixfmt as told by ci ``                                                                    |
| [`f3d6b2eb`](https://github.com/NixOS/nixpkgs/commit/f3d6b2ebef9041b89ce6a5ad929425bddb15c863) | `` emilua: add setup hook that populates EMILUA_PATH ``                                       |
| [`278b2dfe`](https://github.com/NixOS/nixpkgs/commit/278b2dfe7159e61e85c091f625605057a3538361) | `` emiluaPlugins.beast: init at 1.1.0 ``                                                      |
| [`a5122b10`](https://github.com/NixOS/nixpkgs/commit/a5122b101010d2608a333908a454c66656828d81) | `` emilua: expose sitePackages ``                                                             |
| [`93bd1ce1`](https://github.com/NixOS/nixpkgs/commit/93bd1ce196eef1767a73f152f105571142dad247) | `` emiluaPlugins: init scope ``                                                               |
| [`31b900b1`](https://github.com/NixOS/nixpkgs/commit/31b900b152740fdf6d71afd36b635c20be51e0f4) | `` emilua: 0.7.3 -> 0.10.1 ``                                                                 |
| [`5718c438`](https://github.com/NixOS/nixpkgs/commit/5718c4382a26e0b0cdb51a289dbc42c1be626ef9) | `` emilua: add update script ``                                                               |
| [`72cd45cc`](https://github.com/NixOS/nixpkgs/commit/72cd45cc354fad3e1ca254b73d4b27815fdd1371) | `` emilua: sparse checkout trial.protocol as only headers are used ``                         |
| [`64d36bf1`](https://github.com/NixOS/nixpkgs/commit/64d36bf11cd037ee89a8e1023a5337e837d20ab8) | `` agkozak-zsh-prompt: 3.11.3 -> 3.11.4 ``                                                    |
| [`81b2b2a8`](https://github.com/NixOS/nixpkgs/commit/81b2b2a85bb635cc63d3c81d02995d27353d5b1c) | `` qogir-kde: 0-unstable-2024-07-29 -> 0-unstable-2024-09-01 ``                               |
| [`c39e9041`](https://github.com/NixOS/nixpkgs/commit/c39e9041e8e371ee72a8e28217d7dd9072cd6ef6) | `` vpsfree-client: 0.18.0 -> 0.19.0 (#339850) ``                                              |
| [`98140869`](https://github.com/NixOS/nixpkgs/commit/98140869fb1d629acef8973be1d593775fb106ec) | `` gpu-burn: unstable-2023-11-10 -> unstable-2024-04-09; update CUDA packaging ``             |
| [`331aee3e`](https://github.com/NixOS/nixpkgs/commit/331aee3effeefe5d26593a9a1f13200d199a3ee3) | `` restic: 0.17.0 -> 0.17.1 ``                                                                |
| [`c427110f`](https://github.com/NixOS/nixpkgs/commit/c427110f0a4cbe953887a6ba534dd8b341365c86) | `` python312Packages.commoncode: 31.2.1 -> 32.0.0 ``                                          |
| [`24ef2a07`](https://github.com/NixOS/nixpkgs/commit/24ef2a079dd6399e6683ba2990756d78ef9ed26d) | `` unrar-free: fix meta.mainProgram ``                                                        |
| [`6e42fcd9`](https://github.com/NixOS/nixpkgs/commit/6e42fcd9833d83edda39d0ef48d471a9de557a59) | `` python312Packages.asyauth: refactor ``                                                     |
| [`65bcf0b0`](https://github.com/NixOS/nixpkgs/commit/65bcf0b0058299fa38c9048f93859cb62c84c13c) | `` python312Packages.asyauth: 0.0.20 -> 0.0.21 ``                                             |
| [`1464c2ed`](https://github.com/NixOS/nixpkgs/commit/1464c2ed16d6b27d59d6b2f18df53dd71a269b28) | `` python312Packages.types-requests: 2.32.0.20240712 -> 2.32.0.20240905 ``                    |
| [`2fd4c2f2`](https://github.com/NixOS/nixpkgs/commit/2fd4c2f2a15afcb33a09cd372282521b33764430) | `` python312Packages.tencentcloud-sdk-python: 3.0.1225 -> 3.0.1226 ``                         |
| [`63c3178c`](https://github.com/NixOS/nixpkgs/commit/63c3178ca9fcdfc5f04830f5288e7206dff360ba) | `` python312Packages.publicsuffixlist: 1.0.2.20240903 -> 1.0.2.20240905 ``                    |
| [`827bb051`](https://github.com/NixOS/nixpkgs/commit/827bb05129873b2d13f9a3982305f113492c1711) | `` python312Packages.asysocks: refactor ``                                                    |
| [`22b60727`](https://github.com/NixOS/nixpkgs/commit/22b60727f1110514ee6b86ea0cf80ad2a279d909) | `` quantlib: 1.34-1.35 ``                                                                     |
| [`be9d2cbe`](https://github.com/NixOS/nixpkgs/commit/be9d2cbe07ff2c7da09aa256778c1c9a8efe59cf) | `` python312Packages.asysocks: 0.2.12 -> 0.2.13 ``                                            |
| [`37712555`](https://github.com/NixOS/nixpkgs/commit/377125557339aebe4f964992fff3d36e8ca14cf8) | `` python312Packages.angrop: 9.2.9 -> 9.2.10 ``                                               |
| [`b89e4474`](https://github.com/NixOS/nixpkgs/commit/b89e44743edbbb4e1c45d226ac96d976aa53c8e8) | `` python312Packages.frigidaire: 0.18.21 -> 0.18.23 ``                                        |
| [`1a369b65`](https://github.com/NixOS/nixpkgs/commit/1a369b6532e5641f8a993ab61aff3b37bbb15342) | `` python312Packages.mkdocstrings-python: 1.10.9 -> 1.11.1 ``                                 |
| [`d5c686a5`](https://github.com/NixOS/nixpkgs/commit/d5c686a5bd342d98116cb2b85a33a77fb2c4af95) | `` metasploit: 6.4.24 -> 6.4.25 ``                                                            |
| [`5a575e88`](https://github.com/NixOS/nixpkgs/commit/5a575e88b6b395bac6fca5858da08c54b6b74d66) | `` Revert "nixos: support dm-verity" ``                                                       |
| [`a2282d35`](https://github.com/NixOS/nixpkgs/commit/a2282d35a722d1905b9f89d7c43dfe1cae09e6aa) | `` picard: 2.12.2 -> 2.12.3 ``                                                                |
| [`746d9c2d`](https://github.com/NixOS/nixpkgs/commit/746d9c2d30246a1b99321ac0bf6e8c638b99dc96) | `` python312Packages.mailchecker: 6.0.5 -> 6.0.8 ``                                           |
| [`513dcf40`](https://github.com/NixOS/nixpkgs/commit/513dcf4078c32f1b3430af6ed3f1ac8219fe8211) | `` python312Packages.msgraph-sdk: update chagnelog entry ``                                   |
| [`9a87b54f`](https://github.com/NixOS/nixpkgs/commit/9a87b54f702eb8c4b170c1d59a25d13159170928) | `` python312Packages.sshfs: disable test ``                                                   |
| [`18d5bb71`](https://github.com/NixOS/nixpkgs/commit/18d5bb71c700116bcce9ecf08c90d3ab48a053b9) | `` imagemagick: add willow to passthru.tests ``                                               |
| [`05193982`](https://github.com/NixOS/nixpkgs/commit/05193982cfadb19399acfb53d4865473f0d3b847) | `` python312.jaxlib-bin: throw on missing gpuSrc ``                                           |
| [`5b09fecd`](https://github.com/NixOS/nixpkgs/commit/5b09fecd006eff96b769560c3f821ae8bcb1a5db) | `` vsce: 3.0.0 -> 3.1.0 ``                                                                    |
| [`d598d436`](https://github.com/NixOS/nixpkgs/commit/d598d4360d73c87e1b9d9bd42e978a62f4d9ba84) | `` python312Packages.twilio: 9.2.4 -> 9.3.0 ``                                                |
| [`fe0a5507`](https://github.com/NixOS/nixpkgs/commit/fe0a5507a81d6e77fbb127046ee8882f62596730) | `` rcu: disable build on hydra ``                                                             |
| [`4c64146e`](https://github.com/NixOS/nixpkgs/commit/4c64146e452b9beb6fda91b8124d076b4cd1c9eb) | `` treewide: Retire `srgom` from meta.maintainers (#337930) ``                                |
| [`cb82c01e`](https://github.com/NixOS/nixpkgs/commit/cb82c01eefccf8a6008b15c376413b9fa1e5eabb) | `` leetgo: 1.4.8 -> 1.4.9 ``                                                                  |
| [`0f740aaf`](https://github.com/NixOS/nixpkgs/commit/0f740aafd8bfc182be8ea0e90b4e52e36cada388) | `` python3Packages.playwright: fix cli path ``                                                |
| [`22beb958`](https://github.com/NixOS/nixpkgs/commit/22beb958eff30548cfaa3240409f20b44871c720) | `` wine-discord-ipc-bridge: init at unstable-2023-08-09 ``                                    |
| [`9f5bf99b`](https://github.com/NixOS/nixpkgs/commit/9f5bf99b3be22c180a3da283d8a0eb5f2f55e877) | `` qgroundcontrol: 4.4.1 -> 4.4.2 ``                                                          |