### PR TITLE
chore(flake/nur): `08dc863f` -> `fdd43a02`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -833,11 +833,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730444336,
-        "narHash": "sha256-tNLowabw/bIwKkJbJ156dCK9sx8n2Md5DBleMYMztDU=",
+        "lastModified": 1730447952,
+        "narHash": "sha256-DwqZyDTIGwe4cb/BA2R+UdHF8/omvA9RG0SOGFfN0nU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "08dc863ff0cf318a95eda28e97ae8ec032b28526",
+        "rev": "fdd43a02d87ed541931e1998748e08b7983a1258",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fdd43a02`](https://github.com/nix-community/NUR/commit/fdd43a02d87ed541931e1998748e08b7983a1258) | `` automatic update `` |
| [`cb8768d8`](https://github.com/nix-community/NUR/commit/cb8768d8e2dc59c5c56c69c80707c5ac7c61d1a9) | `` automatic update `` |