### PR TITLE
chore(flake/emacs-overlay): `4887992a` -> `3766c53b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -165,11 +165,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1729735549,
-        "narHash": "sha256-qOUGh+hC6w9POe04HTjwcKJccjmKsGfmlWEL32NTlr0=",
+        "lastModified": 1729758051,
+        "narHash": "sha256-B1rmnSK8gBqUYMv/WF4yCUgwx1uvFWLrkYx3YzvKqCU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4887992a11388734b4900f3d16892999b54849ff",
+        "rev": "3766c53bf8c0e24ac5d3aed2b8f772d33f59f96a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`3766c53b`](https://github.com/nix-community/emacs-overlay/commit/3766c53bf8c0e24ac5d3aed2b8f772d33f59f96a) | `` Updated flake inputs `` |