### PR TITLE
chore(flake/srvos): `a2a8f68d` -> `0519f44f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -973,11 +973,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728372701,
-        "narHash": "sha256-n+o0AChteJB6UQjHvvhL1BNgE9npEFSFXEgDd+3C5wk=",
+        "lastModified": 1728521492,
+        "narHash": "sha256-wxFGWXszG02eP6jUXU0r4Yb1sjbe7mxX38VUo5IWSao=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "a2a8f68d881be57c8898c305438aa50cf71ae4b1",
+        "rev": "0519f44f38649b84d3a3864a7cf8d1880f48ef10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`0519f44f`](https://github.com/nix-community/srvos/commit/0519f44f38649b84d3a3864a7cf8d1880f48ef10) | `` dev/private/flake.lock: Update `` |
| [`63612204`](https://github.com/nix-community/srvos/commit/636122040e524b1188d3505307f287a975994dec) | `` flake.lock: Update ``             |