### PR TITLE
chore(flake/nur): `2c3f41ac` -> `f2e441ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -849,11 +849,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730154808,
-        "narHash": "sha256-n5vHV5SIGtDXr0f32+BI9yejIqAaiJoG1klA020/XrU=",
+        "lastModified": 1730171897,
+        "narHash": "sha256-cHzLaPfZpdEoLpNzDYLdg3mxdAxMRgQUUUf76wjt8Ak=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2c3f41acd6644a5994b345992bbc23332cdff464",
+        "rev": "f2e441ae37c6ccc87499dd11f1845178a5eedabf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f2e441ae`](https://github.com/nix-community/NUR/commit/f2e441ae37c6ccc87499dd11f1845178a5eedabf) | `` automatic update `` |
| [`d9b574e2`](https://github.com/nix-community/NUR/commit/d9b574e2c55aae5beb07a2c11a699e8a3b5d89bd) | `` automatic update `` |
| [`f62fbc8c`](https://github.com/nix-community/NUR/commit/f62fbc8c543df0d728d1c5550e019123dceaf9d4) | `` automatic update `` |