### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `7a6eed1d` -> `b3a80a73`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728116549,
-        "narHash": "sha256-uxBrJ9zmxzsTm5nQ/9qwFuUjxWs78+LPAORO+LG4j7w=",
+        "lastModified": 1728180584,
+        "narHash": "sha256-ALMXrLsOS4NxgH4sYf5H1g+QoBT3uFioM1JtVna1Eb0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0e91d6cde618114734b4830d14c3a4e8e4b26d86",
+        "rev": "dd6d5accb4d568022b843af5469abb82c08615a8",
         "type": "github"
       },
       "original": {
@@ -516,11 +516,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1728117363,
-        "narHash": "sha256-fzGlIXOutXvo7ugDkhKjLrU7VDWKFP3zrheN8Botdog=",
+        "lastModified": 1728203703,
+        "narHash": "sha256-xzwhuPAMBIqYLyzwbFlhhkPPf64OA3RQpmsmPIsYvhk=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "7a6eed1d8c5b6464b9b5873e24e14f0709e2c4df",
+        "rev": "b3a80a73c9a4b21c9c28b37641c680e848c3263f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`b3a80a73`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/b3a80a73c9a4b21c9c28b37641c680e848c3263f) | `` flake.lock: Update `` |