### PR TITLE
chore(flake/emacs-overlay): `6ce6925b` -> `b3101a3a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728637252,
-        "narHash": "sha256-LcA21GVbdlWDTOBgWSEdweXEIpfjNSB+yyt4nCKrO/A=",
+        "lastModified": 1728638138,
+        "narHash": "sha256-9BNhvMzh/bQmm0VhhRrl3fmiIjQnvRrVUwXIM5mtYY4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6ce6925b055a93cd747c4132bacaf6714b87bc1b",
+        "rev": "b3101a3a0f3883f97fa867ef56b0f29fa2b2b7f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`b3101a3a`](https://github.com/nix-community/emacs-overlay/commit/b3101a3a0f3883f97fa867ef56b0f29fa2b2b7f1) | `` Updated emacs `` |