### PR TITLE
chore(flake/emacs-overlay): `c5430682` -> `b195d706`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728957992,
-        "narHash": "sha256-lwEP+CzlfRkp4nwpIhKls4kBzpv6doDinxpCmMnucO4=",
+        "lastModified": 1728966217,
+        "narHash": "sha256-oP4ocNELjYaIjpjq7GOqrMjgc6IfxmFh34UxnzZYEFI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c5430682e61cd179555e3c8abb0785dd1c2c1a78",
+        "rev": "b195d7067b4f14651ed55660d7a9a3d8e38afc6d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                       |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
| [`9af2d0c9`](https://github.com/nix-community/emacs-overlay/commit/9af2d0c9f70f686fc85bd78c631bced09ff2154c) | `` recipes-archive-melpa.json: fix hashes for timu-*-theme `` |