### PR TITLE
chore(flake/nix-index-database): `17767638` -> `0e3a8778`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -581,11 +581,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729999029,
-        "narHash": "sha256-yjOtmIJoHWKZ7LytzkI52Wt42NhATbWEvFxq6kRJzRE=",
+        "lastModified": 1729999765,
+        "narHash": "sha256-LYsavZXitFjjyETZoij8usXjTa7fa9AIF3Sk3MJSX+Y=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "17767638332b2de04e28ae1fecb931f40dd47c1e",
+        "rev": "0e3a8778c2ee218eff8de6aacf3d2fa6c33b2d4f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`0e3a8778`](https://github.com/nix-community/nix-index-database/commit/0e3a8778c2ee218eff8de6aacf3d2fa6c33b2d4f) | `` update generated.nix to release 2024-10-27-031722 `` |