### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `76b81c07` -> `1a4dfe45`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727886024,
-        "narHash": "sha256-9cpTSjtShCU5MJwEm3cbL2pALTMwjCDTM3zeQ1wrkRI=",
+        "lastModified": 1728007496,
+        "narHash": "sha256-5WC0lourOxiruuLbiLXjWqzYZ75mg724fbDqdr93MU4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a483757de48eba86f4ab373fd522341555aecfd7",
+        "rev": "c51fe4531ae40b08b61f7ea680f3df2a964cd936",
         "type": "github"
       },
       "original": {
@@ -516,11 +516,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1727959954,
-        "narHash": "sha256-9tWcvGUBWy6b11ro/EZEQIAvjzEEVQvhcV5rlBX8FpQ=",
+        "lastModified": 1728031103,
+        "narHash": "sha256-WOibkXlcn48ODB1+A097ezJazUOXCqCxzXSzWPM7I5M=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "76b81c07a217198f44aa6b0dfc0cc0fddc9326b2",
+        "rev": "1a4dfe45c6c97189fc09a95d958083f3e2eaf82a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`1a4dfe45`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/1a4dfe45c6c97189fc09a95d958083f3e2eaf82a) | `` flake.lock: Update `` |