### PR TITLE
chore(flake/emacs-overlay): `e380fa7e` -> `200231b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1730308411,
-        "narHash": "sha256-KFg9mr+LiJlkOyELdZt31S0cH2wQv1fiIlfe8py/lck=",
+        "lastModified": 1730340456,
+        "narHash": "sha256-Dxo5A6MZuUTJrOo/aamCabem5GbW2sBO7KVD/LkIKKA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e380fa7ec3666a347d3d5bbcacbdd53dd9f89157",
+        "rev": "200231b4367ea41169c472b256ba68b74ebe097f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`200231b4`](https://github.com/nix-community/emacs-overlay/commit/200231b4367ea41169c472b256ba68b74ebe097f) | `` Updated emacs ``  |
| [`60db7647`](https://github.com/nix-community/emacs-overlay/commit/60db7647705e60bbc60eed8b8ebaf44036536440) | `` Updated elpa ``   |
| [`8bb49e9a`](https://github.com/nix-community/emacs-overlay/commit/8bb49e9a3d65294d63c69f7ddc217076fd29767b) | `` Updated nongnu `` |