### PR TITLE
chore(flake/nixpkgs_veilid): `1dba027a` -> `56f8f810`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -863,11 +863,11 @@
     },
     "nixpkgs_veilid": {
       "locked": {
-        "lastModified": 1726364444,
-        "narHash": "sha256-foXjmcjUiKmPMhBcs7bn/rbdVjrLgpk/NSP6p0f6Z80=",
+        "lastModified": 1727065838,
+        "narHash": "sha256-5Apz/vS0vxg1vL0DWtETpCfeWhwn51GUWBps8e97+XA=",
         "owner": "figboy9",
         "repo": "nixpkgs",
-        "rev": "1dba027ae97a0ec3d19826f913c7235546c19442",
+        "rev": "56f8f810aeedd2b03c4bc390f714875fe522e93a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                  |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------- |
| [`56f8f810`](https://github.com/figboy9/nixpkgs/commit/56f8f810aeedd2b03c4bc390f714875fe522e93a) | `` nixos/veilid: fix description link `` |