### PR TITLE
chore(flake/emacs-overlay): `dd66a43b` -> `d3881d1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1729588452,
-        "narHash": "sha256-wwkldM3Ru+3aBBibjYi4MskJzkA7BM3YhL/m3a0x58k=",
+        "lastModified": 1729617178,
+        "narHash": "sha256-WaaMP1sxCDiI7BwSbCDyfungMsdDbPD6aHhSkU6khiI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "dd66a43b14c37c5461bdc4324be3fd32e720c996",
+        "rev": "d3881d1b6f01c5d01d4af9b61026315aeb2367fb",
         "type": "github"
       },
       "original": {
@@ -715,11 +715,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1729307008,
-        "narHash": "sha256-QUvb6epgKi9pCu9CttRQW4y5NqJ+snKr1FZpG/x3Wtc=",
+        "lastModified": 1729449015,
+        "narHash": "sha256-Gf04dXB0n4q0A9G5nTGH3zuMGr6jtJppqdeljxua1fo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a9b86fc2290b69375c5542b622088eb6eca2a7c3",
+        "rev": "89172919243df199fe237ba0f776c3e3e3d72367",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`d3881d1b`](https://github.com/nix-community/emacs-overlay/commit/d3881d1b6f01c5d01d4af9b61026315aeb2367fb) | `` Updated emacs ``        |
| [`7c8d4c6b`](https://github.com/nix-community/emacs-overlay/commit/7c8d4c6bbe78794cd40b5a16adc14dba46f17a9a) | `` Updated elpa ``         |
| [`c34975c1`](https://github.com/nix-community/emacs-overlay/commit/c34975c1b4669ff57aa4d9e03e91a0ea7ea62da7) | `` Updated nongnu ``       |
| [`ccf9bb9a`](https://github.com/nix-community/emacs-overlay/commit/ccf9bb9a2b283904ba4763b30ac0730b358bcc88) | `` Updated flake inputs `` |