### PR TITLE
chore(flake/nur): `19a541cd` -> `8c65ea26`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -849,11 +849,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730262566,
-        "narHash": "sha256-n0Geg661PFZossoeyHuyaoBsCDgbJroBNuTtI9qd6xA=",
+        "lastModified": 1730285360,
+        "narHash": "sha256-fonpwQRAL0XzEQ2dau9YL59Zeo9kNN/1PPmYUMWtnHk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "19a541cdbe442060afa4ca2e0c233befe1cf8288",
+        "rev": "8c65ea26e66721c98348d69b7ae75698f8e56362",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8c65ea26`](https://github.com/nix-community/NUR/commit/8c65ea26e66721c98348d69b7ae75698f8e56362) | `` automatic update `` |
| [`8aabd3d0`](https://github.com/nix-community/NUR/commit/8aabd3d0df003567a730d581ce677e3d7fd1caf0) | `` automatic update `` |
| [`334bdfa4`](https://github.com/nix-community/NUR/commit/334bdfa479c96ad92d753ee6c0d7dcb9458e6c85) | `` automatic update `` |
| [`6df1c38f`](https://github.com/nix-community/NUR/commit/6df1c38f3077b9a4d31b841369af436b979133e3) | `` automatic update `` |
| [`7057c428`](https://github.com/nix-community/NUR/commit/7057c4280ed8be270726ffbbca0de19df7c20973) | `` automatic update `` |
| [`1833d94f`](https://github.com/nix-community/NUR/commit/1833d94f3489a8e9e5851fd2b6be6b31dce8e507) | `` automatic update `` |
| [`4f51380b`](https://github.com/nix-community/NUR/commit/4f51380b183157a611b7e87d1286cca0930c850f) | `` automatic update `` |
| [`21557726`](https://github.com/nix-community/NUR/commit/215577264d9716181fdf2bb3bcbc39ed3c688fb1) | `` automatic update `` |
| [`c4f19853`](https://github.com/nix-community/NUR/commit/c4f19853f558a0cfbc0c590160ec3f5347cf3a1c) | `` automatic update `` |