### PR TITLE
chore(flake/emacs-overlay): `7dc1c795` -> `8ec18ddc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726650823,
-        "narHash": "sha256-/VQbqPjv3PFMerrTJy0dGpxxTjtJz8RSPIDuqiOVomk=",
+        "lastModified": 1726678705,
+        "narHash": "sha256-4fKjGrjdUqB2xjAfzfuIDQMKLAbmJmwDeEEtlJIfyRg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7dc1c795e919fb76fa481874928c90b882fcf19b",
+        "rev": "8ec18ddcc6030e32fa5ab456891519061587511a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`8ec18ddc`](https://github.com/nix-community/emacs-overlay/commit/8ec18ddcc6030e32fa5ab456891519061587511a) | `` Updated melpa ``  |
| [`8b34903f`](https://github.com/nix-community/emacs-overlay/commit/8b34903f77faba399b183bea8b1aac617ba84577) | `` Updated elpa ``   |
| [`9ea515ad`](https://github.com/nix-community/emacs-overlay/commit/9ea515ade059e43bdde6bbc51e1751a6b151dc0d) | `` Updated nongnu `` |