### PR TITLE
chore(flake/nur): `8c65ea26` -> `e0ec7c05`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -849,11 +849,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730285360,
-        "narHash": "sha256-fonpwQRAL0XzEQ2dau9YL59Zeo9kNN/1PPmYUMWtnHk=",
+        "lastModified": 1730292666,
+        "narHash": "sha256-Ll7xh/V9xEJCUMztiBekcV7mDYnpaJTuB+IM7Da/Kpc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8c65ea26e66721c98348d69b7ae75698f8e56362",
+        "rev": "e0ec7c059075b6371dbd6d7ac7a481c14d577d12",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e0ec7c05`](https://github.com/nix-community/NUR/commit/e0ec7c059075b6371dbd6d7ac7a481c14d577d12) | `` automatic update `` |
| [`a606f42c`](https://github.com/nix-community/NUR/commit/a606f42cbcebe353054ea76ebf23205a09f2ec43) | `` automatic update `` |
| [`b1d579b3`](https://github.com/nix-community/NUR/commit/b1d579b3d931139f32fa1f4c0a2dd50c0c07b75d) | `` automatic update `` |