### PR TITLE
chore(flake/emacs-overlay): `b2082080` -> `67374cbd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1730250983,
-        "narHash": "sha256-pDtRlgJ5WlaGcC0A9nm+kMCbjdOn0Eel6Nc8XiIzHm0=",
+        "lastModified": 1730276721,
+        "narHash": "sha256-8nHuYwZ/fSpF9ne1Pws8PdP8xQB1ykV7+38fUluPRrM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b208208055e10d9ff9c8036a77c4e5c1dbf8bba1",
+        "rev": "67374cbdb8400967ef6aba113e6d5815a13bf7bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                         |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`67374cbd`](https://github.com/nix-community/emacs-overlay/commit/67374cbdb8400967ef6aba113e6d5815a13bf7bb) | `` Updated elpa ``                              |
| [`6cce90fc`](https://github.com/nix-community/emacs-overlay/commit/6cce90fcdcd89fd498850f3905eff3bc03c0e12d) | `` Bump actions/checkout from 4.2.1 to 4.2.2 `` |