### PR TITLE
chore(flake/darwin): `5b2d8e9a` -> `4c96bd69`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -88,11 +88,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725975477,
-        "narHash": "sha256-sBnXxmYBb0S85Vkny97z2TFLd5SJW5o0k6KQNwpSLb0=",
+        "lastModified": 1726007501,
+        "narHash": "sha256-4MhYqhyNhsZw5gc4Hetu9LoA7Dy7qQMcuymxKwZDTNM=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "5b2d8e9a47c3e17514650d1ce7d5e907114db82b",
+        "rev": "4c96bd694bab9bd872bb2e1b738133342e77966d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                   |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
| [`15f64efc`](https://github.com/LnL7/nix-darwin/commit/15f64efcaf936f3b77955018d29b4802be6b144f) | `` zsh: prefer Nix completions these from Zsh package ``  |
| [`4d59f660`](https://github.com/LnL7/nix-darwin/commit/4d59f660bc41ba35b1f6df829e8e0b7706b35ee7) | `` zsh: move fpath init from /etc/zshrc to /etc/zshenv `` |