### PR TITLE
chore(flake/srvos): `f12841ce` -> `edc1d31b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -990,11 +990,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727271162,
-        "narHash": "sha256-RtcUoiP53CmjxNA6ipavEOxMoViMV65fHnWL1utLAws=",
+        "lastModified": 1727312898,
+        "narHash": "sha256-PRCWFc/RN5LxNarKMsieSixrwGLm1nJNVxU0MFFBISc=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "f12841cee94e38b289546b756d023ee7be3322c9",
+        "rev": "edc1d31ba4a92afd475cc32bae722dad547464cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                              |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`edc1d31b`](https://github.com/nix-community/srvos/commit/edc1d31ba4a92afd475cc32bae722dad547464cb) | `` dev/private/flake.lock: Update ``                 |
| [`16dceb26`](https://github.com/nix-community/srvos/commit/16dceb26fe6417b7c7f0468da64ef2b5833fd7aa) | `` flake.lock: Update ``                             |
| [`8f05f88e`](https://github.com/nix-community/srvos/commit/8f05f88e6de4ea029ebe152c7555223c3432536f) | `` only disable noXlibs for older nixpkgs version `` |