### PR TITLE
chore(flake/emacs-overlay): `7938dbba` -> `806a6630`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1729415489,
-        "narHash": "sha256-9hl/Pn57ZMeB9MQX01nweRQSs4fw0QP0KCn9SYOEaPg=",
+        "lastModified": 1729441243,
+        "narHash": "sha256-yFU0CFHIWV0Zxo2xEKCOtCCBx9pabNB0FDIWhOUbMn4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7938dbba5b6ba17d90b86aa77e4e0f309225a6d3",
+        "rev": "806a6630330b0c4441da0665397a27ccb2805c33",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`806a6630`](https://github.com/nix-community/emacs-overlay/commit/806a6630330b0c4441da0665397a27ccb2805c33) | `` Updated elpa ``   |
| [`fb0fa2bc`](https://github.com/nix-community/emacs-overlay/commit/fb0fa2bce785c4f304815beeaa39f260e7762042) | `` Updated nongnu `` |