### PR TITLE
chore(flake/nixos-hardware): `64d900ab` -> `e8a2f6d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -643,11 +643,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1729690929,
-        "narHash": "sha256-cTSekmupaDfrhlpLhBUBrU9mUzBaD6mYsMveTX0bKDg=",
+        "lastModified": 1729742320,
+        "narHash": "sha256-u3Of8xRkN//me8PU+RucKA59/6RNy4B2jcGAF36P4jI=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "64d900abe40057393148bc0283d35c2254dd4f57",
+        "rev": "e8a2f6d5513fe7b7d15701b2d05404ffdc3b6dda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                 |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`e8a2f6d5`](https://github.com/NixOS/nixos-hardware/commit/e8a2f6d5513fe7b7d15701b2d05404ffdc3b6dda) | `` common/gpu/intel: Disable intel-ocl due to web.archive.org outage `` |