### PR TITLE
chore(flake/nur): `06e39287` -> `d12c16b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -849,11 +849,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730318187,
-        "narHash": "sha256-dgt5uUp10gcoCVfQP1VOj26qdh1rtxlqDGY008M9qlk=",
+        "lastModified": 1730324739,
+        "narHash": "sha256-RF5zhaoJrSFAa+LH2mNMcV3dWHXMBAZ/QEccUpx1Y7c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "06e39287aa495806b23f45e6377f279aafa12fdb",
+        "rev": "d12c16b3f0aa77a0c80a75d484e8e7b7a1440515",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d12c16b3`](https://github.com/nix-community/NUR/commit/d12c16b3f0aa77a0c80a75d484e8e7b7a1440515) | `` automatic update `` |
| [`fb05ddbe`](https://github.com/nix-community/NUR/commit/fb05ddbead47d12a5cd75124227c58bd91d31384) | `` automatic update `` |
| [`6278dd1c`](https://github.com/nix-community/NUR/commit/6278dd1c295afa20b1941d56e66a0fdbbb6abb88) | `` automatic update `` |