### PR TITLE
chore(flake/emacs-overlay): `c37eef2b` -> `825505b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -165,11 +165,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1729905235,
-        "narHash": "sha256-zFNBBpg63EHLuMhoN12LP+J0uYdnVrrCPvvrrcm07j8=",
+        "lastModified": 1729908225,
+        "narHash": "sha256-e2rUOJXPgeYxtuAwfzeqvYirQp8rbLNRfL/D+Hr2cO0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c37eef2b98dcf0fb77f0d0457f14e4ae7a728050",
+        "rev": "825505b43c276d6efd41c69f9dd5ca3dfc522284",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`825505b4`](https://github.com/nix-community/emacs-overlay/commit/825505b43c276d6efd41c69f9dd5ca3dfc522284) | `` Updated emacs `` |