### PR TITLE
chore(flake/lanzaboote): `97ad865c` -> `7ada9263`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -61,18 +61,12 @@
       }
     },
     "crane": {
-      "inputs": {
-        "nixpkgs": [
-          "lanzaboote",
-          "nixpkgs"
-        ]
-      },
       "locked": {
-        "lastModified": 1721842668,
-        "narHash": "sha256-k3oiD2z2AAwBFLa4+xfU+7G5fisRXfkvrMTCJrjZzXo=",
+        "lastModified": 1728776144,
+        "narHash": "sha256-fROVjMcKRoGHofDm8dY3uDUtCMwUICh/KjBFQnuBzfg=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "529c1a0b1f29f0d78fa3086b8f6a134c71ef3aaf",
+        "rev": "f876e3d905b922502f031aeec1a84490122254b7",
         "type": "github"
       },
       "original": {
@@ -456,11 +450,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1728983114,
-        "narHash": "sha256-4Axy2UDl9Y625ugz1qCCf1p0S9vSDO6t3vo0z/E8G2I=",
+        "lastModified": 1729009906,
+        "narHash": "sha256-KxYn0+WNginUmpmt2U9qJia0C3EievHViOyOyRSJFV4=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "97ad865ceb0d189a96b8121fc2265df5ee6cb4fc",
+        "rev": "7ada9263166655d14dae7a836326dfda6ac72d47",
         "type": "github"
       },
       "original": {
@@ -895,11 +889,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722219664,
-        "narHash": "sha256-xMOJ+HW4yj6e69PvieohUJ3dBSdgCfvI0nnCEe6/yVc=",
+        "lastModified": 1728959392,
+        "narHash": "sha256-fp4he1QQjE+vasDMspZYeXrwTm9otwEqLwEN6FKZ5v0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a6fbda5d9a14fb5f7c69b8489d24afeb349c7bb4",
+        "rev": "4c6e317300f05b8871f585b826b6f583e7dc4a9b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                             |
| --------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`387c699e`](https://github.com/nix-community/lanzaboote/commit/387c699e87d102ca42bfb5e1cf2142b14c963970) | `` uefi: fix typos ``                               |
| [`8d98fd8b`](https://github.com/nix-community/lanzaboote/commit/8d98fd8be08d7bff045e0fa1d226c8fa0882ba65) | `` flake: drop unused nixpkgs override for crane `` |
| [`739cb589`](https://github.com/nix-community/lanzaboote/commit/739cb589e461b7baabb1dfe16b5cad51fdec615f) | `` chore(deps): lock file maintenance ``            |