### PR TITLE
chore(flake/nur): `334c084b` -> `a7b165eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730490402,
-        "narHash": "sha256-RxwmD7U+xhwrb6b8u2vScMFMvTGLQz11XJ1VmWiy8IY=",
+        "lastModified": 1730501827,
+        "narHash": "sha256-xoVeuckuDsCnlJIkNjLtKQjJDrwiF8YZ29eZrkD5lIc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "334c084b8cec0ed0323e8d7d1a81d6bfb2824974",
+        "rev": "a7b165eb4058b48dc60ca727a2c0cbba4236b8dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a7b165eb`](https://github.com/nix-community/NUR/commit/a7b165eb4058b48dc60ca727a2c0cbba4236b8dd) | `` automatic update `` |
| [`6a83c1ed`](https://github.com/nix-community/NUR/commit/6a83c1ed729e1c43cee5bd7ba0fa2f4ea185fb4c) | `` automatic update `` |
| [`55bbf103`](https://github.com/nix-community/NUR/commit/55bbf1030eedddf2de39c0005e12266ef5dc6c41) | `` automatic update `` |
| [`2cbae9ac`](https://github.com/nix-community/NUR/commit/2cbae9ac97e9b41e3f83f0d3e118306ae1a8fd50) | `` automatic update `` |