### PR TITLE
chore(flake/srvos): `33683880` -> `92fa0723`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -973,11 +973,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727723127,
-        "narHash": "sha256-1Wy+v5xPsAb8GvHtU4egpIo8Rhmw1faAbGaIDduVG9I=",
+        "lastModified": 1727881139,
+        "narHash": "sha256-ULeq1IV5PpBndOZJ6MD3+0M2/K7ixR5a0NyGIfcD2rE=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "3368388007de976ceb40f3e19f31ffd8667c36a7",
+        "rev": "92fa0723d2c63005475523282be4ef8677e8604f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                                    |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`92fa0723`](https://github.com/nix-community/srvos/commit/92fa0723d2c63005475523282be4ef8677e8604f) | `` Set watchdog for kexec to prevent hanging in case of missing firmware support (#524) `` |
| [`8cf7a278`](https://github.com/nix-community/srvos/commit/8cf7a278fe5ebf312142f01c472cfc4eeb3050d2) | `` add darwin test configurations (#525) ``                                                |
| [`ce661d20`](https://github.com/nix-community/srvos/commit/ce661d208fee30592db866827b0c0bc41767cb88) | `` Re-use programs.git.package to not add unnecessary gitMinimal when pr… (#531) ``        |