### PR TITLE
chore(flake/emacs-overlay): `3dd4923b` -> `c73112e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728464420,
-        "narHash": "sha256-3RMJk/XL4FKqTvnKt+XLYCYj4Bo47up/idKq1YQcoCo=",
+        "lastModified": 1728465432,
+        "narHash": "sha256-E+wQEaXiGMN9hLStkPw0T3Wqxj05ZqHiE8B2mOA2kmI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3dd4923bdd090186de32c11b1d6945fb8cc4eeea",
+        "rev": "c73112e15bc9c784b4c6f4855ae4acb0a6cc480f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`c73112e1`](https://github.com/nix-community/emacs-overlay/commit/c73112e15bc9c784b4c6f4855ae4acb0a6cc480f) | `` Updated emacs `` |