### PR TITLE
chore(flake/srvos): `c15adcd6` -> `5809adeb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -882,11 +882,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725708209,
-        "narHash": "sha256-Dur8ZkiskNeQxjivdp7Jtmz9ZFTi6q0w34+P6WTRyv0=",
+        "lastModified": 1725843631,
+        "narHash": "sha256-fqaCQYq5kv1huk/RGjekzhF7zCFB4m1ex2uh+1A2GT0=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "c15adcd6056c0e218669e62affb3e27654d18181",
+        "rev": "5809adeb343790263da32637920723c3dd378979",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                      |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`5809adeb`](https://github.com/nix-community/srvos/commit/5809adeb343790263da32637920723c3dd378979) | `` example-hardware-hetzner-online-amd: x86_64-linux only `` |
| [`81aa40aa`](https://github.com/nix-community/srvos/commit/81aa40aa2a518268bf512e94abbbee99e8142890) | `` dev/private/flake.lock: Update ``                         |
| [`70c8e9eb`](https://github.com/nix-community/srvos/commit/70c8e9eb48382799332c8e95230cc7b745a93b23) | `` flake.lock: Update ``                                     |