### PR TITLE
chore(flake/nur): `183b3a99` -> `73638442`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -849,11 +849,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730336832,
-        "narHash": "sha256-hNumkRHIPIHfuUXef5UhujA0psdsqaYBl5Nf2pAKx5E=",
+        "lastModified": 1730340513,
+        "narHash": "sha256-CZmauwFFJ80mo4eXkQ+5R0MfD5szzWXDCG7M2sJbZg8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "183b3a999dc08d64e164aac1bc8184d2efa97dd5",
+        "rev": "73638442a5d792fd3d922d014c856e3970d185f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`73638442`](https://github.com/nix-community/NUR/commit/73638442a5d792fd3d922d014c856e3970d185f3) | `` automatic update `` |
| [`740c39ec`](https://github.com/nix-community/NUR/commit/740c39ecbfb250f20344e47fb7e6b6c2820257f9) | `` automatic update `` |