### PR TITLE
chore(flake/srvos): `92fa0723` -> `275deee7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -973,11 +973,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727881139,
-        "narHash": "sha256-ULeq1IV5PpBndOZJ6MD3+0M2/K7ixR5a0NyGIfcD2rE=",
+        "lastModified": 1727910021,
+        "narHash": "sha256-KISTti0LjBHu7gXlm9yzp1/lTn+yjDRdRqWGXlMusUU=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "92fa0723d2c63005475523282be4ef8677e8604f",
+        "rev": "275deee749322632e42a3039956be6ea4f2cfef8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                      |
| ---------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`275deee7`](https://github.com/nix-community/srvos/commit/275deee749322632e42a3039956be6ea4f2cfef8) | `` Also disable xdg.menus `` |
| [`4930c470`](https://github.com/nix-community/srvos/commit/4930c470e944e46cb8dd001f9610e8aca4e9f451) | `` Disable docs, too ``      |