### PR TITLE
chore(flake/emacs-overlay): `82b1c581` -> `00e79db0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728436493,
-        "narHash": "sha256-5/ZRUpE714nedaGyL7pMCB6OZcHfaDbQS05VzGOQBoI=",
+        "lastModified": 1728439462,
+        "narHash": "sha256-0r+a+L/KCZjeguYyLuog7/7EKqyAbgBmHCRDmUEbom8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "82b1c581575c24ef8ef6724eb1072b2f8e26f279",
+        "rev": "00e79db0e791b9fd393eb98068135cb08d33684b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`00e79db0`](https://github.com/nix-community/emacs-overlay/commit/00e79db0e791b9fd393eb98068135cb08d33684b) | `` Updated emacs `` |
| [`c144308e`](https://github.com/nix-community/emacs-overlay/commit/c144308ef75b28ec3289c1ec7e34ee0ee80a3e3e) | `` Updated melpa `` |