### PR TITLE
chore(flake/emacs-overlay): `bff71020` -> `185ee299`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -165,11 +165,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1729786869,
-        "narHash": "sha256-grNSPysRjEcyQp2wj58+g4HggfmHjy2h4YLamKvmpZ4=",
+        "lastModified": 1729789881,
+        "narHash": "sha256-z5EYOPtIMRTCYqTuk1SxGCTMH5nJMfEWMJT8c+Iy7/w=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bff710200084114208d808f4125d19c804b9a382",
+        "rev": "185ee299bf80de2cfb21517cdff7d9f1a1f0dd9b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`185ee299`](https://github.com/nix-community/emacs-overlay/commit/185ee299bf80de2cfb21517cdff7d9f1a1f0dd9b) | `` Updated emacs `` |