### PR TITLE
chore(flake/emacs-overlay): `b2659787` -> `89860b1c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1729354869,
-        "narHash": "sha256-rVUyE7SV1R8lmpukucJqmqEaZlQzKTiD5fB/uvLxxWc=",
+        "lastModified": 1729390258,
+        "narHash": "sha256-z4Hg8k6iXIV55lA8HUntfJBdBzxOuG8M4ftWoJhrVqU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b2659787c20d75a71a092400932a34d2008baf26",
+        "rev": "89860b1c343648e8d71b6820e9311b98353ff14e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`89860b1c`](https://github.com/nix-community/emacs-overlay/commit/89860b1c343648e8d71b6820e9311b98353ff14e) | `` Updated emacs ``  |
| [`9c511a3c`](https://github.com/nix-community/emacs-overlay/commit/9c511a3c3068f69198a9f272b80c93c8a5853385) | `` Updated elpa ``   |
| [`2f73137d`](https://github.com/nix-community/emacs-overlay/commit/2f73137ddbe9068dfd9f81b8cbf0b0733627df45) | `` Updated nongnu `` |
| [`3adba4b7`](https://github.com/nix-community/emacs-overlay/commit/3adba4b7d1db1d4eba3f682a956fcbb5de1bd7a1) | `` Updated emacs ``  |