### PR TITLE
chore(flake/nur): `5ef5f243` -> `08dc863f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -833,11 +833,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730434297,
-        "narHash": "sha256-7wEy/XwjqAdzsIZJ2AFJaVeshX6yT9vhRsFjvQe0U1E=",
+        "lastModified": 1730444336,
+        "narHash": "sha256-tNLowabw/bIwKkJbJ156dCK9sx8n2Md5DBleMYMztDU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5ef5f243936bc6387b55fc8cb08c88e7cf68092a",
+        "rev": "08dc863ff0cf318a95eda28e97ae8ec032b28526",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`08dc863f`](https://github.com/nix-community/NUR/commit/08dc863ff0cf318a95eda28e97ae8ec032b28526) | `` automatic update `` |
| [`442d589e`](https://github.com/nix-community/NUR/commit/442d589ed82d76d05292e1882460636582b58c26) | `` automatic update `` |
| [`8e7d8d3e`](https://github.com/nix-community/NUR/commit/8e7d8d3e33c2c2666820e9ff32d1dae6ebcc2ebd) | `` automatic update `` |
| [`0e23e731`](https://github.com/nix-community/NUR/commit/0e23e731ded050d563fd4a55b1e29a572e0522ab) | `` automatic update `` |