### PR TITLE
chore(flake/srvos): `d8f07782` -> `98fd0e88`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -882,11 +882,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726456749,
-        "narHash": "sha256-yaNueGEfYX49g4xj8E0Bvy97b+xhQG2jUD9UXQY4qy0=",
+        "lastModified": 1726514355,
+        "narHash": "sha256-rSwStimaCICZ4Reb5hBMKK0bAPpdN1V9c/5jWKUgBtE=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "d8f07782d25b489c89d99cae4b6aaa98e8f26897",
+        "rev": "98fd0e8862bf42ba48e61b22239a861e065318fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                          |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`98fd0e88`](https://github.com/nix-community/srvos/commit/98fd0e8862bf42ba48e61b22239a861e065318fb) | `` build(deps): bump cachix/install-nix-action from V27 to 28 `` |