### PR TITLE
chore(flake/emacs-overlay): `2c5171a3` -> `6ae6f2b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726967971,
-        "narHash": "sha256-UO0TQbj8UFI4tioDTjmui0UqTL8CZkwizolvxqJLGu0=",
+        "lastModified": 1727021989,
+        "narHash": "sha256-UnGVpO2bTMPSAvc3KoA2Z75Ey5Bezg7oo0h5QTjK/ZE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2c5171a36fcd616753b204c34ef38bf7729825e2",
+        "rev": "6ae6f2b182f996c14df856ddb8ec68269d04f403",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`6ae6f2b1`](https://github.com/nix-community/emacs-overlay/commit/6ae6f2b182f996c14df856ddb8ec68269d04f403) | `` Updated elpa ``   |
| [`0f4b4ef3`](https://github.com/nix-community/emacs-overlay/commit/0f4b4ef3ca6a3c6b7559e8987898b88fd3689135) | `` Updated nongnu `` |