### PR TITLE
chore(flake/emacs-overlay): `6a395318` -> `59b865f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1729300482,
-        "narHash": "sha256-yX0wijy9mDtE55XKOlv132fvtySHmmUWaFljgOMzw1k=",
+        "lastModified": 1729303438,
+        "narHash": "sha256-wJaeXpsazBTcIZ3V1AR4eiM/10zBkLpqDN7qu7GkWuM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6a395318b684197b6bc210d0c174c97034248a95",
+        "rev": "59b865f2b0a7036fc7a03de1bfe81e0a810a81ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`59b865f2`](https://github.com/nix-community/emacs-overlay/commit/59b865f2b0a7036fc7a03de1bfe81e0a810a81ca) | `` Updated emacs `` |