### PR TITLE
chore(flake/emacs-overlay): `b195d706` -> `74473259`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728966217,
-        "narHash": "sha256-oP4ocNELjYaIjpjq7GOqrMjgc6IfxmFh34UxnzZYEFI=",
+        "lastModified": 1728983770,
+        "narHash": "sha256-1dB6pb66dNgNw8s6UGxcMjSmsb7F8J+rYPqL3zaSg7I=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b195d7067b4f14651ed55660d7a9a3d8e38afc6d",
+        "rev": "744732598481ac0b82b5fa0128b745f0db0d9116",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`74473259`](https://github.com/nix-community/emacs-overlay/commit/744732598481ac0b82b5fa0128b745f0db0d9116) | `` Updated emacs `` |
| [`2189b8af`](https://github.com/nix-community/emacs-overlay/commit/2189b8afd568c8e2ae710adbc0a51251c36f9e06) | `` Updated melpa `` |