### PR TITLE
chore(flake/nixos-hardware): `b7ca02c7` -> `ecfcd787`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -648,11 +648,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1728056216,
-        "narHash": "sha256-IrO06gFUDTrTlIP3Sz+mRB6WUoO2YsgMtOD3zi0VEt0=",
+        "lastModified": 1728269138,
+        "narHash": "sha256-oKxDImsOvgUZMY4NwXVyUc/c1HiU2qInX+b5BU0yXls=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "b7ca02c7565fbf6d27ff20dd6dbd49c5b82eef28",
+        "rev": "ecfcd787f373f43307d764762e139a7cdeb9c22b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                         |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`ecfcd787`](https://github.com/NixOS/nixos-hardware/commit/ecfcd787f373f43307d764762e139a7cdeb9c22b) | `` build(deps): bump cachix/install-nix-action from 29 to 30 `` |