### PR TITLE
chore(flake/nur): `fdd43a02` -> `0cec4b96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -833,11 +833,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730447952,
-        "narHash": "sha256-DwqZyDTIGwe4cb/BA2R+UdHF8/omvA9RG0SOGFfN0nU=",
+        "lastModified": 1730464205,
+        "narHash": "sha256-J8dDwKgRXrS6Jfija3Fu/UhsjtESq7LVc6rSd3TCRzc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fdd43a02d87ed541931e1998748e08b7983a1258",
+        "rev": "0cec4b96fa9a9f3b348439ede1fd5ef46593b966",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0cec4b96`](https://github.com/nix-community/NUR/commit/0cec4b96fa9a9f3b348439ede1fd5ef46593b966) | `` automatic update `` |
| [`d549bc24`](https://github.com/nix-community/NUR/commit/d549bc24e18325d857d8e39a237e6a4caa5cd030) | `` automatic update `` |
| [`f58aaf65`](https://github.com/nix-community/NUR/commit/f58aaf6579697a5bd3d861cbc93a735f50e667a1) | `` automatic update `` |
| [`5bf60345`](https://github.com/nix-community/NUR/commit/5bf603459b923edbee4955e9fc94b94662add85c) | `` automatic update `` |
| [`6245edb4`](https://github.com/nix-community/NUR/commit/6245edb4d3799103b1a3805b90ca9a9818c5ad1e) | `` automatic update `` |
| [`7f3bc4c9`](https://github.com/nix-community/NUR/commit/7f3bc4c98c7df7d2e13ec03f0a04d38a2214ef6d) | `` automatic update `` |
| [`f4a66e55`](https://github.com/nix-community/NUR/commit/f4a66e555ee802d3d6ac0a0c1d4e86909ce59639) | `` automatic update `` |
| [`1c95a109`](https://github.com/nix-community/NUR/commit/1c95a10940bc0ce0d6b28dd092a3d6a1c45555cb) | `` automatic update `` |