### PR TITLE
chore(flake/nixos-hardware): `dc8b0296` -> `abb44860`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -611,11 +611,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1726489388,
-        "narHash": "sha256-JBHtN+n1HzKawpnOQAz6jdgvrtYV9c/kyzgoIdguQGo=",
+        "lastModified": 1726650330,
+        "narHash": "sha256-UbHzmaOQ18O/kCizipU70N0UQVFIfv8AiFKXw07oZ9Y=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "dc8b0296f68f72f3fe77469c549a6f098555c2e9",
+        "rev": "abb448608a56a60075468e90d8acec2a7cb689b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`32f4fb0b`](https://github.com/NixOS/nixos-hardware/commit/32f4fb0b11fcf3395317ca97a627aa39395d9bff) | `` apple-t2: remove ifd and cleanup drv ``              |
| [`23a4ea7a`](https://github.com/NixOS/nixos-hardware/commit/23a4ea7a0d1c5cb52f6f3ace8ce5b85da9e3b9e6) | `` lenovo-yoga-6-13ALC6: add mkDefault for bluetooth `` |