### PR TITLE
chore(flake/catppuccin): `037e2f09` -> `5f96f9a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1729730584,
-        "narHash": "sha256-iPrs6bLWdp7qdFRba2AfiHj604SpxC6AGASx7I692Lo=",
+        "lastModified": 1729948241,
+        "narHash": "sha256-PFtL/l6KrqN5gj1qD5Y32vwJ3PXtHN9sxT6Qcj/6yyk=",
         "owner": "ryand56",
         "repo": "catppuccin-nix",
-        "rev": "037e2f091a2144433566c5122f385a388cb5d5d3",
+        "rev": "5f96f9a57cb5b52a01d7002149eaec64ce8b3683",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                  | Message                                     |
| ------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`286a6011`](https://github.com/ryand56/catppuccin-nix/commit/286a601142056e3ff308637ec531d1b7976eb9a0) | `` chore: update dev flake inputs (#346) `` |