### PR TITLE
chore(flake/nur): `aff6965a` -> `370eb848`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -849,11 +849,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730202677,
-        "narHash": "sha256-seCp8vsgY212s9EaBkTN7zJg9NMiPvHLBvK13fPqLRA=",
+        "lastModified": 1730206377,
+        "narHash": "sha256-SK97wEqIZXKc+hlGnlN+y8wtkFaFqK5M3NjP5In1UuQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aff6965a8bc9d16a758a45313427b3b5198e3550",
+        "rev": "370eb8489a44f0b13328979be8a3cb0cf3bdf780",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`370eb848`](https://github.com/nix-community/NUR/commit/370eb8489a44f0b13328979be8a3cb0cf3bdf780) | `` automatic update `` |
| [`ddb2cd68`](https://github.com/nix-community/NUR/commit/ddb2cd68ef513412f5a0e4ec1027ff052da4f477) | `` automatic update `` |
| [`e4f56b46`](https://github.com/nix-community/NUR/commit/e4f56b46d16fc6b7f590792f34637d5e1786b6bc) | `` automatic update `` |