### PR TITLE
chore(flake/emacs-overlay): `a1ca2766` -> `a5a21cdc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726765163,
-        "narHash": "sha256-5aX2+iWFzH9b4yVSGMk2w/tDI0c/cn8f1xW6/kurtPo=",
+        "lastModified": 1726794789,
+        "narHash": "sha256-gQ/f9uOtBnSt5b8zRhl08ByEt03hcnwjHrbBb5uXftM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a1ca2766ae9535f16bcac91f7001d24a6837178b",
+        "rev": "a5a21cdc6d37644b5c68a42343a196d02a30079f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`a5a21cdc`](https://github.com/nix-community/emacs-overlay/commit/a5a21cdc6d37644b5c68a42343a196d02a30079f) | `` Updated elpa ``   |
| [`4be8ac59`](https://github.com/nix-community/emacs-overlay/commit/4be8ac597719efc769ceb72fb2bca5206a860968) | `` Updated nongnu `` |