### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `3906980e` -> `819ccd97`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -188,11 +188,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730017242,
-        "narHash": "sha256-L1b8MmY/34kou2htOeptpGr7Mvk28iKqjKc0VOg5Glg=",
+        "lastModified": 1730081286,
+        "narHash": "sha256-vLycOGd85NkGgl5Li0mpWNW5hdlompJhd4UxkJcDSoo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d88dc99503cd831388bef9c8deb06fc65b767478",
+        "rev": "a798b734eeea4177bc9359aa2b1bbb5e8b368acc",
         "type": "github"
       },
       "original": {
@@ -510,11 +510,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1730018218,
-        "narHash": "sha256-mU2xluyH4+QElouEJ9t71vb+Jn+jZ94iDFyx9sW1qZ0=",
+        "lastModified": 1730104776,
+        "narHash": "sha256-+QE41cjSDobfkRCihxUitRhe9qoa23jycLUgBWE0vSQ=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "3906980e61eb2ba97b69a78627962ab148aee800",
+        "rev": "819ccd979bb0eaf66015e42a5550f6f0d2babea4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`819ccd97`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/819ccd979bb0eaf66015e42a5550f6f0d2babea4) | `` flake.lock: Update `` |