### PR TITLE
chore(flake/srvos): `3d632100` -> `b2943d34`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -882,11 +882,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727009428,
-        "narHash": "sha256-FARoovxnjbn76+XWSiA8vbG5fw+6SfyJTxwqLp1sK/Q=",
+        "lastModified": 1727052833,
+        "narHash": "sha256-WxqVKXCPMQEKOLIOb7r4jMVJil45SOJZ5extRo5I9kA=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "3d632100298a1e3d395398cab6641a21a6cd8a91",
+        "rev": "b2943d34b0d545bc636f5e80ca5ed3fd7e6ce7a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`b2943d34`](https://github.com/nix-community/srvos/commit/b2943d34b0d545bc636f5e80ca5ed3fd7e6ce7a4) | `` dev/private/flake.lock: Update `` |
| [`edda5947`](https://github.com/nix-community/srvos/commit/edda59473400592f5baf7faada3024817e27513c) | `` flake.lock: Update ``             |