### PR TITLE
chore(flake/emacs-overlay): `8d737f3f` -> `c3bfafef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728353080,
-        "narHash": "sha256-sgVkj60WP82HvkhLQaO0rIl04ow8T3wrKzmkckFzLkA=",
+        "lastModified": 1728378063,
+        "narHash": "sha256-O/CkecJY78RLEpi28+uc4xr6pqtFYNNOxwiXyjaHsmw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8d737f3f4440f1f30e57fd213180062d6e3f04d8",
+        "rev": "c3bfafef9075c7f7367a0274b0de3c215ef18b2a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`c3bfafef`](https://github.com/nix-community/emacs-overlay/commit/c3bfafef9075c7f7367a0274b0de3c215ef18b2a) | `` Updated melpa ``        |
| [`a637a917`](https://github.com/nix-community/emacs-overlay/commit/a637a9177b12a8ba406bd9786827c4ba5c809264) | `` Updated flake inputs `` |