### PR TITLE
chore(flake/emacs-overlay): `5968833b` -> `3723f9e3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726451612,
-        "narHash": "sha256-dvE4zEpoj2CQZ8EtGi/5dGGLoIb5aUZYPVcDz4pM8tc=",
+        "lastModified": 1726454673,
+        "narHash": "sha256-cvgXPCeiDIDrEE8VijX5uZ2GAOHldOJXuKOb95goxUo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5968833ba4a68d6eb7be4b900f79438d7d271bcb",
+        "rev": "3723f9e35635612c470db1b0aea08d9ff22b39ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                          |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
| [`1cd7f441`](https://github.com/nix-community/emacs-overlay/commit/1cd7f441f2124bf8c16e08a44544a8212f401cdd) | `` Bump cachix/install-nix-action from V27 to 28 ``              |
| [`aa788863`](https://github.com/nix-community/emacs-overlay/commit/aa788863a1cb7fa28d4869097d83cf37603e3ae2) | `` recipes-archive-melpa: fix incorrect source hash of geiser `` |