### PR TITLE
chore(flake/nur): `e0ec7c05` -> `fdff5f70`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -849,11 +849,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730292666,
-        "narHash": "sha256-Ll7xh/V9xEJCUMztiBekcV7mDYnpaJTuB+IM7Da/Kpc=",
+        "lastModified": 1730296202,
+        "narHash": "sha256-hGJZw+NqnAxZW8sxJBgUd2CqhXwJ6qbG0vUCLkBt3NY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e0ec7c059075b6371dbd6d7ac7a481c14d577d12",
+        "rev": "fdff5f708f01925cd2ef15599a3dea76aba5f341",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fdff5f70`](https://github.com/nix-community/NUR/commit/fdff5f708f01925cd2ef15599a3dea76aba5f341) | `` automatic update `` |
| [`f27c5fde`](https://github.com/nix-community/NUR/commit/f27c5fde56338970654ccd7675d4806051858291) | `` automatic update `` |