### PR TITLE
chore(flake/emacs-overlay): `5dee28c8` -> `d10ed46c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726736387,
-        "narHash": "sha256-TwoW/pECQcglKVrKZ9rpBRw2mfES/XUjL5xMhEAtrGc=",
+        "lastModified": 1726737254,
+        "narHash": "sha256-TTZk4+BiHGmgVpo9x3vjra+d2NHak1/xzPb+QOSbU2k=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5dee28c8080e1282dc2240fea689254708fc815f",
+        "rev": "d10ed46cb14c2d6083b3174b52a0c1fbdebe6746",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`d10ed46c`](https://github.com/nix-community/emacs-overlay/commit/d10ed46cb14c2d6083b3174b52a0c1fbdebe6746) | `` Updated emacs `` |