### PR TITLE
chore(flake/nur): `a7b165eb` -> `41c8b0a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730501827,
-        "narHash": "sha256-xoVeuckuDsCnlJIkNjLtKQjJDrwiF8YZ29eZrkD5lIc=",
+        "lastModified": 1730510022,
+        "narHash": "sha256-/FKsDxYEDNScuYuh9UjBwW8+f6WxjoRke8LvbF+ckjc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a7b165eb4058b48dc60ca727a2c0cbba4236b8dd",
+        "rev": "41c8b0a22b37fb114413b504c74ae64065d2fb83",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`41c8b0a2`](https://github.com/nix-community/NUR/commit/41c8b0a22b37fb114413b504c74ae64065d2fb83) | `` automatic update `` |
| [`261ae27b`](https://github.com/nix-community/NUR/commit/261ae27b9a8afe31c613c199ca56327fcb0ff619) | `` automatic update `` |
| [`187f8309`](https://github.com/nix-community/NUR/commit/187f8309facb4c1e05dc068dea2e10c38e8f6b4b) | `` automatic update `` |
| [`b880c8c3`](https://github.com/nix-community/NUR/commit/b880c8c347dd996bd7d4e9e139e15ee210e236cd) | `` automatic update `` |
| [`3d720530`](https://github.com/nix-community/NUR/commit/3d720530c32273537ef723a8b5f72c0ecdd1ad2e) | `` automatic update `` |