### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `7b368854` -> `e652617a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
     "doomemacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1726284534,
-        "narHash": "sha256-JKtxwILi+MDreYycDWtoKU7EknutyqWcniT3TKLCdN0=",
+        "lastModified": 1726344480,
+        "narHash": "sha256-4sfme85Oz1z7Eo00balhS8MDOHSwFBSzLDRr3ravIrM=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "b6815045828e80e1e301b11b900673593d61e419",
+        "rev": "2e5307e4259281d1a233fb1bc99975d528650d53",
         "type": "github"
       },
       "original": {
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726279331,
-        "narHash": "sha256-bYKXkFLXAJBqalviFu6kxG0TSV9qwC8bvMomBzZWE+0=",
+        "lastModified": 1726388373,
+        "narHash": "sha256-XtcLEj1/PHTPOSprd1lMO1rLP/OS7IWvvXCe+5nqfFA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "795d5dc72088bd6c758826c56284b0024b045194",
+        "rev": "b7619a354ed5c8991f3ef2bb537fb3340d27b424",
         "type": "github"
       },
       "original": {
@@ -500,11 +500,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1726302925,
-        "narHash": "sha256-p28RFAbPS+6631FuGH+xrSEiN0VpVsuhR+oUgUr3TY4=",
+        "lastModified": 1726389333,
+        "narHash": "sha256-cgQqVRPZXQykFWsmwaS0xS7ogpIdqzcypiWM0dK/kKU=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "7b368854227c4aaa59cd4be0451a5a09521065b4",
+        "rev": "e652617a38478c550ff308be75203e100896849c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`e652617a`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/e652617a38478c550ff308be75203e100896849c) | `` flake.lock: Update `` |