### PR TITLE
chore(flake/catppuccin): `f350081c` -> `630b559c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1726948720,
-        "narHash": "sha256-p7xDYm8Y/NUCTvD6MoB9qJVV6UrpNNow1PZ2+P7FMVQ=",
+        "lastModified": 1726952185,
+        "narHash": "sha256-l/HbsQjJMT6tlf8KCooFYi3J6wjIips3n6/aWAoLY4g=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "f350081c368916cc4179f1c310764e4fd001f431",
+        "rev": "630b559cc1cb4c0bdd525af506935323e4ccd5d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                        |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`630b559c`](https://github.com/catppuccin/nix/commit/630b559cc1cb4c0bdd525af506935323e4ccd5d1) | `` ci: remove backport workflow (#339) ``                                      |
| [`42ec8a76`](https://github.com/catppuccin/nix/commit/42ec8a76f93097ff9a84ca28d53957d03b5cd7dc) | `` chore(modules): update ports (#320) ``                                      |
| [`c0a887d3`](https://github.com/catppuccin/nix/commit/c0a887d347b11515f9c8d2f507c0a68878ba08fa) | `` style: format 966af28 ``                                                    |
| [`966af28f`](https://github.com/catppuccin/nix/commit/966af28f2d5b7b5bd3f947d6bab5d7da3bf9fee4) | `` feat(home-manager/mako): add accent color support (#323) ``                 |
| [`78342d11`](https://github.com/catppuccin/nix/commit/78342d11f1e4dfde4705c470b466d9f8c125164e) | `` style: format 76dd2b2 ``                                                    |
| [`76dd2b2e`](https://github.com/catppuccin/nix/commit/76dd2b2e1f8d1ec7090c30462f8bcc0b7c598389) | `` feat(home-manager): add support for obs-studio (#324) ``                    |
| [`6effc32e`](https://github.com/catppuccin/nix/commit/6effc32e614405c05a63a1365fd078a0ab996a0e) | `` feat(home-manager): add support for freetube (#327) ``                      |
| [`85a6ef02`](https://github.com/catppuccin/nix/commit/85a6ef0294702eff9fbf3173f236ba4ed02034cf) | `` style: format f91de98 ``                                                    |
| [`f91de989`](https://github.com/catppuccin/nix/commit/f91de989e9671176ee4cda16c4b297d5a9682a45) | `` fix(home-manager/kitty): use new `themeFile` option on 24.11 (#337) ``      |
| [`faea8838`](https://github.com/catppuccin/nix/commit/faea8838116f5e5fa2ab4b00d97d8d1e0e382bae) | `` feat(home-manager): add support for hyprlock (#330) ``                      |
| [`f4c051d1`](https://github.com/catppuccin/nix/commit/f4c051d174b283b6ee0841fe657ca3864b9e17b6) | `` ci: update determinatesystems/magic-nix-cache-action action to v8 (#335) `` |
| [`13665eb1`](https://github.com/catppuccin/nix/commit/13665eb13691e7ba3b8049d3710c1352542b6b68) | `` ci: update determinatesystems/flakehub-push action to v5 (#334) ``          |