### PR TITLE
chore(flake/emacs-overlay): `5e84637f` -> `4c0f8af2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1727572830,
-        "narHash": "sha256-c1aidE5QHL/uh35TVckPYqhwxsfrayomgg3aeXv5ieQ=",
+        "lastModified": 1727575833,
+        "narHash": "sha256-XncSjaN4nhYQTCYD/2k6lrmicoj4N0IQJOVfxeCMiF4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5e84637f4a6db092a29a720a761a54d2444738d5",
+        "rev": "4c0f8af2d094676ffc5db297ffd705817596625f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`4c0f8af2`](https://github.com/nix-community/emacs-overlay/commit/4c0f8af2d094676ffc5db297ffd705817596625f) | `` Updated emacs `` |
| [`e2b94255`](https://github.com/nix-community/emacs-overlay/commit/e2b94255408a9dea82dbe8021c266cd63a9308bc) | `` Updated melpa `` |