### PR TITLE
chore(flake/emacs-overlay): `9b03793f` -> `6e18850d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725902035,
-        "narHash": "sha256-ufaugGlQF+iiwtwSGrZgUpCVeNuY3RuVbjeVTcs4kXQ=",
+        "lastModified": 1725930799,
+        "narHash": "sha256-WPKqDXSrlaXI4SqZg0gBkDD5bklFEd8CeecjzsTfFQ0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9b03793f7d6a2475d0e052aa65a49bbd01ec43e0",
+        "rev": "6e18850db152c6787f51fc0491a8019f9ff2f506",
         "type": "github"
       },
       "original": {
@@ -684,11 +684,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1725693463,
-        "narHash": "sha256-ZPzhebbWBOr0zRWW10FfqfbJlan3G96/h3uqhiFqmwg=",
+        "lastModified": 1725826545,
+        "narHash": "sha256-L64N1rpLlXdc94H+F6scnrbuEu+utC03cDDVvvJGOME=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "68e7dce0a6532e876980764167ad158174402c6f",
+        "rev": "f4c846aee8e1e29062aa8514d5e0ab270f4ec2f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`6e18850d`](https://github.com/nix-community/emacs-overlay/commit/6e18850db152c6787f51fc0491a8019f9ff2f506) | `` Updated elpa ``         |
| [`04be97b0`](https://github.com/nix-community/emacs-overlay/commit/04be97b0996837f6f286f83e3c419ef3d24253a2) | `` Updated nongnu ``       |
| [`a5a2beb7`](https://github.com/nix-community/emacs-overlay/commit/a5a2beb73da66873e03b15b4559042061ca1a67d) | `` Updated flake inputs `` |