### PR TITLE
chore(flake/emacs-overlay): `921c961c` -> `c37eef2b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -165,11 +165,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1729876525,
-        "narHash": "sha256-ufgsc4MzPk+EuWE8Z9wtcvwdaLc4RcgN/peMhrjMF+g=",
+        "lastModified": 1729905235,
+        "narHash": "sha256-zFNBBpg63EHLuMhoN12LP+J0uYdnVrrCPvvrrcm07j8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "921c961c4b0754122a3897bb1d68a40f3f925ef0",
+        "rev": "c37eef2b98dcf0fb77f0d0457f14e4ae7a728050",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`c37eef2b`](https://github.com/nix-community/emacs-overlay/commit/c37eef2b98dcf0fb77f0d0457f14e4ae7a728050) | `` Updated elpa ``   |
| [`42221c01`](https://github.com/nix-community/emacs-overlay/commit/42221c0108e81cc9f0b8219b8a3855eace7be53c) | `` Updated nongnu `` |