### PR TITLE
chore(flake/srvos): `2fa72cea` -> `5607765a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -967,11 +967,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729126279,
-        "narHash": "sha256-F5r7cJYzGOW9S7Y1yASNwY+6QtDg4R3xPRzrkQTu6V4=",
+        "lastModified": 1729472124,
+        "narHash": "sha256-l1uqRV0XPDrCVXb8irXSnIHOdzmss78KiUqB6WkhDMw=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "2fa72cea3d3d15b104f3c69de18316ef575bc837",
+        "rev": "5607765a4ac3a567cfe6bf4efb3c352193604f57",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`5607765a`](https://github.com/nix-community/srvos/commit/5607765a4ac3a567cfe6bf4efb3c352193604f57) | `` dev/private/flake.lock: Update `` |
| [`0e9b7b6b`](https://github.com/nix-community/srvos/commit/0e9b7b6b140680504cd9af93b00f9773900b50fb) | `` flake.lock: Update ``             |