### PR TITLE
chore(flake/emacs-overlay): `5f83b15a` -> `d3072046`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1729964113,
-        "narHash": "sha256-ZDST68C0+5+PbTDPVzErW5zxYiZzOwdHqb+E472qGQo=",
+        "lastModified": 1729992046,
+        "narHash": "sha256-M7ZaS7v1nPqCjg4PgTa1GUBbIjb4C9tE5bc49vf4GrI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5f83b15a9fe67d4dd1edcd281194d4d30925125a",
+        "rev": "d3072046c9b1c2a1313c8ccf9ce1d51fb83bc058",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`d3072046`](https://github.com/nix-community/emacs-overlay/commit/d3072046c9b1c2a1313c8ccf9ce1d51fb83bc058) | `` Updated elpa ``   |
| [`b911fe3b`](https://github.com/nix-community/emacs-overlay/commit/b911fe3bf813b7d1df1245ddd2d0f31592d48136) | `` Updated nongnu `` |