### PR TITLE
chore(flake/emacs-overlay): `5d61fa81` -> `2bacfb48`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1727799645,
-        "narHash": "sha256-K124QgA+yX/ZUY82tCFbqdepgwiW+JHgIGIRPqnWXDI=",
+        "lastModified": 1727831723,
+        "narHash": "sha256-NpuKB149YLZESGvebp8C6kPlkVSj2cH4vXHh2IzFARg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5d61fa810490ef7b33fc6cea2042adaf70020887",
+        "rev": "2bacfb4872b16be80bf91a0110771931a4243ce1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`2bacfb48`](https://github.com/nix-community/emacs-overlay/commit/2bacfb4872b16be80bf91a0110771931a4243ce1) | `` Updated elpa ``   |
| [`ac76459e`](https://github.com/nix-community/emacs-overlay/commit/ac76459ea37692e696b4a5cb890df35df820b98c) | `` Updated nongnu `` |