### PR TITLE
chore(flake/emacs-overlay): `074f3bcc` -> `7f86b977`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -165,11 +165,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1729933816,
-        "narHash": "sha256-8CDsePw+iBuiNd/mOj3nMIC+TBe+GeEM2dsO337SYF8=",
+        "lastModified": 1729959636,
+        "narHash": "sha256-nJ1V+EFn5OYoAdcIQpO9AT8UZjulFXYBmBSblIZoH9U=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "074f3bcc4b6744dcb9088c9197b8b1ac97f3df74",
+        "rev": "7f86b977ad3e397c8cf37be53a6578ec5cd109c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`7f86b977`](https://github.com/nix-community/emacs-overlay/commit/7f86b977ad3e397c8cf37be53a6578ec5cd109c7) | `` Updated elpa ``   |
| [`fc64298c`](https://github.com/nix-community/emacs-overlay/commit/fc64298c41b56fecff1e1b627e4c87ad1a0bffa9) | `` Updated nongnu `` |