### PR TITLE
chore(flake/nur): `41c8b0a2` -> `ddd9ad65`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730510022,
-        "narHash": "sha256-/FKsDxYEDNScuYuh9UjBwW8+f6WxjoRke8LvbF+ckjc=",
+        "lastModified": 1730523164,
+        "narHash": "sha256-auawwzcxBnltYw6lNBAM76NgZ1eB+CrR0vV+XUTjRkY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "41c8b0a22b37fb114413b504c74ae64065d2fb83",
+        "rev": "ddd9ad6580a1d9440fdde35cc6b57d8f8238d829",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ddd9ad65`](https://github.com/nix-community/NUR/commit/ddd9ad6580a1d9440fdde35cc6b57d8f8238d829) | `` automatic update `` |
| [`fc967d61`](https://github.com/nix-community/NUR/commit/fc967d61cfecfa069a88d483e397de1acda53184) | `` automatic update `` |
| [`b777a012`](https://github.com/nix-community/NUR/commit/b777a012c5ebc95888d813f2e0d72ef61163515e) | `` automatic update `` |
| [`443fd160`](https://github.com/nix-community/NUR/commit/443fd1602e4c6360df210ba6a511dbcf80217a63) | `` automatic update `` |
| [`ef99d0a9`](https://github.com/nix-community/NUR/commit/ef99d0a96135618406308434ac5a172a3ee83889) | `` automatic update `` |
| [`4feaeefd`](https://github.com/nix-community/NUR/commit/4feaeefd43631d40f4951c8d9b70aca4a91ccc6b) | `` automatic update `` |