### PR TITLE
chore(flake/git-hooks): `eb74e0be` -> `ff68f917`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1728727368,
-        "narHash": "sha256-7FMyNISP7K6XDSIt1NJxkXZnEdV3HZUXvFoBaJ/qdOg=",
+        "lastModified": 1728778939,
+        "narHash": "sha256-WybK5E3hpGxtCYtBwpRj1E9JoiVxe+8kX83snTNaFHE=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "eb74e0be24a11a1531b5b8659535580554d30b28",
+        "rev": "ff68f91754be6f3427e4986d7949e6273659be1d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                     |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`e76201cb`](https://github.com/cachix/git-hooks.nix/commit/e76201cb5eb84bc613ef4276f7d0095978233a06) | `` hooks: fix rome and nixfmt migrations `` |
| [`c93e347b`](https://github.com/cachix/git-hooks.nix/commit/c93e347b6ffdd98709a949faeb5480a8ccf11da0) | `` feat(run.nix): expose more ``            |