### PR TITLE
chore(flake/lanzaboote): `e7bd94e0` -> `e2365a1d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -456,11 +456,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1725379389,
-        "narHash": "sha256-qS1H/5/20ewJIXmf8FN2A5KTOKKU9elWvCPwdBi1P/U=",
+        "lastModified": 1727792571,
+        "narHash": "sha256-KBzRQVE1j2vrSg8WfYJ+vEvFBC25+2VsFSK7VL2kc1M=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "e7bd94e0b5ff3c1e686f2101004ebf4fcea9d871",
+        "rev": "e2365a1d8dccdcf4bca5111672e80df67d90957d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                 |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`386df64c`](https://github.com/nix-community/lanzaboote/commit/386df64c34fff7ac44a7cd42bbf42e93b6da2bf3) | `` chore(deps): update uefi to 0.31.0 ``                |
| [`97cf4280`](https://github.com/nix-community/lanzaboote/commit/97cf428067be91757e7d23edc3d5d02e1f5cf5c2) | `` stub: Drop duplicate calls to uefi::helpers::init `` |