### PR TITLE
chore(flake/emacs-overlay): `2a676710` -> `426cc95e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1729242842,
-        "narHash": "sha256-0EcjhowjYKNZOhVRAonkCCmn+j22kM2Bs0IYCVzxSGM=",
+        "lastModified": 1729268578,
+        "narHash": "sha256-AFunWGHQE5jVM0SUgMPvLjMNsQbcoWnn5zfS5rI4Lh0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2a6767107654ef30e2b4568312308db13eea9a5d",
+        "rev": "426cc95e354c1c53d296c5822e1a7a65f8b3ed06",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`426cc95e`](https://github.com/nix-community/emacs-overlay/commit/426cc95e354c1c53d296c5822e1a7a65f8b3ed06) | `` Updated nongnu `` |
| [`9cc56167`](https://github.com/nix-community/emacs-overlay/commit/9cc5616723259cf3f69cf1499462077de2ead86f) | `` Updated elpa ``   |