### PR TITLE
chore(flake/emacs-overlay): `e622d87b` -> `5d488eec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1729444244,
-        "narHash": "sha256-EKsHcsEdM6Ep4BiZ7meTspTc8YHfohR10DAltML/324=",
+        "lastModified": 1729476442,
+        "narHash": "sha256-GCrI052UegxjdNRKfV6JSrn4pbJb7SsbuEOXCYxfLm4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e622d87bd6d6fa49c486ed32920dbacb15e67f2d",
+        "rev": "5d488eec63742aca43fb57a6f805ef282294f3a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`5d488eec`](https://github.com/nix-community/emacs-overlay/commit/5d488eec63742aca43fb57a6f805ef282294f3a4) | `` Updated emacs ``  |
| [`eda92813`](https://github.com/nix-community/emacs-overlay/commit/eda9281341686326991b2550780180064900777a) | `` Updated elpa ``   |
| [`8703ee89`](https://github.com/nix-community/emacs-overlay/commit/8703ee8957c906474b524ba5b77d80f6d047a64b) | `` Updated nongnu `` |