### PR TITLE
chore(flake/sops-nix): `78a0e634` -> `b2211d1a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -965,11 +965,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1729775275,
-        "narHash": "sha256-J2vtHq9sw1wWm0aTMXpEEAzsVCUMZDTEe5kiBYccpLE=",
+        "lastModified": 1729931925,
+        "narHash": "sha256-3tjYImjVzsSM4sU+wTySF94Yop1spI/XomMBEpljKvQ=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "78a0e634fc8981d6b564f08b6715c69a755c4c7d",
+        "rev": "b2211d1a537136cc1d0d5c0af391e8712016b34e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                            |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`b2211d1a`](https://github.com/Mic92/sops-nix/commit/b2211d1a537136cc1d0d5c0af391e8712016b34e) | `` fix(home-manager/sops): fix setting unit env `` |