### PR TITLE
chore(flake/nur): `ddd9ad65` -> `6b964444`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730523164,
-        "narHash": "sha256-auawwzcxBnltYw6lNBAM76NgZ1eB+CrR0vV+XUTjRkY=",
+        "lastModified": 1730532120,
+        "narHash": "sha256-jsAW8IiiV+XgG9O4dYDYKzl4juu8hclj3UxfH/iEykI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ddd9ad6580a1d9440fdde35cc6b57d8f8238d829",
+        "rev": "6b96444473a49b2e36cf115cd124493c74be190f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6b964444`](https://github.com/nix-community/NUR/commit/6b96444473a49b2e36cf115cd124493c74be190f) | `` automatic update `` |
| [`2d794780`](https://github.com/nix-community/NUR/commit/2d79478057d747a2f3a9df66b5edde523ba476d2) | `` automatic update `` |
| [`c9c1a787`](https://github.com/nix-community/NUR/commit/c9c1a787fdbe658d3a50e7c2deb42ebee0af2065) | `` automatic update `` |
| [`757d7637`](https://github.com/nix-community/NUR/commit/757d76373b6b5cdc9ec43d16826c4d8ac06a25e9) | `` automatic update `` |
| [`53d7e73e`](https://github.com/nix-community/NUR/commit/53d7e73e918bc6b62acb7c2e218b0c30cf1d4a05) | `` automatic update `` |
| [`6754a781`](https://github.com/nix-community/NUR/commit/6754a7814d6a1d3d9b24d07cef94dbe8f9fbca38) | `` automatic update `` |