### PR TITLE
chore(flake/emacs-overlay): `e303aa1d` -> `5dee28c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726679581,
-        "narHash": "sha256-c7FAyWe5XB4J78Ee0QFuCPs0MIowJMDG1FkTqVnw6gs=",
+        "lastModified": 1726736387,
+        "narHash": "sha256-TwoW/pECQcglKVrKZ9rpBRw2mfES/XUjL5xMhEAtrGc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e303aa1dc000c07ee38a865bccb6e216fb5c1018",
+        "rev": "5dee28c8080e1282dc2240fea689254708fc815f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`5dee28c8`](https://github.com/nix-community/emacs-overlay/commit/5dee28c8080e1282dc2240fea689254708fc815f) | `` Updated melpa ``  |
| [`3525a483`](https://github.com/nix-community/emacs-overlay/commit/3525a48361d4239c95b84d1912830a8f9feca301) | `` Updated elpa ``   |
| [`31123e4a`](https://github.com/nix-community/emacs-overlay/commit/31123e4ac96153cc40b322525d329f0c243f0df6) | `` Updated nongnu `` |