### PR TITLE
chore(flake/emacs-overlay): `017a3747` -> `e81b6546`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1727252497,
-        "narHash": "sha256-wqQKv4vzcGJ/yUysFOyJehV7mWm8gSRxejjxokB4yac=",
+        "lastModified": 1727281458,
+        "narHash": "sha256-wp4a4+dDAjFYm5tI5BjjgcE4hdjpDcv5U3O+07xjwVc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "017a3747a3fdd8430debd4e137df1cfabe67c0b6",
+        "rev": "e81b6546fb597e6204bd6ef1bd0e6d35d498be20",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`e81b6546`](https://github.com/nix-community/emacs-overlay/commit/e81b6546fb597e6204bd6ef1bd0e6d35d498be20) | `` Updated elpa ``   |
| [`51127344`](https://github.com/nix-community/emacs-overlay/commit/51127344bccf7358142bc9a00df256b5bfcac65d) | `` Updated nongnu `` |