### PR TITLE
chore(flake/nixos-hardware): `ecfcd787` -> `a8dd1b21`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -648,11 +648,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1728269138,
-        "narHash": "sha256-oKxDImsOvgUZMY4NwXVyUc/c1HiU2qInX+b5BU0yXls=",
+        "lastModified": 1728729581,
+        "narHash": "sha256-oazkQ/z7r43YkDLLQdMg8oIB3CwWNb+2ZrYOxtLEWTQ=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "ecfcd787f373f43307d764762e139a7cdeb9c22b",
+        "rev": "a8dd1b21995964b115b1e3ec639dd6ce24ab9806",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                              |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`a8dd1b21`](https://github.com/NixOS/nixos-hardware/commit/a8dd1b21995964b115b1e3ec639dd6ce24ab9806) | `` add dell inspiron 7460 (#1177) `` |
| [`6f71da56`](https://github.com/NixOS/nixos-hardware/commit/6f71da566f481d1593d447c31556759732299d13) | `` apple/t2: add tiny-dfr option ``  |
| [`ca0662ed`](https://github.com/NixOS/nixos-hardware/commit/ca0662edb06f07d7b57c1b92037a112b4fc2c82f) | `` fix ordering ``                   |
| [`664b7847`](https://github.com/NixOS/nixos-hardware/commit/664b784722aee2fb139bfe6542406f16c0c4c457) | `` add tuxedo aura 15 gen1 ``        |