### PR TITLE
chore(flake/emacs-overlay): `20e5bc49` -> `9d46b89a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1729559775,
-        "narHash": "sha256-A7hvniewOQvr96j5tn1eMSK8NIaxNZu6qcd8UsY3FNw=",
+        "lastModified": 1729562762,
+        "narHash": "sha256-EXy4Wf4uoPrvVLQWcHfr8a85mCACl/zMEOBLe83OhDE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "20e5bc499055ffb8c97acf13361450e02852153f",
+        "rev": "9d46b89a210d43f294374dc627e03f7164f3a470",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`9d46b89a`](https://github.com/nix-community/emacs-overlay/commit/9d46b89a210d43f294374dc627e03f7164f3a470) | `` Updated emacs `` |