### PR TITLE
chore(flake/nur): `664a098d` -> `183b3a99`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -849,11 +849,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730331873,
-        "narHash": "sha256-LQenSv3wlNGI2lUudItcUVJ/IF/P3Tm9LdBF7Ph2EPA=",
+        "lastModified": 1730336832,
+        "narHash": "sha256-hNumkRHIPIHfuUXef5UhujA0psdsqaYBl5Nf2pAKx5E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "664a098d8fd59ba06980b8ec39fee92d4c213096",
+        "rev": "183b3a999dc08d64e164aac1bc8184d2efa97dd5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`183b3a99`](https://github.com/nix-community/NUR/commit/183b3a999dc08d64e164aac1bc8184d2efa97dd5) | `` automatic update `` |
| [`1a4f6a53`](https://github.com/nix-community/NUR/commit/1a4f6a53c65026c7a11a9b91b14f0ff53e9b0cb0) | `` automatic update `` |
| [`259d80a6`](https://github.com/nix-community/NUR/commit/259d80a6b86f67106c0559a83ac3406a8162a500) | `` automatic update `` |
| [`b5685d21`](https://github.com/nix-community/NUR/commit/b5685d217aa8054c68539e656eb3cc1d3962e4df) | `` automatic update `` |
| [`c9c4d887`](https://github.com/nix-community/NUR/commit/c9c4d88756f0fe72fb3100464f8759379292960f) | `` automatic update `` |