### PR TITLE
chore(flake/emacs-overlay): `8ec18ddc` -> `e303aa1d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726678705,
-        "narHash": "sha256-4fKjGrjdUqB2xjAfzfuIDQMKLAbmJmwDeEEtlJIfyRg=",
+        "lastModified": 1726679581,
+        "narHash": "sha256-c7FAyWe5XB4J78Ee0QFuCPs0MIowJMDG1FkTqVnw6gs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8ec18ddcc6030e32fa5ab456891519061587511a",
+        "rev": "e303aa1dc000c07ee38a865bccb6e216fb5c1018",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`e303aa1d`](https://github.com/nix-community/emacs-overlay/commit/e303aa1dc000c07ee38a865bccb6e216fb5c1018) | `` Updated emacs `` |