### PR TITLE
chore(flake/emacs-overlay): `c8f9c557` -> `7bdbf964`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1727513931,
-        "narHash": "sha256-/cBHpBz2b0CGsuOK+zl4Si/7YZCpVSg+DIs76cuvlXo=",
+        "lastModified": 1727542683,
+        "narHash": "sha256-T4GuKO4+7zChRkmqmCtPJXVJYzUVkc1axuhA8QwlwM8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c8f9c557cc398c64bc8a9d9f90d968c55421098b",
+        "rev": "7bdbf964a126bc3c75aec5a46e7cd516f5423f12",
         "type": "github"
       },
       "original": {
@@ -721,11 +721,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1727264057,
-        "narHash": "sha256-KQPI8CTTnB9CrJ7LrmLC4VWbKZfljEPBXOFGZFRpxao=",
+        "lastModified": 1727397532,
+        "narHash": "sha256-pojbL/qteElw/nIXlN8kmHn/w6PQbEHr7Iz+WOXs0EM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "759537f06e6999e141588ff1c9be7f3a5c060106",
+        "rev": "f65141456289e81ea0d5a05af8898333cab5c53d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`7bdbf964`](https://github.com/nix-community/emacs-overlay/commit/7bdbf964a126bc3c75aec5a46e7cd516f5423f12) | `` Updated melpa ``        |
| [`38c23655`](https://github.com/nix-community/emacs-overlay/commit/38c2365595da317ce6050052e5c04361a41504db) | `` Updated elpa ``         |
| [`2a5f35a4`](https://github.com/nix-community/emacs-overlay/commit/2a5f35a40e256cbb6c978e1485d82791d80084e7) | `` Updated nongnu ``       |
| [`18c1571f`](https://github.com/nix-community/emacs-overlay/commit/18c1571fcb0025a04e58a75a1eeb42c44c63b3f4) | `` Updated flake inputs `` |