### PR TITLE
chore(flake/emacs-overlay): `7f4f073b` -> `a798b734`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1730078310,
-        "narHash": "sha256-TqSJcZzQyov8dcNPqhU7NE/obnIYJnhS8FeX+IT0pD8=",
+        "lastModified": 1730081286,
+        "narHash": "sha256-vLycOGd85NkGgl5Li0mpWNW5hdlompJhd4UxkJcDSoo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7f4f073bbd80eba17bd1e585abe0e4271c63e485",
+        "rev": "a798b734eeea4177bc9359aa2b1bbb5e8b368acc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`a798b734`](https://github.com/nix-community/emacs-overlay/commit/a798b734eeea4177bc9359aa2b1bbb5e8b368acc) | `` Updated emacs `` |