### PR TITLE
chore(flake/emacs-overlay): `4a8f0b4e` -> `59da11db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725729118,
-        "narHash": "sha256-FqF49I5HEF7C/MyhxqwrfdWaygSe4HNmuwPKZ5oG6EQ=",
+        "lastModified": 1725758266,
+        "narHash": "sha256-c4XDF8fRzwdX6z3HqdoAxO8CDbXUTKy5wGU3+I8D9Nc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4a8f0b4eaeede7d01c23e1a835828ef8f2153121",
+        "rev": "59da11dbaf2fc340a0a55a5fd6eb958871d14741",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`59da11db`](https://github.com/nix-community/emacs-overlay/commit/59da11dbaf2fc340a0a55a5fd6eb958871d14741) | `` Updated elpa ``   |
| [`251542d3`](https://github.com/nix-community/emacs-overlay/commit/251542d3366092c757fd893bd5acbfcd0c365f15) | `` Updated nongnu `` |