### PR TITLE
chore(flake/emacs-overlay): `bb242817` -> `4653a87d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728058947,
-        "narHash": "sha256-bR4sH/uYRObL/A1LYqUeVNOHd0AGsaJf2vIW1E53IFg=",
+        "lastModified": 1728090848,
+        "narHash": "sha256-DFf60NL8eZ4kzPdzmJ3d1NZwJoYPQTjUjaUq7w06i1A=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bb242817e911f656031a825f0c5679c5ed82552a",
+        "rev": "4653a87d2a0252deb57a8c50f67cec0af9e4b1d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`4653a87d`](https://github.com/nix-community/emacs-overlay/commit/4653a87d2a0252deb57a8c50f67cec0af9e4b1d5) | `` Updated elpa ``   |
| [`d6f8d789`](https://github.com/nix-community/emacs-overlay/commit/d6f8d7895aaa12d4017d684e1143c425c7812c8e) | `` Updated nongnu `` |