### PR TITLE
chore(flake/catppuccin): `4e08dd54` -> `96cf8b4a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1728406792,
-        "narHash": "sha256-MVja1s0flvklxv47hLMcjqYGQ9B4ddgizfIpuyyJAsk=",
+        "lastModified": 1728407414,
+        "narHash": "sha256-B8LaxUP93eh+it8RW1pGq4SsU2kj7f0ipzFuhBvpON8=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "4e08dd54fb8a0191153df9f71ac60700b6a936c1",
+        "rev": "96cf8b4a05fb23a53c027621b1147b5cf9e5439f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                               |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`96cf8b4a`](https://github.com/catppuccin/nix/commit/96cf8b4a05fb23a53c027621b1147b5cf9e5439f) | `` feat(home-manager): add support for aerc (#338) `` |