### PR TITLE
chore(flake/emacs-overlay): `72a7fec6` -> `a4ee09a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1727399726,
-        "narHash": "sha256-uXrkFxPRqutXGiWITPbgfDfFei7GzQHibjQkWzFFz7E=",
+        "lastModified": 1727411519,
+        "narHash": "sha256-9xQF78yyNv/dkJ56HKVtJLRM6aoytIk6VPyNlR25Zyk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "72a7fec67842b9f3ef2bd07e4a9229736ed40952",
+        "rev": "a4ee09a79bdebef57ee7b1b74586c6d1f438541a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                                      |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
| [`a4ee09a7`](https://github.com/nix-community/emacs-overlay/commit/a4ee09a79bdebef57ee7b1b74586c6d1f438541a) | `` Fix typo in name prefix for emacs-unstable-pgtk ``                        |
| [`e417bd7c`](https://github.com/nix-community/emacs-overlay/commit/e417bd7c85cebf56e6f8b5846f92de9432e4c4b7) | `` Reapply "Use --replace-warn instead of --replace in substituteInPlace" `` |
| [`2933ca78`](https://github.com/nix-community/emacs-overlay/commit/2933ca78e41dc52a149d66c97b46deda985bdad6) | `` Cosmetics: don't specify defaults prescribed by nixpkgs ``                |
| [`fb01b36e`](https://github.com/nix-community/emacs-overlay/commit/fb01b36edc9a01291b48c33f0786e9bcf6e76d0d) | `` Cosmetics: don't use lib.makeOverridable anymore ``                       |
| [`368359d0`](https://github.com/nix-community/emacs-overlay/commit/368359d0f3c9f4ee6ec9bfec2932b49d77d6233f) | `` Cosmetics: remove <= 23.11 handholding ``                                 |
| [`e86adaf7`](https://github.com/nix-community/emacs-overlay/commit/e86adaf7da0f0186c8f21ccb61ff10880434436b) | `` Updated emacs ``                                                          |
| [`2f92a704`](https://github.com/nix-community/emacs-overlay/commit/2f92a7048fc397e2e7bbadce11209c0dcf49a70d) | `` Updated melpa ``                                                          |