### PR TITLE
chore(flake/nixos-cosmic): `918b1645` -> `047e2e5b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -633,11 +633,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1728005793,
-        "narHash": "sha256-vGZzvjGQiHu8WJif/NgdfZYmX16T7opE8phlZSBULNo=",
+        "lastModified": 1728055445,
+        "narHash": "sha256-scHLa/lqaj18MYfjXwlkmr9dIAqo7fvBNwoiyQ3H1fo=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "918b1645285b3c8cc11a9e0017ce347bd55839ef",
+        "rev": "047e2e5beada535ca5465c0c9aee536ed3d00a1c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                                  |
| ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`047e2e5b`](https://github.com/lilyinstarlight/nixos-cosmic/commit/047e2e5beada535ca5465c0c9aee536ed3d00a1c) | `` flake: add new apps to testing vm ``                                  |
| [`a85ae738`](https://github.com/lilyinstarlight/nixos-cosmic/commit/a85ae738ec65457949d6de4fad92771e9d4ee5f2) | `` stellarshot: init at 0-unstable-2024-10-04 ``                         |
| [`c28eb0ff`](https://github.com/lilyinstarlight/nixos-cosmic/commit/c28eb0ff922c51a90095fa3914abdbc72ae9e1a4) | `` cosmic-ext-examine: init at 0-unstable-2024-09-28 ``                  |
| [`7083847a`](https://github.com/lilyinstarlight/nixos-cosmic/commit/7083847a9c7341b16a2efc5b846d9e4c0263a8c8) | `` cosmic-ext-applet-clipboard-manager: init at 0-unstable-2024-10-02 `` |
| [`79611689`](https://github.com/lilyinstarlight/nixos-cosmic/commit/79611689b374f82846d8216302efec25e3111dc3) | `` chronos: init at 0.1.1-unstable-2024-10-04 ``                         |
| [`630a8f39`](https://github.com/lilyinstarlight/nixos-cosmic/commit/630a8f39279b9b93bb485787add099a45a04850c) | `` flake: update vm packages ``                                          |
| [`4ff97e33`](https://github.com/lilyinstarlight/nixos-cosmic/commit/4ff97e33cd86cb70edfbbcd572808e9fb7f0d65f) | `` pkgs: rename cosmic-ext applications/applets ``                       |