### PR TITLE
chore(flake/emacs-overlay): `42247fb5` -> `7f4f073b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1730049053,
-        "narHash": "sha256-Ay16cajt0HvwTTVqBU9kF5UdCSIWOmB+so8QRGRaWqY=",
+        "lastModified": 1730078310,
+        "narHash": "sha256-TqSJcZzQyov8dcNPqhU7NE/obnIYJnhS8FeX+IT0pD8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "42247fb5d6545d95f615538de8d4186006b68357",
+        "rev": "7f4f073bbd80eba17bd1e585abe0e4271c63e485",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`7f4f073b`](https://github.com/nix-community/emacs-overlay/commit/7f4f073bbd80eba17bd1e585abe0e4271c63e485) | `` Updated elpa ``   |
| [`2a1bcc85`](https://github.com/nix-community/emacs-overlay/commit/2a1bcc85cf8ce76836948707d24a8c1f889f02b8) | `` Updated nongnu `` |