### PR TITLE
chore(flake/home-manager): `503af483` -> `f084d653`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -394,11 +394,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726222338,
-        "narHash": "sha256-KuA8ciNR8qCF3dQaCaeh0JWyQUgEwkwDHr/f49Q5/e8=",
+        "lastModified": 1726298145,
+        "narHash": "sha256-QM9I29GBtGGdmd0A1miHQoabclVj17Tb6XweRXXSG/w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "503af483e1b328691ea3a434d331995595fb2e3d",
+        "rev": "f084d653199345ad294abca921a0e25872bd75c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`f084d653`](https://github.com/nix-community/home-manager/commit/f084d653199345ad294abca921a0e25872bd75c0) | `` swaync: fix example configuration ``         |
| [`43845d04`](https://github.com/nix-community/home-manager/commit/43845d04f83d44d744206ea9884b8206e7640633) | `` git: add diff-highlight diff pager option `` |