### PR TITLE
chore(flake/treefmt): `5307ba60` -> `d986489c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1062,11 +1062,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729077719,
-        "narHash": "sha256-zayHqZO9gA1U85c4CPvVSnLV8/cBgc2yVrSKWaKeBUs=",
+        "lastModified": 1729242555,
+        "narHash": "sha256-6jWSWxv2crIXmYSEb3LEVsFkCkyVHNllk61X4uhqfCs=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "5307ba60125bb024d7e52d71d582eafd511f3fee",
+        "rev": "d986489c1c757f6921a48c1439f19bfb9b8ecab5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                  |
| ---------------------------------------------------------------------------------------------------- | ------------------------ |
| [`d986489c`](https://github.com/numtide/treefmt-nix/commit/d986489c1c757f6921a48c1439f19bfb9b8ecab5) | `` nufmt: init (#250) `` |