### PR TITLE
chore(flake/emacs-overlay): `714bc70d` -> `ccdc0418`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1730164659,
-        "narHash": "sha256-sqYGhDkMRNPWxMRF7py3jHlnXEXQp2iWIuEyDOEbYm8=",
+        "lastModified": 1730193338,
+        "narHash": "sha256-DcZMhdIsi2FbHSUy5w1NpcYlOmLo2i8t2WvjboFfe7s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "714bc70d0e19690f5b0c605223fd53874cd71280",
+        "rev": "ccdc04185c596b78387aeabee053aad7e62060c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`ccdc0418`](https://github.com/nix-community/emacs-overlay/commit/ccdc04185c596b78387aeabee053aad7e62060c4) | `` Updated emacs `` |
| [`d212b83f`](https://github.com/nix-community/emacs-overlay/commit/d212b83f4742843c6ef5c93d0ffb73b4d52a1f85) | `` Updated emacs `` |