### PR TITLE
chore(flake/srvos): `0e447b6d` -> `3410eb1e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -984,11 +984,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729731316,
-        "narHash": "sha256-InsUCPq86xyvJ9U+pVijYNBCep/dYACyJblG6fgkkWA=",
+        "lastModified": 1730076936,
+        "narHash": "sha256-jxejLhXjf58VWQiT1p8CsgJZwuXC3lBN5GfGpYSnWfM=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "0e447b6d3f16d6a305ca99ac89686d51042f516a",
+        "rev": "3410eb1ea70a2d723750a0107b38eb2336f6c901",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`3410eb1e`](https://github.com/nix-community/srvos/commit/3410eb1ea70a2d723750a0107b38eb2336f6c901) | `` dev/private/flake.lock: Update `` |
| [`16a56dac`](https://github.com/nix-community/srvos/commit/16a56dac15b9f1076762ab574e578c1b869b3552) | `` flake.lock: Update ``             |