### PR TITLE
chore(flake/emacs-overlay): `806a6630` -> `e622d87b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1729441243,
-        "narHash": "sha256-yFU0CFHIWV0Zxo2xEKCOtCCBx9pabNB0FDIWhOUbMn4=",
+        "lastModified": 1729444244,
+        "narHash": "sha256-EKsHcsEdM6Ep4BiZ7meTspTc8YHfohR10DAltML/324=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "806a6630330b0c4441da0665397a27ccb2805c33",
+        "rev": "e622d87bd6d6fa49c486ed32920dbacb15e67f2d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`e622d87b`](https://github.com/nix-community/emacs-overlay/commit/e622d87bd6d6fa49c486ed32920dbacb15e67f2d) | `` Updated emacs `` |