### PR TITLE
chore(flake/emacs-overlay): `5788c866` -> `2ae0aa81`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726132515,
-        "narHash": "sha256-AmNvjJ5IzJzCHc+I8JYMGFO3dXXTTrIoTfg6tpUImSE=",
+        "lastModified": 1726160308,
+        "narHash": "sha256-WaymR9AgWFvsAavXMHYcpjrh08smhFJkQ6XekKMVdkw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5788c86646c42ebce3d8731fccd4f973b530240b",
+        "rev": "2ae0aa813a98a274610c5d70c47ecb7797ee855b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`2ae0aa81`](https://github.com/nix-community/emacs-overlay/commit/2ae0aa813a98a274610c5d70c47ecb7797ee855b) | `` Updated melpa ``  |
| [`9c76d8bc`](https://github.com/nix-community/emacs-overlay/commit/9c76d8bc60fa77ccc8e60b50e371601c8394b7bd) | `` Updated elpa ``   |
| [`1c6fc32e`](https://github.com/nix-community/emacs-overlay/commit/1c6fc32e67d8c6d9db88ea5df6545bf036bab1cb) | `` Updated nongnu `` |