### PR TITLE
chore(flake/nur): `f2e441ae` -> `5eb3bf1a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -849,11 +849,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730171897,
-        "narHash": "sha256-cHzLaPfZpdEoLpNzDYLdg3mxdAxMRgQUUUf76wjt8Ak=",
+        "lastModified": 1730184753,
+        "narHash": "sha256-eT+1Jt8oLE+3nbo0gMnzLavjUxk4xmTnUeoCvaZ+mkY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f2e441ae37c6ccc87499dd11f1845178a5eedabf",
+        "rev": "5eb3bf1ae6b2e940e0049e27e3632ec4144eb085",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5eb3bf1a`](https://github.com/nix-community/NUR/commit/5eb3bf1ae6b2e940e0049e27e3632ec4144eb085) | `` automatic update `` |
| [`fdc130ab`](https://github.com/nix-community/NUR/commit/fdc130ab85beee841dd929d41e68509fc806c75e) | `` automatic update `` |