### PR TITLE
chore(flake/nixpkgs): `4f807e89` -> `345c263f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -732,11 +732,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1726062873,
-        "narHash": "sha256-IiA3jfbR7K/B5+9byVi9BZGWTD4VSbWe8VLpp9B/iYk=",
+        "lastModified": 1726243404,
+        "narHash": "sha256-sjiGsMh+1cWXb53Tecsm4skyFNag33GPbVgCdfj3n9I=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4f807e8940284ad7925ebd0a0993d2a1791acb2f",
+        "rev": "345c263f2f53a3710abe117f28a5cb86d0ba4059",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                         |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`345c263f`](https://github.com/NixOS/nixpkgs/commit/345c263f2f53a3710abe117f28a5cb86d0ba4059) | `` zoekt: unstable-2022-11-09 -> 0-unstable-2024-09-05 ``                                       |
| [`135b49bb`](https://github.com/NixOS/nixpkgs/commit/135b49bb5cf2f3c459f9734190b6d49708e11da0) | `` fastfetch: update description to match the project ``                                        |
| [`9259479c`](https://github.com/NixOS/nixpkgs/commit/9259479c421ede2348d756f739b5690578ad4a38) | `` maintainers/scripts/sha-to-sri: minor efficiency improvement of the `Nix32` decoder ``       |
| [`c960ba48`](https://github.com/NixOS/nixpkgs/commit/c960ba48d1b84714b29e8fa1157e4ef77d7e848f) | `` nixos/nix-daemon: Enable cgroups delegation (#339310) ``                                     |
| [`5fc3cb3c`](https://github.com/NixOS/nixpkgs/commit/5fc3cb3ca05bf4aedf51987cdc1817cca1794520) | `` ocamlPackages.ocsigenserver: 5.1.2 → 6.0.0 ``                                                |
| [`011daf91`](https://github.com/NixOS/nixpkgs/commit/011daf916106828a70a5adf3a55b393fffec4a11) | `` maintainers/scripts: document sha-to-sri ``                                                  |
| [`dc2f65a6`](https://github.com/NixOS/nixpkgs/commit/dc2f65a6813ba60e982e82ed98ae3203755dd481) | `` python312Packages.elevenlabs: 1.7.0 -> 1.8.0 ``                                              |
| [`e079a279`](https://github.com/NixOS/nixpkgs/commit/e079a279f4be68e45d47c2d424df6f314616ab5c) | `` maintainers/scripts/sha-to-sri: drop unused imports ``                                       |
| [`bf6b5f7f`](https://github.com/NixOS/nixpkgs/commit/bf6b5f7f85e4d0b71392241f3824d880dd9414e5) | `` maintainers/scripts/sha-to-sri: accept directories as input ``                               |
| [`915799a2`](https://github.com/NixOS/nixpkgs/commit/915799a2b9e59a3b32d596a216893554f9c87f07) | `` maintainers/scripts/sha-to-sri: fix file-descriptor leak ``                                  |
| [`c425822e`](https://github.com/NixOS/nixpkgs/commit/c425822e17ca7f599644fde133a629a24677f070) | `` maintainers/scripts/sha-to-sri: format ``                                                    |
| [`a8ab2291`](https://github.com/NixOS/nixpkgs/commit/a8ab229198358f9f2d8e1d133c3b565f5fd9e827) | `` qemu_xen: drop qemu-system-x86_64 ``                                                         |
| [`bc0673da`](https://github.com/NixOS/nixpkgs/commit/bc0673da3c2f2df9665da82c6fd6af54a4063408) | `` localproxy: 3.1.1 -> 3.1.2 ``                                                                |
| [`553095af`](https://github.com/NixOS/nixpkgs/commit/553095afaa914f211fb29356d47c46135a56f8f6) | `` Update deprecated UTF8 option for dictfmt ``                                                 |
| [`515f8b5e`](https://github.com/NixOS/nixpkgs/commit/515f8b5e228948e7bf41a03160d86414014d705f) | `` dictdDBs.wiktionary: update to 20240901 ``                                                   |
| [`537289ee`](https://github.com/NixOS/nixpkgs/commit/537289eed405d1f7653cf02bff9186dfa3f9b344) | `` intel-gpu-tools: 1.27.1 -> 1.29 ``                                                           |
| [`fb6efe3d`](https://github.com/NixOS/nixpkgs/commit/fb6efe3dfb7ac8910aa8fb84c79d2d687fdc607b) | `` marwaita-teal: 20.3.1 -> 21 ``                                                               |
| [`99056612`](https://github.com/NixOS/nixpkgs/commit/9905661267a6f65e148b72b9e6977df1535ef655) | `` python312Packages.weaviate-client: 4.7.1 -> 4.8.0 ``                                         |
| [`4a94f45b`](https://github.com/NixOS/nixpkgs/commit/4a94f45bb4b6acee42893a06128fca97a5f29fec) | `` nixos/installer/cd-dvd: use `EFI/BOOT` and `EFI/BOOT/BOOT$ARCH.EFI` rather than lowercase `` |
| [`cf78535f`](https://github.com/NixOS/nixpkgs/commit/cf78535f9f85194807fff677b699e66ee7493104) | `` python312Packages.ical: 8.1.1 -> 8.2.0 ``                                                    |
| [`b09b1438`](https://github.com/NixOS/nixpkgs/commit/b09b1438b457427496fd10b934f30dc7db9aae23) | `` telegraf: 1.31.3 -> 1.32.0 ``                                                                |
| [`45bbdb9f`](https://github.com/NixOS/nixpkgs/commit/45bbdb9f51461c5998fa4a418a211f0816075c5a) | `` telegraf: move to pkgs/by-name ``                                                            |
| [`35671aab`](https://github.com/NixOS/nixpkgs/commit/35671aabff6fcd9f6ea13741f51691b46712ab51) | `` dotnet/build-dotnet-module: fix eval of `fetch-deps` ``                                      |
| [`9a64284e`](https://github.com/NixOS/nixpkgs/commit/9a64284ea4a3aafd9231f435493f60a2aeb14ab4) | `` nix-weather: 0.0.3 -> 0.0.4 ``                                                               |
| [`ebf27981`](https://github.com/NixOS/nixpkgs/commit/ebf2798150b150b07787416d380b881ee501c107) | `` glamoroustoolkit: 1.0.11 -> 1.1.0 ``                                                         |
| [`f5417608`](https://github.com/NixOS/nixpkgs/commit/f5417608ad418e5fbbd8ee84c91e40d1abbe9ebf) | `` python312Packages.pynetbox: refactor ``                                                      |
| [`591e7cca`](https://github.com/NixOS/nixpkgs/commit/591e7cca4fed5e44414e09d394027cd0a9256fa6) | `` python312Packages.tcolorpy: refactor ``                                                      |
| [`f63ce293`](https://github.com/NixOS/nixpkgs/commit/f63ce293385cc9641977c2805814843724384128) | `` python311Packages.tcolorpy: 0.1.4 -> 0.1.6 ``                                                |
| [`2ec6fe1a`](https://github.com/NixOS/nixpkgs/commit/2ec6fe1a72eec77e108893febd1ac13685b750f9) | `` carapace: 1.0.5 -> 1.0.6 ``                                                                  |
| [`382e693a`](https://github.com/NixOS/nixpkgs/commit/382e693a3e3543ea6dea0da93c06c0895c024c0f) | `` python312Packages.pyreadstat: switch to pypa build ``                                        |
| [`6e8656a0`](https://github.com/NixOS/nixpkgs/commit/6e8656a0f8202ed6c72a84cbf8c6c3c19b0732ed) | `` python312Packages.pyreadstat: 1.2.6 -> 1.2.7 ``                                              |
| [`f8726f98`](https://github.com/NixOS/nixpkgs/commit/f8726f98ae2d06b8b95705f447e30ce6d4819acd) | `` netdata: 1.47.0 -> 1.47.1 ``                                                                 |
| [`da31ab50`](https://github.com/NixOS/nixpkgs/commit/da31ab50f3ad9ed653423890137a7b453aa2dd01) | `` netdata: fix darwin ``                                                                       |
| [`3b619755`](https://github.com/NixOS/nixpkgs/commit/3b6197558a267cd6860c68db2e1742286cd2edb5) | `` netdata: cleanup rec ``                                                                      |
| [`3dbab8ac`](https://github.com/NixOS/nixpkgs/commit/3dbab8acbb9c5a94a722adefe0d6b910f2867949) | `` netdata: format ``                                                                           |
| [`c585a85e`](https://github.com/NixOS/nixpkgs/commit/c585a85e49e44f5d5d1dcb48752cc41916a36804) | `` nsc: 2.8.7 -> 2.8.8 ``                                                                       |
| [`3a93975e`](https://github.com/NixOS/nixpkgs/commit/3a93975e33e275cbaabaab18421935b584431c8c) | `` trivy: 0.55.0 -> 0.55.1 ``                                                                   |
| [`603b5150`](https://github.com/NixOS/nixpkgs/commit/603b51508bdf5865909f5023c50b363948f81291) | `` python312Packages.pypck: 0.7.22 -> 0.7.23 ``                                                 |
| [`cd1ac62f`](https://github.com/NixOS/nixpkgs/commit/cd1ac62f13253ad8da5c5bf94fed802e50c60331) | `` python312Packages.tencentcloud-sdk-python: 3.0.1230 -> 3.0.1231 ``                           |
| [`fc8db928`](https://github.com/NixOS/nixpkgs/commit/fc8db9281287f3f6fe66c201984a97d363a2ce99) | `` python312Packages.lingva: 5.0.3 -> 5.0.4 ``                                                  |
| [`a94bdd91`](https://github.com/NixOS/nixpkgs/commit/a94bdd9131e6fdad1be1015db5e9572ab1a8a5d5) | `` python312Packages.karton-core: 5.4.0 -> 5.5.0 ``                                             |
| [`1e32d722`](https://github.com/NixOS/nixpkgs/commit/1e32d7227a2b895c73a662103002270167a1e634) | `` python312Packages.govee-local-api: 1.5.1 -> 1.5.2 ``                                         |
| [`0dffe410`](https://github.com/NixOS/nixpkgs/commit/0dffe4104e87b7b33efcc8b1e783a22efeecb0e0) | `` python312Packages.types-aiobotocore-*: 2.13.1 -> 2.15.0 ``                                   |
| [`c6560d9b`](https://github.com/NixOS/nixpkgs/commit/c6560d9b60f6409f2d8354227f4ce76636ca2c6e) | `` python312Packages.types-aiobotocore: 2.13.2 -> 2.15.0 ``                                     |
| [`8cef266d`](https://github.com/NixOS/nixpkgs/commit/8cef266dc723368ad77c527fb7b7b854dc09322a) | `` nextcloudPackages: update all ``                                                             |
| [`09fe7f86`](https://github.com/NixOS/nixpkgs/commit/09fe7f8690ef16c5f4cd6a2849a161d7d00e40bc) | `` nextcloud29: 29.0.6 -> 29.0.7 ``                                                             |
| [`1ef3f0b3`](https://github.com/NixOS/nixpkgs/commit/1ef3f0b371b7e47afc07001ecef328cc2faebc54) | `` nextcloud28: 28.0.9 -> 28.0.10 ``                                                            |
| [`484c1da8`](https://github.com/NixOS/nixpkgs/commit/484c1da8e96239809eb68ee08a6c919721f1e4f6) | `` lightgbm: fix build on darwin ``                                                             |
| [`06fc8aa4`](https://github.com/NixOS/nixpkgs/commit/06fc8aa4dc99aa1387566ffee212f2b27bb5c6bf) | `` python312Packages.itk: init at 5.4.0 ``                                                      |
| [`aac18ed2`](https://github.com/NixOS/nixpkgs/commit/aac18ed2c8522dcaf2f51b8c3fe863da578a2a97) | `` lightgbm: 4.4.0 -> 4.5.0 ``                                                                  |
| [`3dfb694b`](https://github.com/NixOS/nixpkgs/commit/3dfb694bc8f0cf92943576a03ab6b8e4c1325631) | `` python312Packages.whenever: 0.6.8 -> 0.6.9 ``                                                |
| [`51b8f2f4`](https://github.com/NixOS/nixpkgs/commit/51b8f2f4680bcd5ca37b7739f687c745c3dace6f) | `` virglrenderer: 1.0.1 -> 1.1.0 ``                                                             |
| [`0043156d`](https://github.com/NixOS/nixpkgs/commit/0043156d184c61a084a79972e9fb99f2622054dc) | `` lnd: 0.18.2 -> 0.18.3 ``                                                                     |
| [`7d3e4af3`](https://github.com/NixOS/nixpkgs/commit/7d3e4af3bb0d9dad535ac20208bfa3fa733c4035) | `` python312Packages.aiotankerkoenig: 0.4.1 -> 0.4.2 ``                                         |
| [`6c31bc6a`](https://github.com/NixOS/nixpkgs/commit/6c31bc6af8ba2d0bb2a3eb68ddaa4c15cea834f2) | `` gzdoom: add myself as maintainer ``                                                          |
| [`6dc99a6a`](https://github.com/NixOS/nixpkgs/commit/6dc99a6a1160de88b8c44ee23b75d0cf166cffdf) | `` gzdoom: nixfmt ``                                                                            |
| [`b3646e9c`](https://github.com/NixOS/nixpkgs/commit/b3646e9cd998d02bf3bfedfdb787f56da0d31bb0) | `` gzdoom: fixes ``                                                                             |
| [`e726b993`](https://github.com/NixOS/nixpkgs/commit/e726b99310e6f516c6b158c595d92753f1a598a3) | `` gzdoom: fix vulkan ``                                                                        |
| [`31246e06`](https://github.com/NixOS/nixpkgs/commit/31246e060b20a05c725bcb369b0af52cc05d61dc) | `` gzdoom: move to pkgs/by-name ``                                                              |
| [`0aeed624`](https://github.com/NixOS/nixpkgs/commit/0aeed624b07a0f26c3af312db089231d43d5fe33) | `` sink-rotate: 1.0.4 -> 2.2.0 ``                                                               |
| [`142d8333`](https://github.com/NixOS/nixpkgs/commit/142d8333bb3e6cc0b3927b50b2b9b1b708d831bc) | `` surrealdb: 1.5.4 -> 1.5.5 ``                                                                 |
| [`bbf4cf5e`](https://github.com/NixOS/nixpkgs/commit/bbf4cf5e77307117d206b58c19281e6195982697) | `` coqPackages.hierarchy-builder: do not pass VFILES if version >= 1.1.0 (#341171) ``           |
| [`e7bcab80`](https://github.com/NixOS/nixpkgs/commit/e7bcab801cdfe48ba982b0d654cc7230a9de6b13) | `` nixos/samba: ensure global section is always first ``                                        |
| [`1218148c`](https://github.com/NixOS/nixpkgs/commit/1218148c55d713b91105675e6a2192e63d90a389) | `` nixpkgs-manual.lib-docs: fix sandboxed build on darwin ``                                    |
| [`68bf1f12`](https://github.com/NixOS/nixpkgs/commit/68bf1f1208b0e793f1770111a48dad35b7735634) | `` python311Packages.swift: 2.33.0 -> 2.34.0 ``                                                 |
| [`64f6ecc7`](https://github.com/NixOS/nixpkgs/commit/64f6ecc725d0369579294906e333af82c2d13f59) | `` python311Packages.python-openstackclient: 7.0.0 -> 7.1.0 ``                                  |
| [`008e8512`](https://github.com/NixOS/nixpkgs/commit/008e8512579bd1e5b2b86b8d9d61ef2d0866f8c3) | `` python311Packages.osprofiler: add meta.mainProgram ``                                        |
| [`aba2d9e6`](https://github.com/NixOS/nixpkgs/commit/aba2d9e6ee6e9407f70243004ae931f95e01ddd6) | `` python311Packages.osprofiler: 4.1.0 -> 4.2.0 ``                                              |
| [`3d218ab3`](https://github.com/NixOS/nixpkgs/commit/3d218ab359393e3b03b3732191ef3658d3451842) | `` python311Packages.tempest: reorder inputs ``                                                 |
| [`846b1292`](https://github.com/NixOS/nixpkgs/commit/846b1292a4854e718bbffb6f1c2174837e5ae7f5) | `` python311Packages.tempest: add meta.mainProgram ``                                           |
| [`085f08d4`](https://github.com/NixOS/nixpkgs/commit/085f08d4f2692f40aa69a7cb56166ee09d66dc68) | `` python311Packages.tempest: 39.0.0 -> 4.0.0 ``                                                |
| [`ee9a4473`](https://github.com/NixOS/nixpkgs/commit/ee9a447348c43ae2eb54eda3decdc6fe4ff9ebdf) | `` python311Packages.python-octaviaclient: 3.7.0 -> 3.8.0 ``                                    |
| [`7d043503`](https://github.com/NixOS/nixpkgs/commit/7d043503327e7f119330af5a48e4d827cd954b9e) | `` peertube-viewer: init at 1.8.6 ``                                                            |
| [`db5f130b`](https://github.com/NixOS/nixpkgs/commit/db5f130b432c501ea758f79ff1dd23cfc4a24cb0) | `` gforth: adjust comment ``                                                                    |
| [`2181ab3e`](https://github.com/NixOS/nixpkgs/commit/2181ab3e2290410c80e83ccda4496439b11d871c) | `` treewide: unpin SWIG 4 ``                                                                    |
| [`e3360d74`](https://github.com/NixOS/nixpkgs/commit/e3360d745c36caed0b868e0447e57fb30b1fb9d9) | `` swig: format with `nixfmt-rfc-style` ``                                                      |
| [`44e6a145`](https://github.com/NixOS/nixpkgs/commit/44e6a1456fc05325fa00e641fb8d0f900874098a) | `` swig: move to `pkgs/by-name` ``                                                              |