### PR TITLE
chore(flake/emacs-overlay): `c164c3ca` -> `73bcee30`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1727457129,
-        "narHash": "sha256-rsOKZ+98SbewEi89JYp7W36D3tqVan3z2ZyAhg3w3dQ=",
+        "lastModified": 1727486076,
+        "narHash": "sha256-5LhJ+3EAWL3ubwrQ0Ny+ZqEVaE+WAZAiJpI54YRT7ac=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c164c3ca326870be7534bdbeacf045d55941fa2c",
+        "rev": "73bcee308cb94aa4d81a053ead98e5ad3e5d2560",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`73bcee30`](https://github.com/nix-community/emacs-overlay/commit/73bcee308cb94aa4d81a053ead98e5ad3e5d2560) | `` Updated elpa ``         |
| [`259a74fe`](https://github.com/nix-community/emacs-overlay/commit/259a74fe865f70531a40737ad7fd20af78a0bc32) | `` Updated nongnu ``       |
| [`bdd33a96`](https://github.com/nix-community/emacs-overlay/commit/bdd33a96dfff44e15d75c1f7a3c9c214639f63f4) | `` Updated flake inputs `` |