### PR TITLE
chore(flake/srvos): `62ba5488` -> `b7404fba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -973,11 +973,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728262740,
-        "narHash": "sha256-JMpTRkf7n2cBH9ocm6cB5/kONguco+eVI2JFHsUx8tw=",
+        "lastModified": 1728331020,
+        "narHash": "sha256-komGffXHZKSt8BwXDlUHuYOJ0fkH+hOvumT50LT567g=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "62ba548841d4d6cc69034db14fbe4291224aad96",
+        "rev": "b7404fba3095921c41484b2e92b2e5cd59b949e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                         |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`b7404fba`](https://github.com/nix-community/srvos/commit/b7404fba3095921c41484b2e92b2e5cd59b949e0) | `` build(deps): bump cachix/install-nix-action from 29 to 30 `` |