### PR TITLE
chore(flake/nur): `4be5fac1` -> `7dbe1e91`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -849,11 +849,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730357793,
-        "narHash": "sha256-5eFGxmShiS3LJ75JZ2x15NO9rsi0daew9axGtIs498M=",
+        "lastModified": 1730360117,
+        "narHash": "sha256-6LgEhKh/1YZGoHZVkZwPzAMFUZ1BO5LnzqTeOklQzPg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4be5fac167dd4d6285c41c68ed914aad4bd94d02",
+        "rev": "7dbe1e914ba993f60a977159bd05788de65af9f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7dbe1e91`](https://github.com/nix-community/NUR/commit/7dbe1e914ba993f60a977159bd05788de65af9f4) | `` automatic update `` |