### PR TITLE
chore(flake/emacs-overlay): `98b4ec1b` -> `5fa07998`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728782395,
-        "narHash": "sha256-teLHCKr+XIQn2F3AoeWBl8PmzPYsbYXackxbXEsxOeg=",
+        "lastModified": 1728785396,
+        "narHash": "sha256-cm+fUV7nemLe2FXY2jFkAZQmDuff8j+YjK22TIAhK3Q=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "98b4ec1b834c278baec2dc17146c6ec026083670",
+        "rev": "5fa07998986f0adc6d6a96b3731097bad4e3304d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`5fa07998`](https://github.com/nix-community/emacs-overlay/commit/5fa07998986f0adc6d6a96b3731097bad4e3304d) | `` Updated emacs `` |
| [`30479b6f`](https://github.com/nix-community/emacs-overlay/commit/30479b6f2c3ea7a25be890276befd9272483e4d3) | `` Updated melpa `` |