### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `f28d7265` -> `52e6adc9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -516,11 +516,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1728290395,
-        "narHash": "sha256-SXIDFeASoYBS9vx5oMkkvvKiiq8YnzVjZmykAih45QA=",
+        "lastModified": 1728303085,
+        "narHash": "sha256-Sjb5RVlnahXQoLLup8WlZEHjRkWyZQwa+xCtXT5yF88=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "f28d72655438fb340cce649671c78acc36f5930a",
+        "rev": "52e6adc90935dbf627fd6a9836a9953f420cff69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                                            |
| ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`e85551e2`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/e85551e27f8561ae1a60feb0f423783d17f00eef) | `` Bump cachix/install-nix-action from 29 to 30 `` |