### PR TITLE
chore(flake/nur): `d12c16b3` -> `51465137`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -849,11 +849,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730324739,
-        "narHash": "sha256-RF5zhaoJrSFAa+LH2mNMcV3dWHXMBAZ/QEccUpx1Y7c=",
+        "lastModified": 1730329096,
+        "narHash": "sha256-81OdXiIuBLqpXcwhHwJshn+eK/Ph5aYTUmLO8W3XwSo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d12c16b3f0aa77a0c80a75d484e8e7b7a1440515",
+        "rev": "5146513799002e9b3ecd50dd111d1f1fce61247d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`51465137`](https://github.com/nix-community/NUR/commit/5146513799002e9b3ecd50dd111d1f1fce61247d) | `` automatic update `` |