### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `900f5839` -> `6ee7c670`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727575833,
-        "narHash": "sha256-XncSjaN4nhYQTCYD/2k6lrmicoj4N0IQJOVfxeCMiF4=",
+        "lastModified": 1727662057,
+        "narHash": "sha256-oMuC7BXm98IQ6falStTp+AaT6EuvhtC71rHJ92zaH/E=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4c0f8af2d094676ffc5db297ffd705817596625f",
+        "rev": "9deee9ccee19d5300bc366c7d28c479777886273",
         "type": "github"
       },
       "original": {
@@ -516,11 +516,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1727598986,
-        "narHash": "sha256-N+NUzgf8v85UBOdPVS6QfopLEPBHfr3SuceMGUvcysc=",
+        "lastModified": 1727685632,
+        "narHash": "sha256-lCNiCYo6JSFEiO1f/KPryLqjRYT3vUv4ZZtyIUDifFk=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "900f58396d7ff2c04ec0eebeb7819ae5c01b9892",
+        "rev": "6ee7c670500dec7fe928a251b4e540ce03efc4ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`6ee7c670`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/6ee7c670500dec7fe928a251b4e540ce03efc4ab) | `` flake.lock: Update `` |