### PR TITLE
chore(flake/emacs-overlay): `6ae6f2b1` -> `b8a1f6f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1727021989,
-        "narHash": "sha256-UnGVpO2bTMPSAvc3KoA2Z75Ey5Bezg7oo0h5QTjK/ZE=",
+        "lastModified": 1727054116,
+        "narHash": "sha256-DgFK45+KW954UuQhARdzjZb0K7588vw+wJCiJI6+FVw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6ae6f2b182f996c14df856ddb8ec68269d04f403",
+        "rev": "b8a1f6f94a8947b5601ab7302ad7dc5a3fc45c26",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`b8a1f6f9`](https://github.com/nix-community/emacs-overlay/commit/b8a1f6f94a8947b5601ab7302ad7dc5a3fc45c26) | `` Updated nongnu `` |
| [`25566cb2`](https://github.com/nix-community/emacs-overlay/commit/25566cb2d874171a6572b0675e734bd5366f76a7) | `` Updated elpa ``   |