### PR TITLE
chore(flake/nixos-cosmic): `4b1d492e` -> `f9290748`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -633,11 +633,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1727266426,
-        "narHash": "sha256-S0vMrmbLCAPuHirynbH/S34JO7ba3GfDBMEQpHReShE=",
+        "lastModified": 1727299875,
+        "narHash": "sha256-mILXRgW9pTFJF9l4GDiPRn5c1wNybqP+/DozWJzlN2U=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "4b1d492e3bfb96292a02f66ddf22848b256f8817",
+        "rev": "f929074895ac91f3d657e642a0d3d38dec682bfd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                               |
| ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`f9290748`](https://github.com/lilyinstarlight/nixos-cosmic/commit/f929074895ac91f3d657e642a0d3d38dec682bfd) | `` cosmic-session: import more relevant environment variables ``      |
| [`6b3a61a7`](https://github.com/lilyinstarlight/nixos-cosmic/commit/6b3a61a7311c9b4fc9a9ca23eb4e5b65ee14ca97) | `` flake: disable pkg aliases in vm to catch alias usage ``           |
| [`4f45a630`](https://github.com/lilyinstarlight/nixos-cosmic/commit/4f45a6305f436b9a15c5912a95a3e474393f2edb) | `` readme: add note about adding flathub ``                           |
| [`5e39809f`](https://github.com/lilyinstarlight/nixos-cosmic/commit/5e39809f4e75535ab782c7b7a11939a202e3a576) | `` nixos/cosmic-greeter: follow nixpkgs convention for system user `` |
| [`0c5f8b07`](https://github.com/lilyinstarlight/nixos-cosmic/commit/0c5f8b07ab80174cdad97139314d96781bc07547) | `` pkgs: nixfmt again because i guess it is not idempotent ``         |
| [`a6e01985`](https://github.com/lilyinstarlight/nixos-cosmic/commit/a6e01985d01a001994e48e9f04d2211b72b965eb) | `` nixos,pkgs: use lib.getExe more ``                                 |
| [`5fbd6d81`](https://github.com/lilyinstarlight/nixos-cosmic/commit/5fbd6d812159f1cd89f72b586fbb97a8ca808d19) | `` pkgs: update cosmic (#361) ``                                      |