### PR TITLE
chore(flake/emacs-overlay): `73ac4908` -> `f91cf70a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726189974,
-        "narHash": "sha256-X1VDnCub5Gp5X6mtoQWUmXol9nMvAXEJwdUaviCK2hA=",
+        "lastModified": 1726193009,
+        "narHash": "sha256-Lvz+t8KlBAolMAr3gtaUb/kgYjFY6EMFiQksPwxcAlQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "73ac490814b8f603709bbf67c5cc293f33519d32",
+        "rev": "f91cf70ac3a0698db119789cf00e8882bd69aec0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`f91cf70a`](https://github.com/nix-community/emacs-overlay/commit/f91cf70ac3a0698db119789cf00e8882bd69aec0) | `` Updated emacs `` |
| [`c64b7d86`](https://github.com/nix-community/emacs-overlay/commit/c64b7d861f5ac2988eddae245e5f5c659866551c) | `` Updated melpa `` |