### PR TITLE
chore(flake/lanzaboote): `0bc127c6` -> `3326a0b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -456,11 +456,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1728199407,
-        "narHash": "sha256-x4G0ja//3pT/epOvwxKR1XB7GAW7Yuwiy6RYCOgRjuQ=",
+        "lastModified": 1728632221,
+        "narHash": "sha256-LnBVdKPsreziZkYbeFqiSYP7tPFlprt9ej2QGd2aNlw=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "0bc127c631999c9555cae2b0cdad2128ff058259",
+        "rev": "3326a0b3974fc04d991990f6497fe1a7d9892439",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                           |
| --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`7a367fa6`](https://github.com/nix-community/lanzaboote/commit/7a367fa69893eb9a3c6586663bf20ab2f6103a9e) | `` module: replace hard-coded executable paths with lib.getExe `` |