### PR TITLE
chore(flake/home-manager): `2cf3abce` -> `8d7e352a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -394,11 +394,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726814843,
-        "narHash": "sha256-dz6K+QWJsmkqPqbVfJNtwWio1v0WGMVL6Ov8x0NNShs=",
+        "lastModified": 1726818292,
+        "narHash": "sha256-sFI+LTeRTPOAZe9ewhQpIq5CkIr4IpzfzuyIFCz6ugY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2cf3abce034432cb357c0a6a670481819c55f564",
+        "rev": "8d7e352a4b25ac2d88a881ffa3472680af916ddc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                           |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`8d7e352a`](https://github.com/nix-community/home-manager/commit/8d7e352a4b25ac2d88a881ffa3472680af916ddc) | `` poweralertd: Enable passing CLI args to the daemon ``          |
| [`6b191238`](https://github.com/nix-community/home-manager/commit/6b1912380e5577063401f58a2deb985fdc7cdc60) | `` ci: bump DeterminateSystems/update-flake-lock from 23 to 24 `` |
| [`f48b181f`](https://github.com/nix-community/home-manager/commit/f48b181f0161db6246a1bd1b05d70a7b3a87ab41) | `` ssh-agent: use POSIX conforming if condition ``                |
| [`ecaed80b`](https://github.com/nix-community/home-manager/commit/ecaed80b18e1d179d728d862c96d2fe43699226b) | `` kitty: remove IFD ``                                           |