### PR TITLE
chore(flake/emacs-overlay): `2f19d976` -> `1ac99536`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728838727,
-        "narHash": "sha256-2gQLQf8Hr4J+tOGS7TTu6P/vUAtlttN+twOVXTm+g6Y=",
+        "lastModified": 1728839477,
+        "narHash": "sha256-HXWknm3vRHknK0yKdlO1qKFxO6f8lJHaufFekxjL4RY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2f19d976990a992fbc67d353d97c21f46e8962f8",
+        "rev": "1ac99536bb5eb9b2b4fc161bd0651bcbbb36c6d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`1ac99536`](https://github.com/nix-community/emacs-overlay/commit/1ac99536bb5eb9b2b4fc161bd0651bcbbb36c6d9) | `` Updated emacs `` |