### PR TITLE
chore(flake/treefmt): `ee41a466` -> `35dfece1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -977,11 +977,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726734507,
-        "narHash": "sha256-VUH5O5AcOSxb0uL/m34dDkxFKP6WLQ6y4I1B4+N3L2w=",
+        "lastModified": 1727098951,
+        "narHash": "sha256-gplorAc0ISAUPemUNOnRUs7jr3WiLiHZb3DJh++IkZs=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "ee41a466c2255a3abe6bc50fc6be927cdee57a9f",
+        "rev": "35dfece10c642eb52928a48bee7ac06a59f93e9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                               |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`35dfece1`](https://github.com/numtide/treefmt-nix/commit/35dfece10c642eb52928a48bee7ac06a59f93e9a) | `` feat: add typos, a spellchecking program (#239) `` |