### PR TITLE
chore(flake/srvos): `5607765a` -> `0e447b6d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -985,11 +985,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729472124,
-        "narHash": "sha256-l1uqRV0XPDrCVXb8irXSnIHOdzmss78KiUqB6WkhDMw=",
+        "lastModified": 1729731316,
+        "narHash": "sha256-InsUCPq86xyvJ9U+pVijYNBCep/dYACyJblG6fgkkWA=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "5607765a4ac3a567cfe6bf4efb3c352193604f57",
+        "rev": "0e447b6d3f16d6a305ca99ac89686d51042f516a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`0e447b6d`](https://github.com/nix-community/srvos/commit/0e447b6d3f16d6a305ca99ac89686d51042f516a) | `` dev/private/flake.lock: Update `` |
| [`59887566`](https://github.com/nix-community/srvos/commit/5988756662ef74d19eb396d655210f2c7ea52164) | `` flake.lock: Update ``             |