### PR TITLE
chore(flake/darwin): `21fe31f2` -> `6374cd7e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -88,11 +88,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726188813,
-        "narHash": "sha256-Vop/VRi6uCiScg/Ic+YlwsdIrLabWUJc57dNczp0eBc=",
+        "lastModified": 1726616680,
+        "narHash": "sha256-i0h300W3t7Q7PltJPmucj+ub45SE/bNQ+pf83tasYAQ=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "21fe31f26473c180390cfa81e3ea81aca0204c80",
+        "rev": "6374cd7e50aa057a688142eed2345083047ad884",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                            |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ |
| [`ef16775e`](https://github.com/LnL7/nix-darwin/commit/ef16775e43db158324528b8a59361d67fd4160eb) | `` checks: show Sequoia migration commands for other installers `` |