### PR TITLE
chore(flake/nixos-hardware): `38279034` -> `8f38d8a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -642,11 +642,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1729333370,
-        "narHash": "sha256-NU+tYe3QWzDNpB8RagpqR3hNQXn4BNuBd7ZGosMHLL8=",
+        "lastModified": 1729417461,
+        "narHash": "sha256-p0j/sUs7noqZw0W+SEuZXskzOfgOH7yY80ksIM0fCi4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "38279034170b1e2929b2be33bdaedbf14a57bfeb",
+        "rev": "8f38d8a4754cf673c2609c4ed399630db87e678b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                   |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`8f38d8a4`](https://github.com/NixOS/nixos-hardware/commit/8f38d8a4754cf673c2609c4ed399630db87e678b) | `` dell/xps/15-9520: use alder-lake gpu profile ``        |
| [`be33295d`](https://github.com/NixOS/nixos-hardware/commit/be33295d69d8864d58df99e5c5602ebff5bf5dd3) | `` gpu/intel/tiger-lake: simplify conditionals ``         |
| [`86a33c3e`](https://github.com/NixOS/nixos-hardware/commit/86a33c3e32822c62127c70766d56731dadfbed5c) | `` common/gpu/intel: update modules to use new options `` |
| [`18409191`](https://github.com/NixOS/nixos-hardware/commit/184091915d8b88c9c44b63cc7dfadfa3ed1044c1) | `` common/gpu/intel: add vaapi configuration options ``   |
| [`0ccdd270`](https://github.com/NixOS/nixos-hardware/commit/0ccdd2705669d68bcafd15f45a70ea3c6df57b60) | `` common/gpu/intel: reformat ``                          |