### PR TITLE
chore(flake/emacs-overlay): `d995ae78` -> `ad40c4b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1727313279,
-        "narHash": "sha256-Nedj+OFRu6UL5+bPu2fH9nHWm1lcbK5J5Farn6DWmOU=",
+        "lastModified": 1727338837,
+        "narHash": "sha256-gYPDeDnGP/ky1CKiRIttv7JhiAPIerjDSypnNXHkJpA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d995ae782711bd65ee738198242f4450e5339995",
+        "rev": "ad40c4b881309a5a96029636c35cc42419d55ce7",
         "type": "github"
       },
       "original": {
@@ -721,11 +721,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1727129439,
-        "narHash": "sha256-nPyrcFm6FSk7CxzVW4x2hu62aLDghNcv9dX6DF3dXw8=",
+        "lastModified": 1727264057,
+        "narHash": "sha256-KQPI8CTTnB9CrJ7LrmLC4VWbKZfljEPBXOFGZFRpxao=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "babc25a577c3310cce57c72d5bed70f4c3c3843a",
+        "rev": "759537f06e6999e141588ff1c9be7f3a5c060106",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`ad40c4b8`](https://github.com/nix-community/emacs-overlay/commit/ad40c4b881309a5a96029636c35cc42419d55ce7) | `` Updated flake inputs `` |