### PR TITLE
chore(flake/emacs-overlay): `5b319994` -> `00859b19`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728118757,
-        "narHash": "sha256-HAW2HQwatOqJQDSgUt8rB4m6zp09tseauIBjdAule4U=",
+        "lastModified": 1728119509,
+        "narHash": "sha256-Pqw3k25wKKnZfoFMm69csGFGnGQoup9M4TZohguCZow=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5b31999426138b11a73101e8124a51b73649e234",
+        "rev": "00859b191a98a4f08e7cffc639a5b9cd3be9cdf7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`00859b19`](https://github.com/nix-community/emacs-overlay/commit/00859b191a98a4f08e7cffc639a5b9cd3be9cdf7) | `` Updated emacs `` |