### PR TITLE
chore(flake/lanzaboote): `e2365a1d` -> `0bc127c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -456,11 +456,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1727792571,
-        "narHash": "sha256-KBzRQVE1j2vrSg8WfYJ+vEvFBC25+2VsFSK7VL2kc1M=",
+        "lastModified": 1728199407,
+        "narHash": "sha256-x4G0ja//3pT/epOvwxKR1XB7GAW7Yuwiy6RYCOgRjuQ=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "e2365a1d8dccdcf4bca5111672e80df67d90957d",
+        "rev": "0bc127c631999c9555cae2b0cdad2128ff058259",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                              |
| --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`98cf6500`](https://github.com/nix-community/lanzaboote/commit/98cf6500402b25b3160b39ebc763fffcf26eade1) | `` linux-bootloader: simplify get_loader_features `` |