### PR TITLE
chore(flake/emacs-overlay): `fd67937f` -> `cedccfff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1730391743,
-        "narHash": "sha256-nQLJIGjHyctzcSQT/bs/jCDKxuVbKX5nz3PUl37GAo0=",
+        "lastModified": 1730394842,
+        "narHash": "sha256-g2OJ2m0lhavtek1wGkn0Bj3VCnvzE3GmtLEY3SJaYoM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fd67937f973307e63540990f568a288fcedb9d67",
+        "rev": "cedccfff0d6e1fb9c62f77fb4e05169256219eca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`cedccfff`](https://github.com/nix-community/emacs-overlay/commit/cedccfff0d6e1fb9c62f77fb4e05169256219eca) | `` Updated emacs `` |