### PR TITLE
chore(flake/nixpkgs): `395c52d1` -> `c04d5652`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -732,11 +732,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1726642912,
-        "narHash": "sha256-wiZzKGHRAhItEuoE599Wm3ic+Lg/NykuBvhb+awf7N8=",
+        "lastModified": 1726755586,
+        "narHash": "sha256-PmUr/2GQGvFTIJ6/Tvsins7Q43KTMvMFhvG6oaYK+Wk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "395c52d142ec1df377acd67db6d4a22950b02a98",
+        "rev": "c04d5652cfa9742b1d519688f65d1bbccea9eb7e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                          |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`7d100074`](https://github.com/NixOS/nixpkgs/commit/7d10007445a5a430f57b05cbb94651b995807d9b) | `` Revert "nix-plugins: 14.0.0 -> 15.0.0" ``                                                     |
| [`b3b9bdd9`](https://github.com/NixOS/nixpkgs/commit/b3b9bdd9018cb0b66df3961e2dc7ad70008e4ff3) | `` Revert "nix: nix_2_18 -> nix_2_24" ``                                                         |
| [`fb382357`](https://github.com/NixOS/nixpkgs/commit/fb3823576689d04901bccabbe2abd7c459e5981c) | `` Revert "nixos/nix-fallback-paths: 2.24.2 -> 2.24.6" ``                                        |
| [`9f3c106b`](https://github.com/NixOS/nixpkgs/commit/9f3c106bf1beeed3b5cffd8530a35e3fb8d63019) | `` sushi: use actual upstream url as homepage ``                                                 |
| [`ba6ec9db`](https://github.com/NixOS/nixpkgs/commit/ba6ec9db9bdf7e0bd697ec55f47909e51748680c) | `` kubectl: set meta.mainProgram ``                                                              |
| [`a597aac6`](https://github.com/NixOS/nixpkgs/commit/a597aac695658848ae043c8beb68651fc1089d05) | `` discord-ptb: 0.0.103 -> 0.0.105 ``                                                            |
| [`f1d16466`](https://github.com/NixOS/nixpkgs/commit/f1d1646620c68e3e0a73aa77dc7db63266fad83a) | `` maintainers: update luc65r's mail address ``                                                  |
| [`ff281841`](https://github.com/NixOS/nixpkgs/commit/ff2818413a256eb792ab6fda5b5d0b5994f178bc) | `` grass: disable opengl support on darwin ``                                                    |
| [`23d10b25`](https://github.com/NixOS/nixpkgs/commit/23d10b25187b6874dae26306c4d0b84d64358592) | `` grass: fix openmp support on darwin ``                                                        |
| [`778d506a`](https://github.com/NixOS/nixpkgs/commit/778d506a690c9f20a34b781b6d4f1f695a34e4c8) | `` docfd: 8.0.2 -> 8.0.3 ``                                                                      |
| [`f6c31a3b`](https://github.com/NixOS/nixpkgs/commit/f6c31a3b668663944545ea4681e283424fae522f) | `` radicle-explorer: init at 0.17.0 ``                                                           |
| [`256855af`](https://github.com/NixOS/nixpkgs/commit/256855afc56e5a698b0f70a037e8e07d14f04802) | `` protobuf_27: 27.4 -> 27.5 ``                                                                  |
| [`0c9495ab`](https://github.com/NixOS/nixpkgs/commit/0c9495abe2305e7950bc874256d7139041cdb6b7) | `` firefoxpwa: 2.12.3 -> 2.12.4 ``                                                               |
| [`06f83913`](https://github.com/NixOS/nixpkgs/commit/06f83913cbd606bae133b4dbfaa4d61285c7369f) | `` ast-grep: 0.27.0 -> 0.27.1 ``                                                                 |
| [`bf957175`](https://github.com/NixOS/nixpkgs/commit/bf95717552dbd05053129069fa31c29a2d3c802c) | `` xlights: 2024.15 -> 2024.16 ``                                                                |
| [`a003c8a2`](https://github.com/NixOS/nixpkgs/commit/a003c8a2c2c17814bdb3fafe7e3fbacafb9f7c1f) | `` elixir: 1.17.2 -> 1.17.3 ``                                                                   |
| [`7547a1f5`](https://github.com/NixOS/nixpkgs/commit/7547a1f5f862cc013fca1712dfbf300ed86c8161) | `` amazon-ssm-agent: add the system's software to the path ``                                    |
| [`d6f49d60`](https://github.com/NixOS/nixpkgs/commit/d6f49d6068228a353f2a846c7fdd0dc249891c20) | `` ollama: add cuda libs to wrapper's `LD_LIBRARY_PATH` ``                                       |
| [`141a5a56`](https://github.com/NixOS/nixpkgs/commit/141a5a56c6071549b6e5becb0af98ca1897809a4) | `` ryzenadj: 0.15.0 -> 0.16.0 ``                                                                 |
| [`1be8e6c8`](https://github.com/NixOS/nixpkgs/commit/1be8e6c8ae2835320c9ccff74e6f404a710dc382) | `` htgettoken: init at 2.0 (#342364) ``                                                          |
| [`4016385f`](https://github.com/NixOS/nixpkgs/commit/4016385fe22cb13cd608d2d738740b037b1c1db6) | `` msolve: 0.7.1 -> 0.7.2 ``                                                                     |
| [`a532aa90`](https://github.com/NixOS/nixpkgs/commit/a532aa909067485cb35a0b3eedbe3f2150982b0d) | `` dart: set meta.mainProgram (#342479) ``                                                       |
| [`6295433b`](https://github.com/NixOS/nixpkgs/commit/6295433b2b0079b063d78761ae52c4f385180cae) | `` installer: only use squashfs threads=multi on supported kernels ``                            |
| [`f6e2fb5e`](https://github.com/NixOS/nixpkgs/commit/f6e2fb5e11f411c56b2076e27d270f2cabf80f40) | `` nixos/services.tarsnap: fix escapeSystemdPath invocation ``                                   |
| [`db8da26f`](https://github.com/NixOS/nixpkgs/commit/db8da26fb9e7a031f2882c14d86e705b853e6104) | `` terraform: 1.9.5 -> 1.9.6 ``                                                                  |
| [`801b8a21`](https://github.com/NixOS/nixpkgs/commit/801b8a218d0a8d1e69e81beed6a1042fa59bdb3a) | `` libmirage: improve meta.description ``                                                        |
| [`5e89ea3d`](https://github.com/NixOS/nixpkgs/commit/5e89ea3d30d282778077157825dd8f77e07e71b6) | `` nixos/cdemu: use lib.getExe ``                                                                |
| [`b798dd7d`](https://github.com/NixOS/nixpkgs/commit/b798dd7d720870ae3e8ac2b5ea4eedec1800e3d1) | `` cdemu-daemon: add meta.mainProgram ``                                                         |
| [`ed138e20`](https://github.com/NixOS/nixpkgs/commit/ed138e20f12652dc724d7328f456987bdebeed1b) | `` linuxPackages.vhba: 20240202 -> 20240917 ``                                                   |
| [`c8d155a2`](https://github.com/NixOS/nixpkgs/commit/c8d155a277530efbfebae4fd511a733b20b24c8d) | `` cdemu-daemon: 3.2.6 -> 3.2.7 ``                                                               |
| [`4983e987`](https://github.com/NixOS/nixpkgs/commit/4983e987c0fcee37b9ba68e8f8ba1d98c385e301) | `` libmirage: 3.2.7 -> 3.2.9 ``                                                                  |
| [`abc51d16`](https://github.com/NixOS/nixpkgs/commit/abc51d1654fceca7c2b91fcce5028508aa73b66e) | `` nixos/authelia: complete level enum ``                                                        |
| [`69ca85cc`](https://github.com/NixOS/nixpkgs/commit/69ca85cc7bb356876544f8ddf4d6bb56e0c6c988) | `` nixos/pulseview: init module ``                                                               |
| [`9e5f77a3`](https://github.com/NixOS/nixpkgs/commit/9e5f77a3e27f725ef4b3555e47acc21c7dce43c0) | `` nixos/xen: refactor dom0 configuration ``                                                     |
| [`9c322bce`](https://github.com/NixOS/nixpkgs/commit/9c322bcec85a899ae79a2ceda5f17173bbfb38c5) | `` remnote: 1.16.111 -> 1.16.116 ``                                                              |
| [`f06e5d63`](https://github.com/NixOS/nixpkgs/commit/f06e5d635fb293a02ea45af76b043e2f6860dc9c) | `` python312Packages.equinox: 0.11.6 -> 0.11.7 ``                                                |
| [`1f7b6347`](https://github.com/NixOS/nixpkgs/commit/1f7b63476a64b2fb11f176fc43448dda2ecc1a5a) | `` mumble: fix building with GCC 14 ``                                                           |
| [`9967b3b3`](https://github.com/NixOS/nixpkgs/commit/9967b3b358948690d33bf5b524043e8c7a2db2fc) | `` mesa: fix changelog URL, add myself as maintainer ``                                          |
| [`a2787576`](https://github.com/NixOS/nixpkgs/commit/a2787576bb8dc31ef608d542d83ec01aca35744b) | `` linux_6_1: 6.1.110 -> 6.1.111 ``                                                              |
| [`9bb5c9ae`](https://github.com/NixOS/nixpkgs/commit/9bb5c9ae1b0b1906e3e3764736c221063dcc2165) | `` linux_6_6: 6.6.51 -> 6.6.52 ``                                                                |
| [`ccdb30bc`](https://github.com/NixOS/nixpkgs/commit/ccdb30bc27cd2dc222fa00e81af660e6b817162e) | `` linux_6_10: 6.10.10 -> 6.10.11 ``                                                             |
| [`46b97e7f`](https://github.com/NixOS/nixpkgs/commit/46b97e7f0f1ce7c1432d156c78f41afc7b7b902c) | `` nixos/plasma6: install discover if flatpak is enabled ``                                      |
| [`d43a6262`](https://github.com/NixOS/nixpkgs/commit/d43a6262139b6342ebf2cb6fe2819037613bc329) | `` ollama: reformat bash where patches are applied ``                                            |
| [`b3a96e6a`](https://github.com/NixOS/nixpkgs/commit/b3a96e6a9fa0c8af951dc172bc1f816ade6b6452) | `` ollama: move `goBuild` environment variables to `env` ``                                      |
| [`ce26d83f`](https://github.com/NixOS/nixpkgs/commit/ce26d83f8c710bb236116a3cf9b40696d3022f3e) | `` python312Packages.twilio: 9.3.0 -> 9.3.1 ``                                                   |
| [`4aeb2288`](https://github.com/NixOS/nixpkgs/commit/4aeb2288434e91534dfd6e0ce1ef6b92061296c3) | `` python312Packages.openai: 1.45.1 -> 1.46.0 ``                                                 |
| [`5b27fe69`](https://github.com/NixOS/nixpkgs/commit/5b27fe69e23d735337186dc975c2d03b37956988) | `` python312Packages.chromadb @ 0.5.5: Cherry-pick patches for ongoing pydantic compatibility `` |
| [`310f0ae4`](https://github.com/NixOS/nixpkgs/commit/310f0ae4d5d6822a7a5c055953d85d47e931a27c) | ``  nixos/k3s: replace deprecated extra flag in usage example ``                                 |
| [`0b8f6029`](https://github.com/NixOS/nixpkgs/commit/0b8f6029b66b54ff558eafbe94ecf6c0d8f5e750) | `` lunatask: add update script ``                                                                |
| [`cea14594`](https://github.com/NixOS/nixpkgs/commit/cea145942d86da8a4747f1a9fb53ad2e58b2ed70) | `` gimx: unstable-2021-08-31 -> 8.0 (#336754) ``                                                 |
| [`0fd46573`](https://github.com/NixOS/nixpkgs/commit/0fd46573bae07033592afeb6397151d180c6c1be) | `` nix-ld: fix hash after #342540 ``                                                             |
| [`5e286fcd`](https://github.com/NixOS/nixpkgs/commit/5e286fcd2424e72dc9762f5c2e9323fe9842cee4) | `` python312Packages.pydaikin: 2.13.6 -> 2.13.7 ``                                               |
| [`9052a2df`](https://github.com/NixOS/nixpkgs/commit/9052a2df9d77163bd707864b49134f60634ce36d) | `` enter-tex: 3.46.0 → 3.47.0, renamed from gnome-latex ``                                       |
| [`f8a752fa`](https://github.com/NixOS/nixpkgs/commit/f8a752fa37f0d89a93bd527d44e9f3ed3667622a) | `` linuxPackages_latest.nct6687d: 0-unstable-2024-02-23 -> 0-unstable-2024-09-02 ``              |
| [`f62493c0`](https://github.com/NixOS/nixpkgs/commit/f62493c03743c00fc0330f24b35156c772c0343d) | `` Add vimPlugins.mini-* ``                                                                      |
| [`ce8da798`](https://github.com/NixOS/nixpkgs/commit/ce8da7980164ba7ac7db37707475c775f768e256) | `` gedit: 47.0 → 48.0 ``                                                                         |
| [`f85803fd`](https://github.com/NixOS/nixpkgs/commit/f85803fd889665d3120c0950067a545c6a1c8fa6) | `` libgedit-tepl: 6.10.0 → 6.11.0 ``                                                             |
| [`e3590749`](https://github.com/NixOS/nixpkgs/commit/e35907492cfa4f2630fb42c49fa28a566ee853fb) | `` libgedit-gtksourceview: 299.2.1 → 299.3.0 ``                                                  |
| [`eade58d2`](https://github.com/NixOS/nixpkgs/commit/eade58d202e65fb8bf602bf5d4e2f74939999c2e) | `` libgedit-gfls: 0.1.0 → 0.2.0 ``                                                               |
| [`bbf75a3c`](https://github.com/NixOS/nixpkgs/commit/bbf75a3c3e4fd7453ab14166eb631f9fbb345866) | `` libgedit-amtk: 5.8.0 → 5.9.0 ``                                                               |
| [`13a0d2d1`](https://github.com/NixOS/nixpkgs/commit/13a0d2d1aceea5a1e5fd5ac857113b15983cbbc4) | `` scaleway-cli: 2.33.0 -> 2.34.0 ``                                                             |
| [`7026cdf2`](https://github.com/NixOS/nixpkgs/commit/7026cdf28c707fe0d2802d093c55d6c13df0d2cd) | `` coqPackages.vscoq-language-server: 2.1.4 → 2.1.7 ``                                           |
| [`9733b2f4`](https://github.com/NixOS/nixpkgs/commit/9733b2f483824931fa01b36671c9222a4f615d99) | `` python312Packages.cyclonedx-python-lib: 7.6.0 -> 7.6.1 ``                                     |
| [`23a02d9e`](https://github.com/NixOS/nixpkgs/commit/23a02d9e008924d0e1c7e68c0fd8048a7e164ae9) | `` terrascan: 1.19.8 -> 1.19.9 ``                                                                |
| [`f3f6a20f`](https://github.com/NixOS/nixpkgs/commit/f3f6a20f617c0b5940f2b18e29b20cafaf01672a) | `` tigerbeetle: 0.15.3 -> 0.15.5 (#332867) ``                                                    |
| [`1a5bd76f`](https://github.com/NixOS/nixpkgs/commit/1a5bd76f58d664dd0e293439be19ca6d89f0630c) | `` eza: 0.19.3 -> 0.19.4 ``                                                                      |
| [`75c4c3d4`](https://github.com/NixOS/nixpkgs/commit/75c4c3d421afa448e647a889eb9dc2377c5827f6) | `` libcsa: init at 1.26-unstable-2024-03-22 ``                                                   |
| [`d174806d`](https://github.com/NixOS/nixpkgs/commit/d174806d6a70e83fbbda5e0b0b8505aa435bcf07) | `` basedpyright: 1.17.4 -> 1.17.5 ``                                                             |
| [`d31416e7`](https://github.com/NixOS/nixpkgs/commit/d31416e794bde8cbc1f54f368a43496396452844) | `` mdbook-alerts: 0.6.4 -> 0.6.5 ``                                                              |
| [`8bccb662`](https://github.com/NixOS/nixpkgs/commit/8bccb662d465c28a0353f6f27f3104e7f68b1942) | `` mediawriter: 5.1.2 -> 5.1.3 ``                                                                |
| [`160e8ad6`](https://github.com/NixOS/nixpkgs/commit/160e8ad6140dcadfeb478a6cebf064e6c86a9ab1) | `` grass: drop clang integer patch ``                                                            |
| [`9008265a`](https://github.com/NixOS/nixpkgs/commit/9008265a35b80a88a93871e28cc8241f45407a29) | `` lazygit: 0.44.0 -> 0.44.1 ``                                                                  |
| [`2d182775`](https://github.com/NixOS/nixpkgs/commit/2d182775317802a15d62d33c2bd948df0b02e351) | `` vimPlugins.vim-jjdescription: init at 2024-05-28 ``                                           |
| [`d006d68c`](https://github.com/NixOS/nixpkgs/commit/d006d68c42ab729af705d29b4f17735e6620be4f) | `` tlclient: init at 4.17.0 ``                                                                   |
| [`cc1d7dcc`](https://github.com/NixOS/nixpkgs/commit/cc1d7dcc9d2b79db2278ea5075bcde6cdd426469) | `` distrobuilder: fix non-x86 builds ``                                                          |
| [`87ad9974`](https://github.com/NixOS/nixpkgs/commit/87ad9974188c55548a3c7b56e916246b8f33c539) | `` troubadix: 24.8.2 -> 24.9.2 ``                                                                |
| [`3e0f775a`](https://github.com/NixOS/nixpkgs/commit/3e0f775a5415012c069bd920989b4d27065d17c4) | `` home-assistant: 2024.9.1 -> 2024.9.2 ``                                                       |
| [`2a0e8929`](https://github.com/NixOS/nixpkgs/commit/2a0e89298a65f4ba07fd1d775acf2192bcfa2d2c) | `` python312Packages.zha: 0.0.32 -> 0.0.33 ``                                                    |
| [`10be3da0`](https://github.com/NixOS/nixpkgs/commit/10be3da063d555ae4d0ca12c0721e31e9f687292) | `` python312Packages.bellows: 0.40.5 -> 0.40.6 ``                                                |
| [`446fdc0f`](https://github.com/NixOS/nixpkgs/commit/446fdc0f05048d47513f2e0952b6db8e97640046) | `` python312Packages.sfrbox-api: 0.0.11 -> 0.0.11 ``                                             |
| [`44cd2d84`](https://github.com/NixOS/nixpkgs/commit/44cd2d84e3c676208ac6892e3a43a81536a88643) | `` python312Packages.aiolifx-themes: 0.5.3 -> 0.5.5 ``                                           |
| [`169020fa`](https://github.com/NixOS/nixpkgs/commit/169020fad3db27b269681c0f8d47a71ed386d713) | `` python312Packages.aiolifx: 1.0.9 -> 1.1.1 ``                                                  |
| [`504bb132`](https://github.com/NixOS/nixpkgs/commit/504bb13273e32beff557bd948a20b605ed2093f4) | `` nix-serve.nix: Add ``                                                                         |
| [`30620e77`](https://github.com/NixOS/nixpkgs/commit/30620e773694286ce59910474a76356bd83dc79f) | `` nixosTests.nix-serve: Use new entrypoint ``                                                   |
| [`21b84d45`](https://github.com/NixOS/nixpkgs/commit/21b84d4549235f8e265c65a22294c6a49048f7ed) | `` oxker: 0.7.0 -> 0.7.2 ``                                                                      |
| [`8e503074`](https://github.com/NixOS/nixpkgs/commit/8e503074d2f3e6d0a94806e3e225644f19d1a4eb) | `` prometheus-frr-exporter: 1.3.0 -> 1.3.1 ``                                                    |
| [`d554e318`](https://github.com/NixOS/nixpkgs/commit/d554e318c3991edbc5bc071cd5aad9ff91f79f86) | `` monitor: 0.17.1 -> 0.17.2 ``                                                                  |
| [`2be4286e`](https://github.com/NixOS/nixpkgs/commit/2be4286e70b74f09c8e19ea11d7f30ee15643fb1) | `` matrix-appservice-irc: 3.0.1 -> 3.0.2 ``                                                      |
| [`6974feb9`](https://github.com/NixOS/nixpkgs/commit/6974feb92c0ce213a9d4564167fe6f2c3f5946c6) | `` nixos/matrix-hookshot: init module ``                                                         |
| [`594e129f`](https://github.com/NixOS/nixpkgs/commit/594e129f27683ece85538959c31b5a7ed823b121) | `` boxbuddy: 2.2.11 -> 2.2.12 ``                                                                 |
| [`862ce2f7`](https://github.com/NixOS/nixpkgs/commit/862ce2f78a2ab3a551087f6c6c7543060f31ddde) | `` python312Packages.uv: 0.4.10 -> 0.4.11 ``                                                     |
| [`ec9cf7a4`](https://github.com/NixOS/nixpkgs/commit/ec9cf7a4785eccf97c54d7eff4434a77c391eb17) | `` serie: 0.3.0 -> 0.4.0 ``                                                                      |