### PR TITLE
chore(flake/emacs-overlay): `0229bbe8` -> `2c5171a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726935676,
-        "narHash": "sha256-7gyRhR5aJTyv0kyOYzuzpXJpm530J7nVS1XvifB02OQ=",
+        "lastModified": 1726967971,
+        "narHash": "sha256-UO0TQbj8UFI4tioDTjmui0UqTL8CZkwizolvxqJLGu0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0229bbe8b5e1d9c6d7ade2f90bab122d0c96e976",
+        "rev": "2c5171a36fcd616753b204c34ef38bf7729825e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`2c5171a3`](https://github.com/nix-community/emacs-overlay/commit/2c5171a36fcd616753b204c34ef38bf7729825e2) | `` Updated elpa ``   |
| [`eafa9726`](https://github.com/nix-community/emacs-overlay/commit/eafa97260a15887a0b77d984f6c75143273622b6) | `` Updated nongnu `` |