### PR TITLE
chore(flake/darwin): `2eb47223` -> `5c0c6aaa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -82,11 +82,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729982130,
-        "narHash": "sha256-HmLLQbX07rYD0RXPxbf3kJtUo66XvEIX9Y+N5QHQ9aY=",
+        "lastModified": 1730070491,
+        "narHash": "sha256-+RYCbdU6l4E4pr40++lrdhdE3gNC/BR54AL7xWG/YRU=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "2eb472230a5400c81d9008014888b4bff23bcf44",
+        "rev": "5c0c6aaa797d6ccbb6cdab14de0248135735709d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                   |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
| [`febc3b3f`](https://github.com/LnL7/nix-darwin/commit/febc3b3f514d1e3d46182975430737d0232e6af0) | `` users: remove `with lib;` ``                                           |
| [`32f0cf21`](https://github.com/LnL7/nix-darwin/commit/32f0cf2140af6a852f8c8b6c8f15e4855d461b87) | `` users: replace FDA check with more fine grained permissions check ``   |
| [`9cd39764`](https://github.com/LnL7/nix-darwin/commit/9cd3976486fd0d189cbb3ad3e71c345502a3b1f5) | `` users: ensure all users' home directories in the config are correct `` |
| [`55be3e1a`](https://github.com/LnL7/nix-darwin/commit/55be3e1a5f9c816f30baf0d9de8ba77c954847dd) | `` users: move checks to `system.checks` ``                               |
| [`dc6f754f`](https://github.com/LnL7/nix-darwin/commit/dc6f754fe5d3b0d1ee6b033495c87ec3199a7f68) | `` users: allow `shell` to be managed by macOS ``                         |
| [`3712ff78`](https://github.com/LnL7/nix-darwin/commit/3712ff78ccacd65c819435a310fe8b1a8a2de2ee) | `` users: change default shell to `/usr/bin/false` to match macOS ``      |
| [`bd161d61`](https://github.com/LnL7/nix-darwin/commit/bd161d61d6f322e1c16543b67b1dbd13934e763c) | `` users: allow `home` to be managed by macOS ``                          |
| [`c9af5c2d`](https://github.com/LnL7/nix-darwin/commit/c9af5c2d1394d1bc34f4722998bcd51714ccd68c) | `` users: update properties on known users ``                             |
| [`13816f68`](https://github.com/LnL7/nix-darwin/commit/13816f682d1f604271651fec193961ee76610670) | `` tests: fix old test getting messed up in refactor ``                   |
| [`fd6660cb`](https://github.com/LnL7/nix-darwin/commit/fd6660cb9182fde5e593246e311dc3c2dd4b9d13) | `` tests: fix negative asserts with `grep` not working ``                 |