### PR TITLE
chore(flake/nix-index-database): `0fbe4bbd` -> `64227544`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -571,11 +571,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725764571,
-        "narHash": "sha256-KTjBFLD53YU72jN3g/8+GJPhFenmLjB5u3M2GCRurlY=",
+        "lastModified": 1725765290,
+        "narHash": "sha256-hwX53i24KyWzp2nWpQsn8lfGQNCP0JoW/bvQmcR1DPY=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "0fbe4bbdd0cd8b255f0182653814dec3accde827",
+        "rev": "642275444c5a9defce57219c944b3179bf2adaa9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`64227544`](https://github.com/nix-community/nix-index-database/commit/642275444c5a9defce57219c944b3179bf2adaa9) | `` update generated.nix to release 2024-09-08-030302 `` |