### PR TITLE
chore(flake/catppuccin): `7a0fedd9` -> `037e2f09`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1729702745,
-        "narHash": "sha256-Y5+Zl3yh1gRWesCE63InQIqIf930xl3I15CD0MHp3tA=",
+        "lastModified": 1729730584,
+        "narHash": "sha256-iPrs6bLWdp7qdFRba2AfiHj604SpxC6AGASx7I692Lo=",
         "owner": "ryand56",
         "repo": "catppuccin-nix",
-        "rev": "7a0fedd9f3f336d38ef55de4e6621e68b8f45869",
+        "rev": "037e2f091a2144433566c5122f385a388cb5d5d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                  | Message                                                                          |
| ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`037e2f09`](https://github.com/ryand56/catppuccin-nix/commit/037e2f091a2144433566c5122f385a388cb5d5d3) | `` fix(home-manager/kvantum): don't uppercase accents and flavors in override `` |