### PR TITLE
chore(flake/emacs-overlay): `6b349a3d` -> `6ab2b1aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725785837,
-        "narHash": "sha256-Q/i/y3KxvxpkatAj53iUtChRpwZrgzEKgTc6LZAgN+Y=",
+        "lastModified": 1725786744,
+        "narHash": "sha256-Rqq4YMe9PZL9lT5gz9nJTYq1U6KZvl485dmk7NwubDc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6b349a3db196fdbc93a541b7ffd5454db0a0770b",
+        "rev": "6ab2b1aa86b3cde735a33d3670b5d2e2f288c4da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`6ab2b1aa`](https://github.com/nix-community/emacs-overlay/commit/6ab2b1aa86b3cde735a33d3670b5d2e2f288c4da) | `` Updated emacs `` |