### PR TITLE
chore(flake/nur): `3088683a` -> `761c6a7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -833,11 +833,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730391764,
-        "narHash": "sha256-1GDfJO/247D5O/ANxCPQkTwJPiNoybBUHocq9kRxOo0=",
+        "lastModified": 1730411166,
+        "narHash": "sha256-o1JcjEnWhnxkkKXYN1gQeO53RUsQExFsgMOJ/FzuFX0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3088683a97c051ee46410cb674c929fbb0dad1ab",
+        "rev": "761c6a7d6859126681d206126ba26ec58306d068",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`761c6a7d`](https://github.com/nix-community/NUR/commit/761c6a7d6859126681d206126ba26ec58306d068) | `` automatic update `` |
| [`3f561643`](https://github.com/nix-community/NUR/commit/3f56164326915180b00cf69913c248036fa0048c) | `` automatic update `` |
| [`a85fbb5b`](https://github.com/nix-community/NUR/commit/a85fbb5b9b7ea836eb40cc4e0ff5f467bdba0cb0) | `` automatic update `` |
| [`e49c6352`](https://github.com/nix-community/NUR/commit/e49c6352513dc101f4c1048acbc923a4048d8225) | `` automatic update `` |