### PR TITLE
chore(flake/emacs-overlay): `1ac33e4b` -> `795d5dc7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726247782,
-        "narHash": "sha256-kFaP/tUotWdmhOUi5UProIQqVIqqMxNeJG+1RjgZUNM=",
+        "lastModified": 1726279331,
+        "narHash": "sha256-bYKXkFLXAJBqalviFu6kxG0TSV9qwC8bvMomBzZWE+0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1ac33e4bb48fac2c3857a4190770f15ec1410556",
+        "rev": "795d5dc72088bd6c758826c56284b0024b045194",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`795d5dc7`](https://github.com/nix-community/emacs-overlay/commit/795d5dc72088bd6c758826c56284b0024b045194) | `` Updated emacs ``  |
| [`51deae12`](https://github.com/nix-community/emacs-overlay/commit/51deae12009b565764890da456a216347b2e38b0) | `` Updated melpa ``  |
| [`33c94620`](https://github.com/nix-community/emacs-overlay/commit/33c94620b7c7ff5d27da7194d7acb17c18ead0be) | `` Updated nongnu `` |