### PR TITLE
chore(flake/emacs-overlay): `77557b52` -> `5e84637f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1727543490,
-        "narHash": "sha256-Ak1cMvsK1gZYQN/iTypTIQr487xraUv7PuucTzHoTVY=",
+        "lastModified": 1727572830,
+        "narHash": "sha256-c1aidE5QHL/uh35TVckPYqhwxsfrayomgg3aeXv5ieQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "77557b526c0d2c57747e44c8de7789f7a6fb741d",
+        "rev": "5e84637f4a6db092a29a720a761a54d2444738d5",
         "type": "github"
       },
       "original": {
@@ -721,11 +721,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1727397532,
-        "narHash": "sha256-pojbL/qteElw/nIXlN8kmHn/w6PQbEHr7Iz+WOXs0EM=",
+        "lastModified": 1727540905,
+        "narHash": "sha256-40J9tW7Y794J7Uw4GwcAKlMxlX2xISBl6IBigo83ih8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f65141456289e81ea0d5a05af8898333cab5c53d",
+        "rev": "fbca5e745367ae7632731639de5c21f29c8744ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`5e84637f`](https://github.com/nix-community/emacs-overlay/commit/5e84637f4a6db092a29a720a761a54d2444738d5) | `` Updated elpa ``         |
| [`3d4ededb`](https://github.com/nix-community/emacs-overlay/commit/3d4ededb77d0881b0f98da524d6a6139d31ac0da) | `` Updated nongnu ``       |
| [`8667d33b`](https://github.com/nix-community/emacs-overlay/commit/8667d33b7cc10e71ae6e397418492bf9f7f77937) | `` Updated flake inputs `` |