### PR TITLE
chore(flake/home-manager): `03863036` -> `8bb5d53c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -410,11 +410,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728337164,
-        "narHash": "sha256-VdRTjJFyq4Q9U7Z/UoC2Q5jK8vSo6E86lHc2OanXtvc=",
+        "lastModified": 1728588172,
+        "narHash": "sha256-wCLcOMOyiFHa4MfAT1SR8jj47GcmCXiR93kgFs38bVY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "038630363e7de57c36c417fd2f5d7c14773403e4",
+        "rev": "8bb5d53c5847d9a9b2ad1bda49f9aa9df0de282a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`8bb5d53c`](https://github.com/nix-community/home-manager/commit/8bb5d53c5847d9a9b2ad1bda49f9aa9df0de282a) | `` docs: add XDG_*_HOME mentions to xdg.*Home options `` |
| [`d47d3325`](https://github.com/nix-community/home-manager/commit/d47d33254fbf4fdbdee9f1f14095f689662e479d) | `` home-manager-manual: expose options.json ``           |
| [`d3ee25c0`](https://github.com/nix-community/home-manager/commit/d3ee25c07848725e924a74a4813de2ad0f5d0878) | `` Translate using Weblate (Hindi) ``                    |