### PR TITLE
chore(flake/emacs-overlay): `2978f49c` -> `ca87a80a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726105728,
-        "narHash": "sha256-hul1YxmvvJk1F4K7mBDt3hBdhOtEAsYgCRffEm5mwTM=",
+        "lastModified": 1726131561,
+        "narHash": "sha256-4qiURbLuU1D125u+Ma3JR5ULii2MHjNS7C6Fy1DXrt4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2978f49cc9c67844c7921a9330655078e127243f",
+        "rev": "ca87a80a345390779e7353364f0d3f248d394e64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`ca87a80a`](https://github.com/nix-community/emacs-overlay/commit/ca87a80a345390779e7353364f0d3f248d394e64) | `` Updated melpa `` |