### PR TITLE
chore(flake/nur): `97783c99` -> `06e39287`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -849,11 +849,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730314180,
-        "narHash": "sha256-0JseDGwMizqbZXLYEG3W31TuIWYUtZ9wAvTH0g1PpoU=",
+        "lastModified": 1730318187,
+        "narHash": "sha256-dgt5uUp10gcoCVfQP1VOj26qdh1rtxlqDGY008M9qlk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "97783c993aed99c0914c81be65777d0e81c07b77",
+        "rev": "06e39287aa495806b23f45e6377f279aafa12fdb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`06e39287`](https://github.com/nix-community/NUR/commit/06e39287aa495806b23f45e6377f279aafa12fdb) | `` automatic update `` |
| [`9eedd5d3`](https://github.com/nix-community/NUR/commit/9eedd5d3e5c81736198e5bf9c064dd8fc05da3fb) | `` automatic update `` |