### PR TITLE
chore(flake/nixos-cosmic): `bb235011` -> `aed7e386`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -611,11 +611,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1730338548,
-        "narHash": "sha256-wwAKXZr5GU36NrVy/gERRWuQjIKvZYrTD5mRahd87vI=",
+        "lastModified": 1730401536,
+        "narHash": "sha256-/pKY+3ntlTF+5GeksrezZXjfUW90cUHWdcx94TKtZLc=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "bb2350119400c47be764c348e67f1b38e858435f",
+        "rev": "aed7e3862e9dd969e1e78f868e496d09b5865470",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                          |
| ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`aed7e386`](https://github.com/lilyinstarlight/nixos-cosmic/commit/aed7e3862e9dd969e1e78f868e496d09b5865470) | `` cosmic-idle: remove /bin/sh impurity ``       |
| [`95ce80ae`](https://github.com/lilyinstarlight/nixos-cosmic/commit/95ce80ae072d1ce2ff8919fce2e4a50dd94e68ef) | `` nixos/cosmic: add cosmic-idle ``              |
| [`31d0f106`](https://github.com/lilyinstarlight/nixos-cosmic/commit/31d0f10695628327045e58a9bb6829ba2a806647) | `` cosmic-idle: init at 0-unstable-2024-10-30 `` |