### PR TITLE
chore(flake/nixos-cosmic): `cf1a8ec5` -> `4b1d492e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -633,11 +633,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1727228258,
-        "narHash": "sha256-rpmOMEpshPjYmISbQAJqEq8Gm6U+gFha8u3KKJ+/gX8=",
+        "lastModified": 1727266426,
+        "narHash": "sha256-S0vMrmbLCAPuHirynbH/S34JO7ba3GfDBMEQpHReShE=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "cf1a8ec54a9be23d4728a15e1810421f605692ee",
+        "rev": "4b1d492e3bfb96292a02f66ddf22848b256f8817",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                                                |
| ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`4b1d492e`](https://github.com/lilyinstarlight/nixos-cosmic/commit/4b1d492e3bfb96292a02f66ddf22848b256f8817) | `` readme: make example flake follow nixos-cosmic nixpkgs rev to avoid cache misses `` |
| [`ceabf01b`](https://github.com/lilyinstarlight/nixos-cosmic/commit/ceabf01bc702ae26288f7d25d2b4577858e874ce) | `` nixos,pkgs: nixfmt ``                                                               |
| [`1599a589`](https://github.com/lilyinstarlight/nixos-cosmic/commit/1599a589f0d1db5ff88c267ed59b8b77ee0b9077) | `` nixos,pkgs: update meta ``                                                          |