### PR TITLE
chore(flake/emacs-overlay): `b3101a3a` -> `c3cecb35`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728638138,
-        "narHash": "sha256-9BNhvMzh/bQmm0VhhRrl3fmiIjQnvRrVUwXIM5mtYY4=",
+        "lastModified": 1728665982,
+        "narHash": "sha256-oqYVwADd0eKzmgwnBAUZIXL3zOKQQkLHotSnksmsBrI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b3101a3a0f3883f97fa867ef56b0f29fa2b2b7f1",
+        "rev": "c3cecb35e0735f81b1b7cd1f928cd2225fe3bdf9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`c3cecb35`](https://github.com/nix-community/emacs-overlay/commit/c3cecb35e0735f81b1b7cd1f928cd2225fe3bdf9) | `` Updated melpa ``  |
| [`650ebad7`](https://github.com/nix-community/emacs-overlay/commit/650ebad778616524c65c7556efe36df24ee76793) | `` Updated elpa ``   |
| [`9b10be00`](https://github.com/nix-community/emacs-overlay/commit/9b10be0060eeda3029ee2da1676c142bdc2e689f) | `` Updated nongnu `` |