### PR TITLE
chore(flake/nur): `73638442` -> `e57f3497`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -849,11 +849,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730340513,
-        "narHash": "sha256-CZmauwFFJ80mo4eXkQ+5R0MfD5szzWXDCG7M2sJbZg8=",
+        "lastModified": 1730349696,
+        "narHash": "sha256-7m3Jyu6sE34aSIxYvF0xP/te74lKStUvfoAKijSEkmI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "73638442a5d792fd3d922d014c856e3970d185f3",
+        "rev": "e57f349741e688d1cb5f239da542aca0495b699f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e57f3497`](https://github.com/nix-community/NUR/commit/e57f349741e688d1cb5f239da542aca0495b699f) | `` automatic update `` |
| [`1ef592c5`](https://github.com/nix-community/NUR/commit/1ef592c50e418e0776762826698bd93e37949a13) | `` automatic update `` |
| [`ded3ff2d`](https://github.com/nix-community/NUR/commit/ded3ff2d12f31f0079cbd01e895a519d0d8a0101) | `` automatic update `` |
| [`7cf96156`](https://github.com/nix-community/NUR/commit/7cf9615692942d6ec5e8e6cab26bb89936c22645) | `` automatic update `` |