### PR TITLE
chore(flake/nur): `a23167e8` -> `318a4f95`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -833,11 +833,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730427162,
-        "narHash": "sha256-bEt0wL2UWS0wNEEox1bHxkwuY71prJBkd/zDBKxTE+E=",
+        "lastModified": 1730430727,
+        "narHash": "sha256-Z1YLpCz8beWZwfRJeqMkLcnV+wghivNjjZsUuYlDqw8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a23167e87c157228bb9110ddc7249b2a50b6af47",
+        "rev": "318a4f9563ab587ab9c888eb5069077a642d2276",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`318a4f95`](https://github.com/nix-community/NUR/commit/318a4f9563ab587ab9c888eb5069077a642d2276) | `` automatic update `` |
| [`e3538cad`](https://github.com/nix-community/NUR/commit/e3538cadd822131ba19c701a851afc1f77877de5) | `` automatic update `` |