### PR TITLE
chore(flake/emacs-overlay): `d3881d1b` -> `04821886`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1729617178,
-        "narHash": "sha256-WaaMP1sxCDiI7BwSbCDyfungMsdDbPD6aHhSkU6khiI=",
+        "lastModified": 1729646107,
+        "narHash": "sha256-uDZ9h9fmzppdsfrkuryyjgQ5jR8kDR7tU01Cw/YaHPU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d3881d1b6f01c5d01d4af9b61026315aeb2367fb",
+        "rev": "0482188677c67f1a95c21d580df61551bc8addef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`04821886`](https://github.com/nix-community/emacs-overlay/commit/0482188677c67f1a95c21d580df61551bc8addef) | `` Updated elpa ``   |
| [`7a402fa1`](https://github.com/nix-community/emacs-overlay/commit/7a402fa16538d93765625fb06cd18364ca2c0be7) | `` Updated nongnu `` |