### PR TITLE
chore(flake/nixos-hardware): `c1f051bf` -> `fb08bde0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -648,11 +648,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1727528503,
-        "narHash": "sha256-wZd8OqPeQt9h7VU2VxsW4Vx0Ze+3hDLHql3pNbIMYEU=",
+        "lastModified": 1727540359,
+        "narHash": "sha256-U+225h1kJZpWb23+RaX1sBkqC4fA7aa7eBbgiQ5HcO4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "c1f051bf032273b9f0e707c8826eb25122d279fa",
+        "rev": "fb08bde00c20252b892a3e57fb094eb62b65ba61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                            |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`2061ba26`](https://github.com/NixOS/nixos-hardware/commit/2061ba2611eb29efb24ffe4d730fc29ad20503a2) | `` dell-precision-5560: remove redundant config `` |
| [`a4e69fc9`](https://github.com/NixOS/nixos-hardware/commit/a4e69fc9ba6728f7ea9c8b7cb9c72b3744885880) | `` dell-precision-5560: add README ``              |
| [`c97623b4`](https://github.com/NixOS/nixos-hardware/commit/c97623b428306711dc07dc68fd98b9f0b882ba3c) | `` dell-precision-5560: cleanup ``                 |
| [`06c46e39`](https://github.com/NixOS/nixos-hardware/commit/06c46e390287088e07eef9db3ff7ba20ef9cbdae) | `` dell-precision-5560: init ``                    |