### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `15b37902` -> `fb3f4e84`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728612252,
-        "narHash": "sha256-qGHK+YmJ9FQFa34ln/2u8VcApg96vBdWdOt6JiXrxsE=",
+        "lastModified": 1728721118,
+        "narHash": "sha256-A/FIm25BDJzubQcHkjIdqC56IblFtn1UWtCtmrEm75o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4b3d8ab182d381b581de10a76754d453c0ae39dc",
+        "rev": "e3634be032a23ea92c871afc57dc748d2c46623d",
         "type": "github"
       },
       "original": {
@@ -516,11 +516,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1728635876,
-        "narHash": "sha256-Rot1ynbgpnzz+/zdwZL7jw87ISzMrEKmR6+RkmfbXQY=",
+        "lastModified": 1728722122,
+        "narHash": "sha256-wHP5kgQqw1qlYB+Hk9hGOotdDZZbSEQs0lVQyn/wQtE=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "15b3790222c2ad9c0a7fd1f47892ba8057be9b20",
+        "rev": "fb3f4e8449d49a9030ca2bb3dbe45fdfe16f0603",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`fb3f4e84`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/fb3f4e8449d49a9030ca2bb3dbe45fdfe16f0603) | `` flake.lock: Update `` |