### PR TITLE
chore(flake/nixos-cosmic): `a2e3670f` -> `a525f1a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -627,11 +627,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1729608372,
-        "narHash": "sha256-+51O+SLkKUyUlNiLXgTEc13DYeLR2k044qSgivNadOs=",
+        "lastModified": 1729609524,
+        "narHash": "sha256-p6puDxo32xVQxiuXGTkBZhvtUPvK3fclmX2gtWXTyyE=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "a2e3670fc2c64513c3950a2149dfa1d2da4ff2ef",
+        "rev": "a525f1a4807046fed83095f1fe2d37a65002fd88",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                                |
| ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`a525f1a4`](https://github.com/lilyinstarlight/nixos-cosmic/commit/a525f1a4807046fed83095f1fe2d37a65002fd88) | `` vm: add default cosmic-comp args to ensure cached status ``         |
| [`bd74fc23`](https://github.com/lilyinstarlight/nixos-cosmic/commit/bd74fc230798db6dee659fac1c16e5ad122d322b) | `` nixos/cosmic: avoid cosmic-comp env pollution for system actions `` |