### PR TITLE
chore(flake/emacs-overlay): `67374cbd` -> `88aa67a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1730276721,
-        "narHash": "sha256-8nHuYwZ/fSpF9ne1Pws8PdP8xQB1ykV7+38fUluPRrM=",
+        "lastModified": 1730279697,
+        "narHash": "sha256-r7ecq+MCAU4kQCze6l9ZAooaGkag1ml7mI/aXGx7eH8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "67374cbdb8400967ef6aba113e6d5815a13bf7bb",
+        "rev": "88aa67a24ebef4001b58945bdc2852f427f1abc9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`88aa67a2`](https://github.com/nix-community/emacs-overlay/commit/88aa67a24ebef4001b58945bdc2852f427f1abc9) | `` Updated emacs `` |