### PR TITLE
chore(flake/emacs-overlay): `67c5ca1b` -> `c691136b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1727369190,
-        "narHash": "sha256-sYCjzhaYcHfu9PXkyZbqCTkPFMMbp0j4/9SBkTu46fo=",
+        "lastModified": 1727388995,
+        "narHash": "sha256-GJbS2z5G6BwuQ6n9wYtoX/fbwzU68wmQ1cy40WwPWQw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "67c5ca1bc124638f45eb20bec40bada15733c9c5",
+        "rev": "c691136bcb2dd7486e6dae9eeb3f30c9c3a4bf98",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                              |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
| [`c691136b`](https://github.com/nix-community/emacs-overlay/commit/c691136bcb2dd7486e6dae9eeb3f30c9c3a4bf98) | `` Use bytecomp-revert.patch for unstable Emacsen `` |