### PR TITLE
chore(flake/srvos): `b2943d34` -> `63ea710b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -882,11 +882,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727052833,
-        "narHash": "sha256-WxqVKXCPMQEKOLIOb7r4jMVJil45SOJZ5extRo5I9kA=",
+        "lastModified": 1727078420,
+        "narHash": "sha256-zAj2AdZ24bcRyDc5B4LqlepodHFLzAboPPm1tiiWyts=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "b2943d34b0d545bc636f5e80ca5ed3fd7e6ce7a4",
+        "rev": "63ea710b10c88f2158251d49eec7cc286cefbd68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                               |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`993d85cd`](https://github.com/nix-community/srvos/commit/993d85cdec8a2fd2e87a2c03fc0612e466688793) | `` latest-zfs-kernel: only mainline kernel and respect zfsUnstable `` |