### PR TITLE
chore(flake/emacs-overlay): `c8644c5d` -> `909372e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726305199,
-        "narHash": "sha256-TuLybRSsT1+AKuX0wgqaZg8LVrjDphQhWRxL0Cyt3ug=",
+        "lastModified": 1726333071,
+        "narHash": "sha256-tVK1rQKPBaQZHSZ+rfG4VmglsfXhO0QVr+dqrnggOic=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c8644c5d59fee9a24a1be146bb6ce5b41d23592e",
+        "rev": "909372e5e86533aac5210403253a01f7ac54fc64",
         "type": "github"
       },
       "original": {
@@ -684,11 +684,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1725930920,
-        "narHash": "sha256-RVhD9hnlTT2nJzPHlAqrWqCkA7T6CYrP41IoVRkciZM=",
+        "lastModified": 1726062281,
+        "narHash": "sha256-PyFVySdGj3enKqm8RQuo4v1KLJLmNLOq2yYOHsI6e2Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "44a71ff39c182edaf25a7ace5c9454e7cba2c658",
+        "rev": "e65aa8301ba4f0ab8cb98f944c14aa9da07394f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`909372e5`](https://github.com/nix-community/emacs-overlay/commit/909372e5e86533aac5210403253a01f7ac54fc64) | `` Updated melpa ``        |
| [`306230b5`](https://github.com/nix-community/emacs-overlay/commit/306230b5859861149b9fa6dbd987d41418507a7f) | `` Updated elpa ``         |
| [`90141bc4`](https://github.com/nix-community/emacs-overlay/commit/90141bc45541e1fef29b7258406a1a8ef8b223fc) | `` Updated nongnu ``       |
| [`49bd32d8`](https://github.com/nix-community/emacs-overlay/commit/49bd32d814722af04c44539099af2aa100292bd5) | `` Updated flake inputs `` |