### PR TITLE
chore(flake/nix-index-database): `32058e91` -> `0fbe4bbd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -571,11 +571,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725161148,
-        "narHash": "sha256-WfAHq3Ag3vLNFfWxKHjFBFdPI6JIideWFJod9mx1eoo=",
+        "lastModified": 1725764571,
+        "narHash": "sha256-KTjBFLD53YU72jN3g/8+GJPhFenmLjB5u3M2GCRurlY=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "32058e9138248874773630c846563b1a78ee7a5b",
+        "rev": "0fbe4bbdd0cd8b255f0182653814dec3accde827",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                  |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`0fbe4bbd`](https://github.com/nix-community/nix-index-database/commit/0fbe4bbdd0cd8b255f0182653814dec3accde827) | `` flake.lock: Update `` |