### PR TITLE
chore(flake/emacs-overlay): `65237d41` -> `6b349a3d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725760466,
-        "narHash": "sha256-3moGx0qUSL3vEyLDpOHj0UJ6rqmdMFnfbdxi7bkKRlA=",
+        "lastModified": 1725785837,
+        "narHash": "sha256-Q/i/y3KxvxpkatAj53iUtChRpwZrgzEKgTc6LZAgN+Y=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "65237d41a4d8c37c2f3f44755cf736e132e0e478",
+        "rev": "6b349a3db196fdbc93a541b7ffd5454db0a0770b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`6b349a3d`](https://github.com/nix-community/emacs-overlay/commit/6b349a3db196fdbc93a541b7ffd5454db0a0770b) | `` Updated melpa `` |