### PR TITLE
chore(flake/srvos): `edc1d31b` -> `e1f0d6e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -990,11 +990,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727312898,
-        "narHash": "sha256-PRCWFc/RN5LxNarKMsieSixrwGLm1nJNVxU0MFFBISc=",
+        "lastModified": 1727491384,
+        "narHash": "sha256-km86bDL46XmO4gkfvCfhCXfZDZPg/O72A65fF+hUPJM=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "edc1d31ba4a92afd475cc32bae722dad547464cb",
+        "rev": "e1f0d6e42d9ea0cf031fd3469f35d78c3af21b85",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                            |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`e1f0d6e4`](https://github.com/nix-community/srvos/commit/e1f0d6e42d9ea0cf031fd3469f35d78c3af21b85) | `` dev/private/flake: update nix-darwin follows `` |