### PR TITLE
chore(flake/emacs-overlay): `6fa58edd` -> `99c6c746`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1727713209,
-        "narHash": "sha256-+So2xtOhGjQu1/AzgU0NI019UtdzqO2+lAZAUm6xwRo=",
+        "lastModified": 1727748717,
+        "narHash": "sha256-W+4FsuVK7t4Rrf/zyiYuUfqG/jaaOpJsP1PS49vldA8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6fa58edd58a554fb75fe1b430adefabf50ade53a",
+        "rev": "99c6c746c5b8651e5993e5b9a649d0a961346299",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`99c6c746`](https://github.com/nix-community/emacs-overlay/commit/99c6c746c5b8651e5993e5b9a649d0a961346299) | `` Updated emacs ``  |
| [`949ed15c`](https://github.com/nix-community/emacs-overlay/commit/949ed15c567ffd5599ef49c9cb96954a2d86dfdc) | `` Updated melpa ``  |
| [`c87710c7`](https://github.com/nix-community/emacs-overlay/commit/c87710c7a3f03214467c2aef993f6f665af10d68) | `` Updated elpa ``   |
| [`414c3ef3`](https://github.com/nix-community/emacs-overlay/commit/414c3ef34d7d33fbed49ad21cf32c28f2f2572a5) | `` Updated nongnu `` |