### PR TITLE
chore(flake/srvos): `c6a0317d` -> `38245e98`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -882,11 +882,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726649617,
-        "narHash": "sha256-pUvlt2mP2qlP7qVMv7Wsnto8u0UyLhmtY09MMh10rtw=",
+        "lastModified": 1726706959,
+        "narHash": "sha256-s9WjvzDsF2Tj9cdq0h3HfFYeaR44o1pVc92lYWm/StI=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "c6a0317d303ad201e3490c79a7c57ddcd62e7757",
+        "rev": "38245e98a548fd2b05024d0435a8e96fc10a58dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`38245e98`](https://github.com/nix-community/srvos/commit/38245e98a548fd2b05024d0435a8e96fc10a58dd) | `` dev/private/flake.lock: Update `` |
| [`6cbefc5c`](https://github.com/nix-community/srvos/commit/6cbefc5cb09e8a1ffdf5d98c30d26f52ef5c66bd) | `` flake.lock: Update ``             |