### PR TITLE
chore(flake/darwin): `f4f18f3d` -> `a0e362a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -88,11 +88,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726032244,
-        "narHash": "sha256-3VvRGPkpBJobQrFD3slQzMAwZlo4/UwxT8933U5tRVM=",
+        "lastModified": 1726135264,
+        "narHash": "sha256-Fb+dznMTAmNj/BShTEc5ITO9nuqQKfCXsQbvDXHct/0=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "f4f18f3d7229845e1c9d517457b7a0b90a38b728",
+        "rev": "a0e362a5c9fa549d61a3ed356bd238352b10f620",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                    |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
| [`b64c1d03`](https://github.com/LnL7/nix-darwin/commit/b64c1d036ffb9a4c4eaaea056e132775de62fc1d) | `` tools: fix darwin-rebuild changelog ``                                  |
| [`6ad463a7`](https://github.com/LnL7/nix-darwin/commit/6ad463a76421022de6762e6f50128febb970dcfc) | `` zsh: don't be noisy when scripts are run with -u ``                     |
| [`7e6c548e`](https://github.com/LnL7/nix-darwin/commit/7e6c548eef2372cef1287ef45350e29ca5740159) | `` zsh: let children shells set their fpath ``                             |
| [`8714f9e2`](https://github.com/LnL7/nix-darwin/commit/8714f9e28529183d65d9f42ac92cdc5d70dbb6f7) | `` flake: put nixpkgs in NIX_PATH and system registry for flake configs `` |