### PR TITLE
chore(flake/nur): `79c5cac3` -> `2590af22`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -849,11 +849,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730254128,
-        "narHash": "sha256-VcyycVX8XExS6AL9Ll7JJUvXzrKtHAbL2TJCElx0gj0=",
+        "lastModified": 1730260192,
+        "narHash": "sha256-WbrlOo32+TQu94tfM7jiWKXv/BL5rLFTgP0gXaMYSPc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "79c5cac39115e820ccaeb8731b3bae132a81e349",
+        "rev": "2590af22bd6b5982e387a588dc5ea84ca2086514",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2590af22`](https://github.com/nix-community/NUR/commit/2590af22bd6b5982e387a588dc5ea84ca2086514) | `` automatic update `` |
| [`acb63767`](https://github.com/nix-community/NUR/commit/acb63767323952a2598c3df23ac190665d16aabb) | `` automatic update `` |
| [`394632cf`](https://github.com/nix-community/NUR/commit/394632cf96b0898651d73445e721fbc346c3ac4c) | `` automatic update `` |
| [`534b4706`](https://github.com/nix-community/NUR/commit/534b4706f5029ad3ea77c5a213fd6c82898a645f) | `` automatic update `` |