### PR TITLE
chore(flake/treefmt): `9fb342d1` -> `77dd46bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -977,11 +977,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725271838,
-        "narHash": "sha256-VcqxWT0O/gMaeWTTjf1r4MOyG49NaNxW4GHTO3xuThE=",
+        "lastModified": 1726560002,
+        "narHash": "sha256-3zr63B6CDZ8FnzrRUvNZlsxLmFjaNyis6R91GjUCIhU=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "9fb342d14b69aefdf46187f6bb80a4a0d97007cd",
+        "rev": "77dd46bf0ec7febbc0022bb6e4449cdc49af95d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                          |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`5cf05d4d`](https://github.com/numtide/treefmt-nix/commit/5cf05d4d96842affc3e8f2c1e7e707e4f5d82a99) | `` inputs: use `nixpkgs-unstable` instead of `nixos-unstable` `` |