### PR TITLE
chore(flake/emacs-overlay): `c64436a2` -> `fa856306`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726822766,
-        "narHash": "sha256-3SC6yL7vqLymqHCU6BCWzcpt5tgS7qGtj12aO1AKNyQ=",
+        "lastModified": 1726851533,
+        "narHash": "sha256-LKriwiqsxcsLD0+mXF4b+k2NwzlTW3RmO1Tz2hOQpNg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c64436a2941e042e63c5efb5eab94a11a12ca5de",
+        "rev": "fa856306db1e44f99d5b1aebd6d1298439419918",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`fa856306`](https://github.com/nix-community/emacs-overlay/commit/fa856306db1e44f99d5b1aebd6d1298439419918) | `` Updated melpa ``        |
| [`75f79c95`](https://github.com/nix-community/emacs-overlay/commit/75f79c95b616bd894562e22a7bb8a8a68dd5dd9b) | `` Updated elpa ``         |
| [`1b4645b0`](https://github.com/nix-community/emacs-overlay/commit/1b4645b0532c6f465d622ca5327db74d6e846b65) | `` Updated nongnu ``       |
| [`afcea8fc`](https://github.com/nix-community/emacs-overlay/commit/afcea8fca5ae2937d7a6fc019185730c4b387285) | `` Updated flake inputs `` |