### PR TITLE
chore(flake/treefmt): `829338a3` -> `ee41a466`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -977,11 +977,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726705685,
-        "narHash": "sha256-byl6ywTyQTUGiuwvBsDtQwUioQ5Kklxirj6YdiWTLdY=",
+        "lastModified": 1726734507,
+        "narHash": "sha256-VUH5O5AcOSxb0uL/m34dDkxFKP6WLQ6y4I1B4+N3L2w=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "829338a3df3dfd492c61abbd090ec1405329c943",
+        "rev": "ee41a466c2255a3abe6bc50fc6be927cdee57a9f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                               |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`01abe60f`](https://github.com/numtide/treefmt-nix/commit/01abe60f41e6227ca2b68759dba975e764a2f3fe) | `` chore: fmt ``                      |
| [`c58f3be1`](https://github.com/numtide/treefmt-nix/commit/c58f3be12ab7d4bc589604c413cf0ac50575e28c) | `` feat(programs): add latexindent `` |