### PR TITLE
chore(flake/lanzaboote): `3326a0b3` -> `6634ab61`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -456,11 +456,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1728632221,
-        "narHash": "sha256-LnBVdKPsreziZkYbeFqiSYP7tPFlprt9ej2QGd2aNlw=",
+        "lastModified": 1728833717,
+        "narHash": "sha256-GkS9SnKRb/PrdcqptLPNxweDdf3Zx2Lk5szEt07P4mE=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "3326a0b3974fc04d991990f6497fe1a7d9892439",
+        "rev": "6634ab618862f1d041c286567a58c554e6136068",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                            |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`45609e42`](https://github.com/nix-community/lanzaboote/commit/45609e422bbedf3d69dad9e6fff4f0e5475aa529) | `` uefi: Drop RuntimeServices param from ensure_efi_variable ``    |
| [`1388d533`](https://github.com/nix-community/lanzaboote/commit/1388d533281fe6df247b9220127e2f24b61e72f4) | `` stub: Drop RuntimeServices param from get_secure_boot_status `` |