### PR TITLE
chore(flake/sops-nix): `2750ed78` -> `06535d0e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -953,11 +953,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1728230538,
-        "narHash": "sha256-sbsMJOZgykaSdFbxLKghc0QMtolzl4P5nqpttBA3d5M=",
+        "lastModified": 1728345710,
+        "narHash": "sha256-lpunY1+bf90ts+sA2/FgxVNIegPDKCpEoWwOPu4ITTQ=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "2750ed784e93e745a33fb55be7c2657adfb57c00",
+        "rev": "06535d0e3d0201e6a8080dd32dbfde339b94f01b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                                                         |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
| [`06535d0e`](https://github.com/Mic92/sops-nix/commit/06535d0e3d0201e6a8080dd32dbfde339b94f01b) | `` build(deps): bump github.com/ProtonMail/go-crypto from 1.1.0-alpha.5-proton to 1.1.0-beta.0-proton (#633) `` |
| [`715dd6cb`](https://github.com/Mic92/sops-nix/commit/715dd6cbd0a59da6e8c2b84eee70652ae2e975a4) | `` build(deps): bump golang.org/x/crypto from 0.27.0 to 0.28.0 (#631) ``                                        |
| [`84d00684`](https://github.com/Mic92/sops-nix/commit/84d006846f98b2bfed3796f1ccc8e62faf0c2ae9) | `` build(deps): bump cachix/install-nix-action from 29 to 30 (#630) ``                                          |