### PR TITLE
chore(flake/emacs-overlay): `b73795c2` -> `ad4b22bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728925191,
-        "narHash": "sha256-d1J/GIV1leFDKj3iBJEabrjD/P1EiZJ4t7+k4SRBIKk=",
+        "lastModified": 1728954966,
+        "narHash": "sha256-Yufv+dyFd+Crc1ICwqM4wqAq8oSnbec5bMxh+hKi+20=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b73795c2481699e60ad9a331db4c7b8be3fee8b4",
+        "rev": "ad4b22bcbca88199c9ac3a95a8ec99e0cd25a4c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`ad4b22bc`](https://github.com/nix-community/emacs-overlay/commit/ad4b22bcbca88199c9ac3a95a8ec99e0cd25a4c4) | `` Updated elpa ``   |
| [`ea207d97`](https://github.com/nix-community/emacs-overlay/commit/ea207d97f06fab220ba915daf40d6a27c6a066c5) | `` Updated nongnu `` |