### PR TITLE
chore(flake/emacs-overlay): `ad40c4b8` -> `67c5ca1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1727338837,
-        "narHash": "sha256-gYPDeDnGP/ky1CKiRIttv7JhiAPIerjDSypnNXHkJpA=",
+        "lastModified": 1727369190,
+        "narHash": "sha256-sYCjzhaYcHfu9PXkyZbqCTkPFMMbp0j4/9SBkTu46fo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ad40c4b881309a5a96029636c35cc42419d55ce7",
+        "rev": "67c5ca1bc124638f45eb20bec40bada15733c9c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                              |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------ |
| [`ecba1d6b`](https://github.com/nix-community/emacs-overlay/commit/ecba1d6b464597b7e8a61461c0645b8fa5657945) | `` Updated elpa ``                   |
| [`7a44cef5`](https://github.com/nix-community/emacs-overlay/commit/7a44cef5ba5e5c62660d33c9ac241bdeceb312d9) | `` Updated nongnu ``                 |
| [`ce4ed6b6`](https://github.com/nix-community/emacs-overlay/commit/ce4ed6b670743b22ae3816b24cd3e72818246aad) | `` Disable webkit2gtk integration `` |