### PR TITLE
chore(flake/nur): `348f25fd` -> `bab7a8b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -849,11 +849,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730371732,
-        "narHash": "sha256-TQaxm27bSH1MleczyXi2w9mKhCaAcaAA85HZ9OIIYO4=",
+        "lastModified": 1730382957,
+        "narHash": "sha256-0aaYzCgPaJT1tPiGc22qHsCBm7y1UrCh6dJctvA/egw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "348f25fd30f91494bca6f65557538fedbc6250d6",
+        "rev": "bab7a8b67b3c84dad81f6f7aa76d5f8137fd30aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bab7a8b6`](https://github.com/nix-community/NUR/commit/bab7a8b67b3c84dad81f6f7aa76d5f8137fd30aa) | `` automatic update `` |
| [`2b1b211b`](https://github.com/nix-community/NUR/commit/2b1b211bd54496cc8ac20d4b6acda59ada5539c8) | `` automatic update `` |