### PR TITLE
chore(flake/srvos): `98fd0e88` -> `c6a0317d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -882,11 +882,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726514355,
-        "narHash": "sha256-rSwStimaCICZ4Reb5hBMKK0bAPpdN1V9c/5jWKUgBtE=",
+        "lastModified": 1726649617,
+        "narHash": "sha256-pUvlt2mP2qlP7qVMv7Wsnto8u0UyLhmtY09MMh10rtw=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "98fd0e8862bf42ba48e61b22239a861e065318fb",
+        "rev": "c6a0317d303ad201e3490c79a7c57ddcd62e7757",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                        |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`a0bae67c`](https://github.com/nix-community/srvos/commit/a0bae67c5291feff898f3027f8c659d90a81ac62) | `` boot.initrd.systemd: now works with growPartition (#508) `` |
| [`f62a58bf`](https://github.com/nix-community/srvos/commit/f62a58bf2cabe529d2ec264542d574dff0e186ef) | `` no longer set networking.useDHCP to false (#509) ``         |
| [`1e11d343`](https://github.com/nix-community/srvos/commit/1e11d343acfae3feacee2504be8168044d654834) | `` zfs: make autosnapshot/autoscrub the default (#510) ``      |
| [`0c7333a4`](https://github.com/nix-community/srvos/commit/0c7333a49bdc32d42376b7917d6dbcf73438244e) | `` run nix-gc with low io/cpu priority ``                      |