### PR TITLE
chore(flake/nixos-hardware): `9fcf30fc` -> `cc2d3c0e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -642,11 +642,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1729455275,
-        "narHash": "sha256-THqzn/7um3oMHUEGXyq+1CJQE7EogwR3HjLMNOlhFBE=",
+        "lastModified": 1729509737,
+        "narHash": "sha256-8OHgqz+tFo21h3hg4/GHizFPws+MMzpEru/+62Z0E8c=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "9fcf30fccf8435f6390efec4a4d38e69c2268a36",
+        "rev": "cc2d3c0e060f981905d52337340ee6ec8b8eb037",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`cc2d3c0e`](https://github.com/NixOS/nixos-hardware/commit/cc2d3c0e060f981905d52337340ee6ec8b8eb037) | `` flake.nix: don't expose alder-lake module ``                        |
| [`77ec51c2`](https://github.com/NixOS/nixos-hardware/commit/77ec51c21c8bc6974f93ae39c102d9d1c6b7859f) | `` common-gpu-intel-kaby-lake: enable HuC firmware loading ``          |
| [`796768cb`](https://github.com/NixOS/nixos-hardware/commit/796768cbc486e24f9154b3aed04a4c789fdbb51c) | `` flake: add common-cpu-intel-alder-lake ``                           |
| [`6791578c`](https://github.com/NixOS/nixos-hardware/commit/6791578c4bd024dbbe7401a3946462f3bb83e950) | `` common-cpu-intel-alder-lake: init ``                                |
| [`8140e825`](https://github.com/NixOS/nixos-hardware/commit/8140e8252a069447ec8aec8d509c7b6eabd46004) | `` lenovo-thinkpad-x1-6th-gen: use cpu architecture-specific module `` |
| [`7495e877`](https://github.com/NixOS/nixos-hardware/commit/7495e877539919988c9ebe4ae0f47343982da0e5) | `` treewide: Switch from gpu/intel to cpu/intel where applicable ``    |
| [`c058019c`](https://github.com/NixOS/nixos-hardware/commit/c058019ce1b72c7d450f5e2b3f0921bd205e9f79) | `` common/cpu/intel: add architecture-specific modules ``              |