### PR TITLE
chore(flake/emacs-overlay): `9d338902` -> `efdb0ad8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726537900,
-        "narHash": "sha256-kwjD+F08vvRVXCepQ5TD+HLCBkwvBF9gfM9ftFX+b0U=",
+        "lastModified": 1726564564,
+        "narHash": "sha256-izOTrtEpdqrUpr5Qj2I4zNJH0q1E49c/1Nd1GeIC4L8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9d338902d478ffba6a7dd0d9c2fb6151cb4b970a",
+        "rev": "efdb0ad85219e9be1f77aaa3ca3085be8b130603",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`efdb0ad8`](https://github.com/nix-community/emacs-overlay/commit/efdb0ad85219e9be1f77aaa3ca3085be8b130603) | `` Updated emacs ``        |
| [`a0de883e`](https://github.com/nix-community/emacs-overlay/commit/a0de883eab6ef8829182cea26db33e875113d480) | `` Updated melpa ``        |
| [`fc8a199c`](https://github.com/nix-community/emacs-overlay/commit/fc8a199c482ba2f82a4e0742a099ba66a1ef9a23) | `` Updated flake inputs `` |