### PR TITLE
chore(flake/nixos-hardware): `cc2d3c0e` -> `22e8de27`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -642,11 +642,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1729509737,
-        "narHash": "sha256-8OHgqz+tFo21h3hg4/GHizFPws+MMzpEru/+62Z0E8c=",
+        "lastModified": 1729624485,
+        "narHash": "sha256-iEffyT68tEU5kHQuyP05QRH+JhWNNLAwHfgZAzXFS7o=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "cc2d3c0e060f981905d52337340ee6ec8b8eb037",
+        "rev": "22e8de2729f40d29a445c8baeaf22740b8b25daf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                          |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`be900587`](https://github.com/NixOS/nixos-hardware/commit/be900587c3aaa67d81658c4bfb1e1055aa36a31f) | `` update test flakes ``                                         |
| [`8c3e99bf`](https://github.com/NixOS/nixos-hardware/commit/8c3e99bfa5c47c4e809fc6fbbd6913886e29a4a4) | `` cpu/intel: make sure we import the local cpu-only profiles `` |
| [`6e486f28`](https://github.com/NixOS/nixos-hardware/commit/6e486f2812e9abae4d05cf58d698e21cb7deb2dd) | `` common/gpu/intel/lunar-lake: enable xe driver ``              |