### PR TITLE
chore(flake/emacs-overlay): `185ef369` -> `2f19d976`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728810729,
-        "narHash": "sha256-b8NMy00ILZHAJWFKy5lcdhi56T2REgmAurhG675cKsE=",
+        "lastModified": 1728838727,
+        "narHash": "sha256-2gQLQf8Hr4J+tOGS7TTu6P/vUAtlttN+twOVXTm+g6Y=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "185ef369068c3d0e164730d855fb31444875b189",
+        "rev": "2f19d976990a992fbc67d353d97c21f46e8962f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`2f19d976`](https://github.com/nix-community/emacs-overlay/commit/2f19d976990a992fbc67d353d97c21f46e8962f8) | `` Updated melpa ``  |
| [`eb7d824a`](https://github.com/nix-community/emacs-overlay/commit/eb7d824a6b3ac22a14328caeb6c34c08afc9eb88) | `` Updated elpa ``   |
| [`0646f852`](https://github.com/nix-community/emacs-overlay/commit/0646f852a92dcbac2cf8b03bc4bcef7752fef0b0) | `` Updated nongnu `` |