### PR TITLE
chore(flake/srvos): `c7ffab6f` -> `3d632100`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -882,11 +882,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726970904,
-        "narHash": "sha256-GVE2yM3Sn18qkUTZHZ8Hmwwm/YSu+oYp3LM106+10UU=",
+        "lastModified": 1727009428,
+        "narHash": "sha256-FARoovxnjbn76+XWSiA8vbG5fw+6SfyJTxwqLp1sK/Q=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "c7ffab6f1dd5acb2a2528842678f61c7b1cebe59",
+        "rev": "3d632100298a1e3d395398cab6641a21a6cd8a91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                             |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`4ca7102c`](https://github.com/nix-community/srvos/commit/4ca7102cc9595d6f3b0fc0c035a02c9e4d1b8c00) | `` telegraf: pkgs.zfs -> config.boot.zfs.package `` |
| [`aba9ec6c`](https://github.com/nix-community/srvos/commit/aba9ec6c00a183eb5a856310ac87b5381f595ebc) | `` add latest zfs-kernel mixin ``                   |