### PR TITLE
chore(flake/emacs-overlay): `2740ccfe` -> `75650e84`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728493181,
-        "narHash": "sha256-a5BQny7/ncCIybTS+Nyh2AxfNvgrXuSJQChNmnkAtpI=",
+        "lastModified": 1728525896,
+        "narHash": "sha256-XpR0FJTAWDMUQhiwEdUWym2kbmz9XS6fifv8PWrm5VI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2740ccfee65e8483cdabd097d98feec9f3f089c8",
+        "rev": "75650e84f17566e47b40ae75e21dff1e4f97fd3d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`75650e84`](https://github.com/nix-community/emacs-overlay/commit/75650e84f17566e47b40ae75e21dff1e4f97fd3d) | `` Updated emacs ``  |
| [`1a666a67`](https://github.com/nix-community/emacs-overlay/commit/1a666a674ac0600b1c7339af84883addf25c8ad6) | `` Updated melpa ``  |
| [`06a78be8`](https://github.com/nix-community/emacs-overlay/commit/06a78be871b652361acf2444388ec9b4257b2a12) | `` Updated elpa ``   |
| [`db751b32`](https://github.com/nix-community/emacs-overlay/commit/db751b329a5927d928894c3232af6c70e04c32a9) | `` Updated nongnu `` |