### PR TITLE
chore(flake/home-manager): `da8406a6` -> `c82fc8cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -394,11 +394,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726142087,
-        "narHash": "sha256-uT4TRd3PgreUD5sJaNioVfMemdyWFLoPHqN4AFszGmw=",
+        "lastModified": 1726209430,
+        "narHash": "sha256-ski2Is3VGChR1LR5U8qw8mqNfl5FDPCCAOsz2RrvJCE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "da8406a6ff556b86dc368e96ca8bd81b2704a91a",
+        "rev": "c82fc8cf3f75e667ad9dd3e5df721119b63723b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`c82fc8cf`](https://github.com/nix-community/home-manager/commit/c82fc8cf3f75e667ad9dd3e5df721119b63723b3) | `` home-manager: use `hostname` from GNU inetutils `` |
| [`2b1957a0`](https://github.com/nix-community/home-manager/commit/2b1957a0a3db7d63c1844abb84223655c30a7eb0) | `` home-manager: fix early exit due to FQDN error ``  |