### PR TITLE
chore(flake/emacs-overlay): `d6bf6cdb` -> `851b8bf5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726589963,
-        "narHash": "sha256-LkX+N4p5kstKfgRHb+PBOEKXALVx7yjhKMahTeIlopY=",
+        "lastModified": 1726625035,
+        "narHash": "sha256-QcTgkHVfWbz02PxkGMx1bZaSRt7hK9yW5A2J+NqXHU8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d6bf6cdb34b7e1acd2c3be4cf19b3f4be9ae0957",
+        "rev": "851b8bf523a5a9974239ceebde31d1f310919ae0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`851b8bf5`](https://github.com/nix-community/emacs-overlay/commit/851b8bf523a5a9974239ceebde31d1f310919ae0) | `` Updated emacs ``  |
| [`ca4df3dd`](https://github.com/nix-community/emacs-overlay/commit/ca4df3dd54a346149cd98e1a0769d48aeb4bc312) | `` Updated melpa ``  |
| [`316e070e`](https://github.com/nix-community/emacs-overlay/commit/316e070ed90ff047b22220b25fc88edcca04ac8a) | `` Updated nongnu `` |
| [`22c0b943`](https://github.com/nix-community/emacs-overlay/commit/22c0b943fd284157ce5db4420054f459c2890746) | `` Updated elpa ``   |