### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `819ccd97` -> `9ae4fcca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -172,11 +172,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730081286,
-        "narHash": "sha256-vLycOGd85NkGgl5Li0mpWNW5hdlompJhd4UxkJcDSoo=",
+        "lastModified": 1730167699,
+        "narHash": "sha256-SeCwW3xfmxkX8yXH4bay7WRXZiV1E/+TbC5e9p9SefU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a798b734eeea4177bc9359aa2b1bbb5e8b368acc",
+        "rev": "d212b83f4742843c6ef5c93d0ffb73b4d52a1f85",
         "type": "github"
       },
       "original": {
@@ -494,11 +494,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1730104776,
-        "narHash": "sha256-+QE41cjSDobfkRCihxUitRhe9qoa23jycLUgBWE0vSQ=",
+        "lastModified": 1730191155,
+        "narHash": "sha256-w20jPWTPobXgFeHY3B+xFpeP1HiboyAlzfmdac5JICI=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "819ccd979bb0eaf66015e42a5550f6f0d2babea4",
+        "rev": "9ae4fcca00718fd9ea9f288acbd463ec913118bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`9ae4fcca`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/9ae4fcca00718fd9ea9f288acbd463ec913118bb) | `` flake.lock: Update `` |