### PR TITLE
chore(flake/emacs-overlay): `79547cb5` -> `6afb2183`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -149,11 +149,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1730478096,
-        "narHash": "sha256-nTH9eT3FDq2BkB+RccSq2UHMWLHbeM6LZX+enhQXvdw=",
+        "lastModified": 1730513067,
+        "narHash": "sha256-0MHc5yR4qmQK4O8MzraisT3gnv907fn813Qb2J134CU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "79547cb5e8968bd1540f01609c1273fe5fb9b53e",
+        "rev": "6afb2183cef03dcfce47c3bf22b2d44ded54ace0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`6afb2183`](https://github.com/nix-community/emacs-overlay/commit/6afb2183cef03dcfce47c3bf22b2d44ded54ace0) | `` Updated emacs ``  |
| [`d00ada52`](https://github.com/nix-community/emacs-overlay/commit/d00ada520498c78e500fb02a45d4a9364f1e5de7) | `` Updated elpa ``   |
| [`d5528e6d`](https://github.com/nix-community/emacs-overlay/commit/d5528e6d32cddac7e8a3db292d4c00fd2c947443) | `` Updated nongnu `` |