### PR TITLE
chore(flake/nur): `51465137` -> `664a098d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -849,11 +849,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730329096,
-        "narHash": "sha256-81OdXiIuBLqpXcwhHwJshn+eK/Ph5aYTUmLO8W3XwSo=",
+        "lastModified": 1730331873,
+        "narHash": "sha256-LQenSv3wlNGI2lUudItcUVJ/IF/P3Tm9LdBF7Ph2EPA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5146513799002e9b3ecd50dd111d1f1fce61247d",
+        "rev": "664a098d8fd59ba06980b8ec39fee92d4c213096",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`664a098d`](https://github.com/nix-community/NUR/commit/664a098d8fd59ba06980b8ec39fee92d4c213096) | `` automatic update `` |