### PR TITLE
chore(flake/home-manager): `c77c3bb2` -> `c0e23159`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729848063,
-        "narHash": "sha256-1uGIPOSJq4IzoDvgfOF6A3sw5it1WX3ZdYl2+jCkjv8=",
+        "lastModified": 1729864597,
+        "narHash": "sha256-qTR1gijynMs9/xD2kYKACU/29MIuDvalA8IMPURrlVk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c77c3bb23390a9ba91860e721edde54856fc5f7a",
+        "rev": "c0e23159872e2e2135c7eb5cf96cd36cfe6ee1f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                           |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`c0e23159`](https://github.com/nix-community/home-manager/commit/c0e23159872e2e2135c7eb5cf96cd36cfe6ee1f4) | `` git-credential-oauth: add extraFlags option `` |
| [`6cc03e33`](https://github.com/nix-community/home-manager/commit/6cc03e337aa1d0222e5942f58839d965075a9781) | `` nix-gc: add `randomizedDelaySec` option ``     |