### PR TITLE
chore(flake/srvos): `e112d809` -> `62ba5488`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -973,11 +973,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728241918,
-        "narHash": "sha256-DGR1tj+LYFqGkhQUzwXyAsvrwPVvt4VB4ZplygYhtak=",
+        "lastModified": 1728262740,
+        "narHash": "sha256-JMpTRkf7n2cBH9ocm6cB5/kONguco+eVI2JFHsUx8tw=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "e112d809ae169c0b64fd30c81c5ed5f2463fb505",
+        "rev": "62ba548841d4d6cc69034db14fbe4291224aad96",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`62ba5488`](https://github.com/nix-community/srvos/commit/62ba548841d4d6cc69034db14fbe4291224aad96) | `` dev/private/flake.lock: Update `` |
| [`70de556a`](https://github.com/nix-community/srvos/commit/70de556a8e34bd601b8034243ff4129ac2f5e691) | `` flake.lock: Update ``             |