### PR TITLE
chore(flake/emacs-overlay): `ae013c11` -> `a882ebf2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1729185271,
-        "narHash": "sha256-DnA39K1di7VuOD8sIEbl78UoyZ9NhiKTLgsYZ27yde4=",
+        "lastModified": 1729214129,
+        "narHash": "sha256-QTjPFmiIUANM/YgtjDZyEj8Lhf2g1fPgpKTB/rqTXJQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ae013c110048505762b9458334094613b3ea6046",
+        "rev": "a882ebf2b169df3342b00f58fe1c719ec3f84d88",
         "type": "github"
       },
       "original": {
@@ -715,11 +715,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1728909085,
-        "narHash": "sha256-WLxED18lodtQiayIPDE5zwAfkPJSjHJ35UhZ8h3cJUg=",
+        "lastModified": 1729044727,
+        "narHash": "sha256-GKJjtPY+SXfLF/yTN7M2cAnQB6RERFKnQhD8UvPSf3M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c0b1da36f7c34a7146501f684e9ebdf15d2bebf8",
+        "rev": "dc2e0028d274394f73653c7c90cc63edbb696be1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`a882ebf2`](https://github.com/nix-community/emacs-overlay/commit/a882ebf2b169df3342b00f58fe1c719ec3f84d88) | `` Updated elpa ``         |
| [`f1915679`](https://github.com/nix-community/emacs-overlay/commit/f191567991033e00c9879147fb4de01465292282) | `` Updated nongnu ``       |
| [`12492040`](https://github.com/nix-community/emacs-overlay/commit/1249204004e17f53a39a3afb1ef9a9c9881dcca6) | `` Updated flake inputs `` |