### PR TITLE
chore(flake/emacs-overlay): `77cb2a48` -> `3887df84`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1729044303,
-        "narHash": "sha256-x9j82JU1CuJKG+lk25dC+Q0pBNJ1EZkjnGTv+L9cFwM=",
+        "lastModified": 1729095679,
+        "narHash": "sha256-fBnCSIZ/Cxmw09Zb9/1lIKn3kUSRut6Wy7v1NLFwlI8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "77cb2a48800525477ef5e34636ed848821760d6a",
+        "rev": "3887df84b086e73986cffcb4c9c98297471f4afb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`3887df84`](https://github.com/nix-community/emacs-overlay/commit/3887df84b086e73986cffcb4c9c98297471f4afb) | `` Updated elpa ``   |
| [`2b5a2ac7`](https://github.com/nix-community/emacs-overlay/commit/2b5a2ac70c95ece37e0d1bb1ad8814a13ea3e1c9) | `` Updated nongnu `` |