### PR TITLE
chore(flake/emacs-overlay): `9deee9cc` -> `63d9075f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1727662057,
-        "narHash": "sha256-oMuC7BXm98IQ6falStTp+AaT6EuvhtC71rHJ92zaH/E=",
+        "lastModified": 1727695378,
+        "narHash": "sha256-J5Ud+Tk6rw2nO6QxWW/OrEkRlAJkO5zyW1ZR6XYGc8Q=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9deee9ccee19d5300bc366c7d28c479777886273",
+        "rev": "63d9075f024973cde96b7b6fd010b36b951d0864",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                             |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------- |
| [`55855cd2`](https://github.com/nix-community/emacs-overlay/commit/55855cd25344644121a9692f4ba59a980d91484d) | `` Bump actions/checkout from 4.1.7 to 4.2.0 ``     |
| [`c3531746`](https://github.com/nix-community/emacs-overlay/commit/c353174633294a1fd1a87f0b9e6cb77a25eb255a) | `` Bump cachix/install-nix-action from V28 to 29 `` |