### PR TITLE
chore(flake/emacs-overlay): `00859b19` -> `d520e1bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728119509,
-        "narHash": "sha256-Pqw3k25wKKnZfoFMm69csGFGnGQoup9M4TZohguCZow=",
+        "lastModified": 1728147495,
+        "narHash": "sha256-CWDaV6dV9PaNh4CtD5E3nmzsAeQ/bMOwfPC2Rl++YkQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "00859b191a98a4f08e7cffc639a5b9cd3be9cdf7",
+        "rev": "d520e1bc76016f5a82fc09e36891bd7f907b1226",
         "type": "github"
       },
       "original": {
@@ -721,11 +721,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1727907660,
-        "narHash": "sha256-QftbyPoieM5M50WKUMzQmWtBWib/ZJbHo7mhj5riQec=",
+        "lastModified": 1728067476,
+        "narHash": "sha256-/uJcVXuBt+VFCPQIX+4YnYrHaubJSx4HoNsJVNRgANM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5966581aa04be7eff830b9e1457d56dc70a0b798",
+        "rev": "6e6b3dd395c3b1eb9be9f2d096383a8d05add030",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`d520e1bc`](https://github.com/nix-community/emacs-overlay/commit/d520e1bc76016f5a82fc09e36891bd7f907b1226) | `` Updated melpa ``        |
| [`dfa44d16`](https://github.com/nix-community/emacs-overlay/commit/dfa44d161338550df03000b535df2ffbaa815dcc) | `` Updated elpa ``         |
| [`fd6e4c36`](https://github.com/nix-community/emacs-overlay/commit/fd6e4c36fad10cff8d494add80c6adc86d6ae947) | `` Updated nongnu ``       |
| [`49d2e0b4`](https://github.com/nix-community/emacs-overlay/commit/49d2e0b4fcba6ed7516eccd168d4f734d0911bfd) | `` Updated flake inputs `` |