### PR TITLE
chore(flake/srvos): `6441ddae` -> `3278df04`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -990,11 +990,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727611199,
-        "narHash": "sha256-oSZ0ChAOyg7FnXdvEePuBE/bW6krrtP64f+39l4iz0k=",
+        "lastModified": 1727657585,
+        "narHash": "sha256-rV6aUtjE0D6BXwnSs5NfDHry65dcu6csTgQ7F2MJ+Z4=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "6441ddae7ab6a0f66fb4f2c8f72e03466508fa61",
+        "rev": "3278df04c117140c425b0f3a573360aad3723682",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`3278df04`](https://github.com/nix-community/srvos/commit/3278df04c117140c425b0f3a573360aad3723682) | `` dev/private/flake.lock: Update `` |
| [`b7a04f4c`](https://github.com/nix-community/srvos/commit/b7a04f4ce1c2d67bad0b689f4453595e60e0d515) | `` flake.lock: Update ``             |