### PR TITLE
chore(flake/emacs-overlay): `c30396ae` -> `5f9116c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725700270,
-        "narHash": "sha256-v3k9orb6E7vf/zE3t2GX7zS1IM1ePc9fNUYpJwQFikc=",
+        "lastModified": 1725728267,
+        "narHash": "sha256-1frFaD+jEGIJhS85qaPGNjGRvTnCVNr0/Xa/rBe5wiM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c30396aea8788285d904c765682411267c28dba1",
+        "rev": "5f9116c581e526bc3dc8dcc2097f9d7ce7d9bacd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`5f9116c5`](https://github.com/nix-community/emacs-overlay/commit/5f9116c581e526bc3dc8dcc2097f9d7ce7d9bacd) | `` Updated melpa ``        |
| [`577b9b17`](https://github.com/nix-community/emacs-overlay/commit/577b9b17e392a1c5bd3f544d2a998539983cd3e7) | `` Updated elpa ``         |
| [`8654269d`](https://github.com/nix-community/emacs-overlay/commit/8654269dae3d0da13b1dfd116ec95d4f18bb1dec) | `` Updated nongnu ``       |
| [`365c341f`](https://github.com/nix-community/emacs-overlay/commit/365c341febef0299a4b6eec28531a7b3fd8ab31e) | `` Updated flake inputs `` |