### PR TITLE
chore(flake/emacs-overlay): `6fd1f939` -> `4887992a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -165,11 +165,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1729700542,
-        "narHash": "sha256-FYFY2uwgnbIcYzSKhvs5lKDjxLaUSWo2jqKUsvdgDxg=",
+        "lastModified": 1729735549,
+        "narHash": "sha256-qOUGh+hC6w9POe04HTjwcKJccjmKsGfmlWEL32NTlr0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6fd1f939e4453206d131744aee904c019f216ecd",
+        "rev": "4887992a11388734b4900f3d16892999b54849ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`4887992a`](https://github.com/nix-community/emacs-overlay/commit/4887992a11388734b4900f3d16892999b54849ff) | `` Updated emacs ``  |
| [`ab0a7f5d`](https://github.com/nix-community/emacs-overlay/commit/ab0a7f5d3a957009c9396e6020c25a6e28c1fe21) | `` Updated elpa ``   |
| [`d9efc55f`](https://github.com/nix-community/emacs-overlay/commit/d9efc55f0843a251f45e32569348edaa8add061e) | `` Updated nongnu `` |