### PR TITLE
chore(flake/srvos): `275deee7` -> `b7aa1d74`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -973,11 +973,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727910021,
-        "narHash": "sha256-KISTti0LjBHu7gXlm9yzp1/lTn+yjDRdRqWGXlMusUU=",
+        "lastModified": 1727916698,
+        "narHash": "sha256-SoL9VVoYXxJ0XZ6m/3mVTwPhpdiaPwAF4pwf5lfgOpU=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "275deee749322632e42a3039956be6ea4f2cfef8",
+        "rev": "b7aa1d742955cfb96615d380f02049ec67f5abc0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`b7aa1d74`](https://github.com/nix-community/srvos/commit/b7aa1d742955cfb96615d380f02049ec67f5abc0) | `` dev/private/flake.lock: Update `` |
| [`95a0f73f`](https://github.com/nix-community/srvos/commit/95a0f73f18fe5b439a605c8c2f02380145f1815e) | `` flake.lock: Update ``             |