### PR TITLE
chore(flake/sops-nix): `a4c33bfe` -> `d089e742`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -947,11 +947,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1729669122,
-        "narHash": "sha256-SpS3rSwYcskdOpx+jeCv1lcZDdkT/K5qT8dlenCBQ8c=",
+        "lastModified": 1729695320,
+        "narHash": "sha256-Fm4cGAlaDwekQvYX0e6t0VjT6YJs3fRXtkyuE4/NzzU=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "a4c33bfecb93458d90f9eb26f1cf695b47285243",
+        "rev": "d089e742fb79259b9c4dd9f18e9de1dd4fa3c1ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                               |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`d089e742`](https://github.com/Mic92/sops-nix/commit/d089e742fb79259b9c4dd9f18e9de1dd4fa3c1ec) | `` feat(home-manager/sops): add environment variable configuration `` |