### PR TITLE
chore(flake/emacs-overlay): `e13b089f` -> `a4447c19`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726019327,
-        "narHash": "sha256-Xudx3pr5rMniYvK13kMdPXJbLcIcqZqQRgx+N7JaP4U=",
+        "lastModified": 1726045286,
+        "narHash": "sha256-s7qA4wJBdicKow6tD33UcO9w55KvchGD+58b5GkVktk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e13b089fe1f8bb7aa6c7ac0bb6bb0f6612cf9f12",
+        "rev": "a4447c19bd3bbdf9f89a40d9585156d0f39ee8b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`a4447c19`](https://github.com/nix-community/emacs-overlay/commit/a4447c19bd3bbdf9f89a40d9585156d0f39ee8b6) | `` Updated melpa `` |