### PR TITLE
chore(flake/srvos): `e1f0d6e4` -> `6441ddae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -990,11 +990,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727491384,
-        "narHash": "sha256-km86bDL46XmO4gkfvCfhCXfZDZPg/O72A65fF+hUPJM=",
+        "lastModified": 1727611199,
+        "narHash": "sha256-oSZ0ChAOyg7FnXdvEePuBE/bW6krrtP64f+39l4iz0k=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "e1f0d6e42d9ea0cf031fd3469f35d78c3af21b85",
+        "rev": "6441ddae7ab6a0f66fb4f2c8f72e03466508fa61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                        |
| ---------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`4271fd0a`](https://github.com/nix-community/srvos/commit/4271fd0a50743337d521472877eb1feb7ecb687e) | `` enable fstrim by default `` |