### PR TITLE
chore(flake/darwin): `5f05c2c3` -> `a5d770b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -83,11 +83,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729727404,
-        "narHash": "sha256-NwBlKkNCgDnD0lSebVGjCSPUHyUTj8JjAAaQueSGvGw=",
+        "lastModified": 1729756277,
+        "narHash": "sha256-I4b/a7CvJWTzC1Nf9bIySw+a/YkNTUgV85fcJQIhA/Y=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "5f05c2c3d296c358dbdee8591528959d5360c247",
+        "rev": "a5d770b257741cd0bf4207b795f872a96cc9c4b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                       |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
| [`b089e7e7`](https://github.com/LnL7/nix-darwin/commit/b089e7e7266403ddda9f96bfd8c5adf9a0f0f6b5) | `` users: switch back to using `dscl` for deleting users ``                   |
| [`b7027502`](https://github.com/LnL7/nix-darwin/commit/b702750226a86abb029440641bfa994ff650cf99) | `` users: ensure Full Disk Access is granted before trying to create users `` |
| [`2be05de0`](https://github.com/LnL7/nix-darwin/commit/2be05de06ed8e634c839ad58ffb895d5bed98c0a) | `` users: add missing newlines for FDA prompt ``                              |
| [`467a0d3d`](https://github.com/LnL7/nix-darwin/commit/467a0d3d0c27ed7e688c040281aced98d37120d2) | `` users: prevent deleting the user calling `darwin-rebuild` ``               |