### PR TITLE
chore(flake/emacs-overlay): `e1ea487e` -> `d50b1c32`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1727489090,
-        "narHash": "sha256-leLAL5QHHmiV/1NMte08yZi7eDuonaQ8RVlHQ6utZhs=",
+        "lastModified": 1727497939,
+        "narHash": "sha256-HeP1DfZ0YzfU05QG3nV/YCWEGHT+L4cU495yGnqj1lg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e1ea487ee539e6afe98cd4067a02a723eb549c88",
+        "rev": "d50b1c32137c01919f3a6ac22b5abd163d321774",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                          |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------- |
| [`ebe44681`](https://github.com/nix-community/emacs-overlay/commit/ebe446814ae4356f21637db24f2fba41b571cd8e) | `` remove: withGTK2, see #431 `` |