### PR TITLE
chore(flake/srvos): `c20ad696` -> `7aaa72eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -973,11 +973,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727991738,
-        "narHash": "sha256-bNy/zyUOp381G/KMiIfM5qD9fD+gMs2y3IdSlTKT4r8=",
+        "lastModified": 1728127082,
+        "narHash": "sha256-MDU/aVPcR5Fk+x1B+SAsyYG47k5cvFvGTrqZIev2Jck=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "c20ad69680e9f62fabc32c511c3964b8af55f955",
+        "rev": "7aaa72eb804248436ea20c084a7891a383e23b02",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                            |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`e8eb997b`](https://github.com/nix-community/srvos/commit/e8eb997b3409ba34763c87d90be5c6e6d0d0b94f) | `` darwin: move nix.daemonIOLowPriority to desktop ``              |
| [`d7a1d76a`](https://github.com/nix-community/srvos/commit/d7a1d76a7bb52bba01953f7c04c1a6e5d2263687) | `` add shared well-known-hosts ``                                  |
| [`168679c9`](https://github.com/nix-community/srvos/commit/168679c97927af4b38bbaa1856732f8ff30b66a4) | `` add shared update-diff (#539) ``                                |
| [`5db64ee0`](https://github.com/nix-community/srvos/commit/5db64ee0bc802e1c8f9a0d89b23d176784842d95) | `` darwin/server: various (#538) ``                                |
| [`7185c611`](https://github.com/nix-community/srvos/commit/7185c6112bccea2878dae166c4e88c0c739ab488) | `` add shared flake config ``                                      |
| [`57b6f51a`](https://github.com/nix-community/srvos/commit/57b6f51aa036f08f4ef26939900a758ee91bf32e) | `` move nix.channel to shared/common ``                            |
| [`1052ea34`](https://github.com/nix-community/srvos/commit/1052ea340a1f6f7be7edcc37636d8eff4f7c6579) | `` darwin: disable AuthorizedKeysFile ``                           |
| [`6aae204e`](https://github.com/nix-community/srvos/commit/6aae204ef3672b8c8e25a699aa91038883219453) | `` decrease watchdog runtimeTime for Raspberry Pi compatibility `` |