### PR TITLE
chore(flake/emacs-overlay): `6ab2b1aa` -> `1c9e73b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725786744,
-        "narHash": "sha256-Rqq4YMe9PZL9lT5gz9nJTYq1U6KZvl485dmk7NwubDc=",
+        "lastModified": 1725814684,
+        "narHash": "sha256-MF40TzFzXxo0vKb6dGsQH8Cuzqx4PPkbuUKMkTrAXlE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6ab2b1aa86b3cde735a33d3670b5d2e2f288c4da",
+        "rev": "1c9e73b2d45cb8f9f4b1e5458ba90419bfdc1bef",
         "type": "github"
       },
       "original": {
@@ -684,11 +684,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1725407940,
-        "narHash": "sha256-tiN5Rlg/jiY0tyky+soJZoRzLKbPyIdlQ77xVgREDNM=",
+        "lastModified": 1725693463,
+        "narHash": "sha256-ZPzhebbWBOr0zRWW10FfqfbJlan3G96/h3uqhiFqmwg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6f6c45b5134a8ee2e465164811e451dcb5ad86e3",
+        "rev": "68e7dce0a6532e876980764167ad158174402c6f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`1c9e73b2`](https://github.com/nix-community/emacs-overlay/commit/1c9e73b2d45cb8f9f4b1e5458ba90419bfdc1bef) | `` Updated melpa ``        |
| [`2b3f8efb`](https://github.com/nix-community/emacs-overlay/commit/2b3f8efbc54e1332d21b931778c98910bf4563fe) | `` Updated elpa ``         |
| [`4d36b9d0`](https://github.com/nix-community/emacs-overlay/commit/4d36b9d03b55cf1803f226784431f17be98849ea) | `` Updated nongnu ``       |
| [`45fa743e`](https://github.com/nix-community/emacs-overlay/commit/45fa743e4e05bd70336f1f5cc445e23fdfb91c9e) | `` Updated flake inputs `` |