### PR TITLE
chore(flake/nixpkgs): `99dc8785` -> `395c52d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -732,11 +732,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1726463316,
-        "narHash": "sha256-gI9kkaH0ZjakJOKrdjaI/VbaMEo9qBbSUl93DnU7f4c=",
+        "lastModified": 1726642912,
+        "narHash": "sha256-wiZzKGHRAhItEuoE599Wm3ic+Lg/NykuBvhb+awf7N8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
+        "rev": "395c52d142ec1df377acd67db6d4a22950b02a98",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                                                |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
| [`d2f0f2af`](https://github.com/NixOS/nixpkgs/commit/d2f0f2afab2b87740e4a90b09b40ba95f8a55d7b) | `` maintainers: add pixelsergey ``                                                                                                     |
| [`26ca094f`](https://github.com/NixOS/nixpkgs/commit/26ca094f5073125eea22749635bb39c0d5681658) | `` meow: init at 2.1.3 ``                                                                                                              |
| [`8a251278`](https://github.com/NixOS/nixpkgs/commit/8a251278699b65a18d3a34b8f6bb48eb0e3ecfb0) | `` telegram-desktop: 5.5.2 -> 5.5.5 ``                                                                                                 |
| [`6c9a6461`](https://github.com/NixOS/nixpkgs/commit/6c9a6461526177195d4ee13f970ac396450f3caa) | `` electron-chromedriver_32: init at 32.1.0, electron-chromedriver_31: 31.4.0 -> 31.6.0, electron-chromedriver_30: 30.4.0 -> 30.5.1 `` |
| [`ae0a8795`](https://github.com/NixOS/nixpkgs/commit/ae0a87956efcfe73f03e058ad27160ece7d5ac46) | `` nix-serve: pin nix to nixVersions.nix_2_18 (previous stable) due to breaking changes ``                                             |
| [`25c916d5`](https://github.com/NixOS/nixpkgs/commit/25c916d554a6a3c2f1fd4c2e27637757b2d522b8) | `` bfs: 3.1.3 -> 4.0.2 ``                                                                                                              |
| [`78bf4dea`](https://github.com/NixOS/nixpkgs/commit/78bf4dea0fbdb0945103a5a4a80a7ae9fbde5fbd) | `` python312Packages.gpy: 1.13.1 -> 1.13.2 (#341238) ``                                                                                |
| [`4e1e27e5`](https://github.com/NixOS/nixpkgs/commit/4e1e27e537b76bbdee5c0526d9e4dbe45e9d81ca) | `` Revert "cdemu: update packages (#342549)" ``                                                                                        |
| [`366e5621`](https://github.com/NixOS/nixpkgs/commit/366e562113ceae0383daa2a8b95a761959e28286) | `` cdemu: update packages (#342549) ``                                                                                                 |
| [`447d1edf`](https://github.com/NixOS/nixpkgs/commit/447d1edf508d7a8256f10eb3863deb8fd85b597f) | `` .github/labeler.yml: mark CONTRIBUTING.md and README's for "policy discussion" ``                                                   |
| [`d71203e9`](https://github.com/NixOS/nixpkgs/commit/d71203e97c437ac7df3440e1c853d1888956cd7e) | `` kops: add 1.30, update 1.28, drop 1.26 ``                                                                                           |
| [`d2f8479f`](https://github.com/NixOS/nixpkgs/commit/d2f8479f886a61e3578ffb4fc278fbf479a593f8) | `` maintainers: drop lychee ``                                                                                                         |
| [`baaedf13`](https://github.com/NixOS/nixpkgs/commit/baaedf1392ed229d43366440aaa2ccdf0d8b2e93) | `` python312Packages.universal-pathlib: 0.2.4 -> 0.2.5 ``                                                                              |
| [`01f74244`](https://github.com/NixOS/nixpkgs/commit/01f7424484760a3cfda762dd6a8fbb5263357bf7) | `` python312Packages.google-cloud-asset: 3.26.3 -> 3.26.4 ``                                                                           |
| [`6a30c10b`](https://github.com/NixOS/nixpkgs/commit/6a30c10b918691042894b6b65d23cfa86645622f) | `` python312Packages.google-cloud-netapp: 0.3.13 -> 0.3.14 ``                                                                          |
| [`d211b9b3`](https://github.com/NixOS/nixpkgs/commit/d211b9b3073ec5dd4079ae9ffec75f5effc9bc98) | `` python312Packages.slack-sdk: 3.32.0 -> 3.33.0 ``                                                                                    |
| [`9b7a02a5`](https://github.com/NixOS/nixpkgs/commit/9b7a02a5a98ca7cb8d998c45e5dc29ce1a455b67) | `` python312Packages.types-pytz: refator ``                                                                                            |
| [`5b340f93`](https://github.com/NixOS/nixpkgs/commit/5b340f9313cb904d7f293e4314fde778d4c799f6) | `` python312Packages.types-pytz: 2024.1.0.20240417 -> 2024.2.0.20240913 ``                                                             |
| [`82cc961d`](https://github.com/NixOS/nixpkgs/commit/82cc961d9288bf55fccd2c149a510bdea7a8ca47) | `` python312Packages.tesla-fleet-api: 0.7.5 -> 0.7.8 ``                                                                                |
| [`fc47f9c5`](https://github.com/NixOS/nixpkgs/commit/fc47f9c5600bc944f6675b3bf0512f437d96634c) | `` python312Packages.orbax-checkpoint: adjust changelog URL ``                                                                         |
| [`a558d61a`](https://github.com/NixOS/nixpkgs/commit/a558d61ae5a26af4ebf496b1627ce80d78b40799) | `` python312Packages.tencentcloud-sdk-python: 3.0.1232 -> 3.0.1233 ``                                                                  |
| [`3aea9d6a`](https://github.com/NixOS/nixpkgs/commit/3aea9d6aaa32125a53950a8ed65bbdca73fe43f5) | `` python312Packages.std2: unstable-2023-10-07 -> 0-unstable-2024-09-02 ``                                                             |
| [`29df8af1`](https://github.com/NixOS/nixpkgs/commit/29df8af169c6c836fd63fe6c311e42e7be55729a) | `` python312Packages.apispec-webframeworks:: refactor ``                                                                               |
| [`62c71011`](https://github.com/NixOS/nixpkgs/commit/62c7101156d152a9f4fcd33deda9e463ae71313f) | `` python312Packages.apispec-webframeworks: 1.1.0 -> 1.2.0 ``                                                                          |
| [`00dd6265`](https://github.com/NixOS/nixpkgs/commit/00dd6265c4c59126eb99f20963f1a3d1befee017) | `` python312Packages.orbax-checkpoint: 0.6.3 -> 0.6.4 ``                                                                               |
| [`fb7e6450`](https://github.com/NixOS/nixpkgs/commit/fb7e6450f936dca9896f3830139876044170b0e6) | `` waylyrics: 0.3.13 -> 0.3.15 ``                                                                                                      |
| [`a5169c15`](https://github.com/NixOS/nixpkgs/commit/a5169c156aaa6425e7793b7b6fc1b7f20e25a96b) | `` python312Packages.lacuscore: 1.10.13 -> 1.11.0 ``                                                                                   |
| [`d95dcb36`](https://github.com/NixOS/nixpkgs/commit/d95dcb364a96fb8138e5862eb07d99b364d4c291) | `` python312Packages.playwrightcapture: 1.25.15 -> 1.26.0 ``                                                                           |
| [`560d82a6`](https://github.com/NixOS/nixpkgs/commit/560d82a6835eb01c3a0b0b933209d39627041214) | `` aws-encryption-sdk-cli: migrate to pkgs/by-name, format with nixfmt-rfc-style ``                                                    |
| [`883679e0`](https://github.com/NixOS/nixpkgs/commit/883679e00f685c87951931ffbde886ac9bf606aa) | `` strawberry-qt6: 1.1.1 -> 1.1.2 ``                                                                                                   |
| [`53c7d6fd`](https://github.com/NixOS/nixpkgs/commit/53c7d6fd6b4cc6c44b9b1598953756a6cf0627b7) | `` asouldocs: add passthru.tests.version ``                                                                                            |
| [`6b6cffe1`](https://github.com/NixOS/nixpkgs/commit/6b6cffe125b35c5e39e5ef3287684c2efab07b8d) | `` jira-cli-go: migrate to pkgs/by-name, format with nixfmt-rfc-style ``                                                               |
| [`91beb4b0`](https://github.com/NixOS/nixpkgs/commit/91beb4b016d6b680248118ae6f7d58b27ea03bed) | `` solfege: migrate to pkgs/by-name, format with nixfmt-rfc-style ``                                                                   |
| [`417bc18f`](https://github.com/NixOS/nixpkgs/commit/417bc18feb28c65e28b8ed91cab06a9f4754f779) | `` adcli: migrate to pkgs/by-name, format with nixfmt-rfc-style ``                                                                     |
| [`1246e83b`](https://github.com/NixOS/nixpkgs/commit/1246e83b488ed5728cbe94a0226beba6603d302c) | `` powertop: migrate to pkgs/by-name, format with nixfmt-rfc-style ``                                                                  |
| [`8b9ca93a`](https://github.com/NixOS/nixpkgs/commit/8b9ca93a748bbdb29f779becada69b6ff3832a58) | `` asouldocs: migrate to pkgs/by-name, format with nixfmt-rfc-style ``                                                                 |
| [`63f137ac`](https://github.com/NixOS/nixpkgs/commit/63f137ac3faa8ac20fba1e12d855102ba94640eb) | `` axis2: migrate to pkgs/by-name, format with nixfmt-rfc-style ``                                                                     |
| [`e0870496`](https://github.com/NixOS/nixpkgs/commit/e08704965a52919348d9dba3570baf9c57befdf9) | `` ccid: migrate to pkgs/by-name, format with nixfmt-rfc-style ``                                                                      |
| [`b85b6425`](https://github.com/NixOS/nixpkgs/commit/b85b6425ffac38485707b92dff56b09c2300eebd) | `` win-pvdrivers: migrate to pkgs/by-name, format with nixfmt-rfc-style ``                                                             |
| [`2b2c6eb3`](https://github.com/NixOS/nixpkgs/commit/2b2c6eb3fca157cea423b1f2cefa622c56906d62) | `` thanos: migrate to pkgs/by-name, format with nixfmt-rfc-style ``                                                                    |
| [`7a386c3c`](https://github.com/NixOS/nixpkgs/commit/7a386c3cc008e142d2218c8885caa0cad2bd519d) | `` amazon-ec2-utils: migrate to pkgs/by-name, format with nixfmt-rfc-style ``                                                          |
| [`ce6a11f4`](https://github.com/NixOS/nixpkgs/commit/ce6a11f471044bfb94d9e4e821001a33d6ddaa2f) | `` vpcs: migrate to pkgs/by-name, format with nixfmt-rfc-style ``                                                                      |
| [`076aa0be`](https://github.com/NixOS/nixpkgs/commit/076aa0be1bfa696063a76be4dd67d0c74c120777) | `` sonic-server: migrate to pkgs/by-name, format with nixfmt-rfc-style ``                                                              |
| [`2d8261dc`](https://github.com/NixOS/nixpkgs/commit/2d8261dc0940886ffd95848c9e73b77e0caabfb8) | `` rdiff-backup: add meta.mainProgram ``                                                                                               |
| [`04338427`](https://github.com/NixOS/nixpkgs/commit/043384277814640ef1b88f8857b9fa4c45acdb2b) | `` sqlitebrowser: Fix build for macOS ``                                                                                               |
| [`51e70f4f`](https://github.com/NixOS/nixpkgs/commit/51e70f4f9b42a38efd871d5e197171dcb0844bfe) | `` dupe-krill: remove Cargo.lock, fix hashes ``                                                                                        |
| [`65629db5`](https://github.com/NixOS/nixpkgs/commit/65629db5d025469512d951aa1d173e8254c5399d) | `` homepage-dashboard: 0.9.8 -> 0.9.9 ``                                                                                               |
| [`afb9fff1`](https://github.com/NixOS/nixpkgs/commit/afb9fff17718125a26caad74d329ab679488ec73) | `` emacs: jansson is now optional ``                                                                                                   |
| [`c499cb13`](https://github.com/NixOS/nixpkgs/commit/c499cb13990a14c9d9f8e7a381d9aac598a70b63) | `` yarnInstallHook: fix temporary directory location ``                                                                                |
| [`a797b80b`](https://github.com/NixOS/nixpkgs/commit/a797b80b6decb91fa8aa6ec1273b0b3e00b587ee) | `` vulkan-loader: backport fix for 32-bit applications on 64-bit inode filesystems ``                                                  |
| [`b585a1d3`](https://github.com/NixOS/nixpkgs/commit/b585a1d35ee8f3d76a89d819026f292319fe19c2) | `` emacs30: init ``                                                                                                                    |
| [`2238a5a1`](https://github.com/NixOS/nixpkgs/commit/2238a5a1d0a80368a326c66d5c571e6aadcc6150) | `` emacs: use lib.getDev to get harfbuzz ``                                                                                            |
| [`a5599c35`](https://github.com/NixOS/nixpkgs/commit/a5599c35f17f682763cf078751968e00f17ea4e8) | `` libspatialindex: nixfmt-rfc-style ``                                                                                                |
| [`27336c66`](https://github.com/NixOS/nixpkgs/commit/27336c661940b1aff02e3e122c0756c4d712d84b) | `` libspatialindex: migrate to by-name ``                                                                                              |
| [`3a8dfd5c`](https://github.com/NixOS/nixpkgs/commit/3a8dfd5c34e31347af93f07f0ef329007b712d1d) | `` libspatialindex: fix on darwin ``                                                                                                   |
| [`24caa79e`](https://github.com/NixOS/nixpkgs/commit/24caa79eb89cf2b4c9c0297ed7ff369857402e57) | `` rippled: drop dead `package.nix` file (#342054) ``                                                                                  |
| [`11de8096`](https://github.com/NixOS/nixpkgs/commit/11de8096d884f0ed38be026e6aaffb71820e3e6f) | `` Pharo: version update to 10.3.1 ``                                                                                                  |
| [`df86bea4`](https://github.com/NixOS/nixpkgs/commit/df86bea46f32d1ce698b86841452c7fa63700243) | `` cups-brother-dcpt725dw: init at 3.5.0-1 ``                                                                                          |
| [`2daad926`](https://github.com/NixOS/nixpkgs/commit/2daad926b8a2eaf5708152f36f18573959ca6f29) | `` nixos/services.cloudflared: fix syntax errors ``                                                                                    |
| [`a284d741`](https://github.com/NixOS/nixpkgs/commit/a284d741a62a12931afa3cca71cc9f8d7bf6afbb) | `` msecli: init at 10.01.012024.00 ``                                                                                                  |
| [`2d314787`](https://github.com/NixOS/nixpkgs/commit/2d314787f4bc5bc56e64584595912c7cfa87405b) | `` intel-compute-runtime: 24.31.30508.7 -> 24.35.30872.22 ``                                                                           |
| [`1047f0a6`](https://github.com/NixOS/nixpkgs/commit/1047f0a6bf88a7eb49a1a7380e17e2077eecec73) | `` nixos/hostapd: set default channel to auto ``                                                                                       |
| [`bf852e35`](https://github.com/NixOS/nixpkgs/commit/bf852e359405f80d1523cfb4ac140a1d6b647b47) | `` tiny-cuda-nn: mark as broken on aarch64-linux ``                                                                                    |
| [`621a378c`](https://github.com/NixOS/nixpkgs/commit/621a378cbbea77fca43c30112a9b2f45bd6d8540) | `` gnucobol: add kiike to maintainers ``                                                                                               |
| [`e1b2d8cf`](https://github.com/NixOS/nixpkgs/commit/e1b2d8cfdffc4a4246d637893aab0e6eb246612d) | `` gnucobol: add NIST test suite ``                                                                                                    |
| [`16686f2b`](https://github.com/NixOS/nixpkgs/commit/16686f2b3f11bb6a93310aeea723f167dc05f736) | `` gnucobol: nixfmt ``                                                                                                                 |
| [`7293c205`](https://github.com/NixOS/nixpkgs/commit/7293c205fd0257b908eed7a49ba815ce3260e2b6) | `` gnucobol: rename from gnu-cobol ``                                                                                                  |
| [`6d6edb96`](https://github.com/NixOS/nixpkgs/commit/6d6edb9689f90b63f8d39fc0cd1c639b78e0031d) | `` gnu-cobol: move to pkgs/by-name ``                                                                                                  |
| [`cda53f64`](https://github.com/NixOS/nixpkgs/commit/cda53f643748ed229c434c39e5e5dcbd31a9a781) | `` vimPlugins.render-markdown: rename to render-markdown.nvim ``                                                                       |
| [`520c7b44`](https://github.com/NixOS/nixpkgs/commit/520c7b447ea016ec43a4d26c3b28353f8905e759) | `` pupdate: 3.13.0 -> 3.15.0 ``                                                                                                        |
| [`e1dbddf2`](https://github.com/NixOS/nixpkgs/commit/e1dbddf2bbb6a902790cc1bbf519454abf5c467a) | `` python312Packages.python-calamine: add missing dependency libiconv ``                                                               |
| [`6c3d27d2`](https://github.com/NixOS/nixpkgs/commit/6c3d27d2bb42432462ece622a7accb5e6e26f232) | `` python312Packages.python-calamine: clean ``                                                                                         |
| [`770f9772`](https://github.com/NixOS/nixpkgs/commit/770f97722895667b3e64c3cfbda1e164e4aefed0) | `` kubernetes-controller-tools: 0.16.1 -> 0.16.3 ``                                                                                    |
| [`09eb3c64`](https://github.com/NixOS/nixpkgs/commit/09eb3c64e8025e86d838e7624ac3063e9c698d5c) | `` lib.fetchers.normalizeHash: more implementation comment and clearer variable names ``                                               |
| [`dc841278`](https://github.com/NixOS/nixpkgs/commit/dc8412781fd21ba33ed9f8564aa165bd7f928057) | `` python312Packages.deepl: 1.18.0 -> 1.19.1 ``                                                                                        |
| [`658e7223`](https://github.com/NixOS/nixpkgs/commit/658e7223191d2598641d50ee4e898126768fe847) | `` orchard: 0.23.0 -> 0.23.2 (#342376) ``                                                                                              |
| [`3022d8e8`](https://github.com/NixOS/nixpkgs/commit/3022d8e8fc3e424bfa9c48c31a0968901fb4ae6e) | `` pysqlrecon: 0.2.0 -> 0.3.0 ``                                                                                                       |
| [`6cda1dde`](https://github.com/NixOS/nixpkgs/commit/6cda1ddee354c6870f02d70788c7665ef897869a) | `` kclvm_cli: 0.9.3 -> 0.10.0 (#342381) ``                                                                                             |
| [`90ed57be`](https://github.com/NixOS/nixpkgs/commit/90ed57bec42e0cf64644ae92aaa0a5a3c8f421cb) | `` Revert #342349: "tree-sitter: 0.22.6 -> 0.23.0" ``                                                                                  |
| [`e265d2d5`](https://github.com/NixOS/nixpkgs/commit/e265d2d55a5d25ec2ef41c60555e2cd10dbe810c) | `` python312Packages.django-vite: 3.0.4 -> 3.0.5 (#342388) ``                                                                          |
| [`7c0167eb`](https://github.com/NixOS/nixpkgs/commit/7c0167eb3ebd4ed02f7e739efec05b7141018ded) | `` libretro.stella: unstable-2024-09-01 -> unstable-2024-09-09 ``                                                                      |
| [`1ea5e7c1`](https://github.com/NixOS/nixpkgs/commit/1ea5e7c1090733feff5749eea2ff8fec6e8c8cec) | `` libretro.prboom: unstable-2024-09-05 -> unstable-2024-09-07 ``                                                                      |
| [`9df5b33f`](https://github.com/NixOS/nixpkgs/commit/9df5b33fadfb5bf63266e71a1b3197d16bebfda0) | `` ugs: 2.1.8 -> 2.1.9 (#342409) ``                                                                                                    |
| [`f1e3be2f`](https://github.com/NixOS/nixpkgs/commit/f1e3be2f53bda881d87dc29d6f3658a72838abc9) | `` reviewdog: 0.20.1 -> 0.20.2 (#342411) ``                                                                                            |
| [`6a18c7b9`](https://github.com/NixOS/nixpkgs/commit/6a18c7b9b71f51dce12d445b7b20d6f328354af0) | `` netbird: 0.29.2 -> 0.29.3 ``                                                                                                        |
| [`ee5a15d9`](https://github.com/NixOS/nixpkgs/commit/ee5a15d93e9ae4fcffa2dc40866543ed5e1fa319) | `` kallisto: 0.51.0 -> 0.51.1 ``                                                                                                       |
| [`9bc055d1`](https://github.com/NixOS/nixpkgs/commit/9bc055d18da4267d8dc00f47aff15301258fdad7) | `` goose: 3.22.0 -> 3.22.1 ``                                                                                                          |
| [`91a73c3c`](https://github.com/NixOS/nixpkgs/commit/91a73c3cc96720c506bc9d5c1e90822b08dd6d0e) | `` ferium: 4.7.0 -> 4.7.1 ``                                                                                                           |
| [`12242b0a`](https://github.com/NixOS/nixpkgs/commit/12242b0ad2d58ed4c4737fae6ce0296881ae5b94) | `` python312Packages.impacket: 0.11.0 -> 0.12.0 ``                                                                                     |
| [`5d690032`](https://github.com/NixOS/nixpkgs/commit/5d690032284abe9909b87ed48a8afbaaefa28133) | `` python312Packages.awkward: 2.6.7 -> 2.6.8 ``                                                                                        |
| [`14b87d6d`](https://github.com/NixOS/nixpkgs/commit/14b87d6d463da65381a2312511fcdadb8efcc58a) | `` python312Packages.awkward-cpp: 37 -> 38 ``                                                                                          |
| [`cb4da3a5`](https://github.com/NixOS/nixpkgs/commit/cb4da3a54286c8e5bf56cb2f3a1f157123d9adcb) | `` steampipePackages.steampipe-plugin-aws: 0.146.0 -> 0.147.0 ``                                                                       |
| [`ef270d88`](https://github.com/NixOS/nixpkgs/commit/ef270d885a4c7522720c83a0292b0239fdb6fd29) | `` steampipePackages.steampipe-plugin-github: 0.43.0 -> 0.44.0 ``                                                                      |
| [`0aa52428`](https://github.com/NixOS/nixpkgs/commit/0aa52428290ee1c8fa4b366373edfb604925abc4) | `` lib.fetchers: add tests ``                                                                                                          |
| [`4c991b74`](https://github.com/NixOS/nixpkgs/commit/4c991b74d39a470111d8c73f82c5b60476eabed5) | `` lib.fetchers.normalizeHash: replace `""` with `lib.fake*` ``                                                                        |
| [`223185ca`](https://github.com/NixOS/nixpkgs/commit/223185ca10d6b4e02b7f08061c4e67a7b8e35cf5) | `` androidStudioPackages.beta: 2024.2.1.6 -> 2024.2.1.7 ``                                                                             |
| [`ecd57460`](https://github.com/NixOS/nixpkgs/commit/ecd57460373ae808f62cb003c11d5213142d4a2a) | `` cargo-lambda: 1.3.0 -> 1.4.0 ``                                                                                                     |
| [`dfd215e2`](https://github.com/NixOS/nixpkgs/commit/dfd215e295123b2715a8dfa1b62be9303d5c5168) | `` python312Packages.pgmpy: 0.1.25 -> 0.1.26 ``                                                                                        |
| [`c58c2843`](https://github.com/NixOS/nixpkgs/commit/c58c2843aea42fd83fad3f895c98796b87810ddb) | `` cargo-mobile2: 0.17.0 -> 0.17.2 ``                                                                                                  |
| [`a1c4e5e0`](https://github.com/NixOS/nixpkgs/commit/a1c4e5e0293a6eee7c162662f5801c214c048b26) | `` v2ray-domain-list-community: 20240905162746 -> 20240914091803 ``                                                                    |
| [`4acc2170`](https://github.com/NixOS/nixpkgs/commit/4acc2170c66b3bffa01e6e2e680ac1fef9738b63) | `` intelephense: 1.12.5 -> 1.12.6 ``                                                                                                   |
| [`25f6b54b`](https://github.com/NixOS/nixpkgs/commit/25f6b54b667193899235de3d474a124f4e3d2547) | `` moon: 1.28.0 -> 1.28.2 ``                                                                                                           |
| [`0ef59ee4`](https://github.com/NixOS/nixpkgs/commit/0ef59ee4e6209d34f57468bac17d7ed2d3e74415) | `` i-pi: add missing, non-declared scipy dependency for the socket driver ``                                                           |
| [`423da96e`](https://github.com/NixOS/nixpkgs/commit/423da96e75493535014d9ade301b0102b22d45d1) | `` test/release: do not add `.git` to the store ``                                                                                     |
| [`493442c4`](https://github.com/NixOS/nixpkgs/commit/493442c470b9a1b0fe638487ad94d10cdf522766) | `` tests: avoid copying `.git` into the store ``                                                                                       |
| [`5c012c54`](https://github.com/NixOS/nixpkgs/commit/5c012c5479472f204cbdf9371023c1f656ce2d6c) | `` androidStudioPackages.canary: 2024.2.1.5 -> 2024.2.2.2 ``                                                                           |
| [`58dbfcff`](https://github.com/NixOS/nixpkgs/commit/58dbfcff203c098abd27059adc05e01319ab8a20) | `` snac2: 2.58 -> 2.59 ``                                                                                                              |
| [`274206a1`](https://github.com/NixOS/nixpkgs/commit/274206a1f103c7dc5a54deb2a2a25c2ae263aabb) | `` doc/maven: `fakeSha256` → `fakeHash` ``                                                                                             |
| [`633f94fa`](https://github.com/NixOS/nixpkgs/commit/633f94fa4a6b0193edb720ae6abef334b4374da3) | `` doc/coq: `sha256` → `hash` ``                                                                                                       |
| [`19cf0942`](https://github.com/NixOS/nixpkgs/commit/19cf0942e3e31e9bb5fd84a977b7d3d00b5a3c99) | `` doc: update all `fetchurl` invocations with a `hash` in SRI format ``                                                               |
| [`13076ec2`](https://github.com/NixOS/nixpkgs/commit/13076ec2621a7c85718e9c012f5c74decfc434e1) | `` vimPlugins.sg-nvim: 2024-09-09 -> 2024-09-17; fix ``                                                                                |