### PR TITLE
chore(flake/sops-nix): `e2d404a7` -> `127a96f4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -970,11 +970,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1726524647,
-        "narHash": "sha256-qis6BtOOBBEAfUl7FMHqqTwRLB61OL5OFzIsOmRz2J4=",
+        "lastModified": 1727423009,
+        "narHash": "sha256-+4B/dQm2EnORIk0k2wV3aHGaE0WXTBjColXjj7qWh10=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "e2d404a7ea599a013189aa42947f66cede0645c8",
+        "rev": "127a96f49ddc377be6ba76964411bab11ae27803",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                       |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`127a96f4`](https://github.com/Mic92/sops-nix/commit/127a96f49ddc377be6ba76964411bab11ae27803) | `` modules/sops/templates: support systemd activation ``      |
| [`3176c111`](https://github.com/Mic92/sops-nix/commit/3176c111120f05b78ff3bb3375ca9f04baa07c4d) | `` Minor fix for binary example in README.md ``               |
| [`5876a12f`](https://github.com/Mic92/sops-nix/commit/5876a12ff688a72a62b553749146612a1d6c12d1) | `` Allow sops-nix to be restarted when systemd is degraded `` |