### PR TITLE
chore(flake/impermanence): `63f4d044` -> `8514fff0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -447,11 +447,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1725690722,
-        "narHash": "sha256-4qWg9sNh5g1qPGO6d/GV2ktY+eDikkBTbWSg5/iD2nY=",
+        "lastModified": 1727198257,
+        "narHash": "sha256-/qMVI+SG9zvhLbQFOnqb4y4BH6DdK3DQHZU5qGptehc=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "63f4d0443e32b0dd7189001ee1894066765d18a5",
+        "rev": "8514fff0f048557723021ffeb31ca55f69b67de3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                   |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`7448d149`](https://github.com/nix-community/impermanence/commit/7448d149b0489f709aa6841d5d2af0635f14d69f) | `` nixos: Fix duplicate definition causing syntax error ``                |
| [`1bfbbfae`](https://github.com/nix-community/impermanence/commit/1bfbbfae306143c737f320f8f90dd6e09e79250d) | `` nixos: Create persisted dirs marked as needed for boot before mount `` |