### PR TITLE
chore(flake/nur): `89e33af8` -> `ea8e3f4f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -849,11 +849,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730213070,
-        "narHash": "sha256-qtpXenNul4ZQq/ooWp8jdj5Y4RuroxHOr4ARxAUPC3c=",
+        "lastModified": 1730216933,
+        "narHash": "sha256-FlJiLg2wGOBuO3rygpNxvFh5wF2DE9qWti6A2CNQaxg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "89e33af8ccfe2275c2c6042034a400ac7500ef60",
+        "rev": "ea8e3f4f12c7205b02be17549d3fb463af2b12d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ea8e3f4f`](https://github.com/nix-community/NUR/commit/ea8e3f4f12c7205b02be17549d3fb463af2b12d3) | `` automatic update `` |
| [`5dc75dc9`](https://github.com/nix-community/NUR/commit/5dc75dc98a61e966fa0e445e8392b3c8ed654416) | `` automatic update `` |
| [`daf38fa7`](https://github.com/nix-community/NUR/commit/daf38fa7f3b8602cb94920c251817a31dcb2abc4) | `` automatic update `` |