### PR TITLE
chore(flake/emacs-overlay): `b3512b3d` -> `dad75975`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1727140563,
-        "narHash": "sha256-uaugOQen4xK3vxect3xZyq3CsNOHcV5nMHS4yteIHFA=",
+        "lastModified": 1727194940,
+        "narHash": "sha256-5xFoPOo35DMSCi0DoEDmMy3eWnC84rSsa+psxnNzHic=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b3512b3df5396e17d9e89cadcc3f57db0ea1fecc",
+        "rev": "dad75975b68c048a06524d8de47affef0b0d91d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`dad75975`](https://github.com/nix-community/emacs-overlay/commit/dad75975b68c048a06524d8de47affef0b0d91d1) | `` Updated elpa ``   |
| [`de632958`](https://github.com/nix-community/emacs-overlay/commit/de632958e0b70e263e6fd66ac858f21209a3700e) | `` Updated nongnu `` |