### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `241fa6a9` -> `bf8e3c82`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727140563,
-        "narHash": "sha256-uaugOQen4xK3vxect3xZyq3CsNOHcV5nMHS4yteIHFA=",
+        "lastModified": 1727252497,
+        "narHash": "sha256-wqQKv4vzcGJ/yUysFOyJehV7mWm8gSRxejjxokB4yac=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b3512b3df5396e17d9e89cadcc3f57db0ea1fecc",
+        "rev": "017a3747a3fdd8430debd4e137df1cfabe67c0b6",
         "type": "github"
       },
       "original": {
@@ -516,11 +516,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1727167161,
-        "narHash": "sha256-g4jqJJjwHoVg1XysPYIMyueQhYYRIs+EhzeIhGBHgvo=",
+        "lastModified": 1727253626,
+        "narHash": "sha256-M4LM7PC33thZlYS77hkMyxs21BK6FYKSSzmVbiPWkFQ=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "241fa6a92b340c83682549080b8cf5c6d4afe88c",
+        "rev": "bf8e3c8229fb59ca13fad28bf35d63b69139031c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`bf8e3c82`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/bf8e3c8229fb59ca13fad28bf35d63b69139031c) | `` flake.lock: Update `` |