### PR TITLE
chore(flake/home-manager): `c0e23159` -> `0c0268a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729864597,
-        "narHash": "sha256-qTR1gijynMs9/xD2kYKACU/29MIuDvalA8IMPURrlVk=",
+        "lastModified": 1729864948,
+        "narHash": "sha256-CeGSqbN6S8JmzYJX/HqZjr7dMGlvHLLnJJarwB45lPs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c0e23159872e2e2135c7eb5cf96cd36cfe6ee1f4",
+        "rev": "0c0268a3c80d30b989d0aadbd65f38d4fa27a9a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                     |
| ----------------------------------------------------------------------------------------------------------- | --------------------------- |
| [`0c0268a3`](https://github.com/nix-community/home-manager/commit/0c0268a3c80d30b989d0aadbd65f38d4fa27a9a0) | `` eza: add color option `` |