### PR TITLE
chore(flake/nur): `318a4f95` -> `5ef5f243`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -833,11 +833,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730430727,
-        "narHash": "sha256-Z1YLpCz8beWZwfRJeqMkLcnV+wghivNjjZsUuYlDqw8=",
+        "lastModified": 1730434297,
+        "narHash": "sha256-7wEy/XwjqAdzsIZJ2AFJaVeshX6yT9vhRsFjvQe0U1E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "318a4f9563ab587ab9c888eb5069077a642d2276",
+        "rev": "5ef5f243936bc6387b55fc8cb08c88e7cf68092a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5ef5f243`](https://github.com/nix-community/NUR/commit/5ef5f243936bc6387b55fc8cb08c88e7cf68092a) | `` automatic update `` |
| [`3ac24393`](https://github.com/nix-community/NUR/commit/3ac243930a3ff3c8f118c4736c50a98799ee4913) | `` automatic update `` |
| [`bba76a25`](https://github.com/nix-community/NUR/commit/bba76a2537db268ba05861aa251d7263ea560259) | `` automatic update `` |