### PR TITLE
chore(flake/emacs-overlay): `01e2bfd5` -> `b3512b3d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1727108506,
-        "narHash": "sha256-RZYnceej7y4DpljD8S0+Aufz37u8D8W/9uvMO1Aqzq0=",
+        "lastModified": 1727140563,
+        "narHash": "sha256-uaugOQen4xK3vxect3xZyq3CsNOHcV5nMHS4yteIHFA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "01e2bfd559a1d47c1dbc3da6103acb1821a6dff3",
+        "rev": "b3512b3df5396e17d9e89cadcc3f57db0ea1fecc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`b3512b3d`](https://github.com/nix-community/emacs-overlay/commit/b3512b3df5396e17d9e89cadcc3f57db0ea1fecc) | `` Updated elpa ``   |
| [`81a008d2`](https://github.com/nix-community/emacs-overlay/commit/81a008d2801c1120fad55d035fd7712fd30e24ee) | `` Updated nongnu `` |