### PR TITLE
chore(flake/emacs-overlay): `2b8a4aea` -> `8da0dcb0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726390749,
-        "narHash": "sha256-aZf0/NpKwrO1J3HHMYL7UEcXyrO/mTdVNGpBCxMTyHM=",
+        "lastModified": 1726420326,
+        "narHash": "sha256-LzYMStC49yhT4rKyG3oA+/rqip0JsEPCPD0AZlWZqcA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2b8a4aeadf19c702355559b02a1593c9d09b1546",
+        "rev": "8da0dcb09e0f890d2a9fbc8c6bb947c6867a5b5f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`8da0dcb0`](https://github.com/nix-community/emacs-overlay/commit/8da0dcb09e0f890d2a9fbc8c6bb947c6867a5b5f) | `` Updated emacs ``        |
| [`8cb3e3ef`](https://github.com/nix-community/emacs-overlay/commit/8cb3e3ef669e599ee2b5e127d4f5bd52d833f695) | `` Updated melpa ``        |
| [`d23ef878`](https://github.com/nix-community/emacs-overlay/commit/d23ef8783b70a40938b0c08942206ca817bc54e5) | `` Updated elpa ``         |
| [`2fd3ce66`](https://github.com/nix-community/emacs-overlay/commit/2fd3ce66218235e65c492287e8750770639cdd64) | `` Updated nongnu ``       |
| [`ba3ebd47`](https://github.com/nix-community/emacs-overlay/commit/ba3ebd4737b74a32922091adfd51f6bb8c103099) | `` Updated flake inputs `` |