### PR TITLE
chore(flake/nixos-cosmic): `38803802` -> `5e11a5f3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -633,11 +633,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1727924857,
-        "narHash": "sha256-bROmbbo2mfX5b2uoyvphi7w60i32mNV77Bl5uzcT7Ug=",
+        "lastModified": 1727970448,
+        "narHash": "sha256-2Gnr6Vitw2bFalErWrEQLld57hgVZZ990131oxgg/D0=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "3880380284d15621fd5577c0c5e5e8fb120adb2a",
+        "rev": "5e11a5f3aeefdc5e482edce8c04d9350de2897d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                    |
| ------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`5e11a5f3`](https://github.com/lilyinstarlight/nixos-cosmic/commit/5e11a5f3aeefdc5e482edce8c04d9350de2897d9) | `` cosmic-files: disable checks for now `` |