### PR TITLE
chore(flake/home-manager): `e8341405` -> `8ca921e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -388,11 +388,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730016908,
-        "narHash": "sha256-bFCxJco7d8IgmjfNExNz9knP8wvwbXU4s/d53KOK6U0=",
+        "lastModified": 1730450782,
+        "narHash": "sha256-0AfApF8aexgB6o34qqLW2cCX4LaWJajBVdU6ddiWZBM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e83414058edd339148dc142a8437edb9450574c8",
+        "rev": "8ca921e5a806b5b6171add542defe7bdac79d189",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`8ca921e5`](https://github.com/nix-community/home-manager/commit/8ca921e5a806b5b6171add542defe7bdac79d189) | `` git-credential-oauth: fix ordering of git extraConfig `` |