### PR TITLE
chore(flake/treefmt): `bae131e5` -> `9ef337e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1079,11 +1079,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730025913,
-        "narHash": "sha256-Y9NtFmP8ciLyRsopcCx1tyoaaStKeq+EndwtGCgww7I=",
+        "lastModified": 1730120726,
+        "narHash": "sha256-LqHYIxMrl/1p3/kvm2ir925tZ8DkI0KA10djk8wecSk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "bae131e525cc8718da22fbeb8d8c7c43c4ea502a",
+        "rev": "9ef337e492a5555d8e17a51c911ff1f02635be15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                   |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`9ef337e4`](https://github.com/numtide/treefmt-nix/commit/9ef337e492a5555d8e17a51c911ff1f02635be15) | `` yamlfmt: add settings option (#193) `` |