### PR TITLE
chore(flake/nixpkgs): `06cf0e1d` -> `27e30d17`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -801,11 +801,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1727634051,
-        "narHash": "sha256-S5kVU7U82LfpEukbn/ihcyNt2+EvG7Z5unsKW9H/yFA=",
+        "lastModified": 1727802920,
+        "narHash": "sha256-HP89HZOT0ReIbI7IJZJQoJgxvB2Tn28V6XS3MNKnfLs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "06cf0e1da4208d3766d898b7fdab6513366d45b9",
+        "rev": "27e30d177e57d912d614c88c622dcfdb2e6e6515",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                 |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`67a452c2`](https://github.com/NixOS/nixpkgs/commit/67a452c21843cf7346d222d2ff74e1eeae3c5463) | `` rhythmbox: use brasero-unwrapped instead of brasero ``                               |
| [`e277415c`](https://github.com/NixOS/nixpkgs/commit/e277415cfed1a4c5bd96183e8ba51c60f046fe22) | `` luaPackages: update on 2024-09-30 ``                                                 |
| [`13146a8c`](https://github.com/NixOS/nixpkgs/commit/13146a8c8468eb895a9f0cc8f1c65b8bfde75c28) | `` vimPlugins.nvim-treesitter: update grammars ``                                       |
| [`7a6f5856`](https://github.com/NixOS/nixpkgs/commit/7a6f5856af6453cf6e427b5f99c2ac2d86220bb6) | `` vimPlugins: update on 2024-09-30 ``                                                  |
| [`f80576f9`](https://github.com/NixOS/nixpkgs/commit/f80576f98559804b3ed84299b0dbfd6f1849f58c) | `` fahclient: 8.3.7 -> 8.3.18 (#344335) ``                                              |
| [`51816d07`](https://github.com/NixOS/nixpkgs/commit/51816d07ce175f22e2077c86c49b5c13a11a2a30) | `` tigerbeetle: add update script to update all hashes at the same time (#345643) ``    |
| [`fe9836b2`](https://github.com/NixOS/nixpkgs/commit/fe9836b27b320017c61f7a637a8d3d4fa67036a7) | `` smassh: 3.1.5 -> 3.1.6 ``                                                            |
| [`0820598d`](https://github.com/NixOS/nixpkgs/commit/0820598d99c5cb45cca39e19fe1581c074f9b491) | `` smassh: add maintainer kraanzu ``                                                    |
| [`ca8c9f10`](https://github.com/NixOS/nixpkgs/commit/ca8c9f103a5b7c49d3d447b40d3272d2edda75b2) | `` smassh: 3.1.4 -> 3.1.5 ``                                                            |
| [`c15e8505`](https://github.com/NixOS/nixpkgs/commit/c15e8505e1839e21eda59912ccab125c312e5fbc) | `` smassh: fix textual version ``                                                       |
| [`9fbc876a`](https://github.com/NixOS/nixpkgs/commit/9fbc876a0d291e37510f2c10976bc6c21fb85282) | `` coursier: 2.1.11 -> 2.1.13 (#343698) ``                                              |
| [`55a45406`](https://github.com/NixOS/nixpkgs/commit/55a45406a60c6ba8122afe216795163206faeb96) | `` nixos/nextcloud: update relatedPackages ``                                           |
| [`b5979250`](https://github.com/NixOS/nixpkgs/commit/b5979250372deb77b5cc452ed50ca25800d4cc90) | `` edgedb: 5.2.3 -> 5.3.0 ``                                                            |
| [`5f91e3dc`](https://github.com/NixOS/nixpkgs/commit/5f91e3dcba6b0e7c34b802843429cabc375b2ef5) | `` nextcloud*Packages: another update to make more apps available on nc30 ``            |
| [`703cb4b3`](https://github.com/NixOS/nixpkgs/commit/703cb4b370dd3c45e0560a85415b330a19ed068f) | `` athens: 0.15.1 -> 0.15.2 ``                                                          |
| [`a021bc6e`](https://github.com/NixOS/nixpkgs/commit/a021bc6eaf44ba1a5302d7b2156d963b718bbc83) | `` python312Packages.speechbrain: update hash ``                                        |
| [`d0952579`](https://github.com/NixOS/nixpkgs/commit/d09525798223ff17015dc2a560f33ad625101938) | `` tailwindcss: 3.4.10 -> 3.4.13 ``                                                     |
| [`5cf0fab5`](https://github.com/NixOS/nixpkgs/commit/5cf0fab579d4b2683c82c8c6173a369e58ff386b) | `` lunar-client: 3.2.18 -> 3.2.19 ``                                                    |
| [`20ed9ccd`](https://github.com/NixOS/nixpkgs/commit/20ed9ccd88c097ba999dc267138d02be840ffdf4) | `` nextcloud: correct stateversion logic ``                                             |
| [`a55948a7`](https://github.com/NixOS/nixpkgs/commit/a55948a786d42b20a1499137e1a29381e9f6b182) | `` nextcloud: format with nixfmt ``                                                     |
| [`1b121c1e`](https://github.com/NixOS/nixpkgs/commit/1b121c1ea2a9e24f34bcccd4743361554fde9a30) | `` nextcloud30: init at 30.0.0 ``                                                       |
| [`1f148e3f`](https://github.com/NixOS/nixpkgs/commit/1f148e3f128fb649fb635bda6a95a6d65276591d) | `` nextcloud29Packages: update ``                                                       |
| [`5ba6fc5d`](https://github.com/NixOS/nixpkgs/commit/5ba6fc5dd54d026f6e5175e420803dedf7b030e4) | `` nextcloud28Packages: update ``                                                       |
| [`6f340c5c`](https://github.com/NixOS/nixpkgs/commit/6f340c5c731f518f5f494dfb6a77e807e1a43278) | `` rat-king-adventure: 2.0.0 -> 2.0.1 ``                                                |
| [`8df276fa`](https://github.com/NixOS/nixpkgs/commit/8df276fa3e612cc617a85c60a4f442c70943b4f2) | `` pipenv: 2024.0.1 -> 2024.1.0 ``                                                      |
| [`ffc57b02`](https://github.com/NixOS/nixpkgs/commit/ffc57b020b5bdf0899693e2916a57a5bbda6ab18) | `` nixos-facter: 0.1.0 -> 0.1.1 ``                                                      |
| [`bf45c154`](https://github.com/NixOS/nixpkgs/commit/bf45c154a700c2f4bea79c5239dd98da015f434a) | `` harlequin: remove unecessary tests.version ``                                        |
| [`b323dbc3`](https://github.com/NixOS/nixpkgs/commit/b323dbc3eb8e69c6386c49581076369316c75afe) | `` esphome: 2024.9.1 -> 2024.9.2 ``                                                     |
| [`53e49fc9`](https://github.com/NixOS/nixpkgs/commit/53e49fc94d683baeb797394e7751669eb727a4dd) | `` panoply: apply nixfmt ``                                                             |
| [`cc3453bb`](https://github.com/NixOS/nixpkgs/commit/cc3453bb445f0e36eb9ba5de758a228d0e60aa46) | `` panoply: 5.5.1 -> 5.5.2 ``                                                           |
| [`2c5fac3e`](https://github.com/NixOS/nixpkgs/commit/2c5fac3edf2d00d948253e392ec1604b29b38f14) | `` wireshark: 4.2.6 -> 4.2.7 ``                                                         |
| [`bafb19f7`](https://github.com/NixOS/nixpkgs/commit/bafb19f793583d8b9bc5e21017211d9a897ba940) | `` zoom-us: add pulseaudio to `PATH` ``                                                 |
| [`affe201a`](https://github.com/NixOS/nixpkgs/commit/affe201a2a247d0661c4c47653e98730301d30bd) | `` zoom-us: patch `ZoomWebviewHost` ``                                                  |
| [`7dd3a665`](https://github.com/NixOS/nixpkgs/commit/7dd3a665b7d14f2045ac31ce756487a84b612d1b) | `` Apply suggestions from code review ``                                                |
| [`50051048`](https://github.com/NixOS/nixpkgs/commit/500510482cb4fff304741e1d5d34fbf7fdd33e41) | `` python312Packages.clarifai-grpc: 10.8.6 -> 10.8.7 ``                                 |
| [`5d602da6`](https://github.com/NixOS/nixpkgs/commit/5d602da62e7026d80f0e9388ba918294b59d4b5b) | `` python312Packages.pulumi-aws: 6.52.0 -> 6.54.1 ``                                    |
| [`f8e9302d`](https://github.com/NixOS/nixpkgs/commit/f8e9302d3a748a2a602fdda8060b1d36c172c910) | `` basedpyright: 1.18.0 -> 1.18.2 ``                                                    |
| [`586a806a`](https://github.com/NixOS/nixpkgs/commit/586a806a5d01b9b2bb0f517528e250b9af0d13d7) | `` mame: 0.269 -> 0.270 ``                                                              |
| [`9ab8b25d`](https://github.com/NixOS/nixpkgs/commit/9ab8b25dc8f5d67a493776fcee307d22110aa9de) | `` pomerium: 0.26.1 -> 0.27.1 ``                                                        |
| [`b23eda16`](https://github.com/NixOS/nixpkgs/commit/b23eda1624f87d91530b265ce0af4aa00a08ed3a) | `` mozcdic-ut-jawiki: 0-unstable-2024-09-21 -> 0-unstable-2024-09-27 ``                 |
| [`100c948c`](https://github.com/NixOS/nixpkgs/commit/100c948cdd053d7ab8e5559ebf9baf80603883e5) | `` jp-zip-codes: 0-unstable-2024-09-01 -> 0-unstable-2024-10-01 ``                      |
| [`966526bd`](https://github.com/NixOS/nixpkgs/commit/966526bda1af9579ae9424c0d20e7e126713d654) | `` jawiki-all-titles-in-ns0: 0-unstable-2024-09-11 -> 0-unstable-2024-10-01 ``          |
| [`8d6134b2`](https://github.com/NixOS/nixpkgs/commit/8d6134b231ec3507aba9c0e50101b15a77bbeacd) | `` gonic: don't use substituteStream --replace ``                                       |
| [`ecf48614`](https://github.com/NixOS/nixpkgs/commit/ecf486145ff0dd2ae9c8915ffcb2d2a94a55185d) | `` gonic: fix tests in darwin sandbox ``                                                |
| [`2a42c191`](https://github.com/NixOS/nixpkgs/commit/2a42c191d437b0a78dd0cee334ccb32d3703af61) | `` pomerium: move to by-name ``                                                         |
| [`e2c5f11c`](https://github.com/NixOS/nixpkgs/commit/e2c5f11c59b4193130123c20976c99eb70c83778) | `` mold: 2.33.0 -> 2.34.0 ``                                                            |
| [`26deec30`](https://github.com/NixOS/nixpkgs/commit/26deec30004e1260f4f907c3889c77e4c71e4942) | `` thunderbird-bin-unwrapped: 128.2.0esr -> 128.2.3esr ``                               |
| [`26b1cefb`](https://github.com/NixOS/nixpkgs/commit/26b1cefb0c84c0145d512e366e37bf18dfb042f1) | `` mouse-actions-gui: use cargo-tauri.hook ``                                           |
| [`a678b77f`](https://github.com/NixOS/nixpkgs/commit/a678b77f9b17d2e24d496489e8a93ae55afe734c) | `` en-croissant: use cargo-tauri.hook ``                                                |
| [`0539d522`](https://github.com/NixOS/nixpkgs/commit/0539d522be2f1a50d0fdfb147eb012c967d4165c) | `` doc/release-notes: add section on `cargo-tauri.hook` ``                              |
| [`328e5178`](https://github.com/NixOS/nixpkgs/commit/328e517888f2b56f05f93a11c74b4cabda8107c4) | `` insulator2: use cargo-tauri.hook & yarnConfigHook ``                                 |
| [`83edf5a6`](https://github.com/NixOS/nixpkgs/commit/83edf5a626499b3d777401ebac2058463d6b143b) | `` kiwitalk: use cargo-tauri.hook ``                                                    |
| [`4f589591`](https://github.com/NixOS/nixpkgs/commit/4f589591492b3c38988b2b9f1787d4787de4fddd) | `` surrealist: use cargo-tauri.hook ``                                                  |
| [`686cff41`](https://github.com/NixOS/nixpkgs/commit/686cff417a98d9e4c30a042cd0a1219717140e46) | `` pot: use cargo-tauri.hook ``                                                         |
| [`43256320`](https://github.com/NixOS/nixpkgs/commit/43256320c550ba38a5082a3e98dc602f25b3df4e) | `` gitbutler: use cargo-tauri.hook ``                                                   |
| [`154d776f`](https://github.com/NixOS/nixpkgs/commit/154d776f51e2afffaf78a6e79d4ed0fce9fab878) | `` cinny-desktop: use cargo-tauri.hook ``                                               |
| [`5b5c9540`](https://github.com/NixOS/nixpkgs/commit/5b5c9540a59481239cbfed1051e717a85527ee52) | `` modrinth-app: use cargo-tauri.hook ``                                                |
| [`ec696bd8`](https://github.com/NixOS/nixpkgs/commit/ec696bd85de1089bd70c103e1b1b308ec1c0c584) | `` doc: init tauri hook section ``                                                      |
| [`f70fb77e`](https://github.com/NixOS/nixpkgs/commit/f70fb77ea1875a09d4641a296932671e65a03cd7) | `` cargo-tauri: add test for setup hooks ``                                             |
| [`b833d6a1`](https://github.com/NixOS/nixpkgs/commit/b833d6a1d3ec777e22b3c1e8cb53a998eb2751fe) | `` cargo-tauri.hook: init ``                                                            |
| [`c1c013bd`](https://github.com/NixOS/nixpkgs/commit/c1c013bd3b83578321c32bb3d747c15138c28c2a) | `` cargo-tauri: add getchoo as a maintainer ``                                          |
| [`4a78651e`](https://github.com/NixOS/nixpkgs/commit/4a78651ed94220ef7835b848460cb0c96e857a46) | `` cargo-tauri: refactor ``                                                             |
| [`e4efc386`](https://github.com/NixOS/nixpkgs/commit/e4efc386131d7b34cc99a6f0ce99d9b3fde8c195) | `` cargo-tauri: migrate to by-name ``                                                   |
| [`0a35428c`](https://github.com/NixOS/nixpkgs/commit/0a35428c2ee657265aa1ba198664296eded41176) | `` pagefind: use available port, fmt, remove with lib ``                                |
| [`727527cf`](https://github.com/NixOS/nixpkgs/commit/727527cfe8b08d7c4b4ac2a68afdb3c1b4df7dbf) | `` vscode-extensions.gitlab-workflow: 5.6.0 -> 5.13.0 (#345458) ``                      |
| [`48bf6aba`](https://github.com/NixOS/nixpkgs/commit/48bf6aba2abe142d62bebeff81f5aaa525063faa) | `` python312Packages.ufomerge: 1.8.1 -> 1.8.2 ``                                        |
| [`24e01516`](https://github.com/NixOS/nixpkgs/commit/24e01516890dd24d2a45f7e5794480915b54a421) | `` python312Packages.aiortm: 0.9.0 -> 0.9.7 ``                                          |
| [`2d27eefb`](https://github.com/NixOS/nixpkgs/commit/2d27eefb96dec253fa62a1739a50ae668517d54d) | `` php81Extensions.spx: 0.4.16 -> 0.4.17 ``                                             |
| [`c5b0b6d2`](https://github.com/NixOS/nixpkgs/commit/c5b0b6d29cdac3faa0d594ac9876916ec5e84d92) | `` mpv: fix build on darwin ``                                                          |
| [`a9fe4d6d`](https://github.com/NixOS/nixpkgs/commit/a9fe4d6d8ccde780e872ed1446f3746498152663) | `` lib.systems: fix rustTarget for WASI ``                                              |
| [`0d1f8619`](https://github.com/NixOS/nixpkgs/commit/0d1f8619a385175132648b5dc98242288cf7345e) | `` mpvScripts.quality-menu: 4.1.1 -> 4.1.2 (#345108) ``                                 |
| [`93c61c1e`](https://github.com/NixOS/nixpkgs/commit/93c61c1e58dd74f0f864eb98820149a5cfe9dc3f) | `` nixos/repart-verity-store: include original roothashes in repart-output.json ``      |
| [`a01bc853`](https://github.com/NixOS/nixpkgs/commit/a01bc8533afa79d32df6e3078c9c334b7a134c92) | `` n8n: 1.60.1 -> 1.61.0 ``                                                             |
| [`504c448b`](https://github.com/NixOS/nixpkgs/commit/504c448b513bdc86a9ea3d99953cd9cb26a48116) | `` brasero: rename brasero-original to brasero-unwrapped ``                             |
| [`02be2068`](https://github.com/NixOS/nixpkgs/commit/02be2068463fbe041698c7c713e21d5b50570e10) | `` nixos/nextcloud: add nc version to drv name of mysql & declarative redis test ``     |
| [`cd6157be`](https://github.com/NixOS/nixpkgs/commit/cd6157bea4d9f571c12cb922940a0608ceca106b) | `` nixos/nextcloud: re-add declarative-redis-and-secrets to matrix ``                   |
| [`0253205c`](https://github.com/NixOS/nixpkgs/commit/0253205c0dc872c7c39c899ca3e5e3353b890993) | `` python312Packages.openai-whisper: 20240927 -> 20240930 ``                            |
| [`485b5c4e`](https://github.com/NixOS/nixpkgs/commit/485b5c4e6ef107f82f7bd6fd906405ab9a3539e3) | `` cnspec: 11.23.0 -> 11.23.1 ``                                                        |
| [`ce0e9ca8`](https://github.com/NixOS/nixpkgs/commit/ce0e9ca8b72adbd84efb59553266b631f4a5d21b) | `` doctl: 1.114.0 -> 1.115.0 ``                                                         |
| [`6cbf5ca0`](https://github.com/NixOS/nixpkgs/commit/6cbf5ca06192afd096fe78750f2f482d90dd357c) | `` inochi2d: add libGL to LD_LIBRARY_PATH ``                                            |
| [`a97827f8`](https://github.com/NixOS/nixpkgs/commit/a97827f878e603a8856233cdb9bbbd29e20d9790) | `` narsil: 1.3.0-187-g96d6b3bbd -> 1.3.0-234-g228c4f0cb ``                              |
| [`ef593972`](https://github.com/NixOS/nixpkgs/commit/ef593972ffdd7384cd97523e09807a701aa204c2) | `` coqPackages.HoTT: 8.19 -> 8.20 ``                                                    |
| [`2a780460`](https://github.com/NixOS/nixpkgs/commit/2a780460b85ca0898ed8060820ab268051447051) | `` libbassmix: init at 2.4.12 ``                                                        |
| [`3f1f20b2`](https://github.com/NixOS/nixpkgs/commit/3f1f20b2a7708b7f77f6252a00f8038608e1fdf1) | `` nixos/repart-image: pass partition attrs to builder instead of JSON file ``          |
| [`e47c457a`](https://github.com/NixOS/nixpkgs/commit/e47c457a91676ab347093ff1bffd4194f36e3731) | `` python3Packages.aw-core: 0.5.16 -> 0.5.17 ``                                         |
| [`7fd17d6c`](https://github.com/NixOS/nixpkgs/commit/7fd17d6c26d139cd192cf285d61b88e71c875328) | `` nuclei: fix hash mismatch on darwin ``                                               |
| [`a2ed02c4`](https://github.com/NixOS/nixpkgs/commit/a2ed02c4c25b8c597f2f2865ebfba6585626d31b) | `` cpython: add python team as maintainers ``                                           |
| [`fdedf708`](https://github.com/NixOS/nixpkgs/commit/fdedf708d17d684b2e8f437d81be732e87129d93) | `` spotube: 3.8.1 -> 3.8.2 ``                                                           |
| [`4772ab4b`](https://github.com/NixOS/nixpkgs/commit/4772ab4bc114e19f2e4e88b150622eb4aab92983) | `` roadrunner: fix postInstall phase ``                                                 |
| [`a1354317`](https://github.com/NixOS/nixpkgs/commit/a1354317d724a46a7caa081e527637015ee08033) | `` ocamlPackages.uunf: 15.1.0 → 16.0.0 ``                                               |
| [`44dd3042`](https://github.com/NixOS/nixpkgs/commit/44dd304227338c03b45b1d1067ca83ce380a408c) | `` zoraxy: mark as Linux-only ``                                                        |
| [`c2b4a5dc`](https://github.com/NixOS/nixpkgs/commit/c2b4a5dc17fdb60b6920c08c218248a6cd6e3bef) | `` mikutter: remove ``                                                                  |
| [`7ba674b0`](https://github.com/NixOS/nixpkgs/commit/7ba674b0761ed70a74015bbbfc44d49ba4209526) | `` roxctl: fix hash ``                                                                  |
| [`dea1e380`](https://github.com/NixOS/nixpkgs/commit/dea1e380d9d975a4c0fe5a4b20d24bc3eae6a613) | `` harlequin: init at 1.24.1 ``                                                         |
| [`2f15b523`](https://github.com/NixOS/nixpkgs/commit/2f15b523d9b9a9d7e9e303830ce9aca572f43234) | `` nixos/hatsu: init module ``                                                          |
| [`7720f1a3`](https://github.com/NixOS/nixpkgs/commit/7720f1a3f39e297a72c1bbf5b3574a088b0f6e58) | `` skkDictionaries: add midchildan as maintainer ``                                     |
| [`c3d1c9cd`](https://github.com/NixOS/nixpkgs/commit/c3d1c9cdf550c1fe3442d007810fd502ea5d3801) | `` skkDictionaries: replace skk-dicts ``                                                |
| [`3b957cfd`](https://github.com/NixOS/nixpkgs/commit/3b957cfd41cbd0dc4a7f9e924b5ea67417d55513) | `` fishPlugins.fish-you-should-use: init at 0-unstable-2022-02-13 ``                    |
| [`df3c93ce`](https://github.com/NixOS/nixpkgs/commit/df3c93ce731e3aa3a1af1c5f3223d400d4da5688) | `` python3.pkgs.pylance: disable tests that are incompatible with duckdb 1.1.1 ``       |
| [`1ee444ad`](https://github.com/NixOS/nixpkgs/commit/1ee444ada4db7b0cfa5106a5f07ab19f4d3f3600) | `` python3.pkgs.duckdb-engine: disable tests that are incompatible with duckdb 1.1.1 `` |
| [`ff274305`](https://github.com/NixOS/nixpkgs/commit/ff2743051025a92000cea92142dc31046ebb11f1) | `` python3.pkgs.datafusion: clean up `typing-extensions` dependency specification ``    |
| [`c5e62102`](https://github.com/NixOS/nixpkgs/commit/c5e621028ec652f133e853ccd9be30ad19c52b84) | `` python3.pkgs.sqlglot: 23.12.1 -> 25.20.1 ``                                          |
| [`cdaee388`](https://github.com/NixOS/nixpkgs/commit/cdaee3882f8a34978fa21ef0a05f4d11f9f5bc7f) | `` python3.pkgs.ibis-framework: 9.1.0 -> 9.5.0 ``                                       |
| [`8a1008f8`](https://github.com/NixOS/nixpkgs/commit/8a1008f8014bcd32e1fe67f8faf0af204fa7f91b) | `` duckdb: 1.0.0 -> 1.1.1 ``                                                            |
| [`88746a79`](https://github.com/NixOS/nixpkgs/commit/88746a794398da15142f91d42c829a4336616596) | `` linux/common-config: update for 6.12 ``                                              |
| [`0bd382c5`](https://github.com/NixOS/nixpkgs/commit/0bd382c5c8a9f0bbe65b98733307d364626eb5ff) | `` dnglab: fix hash mismatch ``                                                         |
| [`f51c991c`](https://github.com/NixOS/nixpkgs/commit/f51c991c4e4fff5b4e235fe275daee02dc809b11) | `` python312Packages.mktestdocs: 0.2.1 -> 0.2.3 ``                                      |
| [`83b13509`](https://github.com/NixOS/nixpkgs/commit/83b1350904d3f4756d56efb95eab25b3adfb7946) | `` nixos/open-webui: fix opensearch ``                                                  |
| [`aed1142d`](https://github.com/NixOS/nixpkgs/commit/aed1142d79b080aa7ace6c458ae88a986275561e) | `` lib.systems.examples: Fix deprecated attr ``                                         |
| [`318ad2b8`](https://github.com/NixOS/nixpkgs/commit/318ad2b8cea18e036fd0c9bee66680cf095db4ec) | `` ryujinx: Include more necessary libraries ``                                         |