### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `2c0d80b9` -> `7b368854`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
     "doomemacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1726171944,
-        "narHash": "sha256-8gJo3Byl3oItXd0fsg5eFK4z36HQDztY38eQUan7NvA=",
+        "lastModified": 1726284534,
+        "narHash": "sha256-JKtxwILi+MDreYycDWtoKU7EknutyqWcniT3TKLCdN0=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "73460f42fd9a7bca76b7b5be47c4d3b6f8aa1040",
+        "rev": "b6815045828e80e1e301b11b900673593d61e419",
         "type": "github"
       },
       "original": {
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726193009,
-        "narHash": "sha256-Lvz+t8KlBAolMAr3gtaUb/kgYjFY6EMFiQksPwxcAlQ=",
+        "lastModified": 1726279331,
+        "narHash": "sha256-bYKXkFLXAJBqalviFu6kxG0TSV9qwC8bvMomBzZWE+0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f91cf70ac3a0698db119789cf00e8882bd69aec0",
+        "rev": "795d5dc72088bd6c758826c56284b0024b045194",
         "type": "github"
       },
       "original": {
@@ -500,11 +500,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1726216568,
-        "narHash": "sha256-o0crk7RXk2tMfSGcjluyEsgpcGmrM8vGq3zMDtsz7YM=",
+        "lastModified": 1726302925,
+        "narHash": "sha256-p28RFAbPS+6631FuGH+xrSEiN0VpVsuhR+oUgUr3TY4=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "2c0d80b9c9f5b8baad09740b380c01c0df8f9797",
+        "rev": "7b368854227c4aaa59cd4be0451a5a09521065b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`7b368854`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/7b368854227c4aaa59cd4be0451a5a09521065b4) | `` flake.lock: Update `` |