### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `92ce1bd6` -> `900f5839`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727497939,
-        "narHash": "sha256-HeP1DfZ0YzfU05QG3nV/YCWEGHT+L4cU495yGnqj1lg=",
+        "lastModified": 1727575833,
+        "narHash": "sha256-XncSjaN4nhYQTCYD/2k6lrmicoj4N0IQJOVfxeCMiF4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d50b1c32137c01919f3a6ac22b5abd163d321774",
+        "rev": "4c0f8af2d094676ffc5db297ffd705817596625f",
         "type": "github"
       },
       "original": {
@@ -516,11 +516,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1727512540,
-        "narHash": "sha256-KNNGmpoHGKSMacrOLXGTPbRcsRBoJnohq+1qifDGd40=",
+        "lastModified": 1727598986,
+        "narHash": "sha256-N+NUzgf8v85UBOdPVS6QfopLEPBHfr3SuceMGUvcysc=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "92ce1bd6960d9ea5356d2618d0ede50da84e4355",
+        "rev": "900f58396d7ff2c04ec0eebeb7819ae5c01b9892",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`900f5839`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/900f58396d7ff2c04ec0eebeb7819ae5c01b9892) | `` flake.lock: Update `` |