### PR TITLE
chore(flake/emacs-overlay): `e4a692ef` -> `ca95bd53`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1729013905,
-        "narHash": "sha256-0D95N5nsfvQAg4RjMgTgTdubMZMUQgodSqgc3KiLRo4=",
+        "lastModified": 1729041368,
+        "narHash": "sha256-kWKTeVFrpqSv54l3hKS4Bz0jyprzWL8VtuJjDyTsldA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e4a692efda41fb5afdfd961bf36cd9c73cbd5307",
+        "rev": "ca95bd53a1c6077cb5169f15aab94fc38da477da",
         "type": "github"
       },
       "original": {
@@ -715,11 +715,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1728740863,
-        "narHash": "sha256-u+rxA79a0lyhG+u+oPBRtTDtzz8kvkc9a6SWSt9ekVc=",
+        "lastModified": 1728909085,
+        "narHash": "sha256-WLxED18lodtQiayIPDE5zwAfkPJSjHJ35UhZ8h3cJUg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a3f9ad65a0bf298ed5847629a57808b97e6e8077",
+        "rev": "c0b1da36f7c34a7146501f684e9ebdf15d2bebf8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`ca95bd53`](https://github.com/nix-community/emacs-overlay/commit/ca95bd53a1c6077cb5169f15aab94fc38da477da) | `` Updated elpa ``         |
| [`f6ee258a`](https://github.com/nix-community/emacs-overlay/commit/f6ee258af245cdaf54958dac5b482956dba237da) | `` Updated nongnu ``       |
| [`6d0d0711`](https://github.com/nix-community/emacs-overlay/commit/6d0d071146d96b69d4ac57515946d2ef49c956b3) | `` Updated flake inputs `` |