### PR TITLE
chore(flake/home-manager): `433e6866` -> `4c8647b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -394,11 +394,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726214280,
-        "narHash": "sha256-LqeIwfMuvAXV3DPZpd6BgOk/YfcJJyu5eredE/tEsJE=",
+        "lastModified": 1726217971,
+        "narHash": "sha256-JePoAIU1SQ/IisfbFpN5YIJ9on5SowxR0OuJukdLIao=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "433e686675ba24176fe3383916a4bd1c9799c676",
+        "rev": "4c8647b1ed35d0e1822c7997172786dfa18cd7da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`4c8647b1`](https://github.com/nix-community/home-manager/commit/4c8647b1ed35d0e1822c7997172786dfa18cd7da) | `` trayscale: add module ``                          |
| [`daaf0c2f`](https://github.com/nix-community/home-manager/commit/daaf0c2f8da6c7b5dc04dd62a3d98422f259551b) | `` kanshi: add support for output aliases ``         |
| [`cb3ab592`](https://github.com/nix-community/home-manager/commit/cb3ab5928cbe8ac3cfee7010ccad4c31dbc1fb5f) | `` helix: add example for use with evil-helix ``     |
| [`ea244c5a`](https://github.com/nix-community/home-manager/commit/ea244c5ae2205f0fced24dde2e555440303d63bc) | `` helix: remove outdated language-server comment `` |