### PR TITLE
chore(flake/catppuccin): `f99984a7` -> `0b7bf046`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1729948644,
-        "narHash": "sha256-o91SqI7aFZZHMoqv99WfYcxu9czFV/nqWXV4v9WGFDg=",
+        "lastModified": 1730036420,
+        "narHash": "sha256-rv2bz7J6Wo7AenPiu4+ptCB1AFyaMcS77y89zbRAtI8=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "f99984a7f4e2a7f92893443dc1d1971d0ff1fe23",
+        "rev": "0b7bf04628414a402d255924f65e9a0d1a53d92b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                         |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`0b7bf046`](https://github.com/catppuccin/nix/commit/0b7bf04628414a402d255924f65e9a0d1a53d92b) | `` feat(home-manager/fcitx5): add accent support (#343) ``      |
| [`250c9865`](https://github.com/catppuccin/nix/commit/250c9865beae02ffaee4f49f7ab39137fc235cda) | `` feat(home-manager): update yazi for accent support (#360) `` |