### PR TITLE
chore(flake/nixos-hardware): `07d15e89` -> `da14839a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -626,11 +626,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1730161780,
-        "narHash": "sha256-z5ILcmwMtiCoHTXS1KsQWqigO7HJO8sbyK7f7wn9F/E=",
+        "lastModified": 1730368399,
+        "narHash": "sha256-F8vJtG389i9fp3k2/UDYHMed3PLCJYfxCqwiVP7b9ig=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "07d15e8990d5d86a631641b4c429bc0a7400cfb8",
+        "rev": "da14839ac5f38ee6adbdb4e6db09b5eef6d6ccdc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`da14839a`](https://github.com/NixOS/nixos-hardware/commit/da14839ac5f38ee6adbdb4e6db09b5eef6d6ccdc) | `` remove broadcom_sta since it was likely already added by nixos-generate-hardware `` |
| [`8cf35efb`](https://github.com/NixOS/nixos-hardware/commit/8cf35efba11b0ab1f4e50aac7a5fdeb42ea5b85c) | `` macbook air 7 ``                                                                    |
| [`4048e9ce`](https://github.com/NixOS/nixos-hardware/commit/4048e9ce2d8b054a7325e573371ede8995d397a1) | `` Fix "nividia" typo ``                                                               |
| [`b486ff2d`](https://github.com/NixOS/nixos-hardware/commit/b486ff2d754c0c396f391f6b83cb048066de8332) | `` Revert "common/gpu/intel: Disable intel-ocl due to web.archive.org outage" ``       |