### PR TITLE
chore(flake/nur): `2e0f8129` -> `334c084b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -833,11 +833,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730486041,
-        "narHash": "sha256-gDYtVZVgq3NUCSgp+9Ps2zoDkYxyEKLhVyEfcBlQ4oM=",
+        "lastModified": 1730490402,
+        "narHash": "sha256-RxwmD7U+xhwrb6b8u2vScMFMvTGLQz11XJ1VmWiy8IY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2e0f81298ba56aa8d615b8c594e1ae77baad744a",
+        "rev": "334c084b8cec0ed0323e8d7d1a81d6bfb2824974",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`334c084b`](https://github.com/nix-community/NUR/commit/334c084b8cec0ed0323e8d7d1a81d6bfb2824974) | `` automatic update `` |