### PR TITLE
chore(flake/darwin): `ccf8cc56` -> `a60ac02f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -88,11 +88,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728874775,
-        "narHash": "sha256-B2C15JAdewAMC29qvogmkck30uDKi7wu/qHX0BLHJVc=",
+        "lastModified": 1728901530,
+        "narHash": "sha256-I9Qd0LnAsEGHtKE9+uVR0iDFmsijWSy7GT0g3jihG4Q=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "ccf8cc56c9846ff2490244e05abe2ef737bf3df4",
+        "rev": "a60ac02f9466f85f092e576fd8364dfc4406b5a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                          |
| ------------------------------------------------------------------------------------------------ | -------------------------------- |
| [`6347a9dc`](https://github.com/LnL7/nix-darwin/commit/6347a9dcd1e43b9a5d43b837cfa4ca0073c2eb0e) | `` skhd: add `skhd` to `PATH` `` |