### PR TITLE
chore(flake/emacs-overlay): `c3bfafef` -> `14b82b95`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728378063,
-        "narHash": "sha256-O/CkecJY78RLEpi28+uc4xr6pqtFYNNOxwiXyjaHsmw=",
+        "lastModified": 1728407619,
+        "narHash": "sha256-yI5QtURXSj7wM9d8bvO7lc/taooGQ+hEXxCFlG2CZQE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c3bfafef9075c7f7367a0274b0de3c215ef18b2a",
+        "rev": "14b82b9590a9cfced6c702a184613b428ed676f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`14b82b95`](https://github.com/nix-community/emacs-overlay/commit/14b82b9590a9cfced6c702a184613b428ed676f3) | `` Updated emacs ``  |
| [`e50af9e8`](https://github.com/nix-community/emacs-overlay/commit/e50af9e8275ef9dfd2ced7df52c796f13f1af6a1) | `` Updated melpa ``  |
| [`2f0acb10`](https://github.com/nix-community/emacs-overlay/commit/2f0acb10d4ca8535fc1c5186531d0dde19e8a947) | `` Updated elpa ``   |
| [`dc726e7c`](https://github.com/nix-community/emacs-overlay/commit/dc726e7c476bc262832391a0fd02f4cfc072dc25) | `` Updated nongnu `` |