### PR TITLE
chore(flake/srvos): `63ea710b` -> `f12841ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -990,11 +990,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727078420,
-        "narHash": "sha256-zAj2AdZ24bcRyDc5B4LqlepodHFLzAboPPm1tiiWyts=",
+        "lastModified": 1727271162,
+        "narHash": "sha256-RtcUoiP53CmjxNA6ipavEOxMoViMV65fHnWL1utLAws=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "63ea710b10c88f2158251d49eec7cc286cefbd68",
+        "rev": "f12841cee94e38b289546b756d023ee7be3322c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                       |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`979c47cd`](https://github.com/nix-community/srvos/commit/979c47cd90b3b54e5b57ec33928d9e711494576f) | `` Update nixos/server/default.nix ``                                         |
| [`331c7a18`](https://github.com/nix-community/srvos/commit/331c7a1882edecc18512a4f00c8dd2aae271e7c2) | `` Make sure the serial console is visible in qemu when testing the server `` |