### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `47a22d36` -> `76b81c07`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
     "doomemacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1726608657,
-        "narHash": "sha256-iwpBfHuJUd5jJjSGSXqlU9V0XKRNTeh6PvUq8riDnCE=",
+        "lastModified": 1727936788,
+        "narHash": "sha256-bIXSqOlmJL/PZUou2dx7Lj2wDkF98V9XiVsP1ffnbaw=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "c8a5e6ec1ca85a35f94d6c820c2fd8888373c2ae",
+        "rev": "8b9168de6e6a9cabf13d1c92558e2ef71aa37a72",
         "type": "github"
       },
       "original": {
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727834690,
-        "narHash": "sha256-I+wTQnZgZaNE7fj1fqeajvrMH+fPUl1ofD1JAp2uPKo=",
+        "lastModified": 1727886024,
+        "narHash": "sha256-9cpTSjtShCU5MJwEm3cbL2pALTMwjCDTM3zeQ1wrkRI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "57f92101924dff3eb03689bf9ba0ce0c49a6d6e8",
+        "rev": "a483757de48eba86f4ab373fd522341555aecfd7",
         "type": "github"
       },
       "original": {
@@ -516,11 +516,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1727858355,
-        "narHash": "sha256-kc4OvHEE69yZ0W9OG8cRwMqaglnVxsO4s6MUgbHGn60=",
+        "lastModified": 1727959954,
+        "narHash": "sha256-9tWcvGUBWy6b11ro/EZEQIAvjzEEVQvhcV5rlBX8FpQ=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "47a22d36218e2ed3ca420acc94a0d78bd16e7462",
+        "rev": "76b81c07a217198f44aa6b0dfc0cc0fddc9326b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                                             |
| ---------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`fb5251dd`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/fb5251ddfbfaa37068d98a02da560fe1fd4f4ef4) | `` flake.lock: Update ``                            |
| [`f5d857c3`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/f5d857c30786b5c3b5b59ce539e22d3b9cbe2879) | `` Bump cachix/install-nix-action from V28 to 29 `` |