### PR TITLE
chore(flake/home-manager): `eea1bc60` -> `c77c3bb2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729842821,
-        "narHash": "sha256-TOLiSoV9h3+Qn9sVNFCQyKo+1a1IhKj4LYqv1VOHDQk=",
+        "lastModified": 1729848063,
+        "narHash": "sha256-1uGIPOSJq4IzoDvgfOF6A3sw5it1WX3ZdYl2+jCkjv8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "eea1bc607249f0b79fb437b5e9709aa6d2218bac",
+        "rev": "c77c3bb23390a9ba91860e721edde54856fc5f7a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`c77c3bb2`](https://github.com/nix-community/home-manager/commit/c77c3bb23390a9ba91860e721edde54856fc5f7a) | `` yazi: enable shell integration values by default ``    |
| [`8bd6e0a1`](https://github.com/nix-community/home-manager/commit/8bd6e0a1a805c373686e21678bb07f23293d357b) | `` nixgl: add support for channel-based configuration ``  |
| [`7a587970`](https://github.com/nix-community/home-manager/commit/7a5879707bb49c350aee7ab270c917584d430193) | `` nixgl: API rework for flexibility and dual-GPU ``      |
| [`e61f8796`](https://github.com/nix-community/home-manager/commit/e61f87969ae179139164c7fb5e0bb76b791144e5) | `` nixgl: Improve option documentation ``                 |
| [`7dee0dc8`](https://github.com/nix-community/home-manager/commit/7dee0dc8f0c7d4f174c481f36d04b9edadba3b7e) | `` nixgl: reference lib directly ``                       |
| [`d0c036ca`](https://github.com/nix-community/home-manager/commit/d0c036ca4904701289e0a779253f241feeacbf40) | `` nixgl: ensure makeWrapper is present during build ``   |
| [`199cf563`](https://github.com/nix-community/home-manager/commit/199cf5634c2ed39fceae0da3b1d0a76f7d47e1b1) | `` nixgl: use -q to silence grep ``                       |
| [`b9fe7479`](https://github.com/nix-community/home-manager/commit/b9fe747915d95c3ea37539cccea67d3df39526a9) | `` nixgl: use makeWrapper and update docs ``              |
| [`bbd4254d`](https://github.com/nix-community/home-manager/commit/bbd4254d00e8c69c4c958ddb51fb18637ca7f9b8) | `` nixgl: make desktop files point to wrapped exe ``      |
| [`44629358`](https://github.com/nix-community/home-manager/commit/446293584f10d56b91368f500c022f7a93edbe2c) | `` nixgl: add module ``                                   |
| [`82378b3f`](https://github.com/nix-community/home-manager/commit/82378b3f7f8c12ecfab8539df780e495e6ba4cb6) | `` htop: use attrsOf instead of attrs as settings type `` |
| [`c7cfdb38`](https://github.com/nix-community/home-manager/commit/c7cfdb386430b01fd9748139a0e9cfa40e36c265) | `` spotify-player: add support for actions ``             |