### PR TITLE
chore(flake/srvos): `b7aa1d74` -> `61b4d9b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -973,11 +973,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727916698,
-        "narHash": "sha256-SoL9VVoYXxJ0XZ6m/3mVTwPhpdiaPwAF4pwf5lfgOpU=",
+        "lastModified": 1727942108,
+        "narHash": "sha256-XEXrXew+/u3Ar+OyfWklJ0SsiSvb1vDnGNwpEwMxRpE=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "b7aa1d742955cfb96615d380f02049ec67f5abc0",
+        "rev": "61b4d9b2f53ce114541ed4f3ad3713d7a42a1cb7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                          |
| ---------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`5293526a`](https://github.com/nix-community/srvos/commit/5293526ad15c2df54926269fce357ddd657db1f8) | `` add shared telegraf config `` |
| [`5c176454`](https://github.com/nix-community/srvos/commit/5c17645462604f9a548a7c6733afa91fcae8c1a9) | `` add shared nix config ``      |