### PR TITLE
chore(flake/emacs-overlay): `04821886` -> `cc8c7d43`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1729646107,
-        "narHash": "sha256-uDZ9h9fmzppdsfrkuryyjgQ5jR8kDR7tU01Cw/YaHPU=",
+        "lastModified": 1729649116,
+        "narHash": "sha256-2vWnL4lqSwqFUP6iMibJ9YW0SamsDTCX4e6saV/K+BQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0482188677c67f1a95c21d580df61551bc8addef",
+        "rev": "cc8c7d43b2bc0f2e3fa7433ce33fc49887245427",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`cc8c7d43`](https://github.com/nix-community/emacs-overlay/commit/cc8c7d43b2bc0f2e3fa7433ce33fc49887245427) | `` Updated emacs `` |