### PR TITLE
chore(flake/nixos-cosmic): `f9290748` -> `daeda6c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -633,11 +633,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1727299875,
-        "narHash": "sha256-mILXRgW9pTFJF9l4GDiPRn5c1wNybqP+/DozWJzlN2U=",
+        "lastModified": 1727302402,
+        "narHash": "sha256-NLCE+FKeUmhe7NmUhNMTE3eYyyfNyiXO89Jv3rfOSzQ=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "f929074895ac91f3d657e642a0d3d38dec682bfd",
+        "rev": "daeda6c974fccc002e4bb56874bd47db730f65ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                            |
| ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`daeda6c9`](https://github.com/lilyinstarlight/nixos-cosmic/commit/daeda6c974fccc002e4bb56874bd47db730f65ee) | `` cosmic-session: nit variable import a little `` |
| [`55ef9a76`](https://github.com/lilyinstarlight/nixos-cosmic/commit/55ef9a7603e7b5600ea1a06f64232d2db90a7ed0) | `` cosmic-session: make variable import quieter `` |