### PR TITLE
chore(flake/srvos): `30769188` -> `2fa72cea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -967,11 +967,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729032437,
-        "narHash": "sha256-87XHccsA9/hO8HNk1j8jDpKPIF2i+FIrpI+WPl8NBv4=",
+        "lastModified": 1729126279,
+        "narHash": "sha256-F5r7cJYzGOW9S7Y1yASNwY+6QtDg4R3xPRzrkQTu6V4=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "30769188955f45c6f4d9c610fc092749349973bc",
+        "rev": "2fa72cea3d3d15b104f3c69de18316ef575bc837",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`2fa72cea`](https://github.com/nix-community/srvos/commit/2fa72cea3d3d15b104f3c69de18316ef575bc837) | `` dev/private/flake.lock: Update `` |
| [`98a547b3`](https://github.com/nix-community/srvos/commit/98a547b341a3931d73c344f4f23175db88f3c18c) | `` flake.lock: Update ``             |