### PR TITLE
chore(flake/emacs-overlay): `8da0dcb0` -> `b7aec685`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726420326,
-        "narHash": "sha256-LzYMStC49yhT4rKyG3oA+/rqip0JsEPCPD0AZlWZqcA=",
+        "lastModified": 1726449437,
+        "narHash": "sha256-JoBKi+PKtCA6hba6VRCRjVSSh/xGqEETpRvvnL1ZRkE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8da0dcb09e0f890d2a9fbc8c6bb947c6867a5b5f",
+        "rev": "b7aec685e9d3c6866a451dee1fd72c6b17229e1a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`b7aec685`](https://github.com/nix-community/emacs-overlay/commit/b7aec685e9d3c6866a451dee1fd72c6b17229e1a) | `` Updated elpa ``   |
| [`f861548d`](https://github.com/nix-community/emacs-overlay/commit/f861548dfdd6825fa3309eb705dcbc97a33e0b11) | `` Updated nongnu `` |