### PR TITLE
chore(flake/nixpkgs): `5633bcff` -> `a3c0b3b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -795,11 +795,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1728492678,
-        "narHash": "sha256-9UTxR8eukdg+XZeHgxW5hQA9fIKHsKCdOIUycTryeVw=",
+        "lastModified": 1728888510,
+        "narHash": "sha256-nsNdSldaAyu6PE3YUA+YQLqUDJh+gRbBooMMekZJwvI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+        "rev": "a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`a3c0b3b2`](https://github.com/NixOS/nixpkgs/commit/a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c) | `` Revert "nixos/tests/networking: test nameservers via DHCP" ``             |
| [`0932441e`](https://github.com/NixOS/nixpkgs/commit/0932441e91d13ea710cc60439fb006828d40350d) | `` miniaudicle: 1.5.2.0 -> 1.5.3.0 ``                                        |
| [`310061a7`](https://github.com/NixOS/nixpkgs/commit/310061a7f9d3bf03c4bb762dc5dca99f7246979e) | `` justbuild: use default version of protobuf ``                             |
| [`7de2696d`](https://github.com/NixOS/nixpkgs/commit/7de2696dc2ae8c4a7326e2c469abf38ba5c86e3a) | `` justbuild: add update script ``                                           |
| [`a9679031`](https://github.com/NixOS/nixpkgs/commit/a9679031d9fac9ef67422626b655f2b008841ef9) | `` justbuild: add tests.version test ``                                      |
| [`8c4502b9`](https://github.com/NixOS/nixpkgs/commit/8c4502b9efce0d079262c9c832a055796bace96a) | `` justbuild: 1.3.1 -> 1.3.2 ``                                              |
| [`ffd9d8f0`](https://github.com/NixOS/nixpkgs/commit/ffd9d8f0f11548303f6d9e7dc9846d40e2bcdd41) | `` justbuild: format ``                                                      |
| [`383c4d13`](https://github.com/NixOS/nixpkgs/commit/383c4d132c704530af0daa2d57cc7ee670c898c6) | `` fastjet-contrib: 1.053 -> 1.055 (#348372) ``                              |
| [`89f13435`](https://github.com/NixOS/nixpkgs/commit/89f13435d2747d9051042e6da0652b5197d9ac0d) | `` subread: 2.0.6 -> 2.0.7 ``                                                |
| [`b0d40191`](https://github.com/NixOS/nixpkgs/commit/b0d40191821b6eaf56729d5f2c1e59805369119f) | `` mingtest: 0.1.9 -> 0.2.1 ``                                               |
| [`9787a44e`](https://github.com/NixOS/nixpkgs/commit/9787a44e4ebb04c6c0a477eb7086893b24c2f531) | `` khal: modernize ``                                                        |
| [`6cb9e538`](https://github.com/NixOS/nixpkgs/commit/6cb9e538e532e11fdec75d873c59a2398e0e264e) | `` khal: pin icalendar at 5.0.13 ``                                          |
| [`b23d5f61`](https://github.com/NixOS/nixpkgs/commit/b23d5f6129afc312cf087fd42e6354bc78d1ad03) | `` autosuspend: 7.0.1 -> 7.0.2 ``                                            |
| [`b5efcf2a`](https://github.com/NixOS/nixpkgs/commit/b5efcf2ae66e198feb0856de8421518afcfee580) | `` python312Packages.icalendar: 6.0.0 -> 6.0.1 ``                            |
| [`37e98ac2`](https://github.com/NixOS/nixpkgs/commit/37e98ac2417ec93d0079e6a2da445db58e5b0254) | `` evcc: 0.130.9 -> 0.130.13 ``                                              |
| [`afc6b067`](https://github.com/NixOS/nixpkgs/commit/afc6b067d18258291021e1b8d3f6d561b57d9af1) | `` emacsPackages.bpr: override only when needed ``                           |
| [`bad80f68`](https://github.com/NixOS/nixpkgs/commit/bad80f68410e0aa2c2be99c37c119c83b043ddc6) | `` emacsPackages.alectryon: override only when needed ``                     |
| [`01ea823e`](https://github.com/NixOS/nixpkgs/commit/01ea823ea5f63e6cab5602300709aa018f5f6700) | `` emacsPackages.frontside-javascript: override only when needed ``          |
| [`8fb8d6f9`](https://github.com/NixOS/nixpkgs/commit/8fb8d6f95c9579922ca4b4cd43d7af229ec78824) | `` emacsPackages.chronometrist-key-values: override when only needed ``      |
| [`b0cc794d`](https://github.com/NixOS/nixpkgs/commit/b0cc794dcd68b21c1113a2372affe8b91ffedf23) | `` emacsPackages.psgml: add upstream bug link ``                             |
| [`196fbd43`](https://github.com/NixOS/nixpkgs/commit/196fbd43c2e25fb30fa034e526c4e2055db7f865) | `` lmstudio: 0.3.3 -> 0.3.4 ``                                               |
| [`fb12a894`](https://github.com/NixOS/nixpkgs/commit/fb12a8942d05d454f7560b434fadbab7b64e2265) | `` home-assistant-custom-components.smartthinq-sensors: 0.40.0 -> 0.40.1 ``  |
| [`4ac131ac`](https://github.com/NixOS/nixpkgs/commit/4ac131ac49173049a06da68605bae17af6d98510) | `` firefox-esr-115-unwrapped: drop ``                                        |
| [`5539ab4a`](https://github.com/NixOS/nixpkgs/commit/5539ab4a22b75b4519a2395959cf4790bfb6585b) | `` emacsPackages.clingo-mode: fix build ``                                   |
| [`59adbcdf`](https://github.com/NixOS/nixpkgs/commit/59adbcdfb5086dd0ba2c571a44ac93ae846ed582) | `` python312Packages.sagemaker: 2.232.1 -> 2.232.2 ``                        |
| [`b8ec1309`](https://github.com/NixOS/nixpkgs/commit/b8ec1309e6995dd5504b5b6f69b7a5ac256115e9) | `` python312Packages.sagemaker-mlflow: init at 0.1.0 ``                      |
| [`6572a49f`](https://github.com/NixOS/nixpkgs/commit/6572a49f3c8ba5e1e3aba47c3e86a9c313fa8171) | `` natscli: set `main.version=${version}` ``                                 |
| [`13209864`](https://github.com/NixOS/nixpkgs/commit/132098649f8cf513cc35eaa17cd5f414284f0516) | `` uv: 0.4.11 -> 0.4.20 ``                                                   |
| [`97ad9186`](https://github.com/NixOS/nixpkgs/commit/97ad9186cabd49e5b03a28838ae047d1f62c13cf) | `` nixos/release-notes: add power.ups entry ``                               |
| [`21529d18`](https://github.com/NixOS/nixpkgs/commit/21529d18130c52ac7b00fd461b182686ce9a66d1) | `` nixos/ups: shutdown UPS at host shutdown ``                               |
| [`3b781a1e`](https://github.com/NixOS/nixpkgs/commit/3b781a1e72972a4c33c3c6e1cb9464d7e869c9eb) | `` nixos/ups: document default upsmon MONITOR value ``                       |
| [`2b90f4cd`](https://github.com/NixOS/nixpkgs/commit/2b90f4cdb3a17a95ecf59b43fd01b0b577109709) | `` nixos/ups: sort settings attributes ``                                    |
| [`328c5aed`](https://github.com/NixOS/nixpkgs/commit/328c5aed28bc523621b11ccec74b4d8a37765832) | `` angelscript: 2.36.1 -> 2.37.0 ``                                          |
| [`4fc86eda`](https://github.com/NixOS/nixpkgs/commit/4fc86edad434431a26f946e279eac3c4aeed2f70) | `` weblate: fix version constraints ``                                       |
| [`3338cab6`](https://github.com/NixOS/nixpkgs/commit/3338cab6bc4c0d820ee83dfd50297cb9612a47ff) | `` nvrh: 0.1.12 -> 0.1.13 ``                                                 |
| [`3539d051`](https://github.com/NixOS/nixpkgs/commit/3539d051c12187589158f2b0af68b5c57101887e) | `` luakit: hammer ``                                                         |
| [`d41f0ad3`](https://github.com/NixOS/nixpkgs/commit/d41f0ad3d8002f1024b13305679753c9be7bbf80) | `` luakit: migrate to by-name ``                                             |
| [`25ede4e8`](https://github.com/NixOS/nixpkgs/commit/25ede4e8fdbf6552ebb73a4a087e9e819ce87f17) | `` luakit: clear input parameters ``                                         |
| [`6b6ffbd8`](https://github.com/NixOS/nixpkgs/commit/6b6ffbd802e4086a9555259a456e6f0da1f8a88f) | `` eslint_d: Move to pkgs/by-name/ folder ``                                 |
| [`206539c2`](https://github.com/NixOS/nixpkgs/commit/206539c2d5a94d0cfd73a52b429027f49713204a) | `` home-assistant-custom-components.solax_modbus: 2024.09.5 -> 2024.10.3 ``  |
| [`8a935eee`](https://github.com/NixOS/nixpkgs/commit/8a935eeecf869cdd3cb8f5f7ddc219619f6b4df3) | `` mediaelch: 2.10.6 -> 2.12.0 ``                                            |
| [`8b4b8df1`](https://github.com/NixOS/nixpkgs/commit/8b4b8df1c826eb675105642e3bce5f4657c8a35b) | `` vscode-extensions.azdavis.millet: 0.13.5 -> 0.14.7 ``                     |
| [`79ad10e0`](https://github.com/NixOS/nixpkgs/commit/79ad10e0f4e477fe9e6dc4a89a080490ccc7e5fe) | `` easytier: 2.0.0 -> 2.0.3 ``                                               |
| [`e7c04b24`](https://github.com/NixOS/nixpkgs/commit/e7c04b24148a11d25a6157db7e07264520f24328) | `` eslint_d: Add passthru.tests.version ``                                   |
| [`7ac7bd10`](https://github.com/NixOS/nixpkgs/commit/7ac7bd10e8c58a3fb96988c03f56b873222fbd00) | `` eslint_d: 14.0.3 -> 14.1.1 ``                                             |
| [`d2d9d9f0`](https://github.com/NixOS/nixpkgs/commit/d2d9d9f00535875766ce8f8c725eeeb9b7f1cdb1) | `` neovim.tests: add a test for passthru.initRc ``                           |
| [`12dafac2`](https://github.com/NixOS/nixpkgs/commit/12dafac23cc3d9998cc5a4ce3485bad1bbba3ae9) | `` neovim: make the wrapper more evolvable ``                                |
| [`11cf80ae`](https://github.com/NixOS/nixpkgs/commit/11cf80ae321c35132c1aff950f026e9783f06fec) | `` vimPlugins.nvim-treesitter: update grammars ``                            |
| [`152e9d39`](https://github.com/NixOS/nixpkgs/commit/152e9d394aa642c03600f1ae66e510bda3236835) | `` vimPlugins: update on 2024-10-13 ``                                       |
| [`54cd53c6`](https://github.com/NixOS/nixpkgs/commit/54cd53c61de3b07499be2646cd169050fcf41847) | `` inferno: 0.11.20 -> 0.11.21 ``                                            |
| [`ad770642`](https://github.com/NixOS/nixpkgs/commit/ad770642546822d5146f23f739c4bd57d850f13e) | `` signal-desktop: add darwin support (#348165) ``                           |
| [`e9a36b94`](https://github.com/NixOS/nixpkgs/commit/e9a36b94f80b2d8076400b204bfe05ac15f98cbe) | `` qmk_hid: 0.1.11 -> 0.1.12 ``                                              |
| [`a8c8ff50`](https://github.com/NixOS/nixpkgs/commit/a8c8ff50e637b6b18e0d223ead9c5a2bc547a129) | `` cargo-benchcmp: 0.4.4 -> 0.4.5 ``                                         |
| [`2263b918`](https://github.com/NixOS/nixpkgs/commit/2263b9182713b26996d48e14d9f43e58e2c56031) | `` pbpctrl: 0.1.5 -> 0.1.6 ``                                                |
| [`acf6b15f`](https://github.com/NixOS/nixpkgs/commit/acf6b15f946a74c61ed6a6266be47ec550149c21) | `` gnome-settings-daemon: add withSystemd option ``                          |
| [`9704a4f8`](https://github.com/NixOS/nixpkgs/commit/9704a4f856b02400d9db1feb82ab4cdd122259fe) | `` upower: add withSystemd option ``                                         |
| [`e7a5d9ec`](https://github.com/NixOS/nixpkgs/commit/e7a5d9ec42bf6c7040070836065b3262402e02e2) | `` upower: fix disabling introspection ``                                    |
| [`6f700a0b`](https://github.com/NixOS/nixpkgs/commit/6f700a0b613fa886723f60c4726882d80ae293fd) | `` gnome-desktop: add withSystemd option ``                                  |
| [`744ab7a5`](https://github.com/NixOS/nixpkgs/commit/744ab7a50ec849e763c779f31e5716b3eb07bef2) | `` gcr_4: add systemdSupport option ``                                       |
| [`4b2dbd45`](https://github.com/NixOS/nixpkgs/commit/4b2dbd4511310d4e15c7af0bf87017880e640d9a) | `` colord: add enableSystemd option ``                                       |
| [`b816a99c`](https://github.com/NixOS/nixpkgs/commit/b816a99cea333baef5d215bb05f4b10181721e9b) | `` systemd.meta.pkgConfigModules: init ``                                    |
| [`24aaa8a8`](https://github.com/NixOS/nixpkgs/commit/24aaa8a8d420f2979e1cdf6ab292b15ac473c718) | `` libudev-zero.meta.pkgConfigModules: init ``                               |
| [`37442e77`](https://github.com/NixOS/nixpkgs/commit/37442e7792e18a8cbf09970a7aceeb3cfca2bdf1) | `` eudev.meta.pkgConfigModules: init ``                                      |
| [`db00856e`](https://github.com/NixOS/nixpkgs/commit/db00856e06834eb216ad6a7e74abbe1f100ad7dc) | `` vscode-extensions.wakatime.vscode-wakatime: 18.0.5 -> 24.2.0 ``           |
| [`cd4eb9d7`](https://github.com/NixOS/nixpkgs/commit/cd4eb9d7b2e421f2af652ebd6928a690965398f5) | `` vimPlugins.cmp-nixpkgs-maintainers: init at 2024-10-12 ``                 |
| [`94a78218`](https://github.com/NixOS/nixpkgs/commit/94a78218520223eb6ab56faf5ed148061e4020d5) | `` ecdsautils: 0.4.1 -> 0.4.2 ``                                             |
| [`b4607ffd`](https://github.com/NixOS/nixpkgs/commit/b4607ffd82dc3436bb41d6cb70297fcaf198d99e) | `` gcov2lcov: 1.0.6 -> 1.1.0 ``                                              |
| [`a1b439d1`](https://github.com/NixOS/nixpkgs/commit/a1b439d1c6e9cc8661c7d1e09a8e8388d1aa3f76) | `` python312Packages.tencentcloud-sdk-python: 3.0.1147 -> 3.0.1248 ``        |
| [`fe944df5`](https://github.com/NixOS/nixpkgs/commit/fe944df56f8389da5528ab9325060adab44fb5e8) | `` certbot: fixup build by upstream patch ``                                 |
| [`79663cf1`](https://github.com/NixOS/nixpkgs/commit/79663cf113edf0e41165c12cf36ddb45f2329c1a) | `` opencascade-occt: fixup build by avoiding warning ``                      |
| [`695636a7`](https://github.com/NixOS/nixpkgs/commit/695636a77c980f03c4f134591666396c0f369e7e) | `` scummvm: fixup build by avoiding warning ``                               |
| [`8cb0425b`](https://github.com/NixOS/nixpkgs/commit/8cb0425b5b7f059c30c43a35aa7ee524936c1dae) | `` unifi8: 8.4.62 -> 8.5.6 ``                                                |
| [`8e074016`](https://github.com/NixOS/nixpkgs/commit/8e074016f3204a712e62c8b31e5a3ddbec5f577f) | `` python312Packages.mkl-service: 2.4.1 -> 2.4.2 ``                          |
| [`3bc8c4ab`](https://github.com/NixOS/nixpkgs/commit/3bc8c4ab7cd4a7a9ff25cd41297f38b1c0bfb726) | `` oink: 1.3.0 -> 1.3.1 ``                                                   |
| [`5d2a2c80`](https://github.com/NixOS/nixpkgs/commit/5d2a2c808968382abbc8cb2b1b2a84def570ef70) | `` crow: init at 1.2 ``                                                      |
| [`eed02089`](https://github.com/NixOS/nixpkgs/commit/eed0208988e7e78db20715defae0185f8205d193) | `` maintainers: add l33tname ``                                              |
| [`9bb4fa90`](https://github.com/NixOS/nixpkgs/commit/9bb4fa901d1d9daefaa6248eb976dbc709a54b6d) | `` emacs: refactor to fix maintainers of emacs-macport ``                    |
| [`2dac67a2`](https://github.com/NixOS/nixpkgs/commit/2dac67a2ae1ac2392496083ba54eb020c33f464e) | `` gptcommit: 0.5.16 -> 0.5.17 ``                                            |
| [`4054c687`](https://github.com/NixOS/nixpkgs/commit/4054c68739e77f0840599a7881081d10f91d26f0) | `` python312Packages.aioairzone-cloud: 0.6.6 -> 0.6.7 ``                     |
| [`81369ea8`](https://github.com/NixOS/nixpkgs/commit/81369ea8628451ee334b80ed86ca9f58cfadb2c0) | `` epson-escpr2: 1.2.13 -> 1.2.18 ``                                         |
| [`9ddc91db`](https://github.com/NixOS/nixpkgs/commit/9ddc91dbe5f13f904b25266b44f5dc8e1414c79c) | `` vscode-extensions.eugleo.magic-racket: 0.6.4 -> 0.6.7 ``                  |
| [`bd3bca3e`](https://github.com/NixOS/nixpkgs/commit/bd3bca3e9735ccadc66ec00ccef741c33a92b077) | `` vimPlugins.vim-afterglow: init at 2024-03-31 ``                           |
| [`b791360e`](https://github.com/NixOS/nixpkgs/commit/b791360ec6c5d96e7c6bdb6f3e1867b47fed7bb9) | `` vimPlugins.langmapper-nvim: init at 2024-09-19 ``                         |
| [`cd1c8e9e`](https://github.com/NixOS/nixpkgs/commit/cd1c8e9e20ad15ffd5a85f033ad04943f935b01b) | `` krohnkite: simplify installPhase ``                                       |
| [`2b39be23`](https://github.com/NixOS/nixpkgs/commit/2b39be23b1b09200b6ddc4680bc15502be6ea341) | `` krohnkite: 0.9.7 -> 0.9.8.2 ``                                            |
| [`963540ad`](https://github.com/NixOS/nixpkgs/commit/963540ad3515e23fe5016eba9ad81235a1d229f0) | `` czkawka: add versionCheckHook ``                                          |
| [`555a42d6`](https://github.com/NixOS/nixpkgs/commit/555a42d6d8abdce993762ca62a3a5677a241f017) | `` czkawka: 7.0.0 -> 8.0.0 ``                                                |
| [`9234905d`](https://github.com/NixOS/nixpkgs/commit/9234905dee8bfa23c64519ff5cbfff49ffc60e93) | `` nvrh: 0.1.9 -> 0.1.12 ``                                                  |
| [`a99edf24`](https://github.com/NixOS/nixpkgs/commit/a99edf24cb715b0437790ba3d930bc41c15938d4) | `` vscode-extensions.eamodio.gitlens: 15.1.0 -> 15.6.0 ``                    |
| [`f5627723`](https://github.com/NixOS/nixpkgs/commit/f5627723fb1905c4da936a93fb16ea6ee0f648ba) | `` discord: remove `with lib;` from `meta` ``                                |
| [`db661a42`](https://github.com/NixOS/nixpkgs/commit/db661a422d8ed7a0a048850a185db62f69141770) | `` discord: add maintainer donteatoreo ``                                    |
| [`403b0976`](https://github.com/NixOS/nixpkgs/commit/403b09768a7376fff6a4861d94bb0a83591524d5) | `` discord: sort `meta.maintainers` alphabetically ``                        |
| [`209450e5`](https://github.com/NixOS/nixpkgs/commit/209450e50fc1e345d197ab5934fe2cc716b45ed0) | `` discord: sort `meta` alphabetically ``                                    |
| [`ad01515d`](https://github.com/NixOS/nixpkgs/commit/ad01515d064125998ca2174d5ebc8beff18470c4) | `` discord-canary: 0.0.502 -> 0.0.503 ``                                     |
| [`d7c3bc45`](https://github.com/NixOS/nixpkgs/commit/d7c3bc45e5fae125e1d8f13bd72c80cb12f960d7) | `` discord-ptb: 0.0.110 -> 0.0.111 ``                                        |
| [`483b696b`](https://github.com/NixOS/nixpkgs/commit/483b696bc35e5fc81d19f2ef1489172d89387b36) | `` pkgsCross.x86_64-darwin.discord-ptb: 0.0.140 -> 0.0.141 ``                |
| [`b7248fa4`](https://github.com/NixOS/nixpkgs/commit/b7248fa4ca43a9eab3cd38124715c76ac501d0f1) | `` pkgsCross.x86_64-darwin.discord-canary: 0.0.611 -> 0.0.612 ``             |
| [`84e88c59`](https://github.com/NixOS/nixpkgs/commit/84e88c59eebf2665681cb18226420d10b8bcd6ef) | `` discord: format {darwin,default,linux}.nix files with nixfmt-rfc-style `` |
| [`56a27089`](https://github.com/NixOS/nixpkgs/commit/56a27089c7d49d3eaeab8b5d9e244727e116b362) | `` jackett: define meta.mainProgram ``                                       |
| [`9e447b48`](https://github.com/NixOS/nixpkgs/commit/9e447b48546c8ccf80ad039cbb56cc936fd82889) | `` hamster: fix install ``                                                   |
| [`bcd74f3d`](https://github.com/NixOS/nixpkgs/commit/bcd74f3d4bd6680b1652528fac0ee87fc2844d10) | `` caido: 0.41.0 -> 0.42.0 ``                                                |
| [`6d73285d`](https://github.com/NixOS/nixpkgs/commit/6d73285d8a6f81247efe07c4d9baef4c9d6013d1) | `` vscode-extensions.tauri-apps.tauri-vscode: init at 0.2.9 ``               |
| [`b51cee0a`](https://github.com/NixOS/nixpkgs/commit/b51cee0ae048d98f34fbcbabbbc2dbce457b2983) | `` misskey: 2024.5.0 -> 2024.10.0 ``                                         |
| [`ba5676fc`](https://github.com/NixOS/nixpkgs/commit/ba5676fc4236228ca5dee5ff6bc1b52ac3428864) | `` python312Packages.ffmpeg-progress-yield: 0.7.8 -> 0.9.1 ``                |
| [`a9e9dccf`](https://github.com/NixOS/nixpkgs/commit/a9e9dccf6b576ed9d19439eb956ce3d5f6eb1866) | `` python3Packages.opentelemetry-propagator-aws-xray: init at 0.47b0 ``      |
| [`e740696e`](https://github.com/NixOS/nixpkgs/commit/e740696edc7ba0ec621c4059ec01d83bca66750c) | `` python3Packages.opentelemetry-instrumentation-botocore: init at 0.47b0 `` |
| [`5f1e3fa4`](https://github.com/NixOS/nixpkgs/commit/5f1e3fa49da3769b45289c6486831669aa8e0f8b) | `` telegram-desktop: 5.6.1 -> 5.6.1-unstable to fix build with Qt 6.8 ``     |
| [`bf171746`](https://github.com/NixOS/nixpkgs/commit/bf171746655a97d46cc7a1037749d9e2f15e5889) | `` python312Packages.catboost: clean derivation ``                           |
| [`dbd3d28e`](https://github.com/NixOS/nixpkgs/commit/dbd3d28e558bda0430e9ae97a9ef73af727b2014) | `` catboost: mark as broken on x86_64-darwin ``                              |
| [`8ff97cbe`](https://github.com/NixOS/nixpkgs/commit/8ff97cbeb128f796ae6de76bc5e44470161ca111) | `` catboost: 1.2.5 -> 1.2.7 ``                                               |
| [`5d2c1a96`](https://github.com/NixOS/nixpkgs/commit/5d2c1a9655ab765314e35a05d423cbac49743b9e) | `` catboost: format ``                                                       |
| [`58cd045b`](https://github.com/NixOS/nixpkgs/commit/58cd045b17f588c0897f44201e1168845668ae1e) | `` catboost: move to by-name ``                                              |
| [`7ffeca78`](https://github.com/NixOS/nixpkgs/commit/7ffeca78dc6fd8fc7097b37c387d9bf1106ae4c3) | `` python3Packages.opentelemetry-instrumentation-logging: init at 0.47b0 ``  |
| [`fb0586c6`](https://github.com/NixOS/nixpkgs/commit/fb0586c6136a504a929a3862a2b0bd3ff34e7c86) | `` python312Packages.napari: 0.4.19.post1 -> 0.5.4 ``                        |
| [`bd7f178c`](https://github.com/NixOS/nixpkgs/commit/bd7f178cad994799380845542fd5e0abe0824881) | `` python312Packages.napari-npe2: 0.7.2-unstable-2023-10-20 -> 0.7.7 ``      |
| [`80176cfb`](https://github.com/NixOS/nixpkgs/commit/80176cfbe29d6bec1285ff8b93aa63cffe09b2e6) | `` python312Packages.magicgui: 0.5.1 -> 0.9.1 ``                             |
| [`adcc088c`](https://github.com/NixOS/nixpkgs/commit/adcc088cb97aa88ecd14e57c5e657c2d11a8820f) | `` faiss: restore `passthru` attributes ``                                   |
| [`d3e6c8fc`](https://github.com/NixOS/nixpkgs/commit/d3e6c8fc751a9be31e0f68400c835ac1534aaabb) | `` linux: implement `rustAvailable` condition ``                             |
| [`bda6c82a`](https://github.com/NixOS/nixpkgs/commit/bda6c82a8162ebbf3c25e028992a4b8a9c323065) | `` linux_testing: disable NFS_LOCALIO on aarch64-linux ``                    |
| [`3bf9c88c`](https://github.com/NixOS/nixpkgs/commit/3bf9c88c1d8200f17c69bddb0b7dc047e6dfc6fe) | `` linux_testing: enable Rust by default for aarch64-linux ``                |