### PR TITLE
chore(flake/srvos): `e7022e39` -> `b9fae7b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -882,11 +882,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725909399,
-        "narHash": "sha256-4+SWOnHF0ccWW83bRwNdCoRT1guUP0NFb9MjmUAtL/0=",
+        "lastModified": 1726102228,
+        "narHash": "sha256-9WRTBxEq2P1lqFGXcVAlXx5Eh95rmvHM6/x13fVcUAY=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "e7022e399408e7d1be6abdd16fa4c041755df14b",
+        "rev": "b9fae7b4351851d050333df6cef1b02b01b2ca2d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`b9fae7b4`](https://github.com/nix-community/srvos/commit/b9fae7b4351851d050333df6cef1b02b01b2ca2d) | `` dev/private/flake.lock: Update `` |
| [`2b3a3e7f`](https://github.com/nix-community/srvos/commit/2b3a3e7fcee53ed96c70abc35f56dbe00a56bfb7) | `` flake.lock: Update ``             |