### PR TITLE
chore(flake/emacs-overlay): `87e8ffcc` -> `5875b25c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728873482,
-        "narHash": "sha256-pPzaB8a70Lc4utiOBJkoTg2Hw9R5KrQYbnxDXZLXEd4=",
+        "lastModified": 1728896490,
+        "narHash": "sha256-VO8P23YpNY/pMM6Cv61lWas+NIY8g8fpy+E/qf27z7Y=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "87e8ffccb53aa67dfaab7bd4fd9f27b543e73cec",
+        "rev": "5875b25cdcc87d39edf86534ca490e6c43ffb5e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`5875b25c`](https://github.com/nix-community/emacs-overlay/commit/5875b25cdcc87d39edf86534ca490e6c43ffb5e6) | `` Updated melpa `` |