### PR TITLE
chore(flake/emacs-overlay): `d83373c6` -> `1c42ffa2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728234711,
-        "narHash": "sha256-wx6dR0PXKo5UEaa2HObGNqy8pPIFn2Lm+DTzWnmP/X8=",
+        "lastModified": 1728273430,
+        "narHash": "sha256-F4ZkOlQn7PlIZv6ryjHG90dZ19RkxoxBUVzyamRxP7k=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d83373c669b43b08219d63270662ab6585aeec6c",
+        "rev": "1c42ffa2bbfe2b898a4cfc2c73edbfca77baf994",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                            |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
| [`1c42ffa2`](https://github.com/nix-community/emacs-overlay/commit/1c42ffa2bbfe2b898a4cfc2c73edbfca77baf994) | `` Bump cachix/install-nix-action from 29 to 30 `` |
| [`3d41910d`](https://github.com/nix-community/emacs-overlay/commit/3d41910d37e4f1d447ab0ff34a69f9e13756f0bf) | `` Updated emacs ``                                |
| [`aab83d8f`](https://github.com/nix-community/emacs-overlay/commit/aab83d8fe8b65054ffb82de177d6ef286e00a49b) | `` Updated melpa ``                                |
| [`641f4fa6`](https://github.com/nix-community/emacs-overlay/commit/641f4fa6e16a8f61611409c3228d45071c80870c) | `` Updated elpa ``                                 |
| [`6c1d9191`](https://github.com/nix-community/emacs-overlay/commit/6c1d919107fb94c9968a3d3bedde40ad8433000a) | `` Updated nongnu ``                               |