### PR TITLE
chore(flake/nur): `bab7a8b6` -> `3af69e17`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -849,11 +849,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730382957,
-        "narHash": "sha256-0aaYzCgPaJT1tPiGc22qHsCBm7y1UrCh6dJctvA/egw=",
+        "lastModified": 1730388299,
+        "narHash": "sha256-ekITKYsBlNJu1Ltk81gCD/7UJrPi7luLfHFQdXiCfB0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bab7a8b67b3c84dad81f6f7aa76d5f8137fd30aa",
+        "rev": "3af69e17e4cdb4c2b63717ded66b354d18ed46cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3af69e17`](https://github.com/nix-community/NUR/commit/3af69e17e4cdb4c2b63717ded66b354d18ed46cd) | `` automatic update `` |