### PR TITLE
chore(flake/sops-nix): `f30b1bac` -> `e2d404a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -862,11 +862,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1726218807,
-        "narHash": "sha256-z7CoWbSOtsOz8TmRKDnobURkKfv6nPZCo3ayolNuQGc=",
+        "lastModified": 1726524647,
+        "narHash": "sha256-qis6BtOOBBEAfUl7FMHqqTwRLB61OL5OFzIsOmRz2J4=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "f30b1bac192e2dc252107ac8a59a03ad25e1b96e",
+        "rev": "e2d404a7ea599a013189aa42947f66cede0645c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                 |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`e2d404a7`](https://github.com/Mic92/sops-nix/commit/e2d404a7ea599a013189aa42947f66cede0645c8) | `` build(deps): bump cachix/install-nix-action from V27 to 28 (#623) `` |