### PR TITLE
chore(flake/emacs-overlay): `285f8d59` -> `3ff861b0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1729098765,
-        "narHash": "sha256-WaNL++iQ1bF7pkTq49h0uHPFFizVE6xoHzfGbPwc7tQ=",
+        "lastModified": 1729130734,
+        "narHash": "sha256-U1bIksHGGN/bObrRoiJxov51rVM3A5gNqw5oamo7yEI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "285f8d59e8748a46035518ad906ac812893e9865",
+        "rev": "3ff861b0b86704afa226b70312b584bfcdb46bd7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`3ff861b0`](https://github.com/nix-community/emacs-overlay/commit/3ff861b0b86704afa226b70312b584bfcdb46bd7) | `` Updated emacs ``  |
| [`76f66a4f`](https://github.com/nix-community/emacs-overlay/commit/76f66a4f74341608e0f3c835f7b809a97f223219) | `` Updated elpa ``   |
| [`103a3b28`](https://github.com/nix-community/emacs-overlay/commit/103a3b289392d1d6b6335b5dd1b05e11e9d019db) | `` Updated nongnu `` |