### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `dfe1d256` -> `8f41e765`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1730277695,
-        "narHash": "sha256-//z5JbHeReyUjtBDAl2UGrWy3qyB2ktm8bjWEcBAQM0=",
+        "lastModified": 1730342415,
+        "narHash": "sha256-UwDiZMZZlbyzclbbfexNo8PQiWD6rK5MHUiqmMp6ogo=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "dfe1d256113b6be9f79e990c40080667b913226c",
+        "rev": "8f41e765138b0d94fd42f67bec5791a7f3a5e81c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                      |
| ---------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`8f41e765`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/8f41e765138b0d94fd42f67bec5791a7f3a5e81c) | `` feat: add macos bundle `` |