### PR TITLE
chore(flake/nur): `3af69e17` -> `3088683a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -833,11 +833,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730388299,
-        "narHash": "sha256-ekITKYsBlNJu1Ltk81gCD/7UJrPi7luLfHFQdXiCfB0=",
+        "lastModified": 1730391764,
+        "narHash": "sha256-1GDfJO/247D5O/ANxCPQkTwJPiNoybBUHocq9kRxOo0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3af69e17e4cdb4c2b63717ded66b354d18ed46cd",
+        "rev": "3088683a97c051ee46410cb674c929fbb0dad1ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3088683a`](https://github.com/nix-community/NUR/commit/3088683a97c051ee46410cb674c929fbb0dad1ab) | `` automatic update `` |