### PR TITLE
chore(flake/srvos): `0519f44f` -> `30769188`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -967,11 +967,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728521492,
-        "narHash": "sha256-wxFGWXszG02eP6jUXU0r4Yb1sjbe7mxX38VUo5IWSao=",
+        "lastModified": 1729032437,
+        "narHash": "sha256-87XHccsA9/hO8HNk1j8jDpKPIF2i+FIrpI+WPl8NBv4=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "0519f44f38649b84d3a3864a7cf8d1880f48ef10",
+        "rev": "30769188955f45c6f4d9c610fc092749349973bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`30769188`](https://github.com/nix-community/srvos/commit/30769188955f45c6f4d9c610fc092749349973bc) | `` dev/private/flake.lock: Update `` |
| [`ac966673`](https://github.com/nix-community/srvos/commit/ac966673503f92821cddf1dcf424102c1b50f402) | `` flake.lock: Update ``             |