### PR TITLE
chore(flake/srvos): `d0c3f926` -> `d8f07782`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -882,11 +882,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726401083,
-        "narHash": "sha256-u8eAaMH61L62AHQF3iPAR9F8ogoMN3SBMc5+SjxeZcs=",
+        "lastModified": 1726456749,
+        "narHash": "sha256-yaNueGEfYX49g4xj8E0Bvy97b+xhQG2jUD9UXQY4qy0=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "d0c3f9260629f865e1258988cd0d7c01053779f0",
+        "rev": "d8f07782d25b489c89d99cae4b6aaa98e8f26897",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                 |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`d8f07782`](https://github.com/nix-community/srvos/commit/d8f07782d25b489c89d99cae4b6aaa98e8f26897) | `` ci(Mergify): configuration update `` |
| [`ace29ab8`](https://github.com/nix-community/srvos/commit/ace29ab84e1c9eb542b457b347ace909151084a2) | `` dev/private/flake.lock: Update ``    |
| [`fcc4b140`](https://github.com/nix-community/srvos/commit/fcc4b1401f8201bb88870fd47efd8c8a51cf26f0) | `` flake.lock: Update ``                |