### PR TITLE
chore(flake/nixos-cosmic): `daeda6c9` -> `f2aa34f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -633,11 +633,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1727302402,
-        "narHash": "sha256-NLCE+FKeUmhe7NmUhNMTE3eYyyfNyiXO89Jv3rfOSzQ=",
+        "lastModified": 1727314564,
+        "narHash": "sha256-UE98O6EQYUiDp7rypkBfJG0XSz0c5FxkslyP+7Gskt8=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "daeda6c974fccc002e4bb56874bd47db730f65ee",
+        "rev": "f2aa34f521da1d6335301fc1b58dde8ed779d632",
         "type": "github"
       },
       "original": {
@@ -753,11 +753,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1726969270,
-        "narHash": "sha256-8fnFlXBgM/uSvBlLWjZ0Z0sOdRBesyNdH0+esxqizGc=",
+        "lastModified": 1727129439,
+        "narHash": "sha256-nPyrcFm6FSk7CxzVW4x2hu62aLDghNcv9dX6DF3dXw8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "23cbb250f3bf4f516a2d0bf03c51a30900848075",
+        "rev": "babc25a577c3310cce57c72d5bed70f4c3c3843a",
         "type": "github"
       },
       "original": {
@@ -933,11 +933,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727144949,
-        "narHash": "sha256-uMZMjoCS2nf40TAE1686SJl3OXWfdfM+BDEfRdr+uLc=",
+        "lastModified": 1727231386,
+        "narHash": "sha256-XLloPtQHKk/Tdt8t8zIb+JhmunlH3YB9Jz8RTlQ3N/4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2e19799819104b46019d339e78d21c14372d3666",
+        "rev": "b5f76c3b09a8194889f5328a480fbea1a9115518",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                           |
| ------------------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`f2aa34f5`](https://github.com/lilyinstarlight/nixos-cosmic/commit/f2aa34f521da1d6335301fc1b58dde8ed779d632) | `` flake: update inputs (#363) `` |
| [`1be16eec`](https://github.com/lilyinstarlight/nixos-cosmic/commit/1be16eec8d73aae5dffaf3507554a1b74c6f16f2) | `` pkgs: update cosmic (#362) ``  |