### PR TITLE
chore(flake/emacs-overlay): `fa856306` -> `5dc958d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726851533,
-        "narHash": "sha256-LKriwiqsxcsLD0+mXF4b+k2NwzlTW3RmO1Tz2hOQpNg=",
+        "lastModified": 1726852416,
+        "narHash": "sha256-2HnfdVnEajfW2rSfVQ6d7kGgxUb7AFQp7tCyUF8BfU0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fa856306db1e44f99d5b1aebd6d1298439419918",
+        "rev": "5dc958d29c79253341fec0e37130041444d57f0c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`5dc958d2`](https://github.com/nix-community/emacs-overlay/commit/5dc958d29c79253341fec0e37130041444d57f0c) | `` Updated emacs `` |