### PR TITLE
chore(flake/emacs-overlay): `6b8d885b` -> `bff71020`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -165,11 +165,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1729761270,
-        "narHash": "sha256-l1DdhhsED58dJB/zZgnCNp0bxXVMAcl4ySNZR0hObao=",
+        "lastModified": 1729786869,
+        "narHash": "sha256-grNSPysRjEcyQp2wj58+g4HggfmHjy2h4YLamKvmpZ4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6b8d885bbe788308c3c6cea8c1fe637660793424",
+        "rev": "bff710200084114208d808f4125d19c804b9a382",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`bff71020`](https://github.com/nix-community/emacs-overlay/commit/bff710200084114208d808f4125d19c804b9a382) | `` Updated elpa ``   |
| [`2db30fcc`](https://github.com/nix-community/emacs-overlay/commit/2db30fccd45552347394b56b9a143db49ad0c8b3) | `` Updated nongnu `` |