### PR TITLE
chore(flake/lanzaboote): `bd01eac8` -> `2fa1368f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -450,11 +450,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1729028850,
-        "narHash": "sha256-eOhjiU+3TCaSYZESYhU2ZTUQKrBcer9cQ/XpVkergAg=",
+        "lastModified": 1729064530,
+        "narHash": "sha256-oSr/w/5dvf/8ll6NvQlL7+rrK8wzjIcEMP1LvI4Ag08=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "bd01eac8c7cfa9b7e25304f0e7f0fed80de63f9d",
+        "rev": "2fa1368f938b50e35ca87334b5aeba38a3402165",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`8b848c3b`](https://github.com/nix-community/lanzaboote/commit/8b848c3b4f2a099fb6871540b12be5462865a2cf) | `` fix(tool): better error if public key is missing `` |
| [`6fdd9ad7`](https://github.com/nix-community/lanzaboote/commit/6fdd9ad750f233ebe2e7acf5833b30b70018d028) | `` stub: fix compilation after uefi crate update ``    |
| [`295ce01b`](https://github.com/nix-community/lanzaboote/commit/295ce01b28c43b5bbde32345c9a210a8541b1cfa) | `` fix(deps): update rust crate uefi to 0.32.0 ``      |