### PR TITLE
chore(flake/home-manager): `4a4a8b14` -> `d2493de5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -394,11 +394,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726593622,
-        "narHash": "sha256-ZtPJLbeyqSXOeHTBzQJRAM7sFjOxsqTO+ozigqCxyj8=",
+        "lastModified": 1726611255,
+        "narHash": "sha256-/bxaYvIK6/d3zqpW26QFS0rqfd0cO4qreSNWvYLTl/w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4a4a8b145463ccfef579bb0e26275c97bf0b5bf2",
+        "rev": "d2493de5cd1da06b6a4c3e97f4e7d5dd791df457",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`d2493de5`](https://github.com/nix-community/home-manager/commit/d2493de5cd1da06b6a4c3e97f4e7d5dd791df457) | `` ci: remove 23.11 from dependabot ``          |
| [`4974dfb2`](https://github.com/nix-community/home-manager/commit/4974dfb26e1c84d22bfdf943d41a33c9e51209a8) | `` thunderbird: change settings type to json `` |