### PR TITLE
chore(flake/emacs-overlay): `5875b25c` -> `b73795c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728896490,
-        "narHash": "sha256-VO8P23YpNY/pMM6Cv61lWas+NIY8g8fpy+E/qf27z7Y=",
+        "lastModified": 1728925191,
+        "narHash": "sha256-d1J/GIV1leFDKj3iBJEabrjD/P1EiZJ4t7+k4SRBIKk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5875b25cdcc87d39edf86534ca490e6c43ffb5e6",
+        "rev": "b73795c2481699e60ad9a331db4c7b8be3fee8b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`b73795c2`](https://github.com/nix-community/emacs-overlay/commit/b73795c2481699e60ad9a331db4c7b8be3fee8b4) | `` Updated melpa ``  |
| [`2c40c476`](https://github.com/nix-community/emacs-overlay/commit/2c40c4767fdf246fc4e8e63897b1f9ebb507a07c) | `` Updated elpa ``   |
| [`7b64ceb1`](https://github.com/nix-community/emacs-overlay/commit/7b64ceb1b9699dab4153e670bb146836466dfb23) | `` Updated nongnu `` |