### PR TITLE
chore(flake/nur): `54ad9b9d` -> `39324635`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -849,11 +849,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730233742,
-        "narHash": "sha256-3LeGyhimntM/4u6vxz5xVJhsQeuiaFt8+bWOBdA1YQQ=",
+        "lastModified": 1730238054,
+        "narHash": "sha256-waPsdPXjab3m4RVQ3qQ9t9smlDDVpnKUtMsQZEk3JX0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "54ad9b9d402140f7dadb9d9de6d9c21ebbcc9072",
+        "rev": "393246354e12f6f09068c87dad6e8bc20be42ecd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`39324635`](https://github.com/nix-community/NUR/commit/393246354e12f6f09068c87dad6e8bc20be42ecd) | `` automatic update `` |