### PR TITLE
chore(flake/emacs-overlay): `29af1ca6` -> `cc15718c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728291655,
-        "narHash": "sha256-4gMIwmMFessucJCballowya2bjQYdI4pyZwQHixgd5M=",
+        "lastModified": 1728320368,
+        "narHash": "sha256-rIJoQsEs505fhSPcXtq4cL//I3qvPdpJCO+pQF2Sn30=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "29af1ca608ec75e42c3d7a59459546a90c2ac417",
+        "rev": "cc15718cbc1ad62bd9ec488ae07a4ab82ff537e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`cc15718c`](https://github.com/nix-community/emacs-overlay/commit/cc15718cbc1ad62bd9ec488ae07a4ab82ff537e6) | `` Updated melpa ``  |
| [`d9143db1`](https://github.com/nix-community/emacs-overlay/commit/d9143db19d5f770d3688ab8ecfabbce092bdd492) | `` Updated elpa ``   |
| [`0ed40004`](https://github.com/nix-community/emacs-overlay/commit/0ed4000480e3f21e67a99d30248d6768b9f2f6ee) | `` Updated nongnu `` |