### PR TITLE
chore(flake/emacs-overlay): `d50b1c32` -> `c8f9c557`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1727497939,
-        "narHash": "sha256-HeP1DfZ0YzfU05QG3nV/YCWEGHT+L4cU495yGnqj1lg=",
+        "lastModified": 1727513931,
+        "narHash": "sha256-/cBHpBz2b0CGsuOK+zl4Si/7YZCpVSg+DIs76cuvlXo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d50b1c32137c01919f3a6ac22b5abd163d321774",
+        "rev": "c8f9c557cc398c64bc8a9d9f90d968c55421098b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`c8f9c557`](https://github.com/nix-community/emacs-overlay/commit/c8f9c557cc398c64bc8a9d9f90d968c55421098b) | `` Updated melpa `` |