### PR TITLE
chore(flake/nixos-cosmic): `04408bf4` -> `b6449fd7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -628,11 +628,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1729857853,
-        "narHash": "sha256-IVaFOTG4i2K0YWKrJui09YCAEWyTSK+zaUTUvj/SbC4=",
+        "lastModified": 1729897845,
+        "narHash": "sha256-+c5xcaG6lr0hd9yFivoaJ5ALg0uqxCFVVTnzNb/ibGk=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "04408bf4afe2bf2b15227c43914130c8bdf4ed3c",
+        "rev": "b6449fd70d6457b858175514e8f23ea366b7dede",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                                          |
| ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`b6449fd7`](https://github.com/lilyinstarlight/nixos-cosmic/commit/b6449fd70d6457b858175514e8f23ea366b7dede) | `` cosmic-ext-forecast: 0-unstable-2024-10-15 -> 0-unstable-2024-10-25 (#441) `` |