### PR TITLE
chore(flake/darwin): `a5d770b2` -> `04193f18`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -83,11 +83,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729756277,
-        "narHash": "sha256-I4b/a7CvJWTzC1Nf9bIySw+a/YkNTUgV85fcJQIhA/Y=",
+        "lastModified": 1729757100,
+        "narHash": "sha256-x+8uGaX66V5+fUBHY23Q/OQyibQ38nISzxgj7A7Jqds=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "a5d770b257741cd0bf4207b795f872a96cc9c4b2",
+        "rev": "04193f188e4144d7047f83ad1de81d6034d175cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                         |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`bbe19172`](https://github.com/LnL7/nix-darwin/commit/bbe1917238b3ea22890e5aa3fe51ed6910ee9429) | `` users: ensure users' shells are installed `` |