### PR TITLE
chore(flake/treefmt): `879b29ae` -> `a10a0cbe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1068,11 +1068,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727431250,
-        "narHash": "sha256-uGRlRT47ecicF9iLD1G3g43jn2e+b5KaMptb59LHnvM=",
+        "lastModified": 1727941393,
+        "narHash": "sha256-GFOQZDSvF0l6Jp8DdCW8qW8oR5hR0XjdvHFkmSan1Vo=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "879b29ae9a0378904fbbefe0dadaed43c8905754",
+        "rev": "a10a0cbe2196120aa90e4f86d459376e1d108d58",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                    |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`a10a0cbe`](https://github.com/numtide/treefmt-nix/commit/a10a0cbe2196120aa90e4f86d459376e1d108d58) | `` wrapper: add treefmt-nix executable to output (#243) `` |