### PR TITLE
chore(flake/emacs-overlay): `5a9afdef` -> `c51fe453`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728004502,
-        "narHash": "sha256-yB3mqqewqPitbBIeK3YaJuv/GhKx59JTyIE1TIDQSlk=",
+        "lastModified": 1728007496,
+        "narHash": "sha256-5WC0lourOxiruuLbiLXjWqzYZ75mg724fbDqdr93MU4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5a9afdefc4ce17c3bafeaefd4eb023e87d01dc6a",
+        "rev": "c51fe4531ae40b08b61f7ea680f3df2a964cd936",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`c51fe453`](https://github.com/nix-community/emacs-overlay/commit/c51fe4531ae40b08b61f7ea680f3df2a964cd936) | `` Updated emacs `` |
| [`7ad60568`](https://github.com/nix-community/emacs-overlay/commit/7ad60568c11f84dc3dbc455d06cabd324c32e728) | `` Updated melpa `` |