### PR TITLE
chore(flake/emacs-overlay): `80b32011` -> `87e8ffcc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728870811,
-        "narHash": "sha256-fJy0fnS18sm40cdrbZFcBn5yTeBzHEvLtDVpC9jKJF4=",
+        "lastModified": 1728873482,
+        "narHash": "sha256-pPzaB8a70Lc4utiOBJkoTg2Hw9R5KrQYbnxDXZLXEd4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "80b32011f432a98b91e0189eb764b93a34c4e90d",
+        "rev": "87e8ffccb53aa67dfaab7bd4fd9f27b543e73cec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                         |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`87e8ffcc`](https://github.com/nix-community/emacs-overlay/commit/87e8ffccb53aa67dfaab7bd4fd9f27b543e73cec) | `` Bump actions/checkout from 4.2.0 to 4.2.1 `` |