### PR TITLE
chore(flake/nur): `806f4101` -> `10b3c0b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -849,11 +849,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730220393,
-        "narHash": "sha256-J8lIzb4C6LKGfPgq71fRIdW4yvQ+dNnmYRqGEQP0JOo=",
+        "lastModified": 1730224010,
+        "narHash": "sha256-FbjB76TlKf6lQoSFwAN2O8xyZc0A7Vo44UlnemQcQdg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "806f4101da89a9fbcafad025d91c091206871594",
+        "rev": "10b3c0b1e85839e8d2c00661342f8845e5c3486c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`10b3c0b1`](https://github.com/nix-community/NUR/commit/10b3c0b1e85839e8d2c00661342f8845e5c3486c) | `` automatic update `` |