### PR TITLE
chore(flake/nur): `370eb848` -> `89e33af8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -849,11 +849,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730206377,
-        "narHash": "sha256-SK97wEqIZXKc+hlGnlN+y8wtkFaFqK5M3NjP5In1UuQ=",
+        "lastModified": 1730213070,
+        "narHash": "sha256-qtpXenNul4ZQq/ooWp8jdj5Y4RuroxHOr4ARxAUPC3c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "370eb8489a44f0b13328979be8a3cb0cf3bdf780",
+        "rev": "89e33af8ccfe2275c2c6042034a400ac7500ef60",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                  |
| -------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`89e33af8`](https://github.com/nix-community/NUR/commit/89e33af8ccfe2275c2c6042034a400ac7500ef60) | `` automatic update ``                   |
| [`d55e02e5`](https://github.com/nix-community/NUR/commit/d55e02e57dd4d433a43a5f1cd0128bcc979eed1d) | `` automatic update ``                   |
| [`ad05c089`](https://github.com/nix-community/NUR/commit/ad05c08986883815c2034222912cf385786d9d55) | `` add nukdokplex repository ``          |
| [`8a4db419`](https://github.com/nix-community/NUR/commit/8a4db419e0daf22a028dac998d698dde2aea817e) | `` automatic update ``                   |
| [`2f45a194`](https://github.com/nix-community/NUR/commit/2f45a19466c448378053ca35cb65810e606bca39) | `` automatic update ``                   |
| [`c2315acf`](https://github.com/nix-community/NUR/commit/c2315acf488a791d97a275dc8dec1c6aa8c2cbc4) | `` add nelonn/nur-packages repository `` |