### PR TITLE
chore(flake/darwin): `a0e362a5` -> `9d7aebb3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -88,11 +88,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726135264,
-        "narHash": "sha256-Fb+dznMTAmNj/BShTEc5ITO9nuqQKfCXsQbvDXHct/0=",
+        "lastModified": 1726146727,
+        "narHash": "sha256-/FDZ7N0ttDxmu2Orzz+RuVGkVceagh/eKMzdgo3g+hQ=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "a0e362a5c9fa549d61a3ed356bd238352b10f620",
+        "rev": "9d7aebb3039fbfb93afebef53210e2999f8b7e1a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                   |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------- |
| [`537097b3`](https://github.com/LnL7/nix-darwin/commit/537097b3312b6089535d715b5f4a6e22ce4c5b41) | `` ci/update-manual: use Nixpkgs 24.05 `` |