### PR TITLE
chore(flake/nixos-hardware): `880be1ab` -> `04a1cda0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -611,11 +611,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1725477728,
-        "narHash": "sha256-ahej1VRqKmWbG7gewty+GlrSBEeGY/J2Zy8Nt8+3fdg=",
+        "lastModified": 1725716377,
+        "narHash": "sha256-7NzW9O/cAw7iWzRfh7Oo/SuSudL4a1YTKS6yoh3tMck=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "880be1ab837e1e9fe0449dae41ac4d034694d4ce",
+        "rev": "04a1cda0c1725094a4db703cccbb956b7558f5a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                   |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`04a1cda0`](https://github.com/NixOS/nixos-hardware/commit/04a1cda0c1725094a4db703cccbb956b7558f5a6) | `` starlabs: init, add starlite 5 tablet ``               |
| [`502e0aed`](https://github.com/NixOS/nixos-hardware/commit/502e0aed3102124d7034a2ed2ed245e35c9b9a4e) | `` apple-macbook-pro-8-1: add README.md ``                |
| [`1b3a5471`](https://github.com/NixOS/nixos-hardware/commit/1b3a5471263d91705dc6ab8bc2597013befe0561) | `` Treewide: Add new profile for Apple MacBook Pro 8,1 `` |