### PR TITLE
chore(flake/home-manager): `d57112db` -> `64c6325b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -410,11 +410,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728726232,
-        "narHash": "sha256-8ZWr1HpciQsrFjvPMvZl0W+b0dilZOqXPoKa2Ux36bc=",
+        "lastModified": 1728791962,
+        "narHash": "sha256-nr5QiXwQcZmf6/auC1UpX8iAtINMtdi2mH+OkqJQVmU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d57112db877f07387ce7104b5ac346ede556d2d7",
+        "rev": "64c6325b28ebd708653dd41d88f306023f296184",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                  |
| ----------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`64c6325b`](https://github.com/nix-community/home-manager/commit/64c6325b28ebd708653dd41d88f306023f296184) | `` flake.lock: Update `` |