### PR TITLE
chore(flake/emacs-overlay): `fa3ce462` -> `a8a34f45`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726333983,
-        "narHash": "sha256-yo1QMe+VvdRvEP8oi2Rj8CKPYMUKUz9ZASnOytcI8PA=",
+        "lastModified": 1726366232,
+        "narHash": "sha256-e0/HXORX0IC4BCoKn8AZ/W1zlpUuAICSaqa5qsk9hfM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fa3ce46208f452a6ae30adf8f98e868871f4b463",
+        "rev": "a8a34f45a3db87fd82f307228c587c0eadbd4045",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`a8a34f45`](https://github.com/nix-community/emacs-overlay/commit/a8a34f45a3db87fd82f307228c587c0eadbd4045) | `` Updated emacs ``  |
| [`c8dc302d`](https://github.com/nix-community/emacs-overlay/commit/c8dc302d516e0c94af66b9a1504f9b4d2433fe6c) | `` Updated melpa ``  |
| [`eb47ae00`](https://github.com/nix-community/emacs-overlay/commit/eb47ae00752b779354a04603b7945493f1164e09) | `` Updated elpa ``   |
| [`fae7498c`](https://github.com/nix-community/emacs-overlay/commit/fae7498cd0cfa1854562c765c1af3a77922e2d33) | `` Updated nongnu `` |