### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `f3e2152f` -> `15b37902`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728548418,
-        "narHash": "sha256-/HMh/jp5PgoOq33EDGk81Ww/wAFPIdIDa2b7+PA5aUk=",
+        "lastModified": 1728612252,
+        "narHash": "sha256-qGHK+YmJ9FQFa34ln/2u8VcApg96vBdWdOt6JiXrxsE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "976544e11b9f3689f33c0cfd73431fe4bb23abd0",
+        "rev": "4b3d8ab182d381b581de10a76754d453c0ae39dc",
         "type": "github"
       },
       "original": {
@@ -516,11 +516,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1728549533,
-        "narHash": "sha256-xkU5FqFi+60nDFxlZoC778uxJt20rPBh/ymhi46xHsA=",
+        "lastModified": 1728635876,
+        "narHash": "sha256-Rot1ynbgpnzz+/zdwZL7jw87ISzMrEKmR6+RkmfbXQY=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "f3e2152fecd5c6d8b83dc2f4be0beee00ca9bf6b",
+        "rev": "15b3790222c2ad9c0a7fd1f47892ba8057be9b20",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`15b37902`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/15b3790222c2ad9c0a7fd1f47892ba8057be9b20) | `` flake.lock: Update `` |