### PR TITLE
chore(flake/emacs-overlay): `13806d71` -> `dd6d5acc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728177608,
-        "narHash": "sha256-gDTiIhy3SiEmzLlcA8skl2sVWPrpx2CZBXOLwjSP4Ww=",
+        "lastModified": 1728180584,
+        "narHash": "sha256-ALMXrLsOS4NxgH4sYf5H1g+QoBT3uFioM1JtVna1Eb0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "13806d71fd499fd1300e0ae3420f9ed856adf961",
+        "rev": "dd6d5accb4d568022b843af5469abb82c08615a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`dd6d5acc`](https://github.com/nix-community/emacs-overlay/commit/dd6d5accb4d568022b843af5469abb82c08615a8) | `` Updated emacs `` |
| [`4abe6300`](https://github.com/nix-community/emacs-overlay/commit/4abe6300515446deceb150312274b42a72bddf75) | `` Updated melpa `` |