### PR TITLE
chore(flake/emacs-overlay): `e588118d` -> `0229bbe8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726880978,
-        "narHash": "sha256-3iQhDgPgU2Ft5TKg2zi6lATNo0ekFMYABMh7q3A7o/o=",
+        "lastModified": 1726935676,
+        "narHash": "sha256-7gyRhR5aJTyv0kyOYzuzpXJpm530J7nVS1XvifB02OQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e588118d85745bfabfd58aaeb400e3fe6c66daf1",
+        "rev": "0229bbe8b5e1d9c6d7ade2f90bab122d0c96e976",
         "type": "github"
       },
       "original": {
@@ -684,11 +684,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1726688310,
-        "narHash": "sha256-Xc9lEtentPCEtxc/F1e6jIZsd4MPDYv4Kugl9WtXlz0=",
+        "lastModified": 1726838390,
+        "narHash": "sha256-NmcVhGElxDbmEWzgXsyAjlRhUus/nEqPC5So7BOJLUM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dbebdd67a6006bb145d98c8debf9140ac7e651d0",
+        "rev": "944b2aea7f0a2d7c79f72468106bc5510cbf5101",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`0229bbe8`](https://github.com/nix-community/emacs-overlay/commit/0229bbe8b5e1d9c6d7ade2f90bab122d0c96e976) | `` Updated elpa ``         |
| [`545d43be`](https://github.com/nix-community/emacs-overlay/commit/545d43beb336e58918c2a2aaf253f2be888108c9) | `` Updated nongnu ``       |
| [`ca2f88f4`](https://github.com/nix-community/emacs-overlay/commit/ca2f88f41141cac4d39e9f0b1d819807d19fcfdc) | `` Updated flake inputs `` |