### PR TITLE
chore(flake/srvos): `b7404fba` -> `a2a8f68d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -973,11 +973,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728331020,
-        "narHash": "sha256-komGffXHZKSt8BwXDlUHuYOJ0fkH+hOvumT50LT567g=",
+        "lastModified": 1728372701,
+        "narHash": "sha256-n+o0AChteJB6UQjHvvhL1BNgE9npEFSFXEgDd+3C5wk=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "b7404fba3095921c41484b2e92b2e5cd59b949e0",
+        "rev": "a2a8f68d881be57c8898c305438aa50cf71ae4b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`a2a8f68d`](https://github.com/nix-community/srvos/commit/a2a8f68d881be57c8898c305438aa50cf71ae4b1) | `` add shared trusted caches (#544) `` |