### PR TITLE
chore(flake/catppuccin): `45745fe5` -> `f350081c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1725509983,
-        "narHash": "sha256-NHCgHVqumPraFJnLrkanoLDuhOoUHUvRhvp/RIHJR+A=",
+        "lastModified": 1726948720,
+        "narHash": "sha256-p7xDYm8Y/NUCTvD6MoB9qJVV6UrpNNow1PZ2+P7FMVQ=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "45745fe5960acaefef2b60f3455bcac6a0ca6bc9",
+        "rev": "f350081c368916cc4179f1c310764e4fd001f431",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                     |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`f350081c`](https://github.com/catppuccin/nix/commit/f350081c368916cc4179f1c310764e4fd001f431) | `` chore: update dev flake inputs (#306) `` |