### PR TITLE
chore(flake/emacs-overlay): `ba0b7636` -> `2978f49c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726076326,
-        "narHash": "sha256-yilQd6wvHDcNFlGJqmKCRCRO/qd8qQCIrDXiKtRewNU=",
+        "lastModified": 1726105728,
+        "narHash": "sha256-hul1YxmvvJk1F4K7mBDt3hBdhOtEAsYgCRffEm5mwTM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ba0b7636b47b5423ec09f89bcba06aadb68a607d",
+        "rev": "2978f49cc9c67844c7921a9330655078e127243f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`2978f49c`](https://github.com/nix-community/emacs-overlay/commit/2978f49cc9c67844c7921a9330655078e127243f) | `` Updated melpa ``  |
| [`397195d6`](https://github.com/nix-community/emacs-overlay/commit/397195d6c2b3480cf62e681163661aa536d2f64d) | `` Updated emacs ``  |
| [`6560f39f`](https://github.com/nix-community/emacs-overlay/commit/6560f39fd828385e72a931e0d567d97e203781d8) | `` Updated nongnu `` |
| [`d96fb46b`](https://github.com/nix-community/emacs-overlay/commit/d96fb46b9753b420df45c90382825f761667c0b8) | `` Updated elpa ``   |