### PR TITLE
chore(flake/emacs-overlay): `9c64b595` -> `4c55fe25`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725959624,
-        "narHash": "sha256-Ap9Kt23p81zXbnp23R5wXg7i9AToz7sSSamHJbBmMRc=",
+        "lastModified": 1725987514,
+        "narHash": "sha256-zZxDF+Qi4zw2KqhXt9Qgfa72sr8MA8l2X3+R1bqobLI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9c64b595f3ba6670c7ac89d57e6822c0fce7d46e",
+        "rev": "4c55fe25e71211cf8fcd5b00ae54dec7471ed839",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`4c55fe25`](https://github.com/nix-community/emacs-overlay/commit/4c55fe25e71211cf8fcd5b00ae54dec7471ed839) | `` Updated melpa ``  |
| [`90b45415`](https://github.com/nix-community/emacs-overlay/commit/90b45415f65c9403559c1e119bd7bb0709a417b9) | `` Updated elpa ``   |
| [`4ea95bb2`](https://github.com/nix-community/emacs-overlay/commit/4ea95bb27d9ece5762980c9d64e0d6062dbefb5c) | `` Updated nongnu `` |