### PR TITLE
chore(flake/deploy-rs): `3867348f` -> `aa07eb05`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -130,11 +130,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718194053,
-        "narHash": "sha256-FaGrf7qwZ99ehPJCAwgvNY5sLCqQ3GDiE/6uLhxxwSY=",
+        "lastModified": 1727447169,
+        "narHash": "sha256-3KyjMPUKHkiWhwR91J1YchF6zb6gvckCAY1jOE+ne0U=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "3867348fa92bc892eba5d9ddb2d7a97b9e127a8a",
+        "rev": "aa07eb05537d4cd025e2310397a6adcedfe72c76",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                       |
| --------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`a1eb366d`](https://github.com/serokell/deploy-rs/commit/a1eb366d134308e6e8db781e15b05c6f2cf3de83) | `` doc: add option doc for interactiveSudo `` |