### PR TITLE
chore(flake/nur): `ea8e3f4f` -> `806f4101`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -849,11 +849,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730216933,
-        "narHash": "sha256-FlJiLg2wGOBuO3rygpNxvFh5wF2DE9qWti6A2CNQaxg=",
+        "lastModified": 1730220393,
+        "narHash": "sha256-J8lIzb4C6LKGfPgq71fRIdW4yvQ+dNnmYRqGEQP0JOo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ea8e3f4f12c7205b02be17549d3fb463af2b12d3",
+        "rev": "806f4101da89a9fbcafad025d91c091206871594",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`806f4101`](https://github.com/nix-community/NUR/commit/806f4101da89a9fbcafad025d91c091206871594) | `` automatic update `` |