### PR TITLE
chore(flake/darwin): `a001f44c` -> `64d9d1ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -82,11 +82,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729382845,
-        "narHash": "sha256-REiWck1zIOnZIgGmmOWfwvkQw1f4UrBsxxOSKVSAG4w=",
+        "lastModified": 1729579044,
+        "narHash": "sha256-0kEUVl5s8LHbK4/xEePflsdYVwG+RRFSIofSvITYmIU=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "a001f44cfc47164839eb61c6b1e7f4288813f7e8",
+        "rev": "64d9d1ae25215c274c37e3e4016977a6779cf0d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                            |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
| [`cbb190ec`](https://github.com/LnL7/nix-darwin/commit/cbb190eccbc01f9b492fab11185a9cd729562ec6) | `` ci: update Nix to match versions in nixpkgs ``  |
| [`8724129d`](https://github.com/LnL7/nix-darwin/commit/8724129dc862432dc5e5c548f1af48f38c4368c4) | `` ci: don't run tests twice for PRs from forks `` |