### PR TITLE
chore(flake/emacs-overlay): `1b1979c4` -> `eac5f274`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728695801,
-        "narHash": "sha256-KTrp1+7lJ62J3yFjwi41cTzvXzT4xCl05M82Ej1hjXY=",
+        "lastModified": 1728698619,
+        "narHash": "sha256-DcJvKq0HDrPc2PHw9mtXzaiGYiAG2SgQPHov36voDkU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1b1979c475db2546c86a9ed711ff66635e88b431",
+        "rev": "eac5f2748d0719b747e21b486c1686aa1e23a9ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`eac5f274`](https://github.com/nix-community/emacs-overlay/commit/eac5f2748d0719b747e21b486c1686aa1e23a9ae) | `` Updated emacs `` |
| [`3c9143c3`](https://github.com/nix-community/emacs-overlay/commit/3c9143c30e06ea70c1ca87f50f84f72c6a79c787) | `` Updated melpa `` |