### PR TITLE
chore(flake/nixos-cosmic): `047e2e5b` -> `a40f901f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -633,11 +633,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1728055445,
-        "narHash": "sha256-scHLa/lqaj18MYfjXwlkmr9dIAqo7fvBNwoiyQ3H1fo=",
+        "lastModified": 1728055563,
+        "narHash": "sha256-Z4TdoiJYxRoVsGp0FFUxAE8VMAulu8Q7uffaAxGWxv8=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "047e2e5beada535ca5465c0c9aee536ed3d00a1c",
+        "rev": "a40f901f40a69e9d13903cf86cf562b6cdb1b126",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                             |
| ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`a40f901f`](https://github.com/lilyinstarlight/nixos-cosmic/commit/a40f901f40a69e9d13903cf86cf562b6cdb1b126) | `` libcosmicAppHook: fix SOURCE_DATE_EPOCH usage `` |