### PR TITLE
chore(flake/srvos): `3410eb1e` -> `b80b3ffa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -982,11 +982,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730076936,
-        "narHash": "sha256-jxejLhXjf58VWQiT1p8CsgJZwuXC3lBN5GfGpYSnWfM=",
+        "lastModified": 1730335989,
+        "narHash": "sha256-hG7H+EcNZfNa5tsUzMX+NBYpG4viCTvfRp5t7ZUnKW8=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "3410eb1ea70a2d723750a0107b38eb2336f6c901",
+        "rev": "b80b3ffabd20e39b579f45a33e638bbb1b297b60",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`b80b3ffa`](https://github.com/nix-community/srvos/commit/b80b3ffabd20e39b579f45a33e638bbb1b297b60) | `` dev/private/flake.lock: Update `` |
| [`c9b97efe`](https://github.com/nix-community/srvos/commit/c9b97efe69b603c10656f22d00b754781c54b2f7) | `` flake.lock: Update ``             |