### PR TITLE
chore(flake/catppuccin): `bad96d3f` -> `4e08dd54`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1727910534,
-        "narHash": "sha256-IjdGPDnBNk3r5h02kiPTKUOfn+UiKNWlhy/ozC0NgyQ=",
+        "lastModified": 1728406792,
+        "narHash": "sha256-MVja1s0flvklxv47hLMcjqYGQ9B4ddgizfIpuyyJAsk=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "bad96d3fabf8d2e8f0bf0c2cb899a9fccf01ea03",
+        "rev": "4e08dd54fb8a0191153df9f71ac60700b6a936c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                    |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`4e08dd54`](https://github.com/catppuccin/nix/commit/4e08dd54fb8a0191153df9f71ac60700b6a936c1) | `` ci: update determinatesystems/update-flake-lock action to v24 (#344) `` |
| [`65f2a8a3`](https://github.com/catppuccin/nix/commit/65f2a8a36422e54ae469f3fc6325775ce497724b) | `` fix(home-manager/hyprland): import accents from file (#347) ``          |