### PR TITLE
chore(flake/sops-nix): `127a96f4` -> `3198a242`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -953,11 +953,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1727423009,
-        "narHash": "sha256-+4B/dQm2EnORIk0k2wV3aHGaE0WXTBjColXjj7qWh10=",
+        "lastModified": 1727734513,
+        "narHash": "sha256-i47LQwoGCVQq4upV2YHV0OudkauHNuFsv306ualB/Sw=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "127a96f49ddc377be6ba76964411bab11ae27803",
+        "rev": "3198a242e547939c5e659353551b0668ec150268",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                 |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`3198a242`](https://github.com/Mic92/sops-nix/commit/3198a242e547939c5e659353551b0668ec150268) | `` build(deps): bump cachix/install-nix-action from V28 to 29 (#628) `` |