### PR TITLE
chore(flake/emacs-overlay): `b8a1f6f9` -> `01e2bfd5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1727054116,
-        "narHash": "sha256-DgFK45+KW954UuQhARdzjZb0K7588vw+wJCiJI6+FVw=",
+        "lastModified": 1727108506,
+        "narHash": "sha256-RZYnceej7y4DpljD8S0+Aufz37u8D8W/9uvMO1Aqzq0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b8a1f6f94a8947b5601ab7302ad7dc5a3fc45c26",
+        "rev": "01e2bfd559a1d47c1dbc3da6103acb1821a6dff3",
         "type": "github"
       },
       "original": {
@@ -684,11 +684,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1726838390,
-        "narHash": "sha256-NmcVhGElxDbmEWzgXsyAjlRhUus/nEqPC5So7BOJLUM=",
+        "lastModified": 1726969270,
+        "narHash": "sha256-8fnFlXBgM/uSvBlLWjZ0Z0sOdRBesyNdH0+esxqizGc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "944b2aea7f0a2d7c79f72468106bc5510cbf5101",
+        "rev": "23cbb250f3bf4f516a2d0bf03c51a30900848075",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`01e2bfd5`](https://github.com/nix-community/emacs-overlay/commit/01e2bfd559a1d47c1dbc3da6103acb1821a6dff3) | `` Updated elpa ``         |
| [`217992fe`](https://github.com/nix-community/emacs-overlay/commit/217992fe3eadc4771948900f31b6ef878e83d948) | `` Updated nongnu ``       |
| [`df4d0f85`](https://github.com/nix-community/emacs-overlay/commit/df4d0f85da9ac732d96eba5f2b15dab86d25a3ad) | `` Updated flake inputs `` |