### PR TITLE
chore(flake/emacs-overlay): `12e60221` -> `4567080e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726046165,
-        "narHash": "sha256-ZppVrHiVnntCJsyjdfxEJKj8WAMrhQONj2iekFnMhpU=",
+        "lastModified": 1726073956,
+        "narHash": "sha256-+Z70r5YFzxOmmLMEdfMmGsnwZNu3ngnk2Ui+w31AfrY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "12e602219fc2ca3ca0f9a0fc9a7701853b7e3998",
+        "rev": "4567080e119f5d5c1695451c5620761c1cb2d0fe",
         "type": "github"
       },
       "original": {
@@ -684,11 +684,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1725826545,
-        "narHash": "sha256-L64N1rpLlXdc94H+F6scnrbuEu+utC03cDDVvvJGOME=",
+        "lastModified": 1725930920,
+        "narHash": "sha256-RVhD9hnlTT2nJzPHlAqrWqCkA7T6CYrP41IoVRkciZM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f4c846aee8e1e29062aa8514d5e0ab270f4ec2f9",
+        "rev": "44a71ff39c182edaf25a7ace5c9454e7cba2c658",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`4567080e`](https://github.com/nix-community/emacs-overlay/commit/4567080e119f5d5c1695451c5620761c1cb2d0fe) | `` Updated melpa ``        |
| [`38425b82`](https://github.com/nix-community/emacs-overlay/commit/38425b825b768b5282c1e6e2c2c7e237d69274f9) | `` Updated elpa ``         |
| [`a2574010`](https://github.com/nix-community/emacs-overlay/commit/a25740102b9c0c479f5e75cb0d215cd47fedc817) | `` Updated nongnu ``       |
| [`b51b85f5`](https://github.com/nix-community/emacs-overlay/commit/b51b85f50a3a4a1881f70ecb686dab03d6c052fc) | `` Updated flake inputs `` |