### PR TITLE
chore(flake/home-manager): `0c0268a3` -> `93435d27`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729864948,
-        "narHash": "sha256-CeGSqbN6S8JmzYJX/HqZjr7dMGlvHLLnJJarwB45lPs=",
+        "lastModified": 1729894599,
+        "narHash": "sha256-nL9nzNE5/re/P+zOv7NX6bRm5e+DeS1HIufQUJ01w20=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0c0268a3c80d30b989d0aadbd65f38d4fa27a9a0",
+        "rev": "93435d27d250fa986bfec6b2ff263161ff8288cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`93435d27`](https://github.com/nix-community/home-manager/commit/93435d27d250fa986bfec6b2ff263161ff8288cb) | `` direnv: add support for mise integration `` |