### PR TITLE
chore(flake/emacs-overlay): `ad4b22bc` -> `c5430682`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728954966,
-        "narHash": "sha256-Yufv+dyFd+Crc1ICwqM4wqAq8oSnbec5bMxh+hKi+20=",
+        "lastModified": 1728957992,
+        "narHash": "sha256-lwEP+CzlfRkp4nwpIhKls4kBzpv6doDinxpCmMnucO4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ad4b22bcbca88199c9ac3a95a8ec99e0cd25a4c4",
+        "rev": "c5430682e61cd179555e3c8abb0785dd1c2c1a78",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`c5430682`](https://github.com/nix-community/emacs-overlay/commit/c5430682e61cd179555e3c8abb0785dd1c2c1a78) | `` Updated emacs `` |
| [`ae28e5b4`](https://github.com/nix-community/emacs-overlay/commit/ae28e5b42265fdc79965ec4f0958d591c3667d95) | `` Updated melpa `` |