### PR TITLE
chore(flake/emacs-overlay): `22e87ed5` -> `5b749002`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728723534,
-        "narHash": "sha256-S421Y8vdeCG7bvn29A9zYlAVYoJVSPGpO6+pOr3yUlg=",
+        "lastModified": 1728752343,
+        "narHash": "sha256-nQHqhLfFGaERh7OlH3H0laifbIxqRIIYGzYQzB+4TDg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "22e87ed52062b0732339ac5f13cd0c38dad62e28",
+        "rev": "5b749002dc81cbc503c10eee9bb8e0b129e805f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`5b749002`](https://github.com/nix-community/emacs-overlay/commit/5b749002dc81cbc503c10eee9bb8e0b129e805f1) | `` Updated melpa ``  |
| [`7bc37ea4`](https://github.com/nix-community/emacs-overlay/commit/7bc37ea48b0ac6531b4cd260f742be94e8429f4f) | `` Updated elpa ``   |
| [`d9fcbf59`](https://github.com/nix-community/emacs-overlay/commit/d9fcbf59e2675866e61c33985877a98f05b27df9) | `` Updated nongnu `` |