### PR TITLE
chore(flake/emacs-overlay): `36dcfe7c` -> `7bdcd77e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1727859620,
-        "narHash": "sha256-6/fscescVI8/eXuML+Mr8LGNYACjFzX5GS6npYo3fmc=",
+        "lastModified": 1727860369,
+        "narHash": "sha256-sS83Q/2pl6U+LnRKVH95ntBRIpzr2x1llLPZlfX0GXg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "36dcfe7c348ec4a492775c388265173ee5e0d5ff",
+        "rev": "7bdcd77e2b8fd8e10d8d8bfae5ba7302dbd69d3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`7bdcd77e`](https://github.com/nix-community/emacs-overlay/commit/7bdcd77e2b8fd8e10d8d8bfae5ba7302dbd69d3e) | `` Updated emacs `` |