### PR TITLE
chore(flake/emacs-overlay): `bc42fc2a` -> `b2659787`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1729329083,
-        "narHash": "sha256-TPzDMRwA9G5LG5DwPccsBJ4KxOiGNZOhAuG25nSiLPc=",
+        "lastModified": 1729354869,
+        "narHash": "sha256-rVUyE7SV1R8lmpukucJqmqEaZlQzKTiD5fB/uvLxxWc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bc42fc2a962dd3e7321b4503fb534f3ab3a161e9",
+        "rev": "b2659787c20d75a71a092400932a34d2008baf26",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`b2659787`](https://github.com/nix-community/emacs-overlay/commit/b2659787c20d75a71a092400932a34d2008baf26) | `` Updated elpa ``         |
| [`aa5cc861`](https://github.com/nix-community/emacs-overlay/commit/aa5cc861152f1d7b28f00d2e1f0a3f926dcb1fec) | `` Updated nongnu ``       |
| [`6357bea9`](https://github.com/nix-community/emacs-overlay/commit/6357bea9436dd7817681c7bc10412a63e3e818ef) | `` Updated flake inputs `` |