### PR TITLE
chore(flake/nix-index-database): `04f8a11f` -> `17767638`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -581,11 +581,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729394935,
-        "narHash": "sha256-2ntUG+NJKdfhlrh/tF+jOU0fOesO7lm5ZZVSYitsvH8=",
+        "lastModified": 1729999029,
+        "narHash": "sha256-yjOtmIJoHWKZ7LytzkI52Wt42NhATbWEvFxq6kRJzRE=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "04f8a11f247ba00263b060fbcdc95484fd046104",
+        "rev": "17767638332b2de04e28ae1fecb931f40dd47c1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                  |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`17767638`](https://github.com/nix-community/nix-index-database/commit/17767638332b2de04e28ae1fecb931f40dd47c1e) | `` flake.lock: Update `` |