### PR TITLE
chore(flake/emacs-overlay): `619e3ff8` -> `9deee9cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1727659039,
-        "narHash": "sha256-sn+5WnLAF89n2AG3iEB2owJWRPpM2eY7aqaBjB4kGrQ=",
+        "lastModified": 1727662057,
+        "narHash": "sha256-oMuC7BXm98IQ6falStTp+AaT6EuvhtC71rHJ92zaH/E=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "619e3ff8298c76f2036b59d48d2dc3dfea3a6388",
+        "rev": "9deee9ccee19d5300bc366c7d28c479777886273",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`9deee9cc`](https://github.com/nix-community/emacs-overlay/commit/9deee9ccee19d5300bc366c7d28c479777886273) | `` Updated emacs `` |
| [`3e8cb7b3`](https://github.com/nix-community/emacs-overlay/commit/3e8cb7b37da4a86a1f640ef676f41c107290ac4e) | `` Updated melpa `` |