### PR TITLE
chore(flake/emacs-overlay): `15484da3` -> `5b319994`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728093901,
-        "narHash": "sha256-Jr9gXEYf2/heV6uotxIdn4xebyGD86BPzWnTT/FCFEM=",
+        "lastModified": 1728118757,
+        "narHash": "sha256-HAW2HQwatOqJQDSgUt8rB4m6zp09tseauIBjdAule4U=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "15484da3f9409ea034986671133c894b061e9df5",
+        "rev": "5b31999426138b11a73101e8124a51b73649e234",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`5b319994`](https://github.com/nix-community/emacs-overlay/commit/5b31999426138b11a73101e8124a51b73649e234) | `` Updated melpa ``        |
| [`0e91d6cd`](https://github.com/nix-community/emacs-overlay/commit/0e91d6cde618114734b4830d14c3a4e8e4b26d86) | `` Updated nongnu ``       |
| [`088b49a8`](https://github.com/nix-community/emacs-overlay/commit/088b49a8267b149ea3be1ec54e661d856a5e7e24) | `` Updated flake inputs `` |