### PR TITLE
chore(flake/emacs-overlay): `a483757d` -> `b84e0f98`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1727886024,
-        "narHash": "sha256-9cpTSjtShCU5MJwEm3cbL2pALTMwjCDTM3zeQ1wrkRI=",
+        "lastModified": 1727988616,
+        "narHash": "sha256-+rjvrNnJ4Bu1alHKQerhx7EXVDkO00Y4nfPYrsHF7io=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a483757de48eba86f4ab373fd522341555aecfd7",
+        "rev": "b84e0f98a6f3c8e232245871d4ac1d7aa05b8f51",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                          |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
| [`b84e0f98`](https://github.com/nix-community/emacs-overlay/commit/b84e0f98a6f3c8e232245871d4ac1d7aa05b8f51) | `` Updated elpa ``                                               |
| [`eb7cc658`](https://github.com/nix-community/emacs-overlay/commit/eb7cc658d453cdeb1d978a1f83ccf375ba42a095) | `` Updated nongnu ``                                             |
| [`5efcd2e6`](https://github.com/nix-community/emacs-overlay/commit/5efcd2e6e3bce767b94234a554d6c05dac8918bd) | `` Adapt Emacs update script to chop off more extraneous info `` |