### PR TITLE
chore(flake/emacs-overlay): `3a3004a9` -> `9b03793f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725901110,
-        "narHash": "sha256-RLG/b2FJrzP2gMFqj01NO/ZZZPwPfBjdqQfNTfALnvA=",
+        "lastModified": 1725902035,
+        "narHash": "sha256-ufaugGlQF+iiwtwSGrZgUpCVeNuY3RuVbjeVTcs4kXQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3a3004a9c55c1b0e6d2086293b1229542dd42a8e",
+        "rev": "9b03793f7d6a2475d0e052aa65a49bbd01ec43e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`9b03793f`](https://github.com/nix-community/emacs-overlay/commit/9b03793f7d6a2475d0e052aa65a49bbd01ec43e0) | `` Updated emacs `` |