### PR TITLE
chore(flake/nixos-cosmic): `db8f40db` -> `5b0f33c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -633,11 +633,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1727574072,
-        "narHash": "sha256-HuQnfjvImOoHbwzrKV9bJM8/2zDf9Wk5FfsmHUuzyI8=",
+        "lastModified": 1727616413,
+        "narHash": "sha256-EuipmcqmOK+xRtwElUlrp+S8h24uqgZ+LQmNhEZTrTU=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "db8f40db093bfc1fffd5e891625ae7cea1322db2",
+        "rev": "5b0f33c0fbf07e9d1cec4e15e32bf2e7c1979df1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                            |
| ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`5b0f33c0`](https://github.com/lilyinstarlight/nixos-cosmic/commit/5b0f33c0fbf07e9d1cec4e15e32bf2e7c1979df1) | `` flake: add cosmic-tweaks to test VM ``          |
| [`338c717e`](https://github.com/lilyinstarlight/nixos-cosmic/commit/338c717e405358b46288e666b0baf8403f3f6c52) | `` cosmic-tweaks: init at 0-unstable-2024-09-29 `` |