### PR TITLE
chore(flake/sops-nix): `d089e742` -> `78a0e634`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -965,11 +965,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1729695320,
-        "narHash": "sha256-Fm4cGAlaDwekQvYX0e6t0VjT6YJs3fRXtkyuE4/NzzU=",
+        "lastModified": 1729775275,
+        "narHash": "sha256-J2vtHq9sw1wWm0aTMXpEEAzsVCUMZDTEe5kiBYccpLE=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "d089e742fb79259b9c4dd9f18e9de1dd4fa3c1ec",
+        "rev": "78a0e634fc8981d6b564f08b6715c69a755c4c7d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                            |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`78a0e634`](https://github.com/Mic92/sops-nix/commit/78a0e634fc8981d6b564f08b6715c69a755c4c7d) | `` fix(home-manager/sops): fix setting systemd unit environment `` |