### PR TITLE
chore(flake/emacs-overlay): `616bb077` -> `2508d6b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1727428402,
-        "narHash": "sha256-b5PRYZFQYSBxmQMrzwap2DbIWBHVmpOlSWNEqR5KpIQ=",
+        "lastModified": 1727456357,
+        "narHash": "sha256-D8pcNwSsqKgpQr8X4HO7KwPhQyM5jnG2po4WkfHJVwY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "616bb0773b238f89120fa07a38d19a55f04db90a",
+        "rev": "2508d6b78c40293a1e271feeccabe5d6a0be6ea5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`2508d6b7`](https://github.com/nix-community/emacs-overlay/commit/2508d6b78c40293a1e271feeccabe5d6a0be6ea5) | `` Updated melpa ``  |
| [`cbd5ad1b`](https://github.com/nix-community/emacs-overlay/commit/cbd5ad1b0cd6b709c5089c5778b449dcf2281d28) | `` Updated elpa ``   |
| [`ecc8dff5`](https://github.com/nix-community/emacs-overlay/commit/ecc8dff54ca08415a4dc21f10d37f6c9ac620adf) | `` Updated nongnu `` |