### PR TITLE
chore(flake/emacs-overlay): `a6cb07e5` -> `c4a2b881`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726217926,
-        "narHash": "sha256-ESprP9rK7ZLYWCdCwpN74meoG//g80avTzfnQGo5OFI=",
+        "lastModified": 1726246699,
+        "narHash": "sha256-3DiEBIJD8ArDoP9jEYmME5U/38S7Q0Bg+gPi876B7jo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a6cb07e5f45014d7fd42a9775a352901952c48ad",
+        "rev": "c4a2b8812949d2296ae977f7551fc441af21d9fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`c4a2b881`](https://github.com/nix-community/emacs-overlay/commit/c4a2b8812949d2296ae977f7551fc441af21d9fe) | `` Updated melpa ``        |
| [`2c810d17`](https://github.com/nix-community/emacs-overlay/commit/2c810d178a64313231350a9bdd432c48cc6b7ba4) | `` Updated elpa ``         |
| [`2ba1eaca`](https://github.com/nix-community/emacs-overlay/commit/2ba1eaca5b45d42bf17064b7c1547c95841e7350) | `` Updated nongnu ``       |
| [`905565ae`](https://github.com/nix-community/emacs-overlay/commit/905565ae69b6928505945420f896fc1fc87f1de7) | `` Updated flake inputs `` |