### PR TITLE
chore(flake/git-hooks): `ff68f917` -> `43983c59`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -363,11 +363,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1728778939,
-        "narHash": "sha256-WybK5E3hpGxtCYtBwpRj1E9JoiVxe+8kX83snTNaFHE=",
+        "lastModified": 1729087992,
+        "narHash": "sha256-u9bQsT6G/yzDVQ7xCcudnKXkS4ZR240Y4Cd9BmrKejc=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "ff68f91754be6f3427e4986d7949e6273659be1d",
+        "rev": "43983c5976fef25e774e3f1c9bd04f658e9481c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                        |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`af52f533`](https://github.com/cachix/git-hooks.nix/commit/af52f533c96d6ccf706de85d47ea79c86210ec80) | `` fix(rustfmt): add cargoManifestPath back `` |
| [`7e36b4c2`](https://github.com/cachix/git-hooks.nix/commit/7e36b4c2aba327e73cddd7ec833f51874f3bf5e5) | `` fix: add golines to tools.nix ``            |
| [`1a1c7c6b`](https://github.com/cachix/git-hooks.nix/commit/1a1c7c6b618aed1602a609c184a948836b7bbc67) | `` add golines pre-commit hook ``              |