### PR TITLE
chore(flake/emacs-overlay): `b99fa8fd` -> `ae013c11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1729182207,
-        "narHash": "sha256-O/ZbtstUKLE/UNYY8/KQOpS/oDHVQFUh2poP+G5Jx7s=",
+        "lastModified": 1729185271,
+        "narHash": "sha256-DnA39K1di7VuOD8sIEbl78UoyZ9NhiKTLgsYZ27yde4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b99fa8fd7812f1d2a3114cff4a6a50ee1f604390",
+        "rev": "ae013c110048505762b9458334094613b3ea6046",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`ae013c11`](https://github.com/nix-community/emacs-overlay/commit/ae013c110048505762b9458334094613b3ea6046) | `` Updated emacs `` |