### PR TITLE
chore(flake/emacs-overlay): `64e6dba5` -> `1b1979c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728666726,
-        "narHash": "sha256-ThrjDk8mDhsoxW50iIpyk2YKPpT0ovLOOcOI32BqL2Y=",
+        "lastModified": 1728695801,
+        "narHash": "sha256-KTrp1+7lJ62J3yFjwi41cTzvXzT4xCl05M82Ej1hjXY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "64e6dba516f22ccfa4eb4e8c6b881fa1e1ec80d4",
+        "rev": "1b1979c475db2546c86a9ed711ff66635e88b431",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                              |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
| [`90541546`](https://github.com/nix-community/emacs-overlay/commit/90541546caac508094be72becb8e3ebb24f9c217) | `` Updated elpa ``                                   |
| [`8394b717`](https://github.com/nix-community/emacs-overlay/commit/8394b717055c5ef50756ae1e3fbca4749163e1bb) | `` README.org: change to official nixos wiki link `` |