### PR TITLE
chore(flake/nixos-hardware): `8f38d8a4` -> `9fcf30fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -642,11 +642,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1729417461,
-        "narHash": "sha256-p0j/sUs7noqZw0W+SEuZXskzOfgOH7yY80ksIM0fCi4=",
+        "lastModified": 1729455275,
+        "narHash": "sha256-THqzn/7um3oMHUEGXyq+1CJQE7EogwR3HjLMNOlhFBE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "8f38d8a4754cf673c2609c4ed399630db87e678b",
+        "rev": "9fcf30fccf8435f6390efec4a4d38e69c2268a36",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`9fcf30fc`](https://github.com/NixOS/nixos-hardware/commit/9fcf30fccf8435f6390efec4a4d38e69c2268a36) | `` Make starfive-visionfive-2 merge with sd-image module `` |
| [`9da64c8f`](https://github.com/NixOS/nixos-hardware/commit/9da64c8fd97274d6cd2fda6bc161abc229aeb6c9) | `` dell/xps/15-9520: add alder-lake gpu profile ``          |
| [`3854ace1`](https://github.com/NixOS/nixos-hardware/commit/3854ace106bd53c1780bc05bcb0e63bade2cd2e5) | `` Revert "dell/xps/15-9520: use alder-lake gpu profile" `` |