### PR TITLE
chore(flake/emacs-overlay): `b84e0f98` -> `85f404eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1727988616,
-        "narHash": "sha256-+rjvrNnJ4Bu1alHKQerhx7EXVDkO00Y4nfPYrsHF7io=",
+        "lastModified": 1727991586,
+        "narHash": "sha256-b57R2jUSSKCEuLhmbgxRpVntxenKlI9QLQOTGXhHmls=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b84e0f98a6f3c8e232245871d4ac1d7aa05b8f51",
+        "rev": "85f404ebb7a17ed7c6e42b1e68aafb2ebaf023dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`85f404eb`](https://github.com/nix-community/emacs-overlay/commit/85f404ebb7a17ed7c6e42b1e68aafb2ebaf023dc) | `` Updated emacs `` |
| [`c652df2b`](https://github.com/nix-community/emacs-overlay/commit/c652df2b2d75fcc0a08fc123f18321ea882f9e22) | `` Updated melpa `` |