### PR TITLE
chore(flake/emacs-overlay): `b7aec685` -> `5968833b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726449437,
-        "narHash": "sha256-JoBKi+PKtCA6hba6VRCRjVSSh/xGqEETpRvvnL1ZRkE=",
+        "lastModified": 1726451612,
+        "narHash": "sha256-dvE4zEpoj2CQZ8EtGi/5dGGLoIb5aUZYPVcDz4pM8tc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b7aec685e9d3c6866a451dee1fd72c6b17229e1a",
+        "rev": "5968833ba4a68d6eb7be4b900f79438d7d271bcb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`5968833b`](https://github.com/nix-community/emacs-overlay/commit/5968833ba4a68d6eb7be4b900f79438d7d271bcb) | `` Updated melpa `` |