### PR TITLE
chore(flake/srvos): `5809adeb` -> `e7022e39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -882,11 +882,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725843631,
-        "narHash": "sha256-fqaCQYq5kv1huk/RGjekzhF7zCFB4m1ex2uh+1A2GT0=",
+        "lastModified": 1725909399,
+        "narHash": "sha256-4+SWOnHF0ccWW83bRwNdCoRT1guUP0NFb9MjmUAtL/0=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "5809adeb343790263da32637920723c3dd378979",
+        "rev": "e7022e399408e7d1be6abdd16fa4c041755df14b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                             |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`e7022e39`](https://github.com/nix-community/srvos/commit/e7022e399408e7d1be6abdd16fa4c041755df14b) | `` build(deps): bump peter-evans/create-pull-request from 6 to 7 `` |