### PR TITLE
chore(flake/nur): `6b964444` -> `7f816e1d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730532120,
-        "narHash": "sha256-jsAW8IiiV+XgG9O4dYDYKzl4juu8hclj3UxfH/iEykI=",
+        "lastModified": 1730537575,
+        "narHash": "sha256-UUtvjcWyn3nHm3yNzSlt2KZAO2p1mMZld4CAPMBwLI8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6b96444473a49b2e36cf115cd124493c74be190f",
+        "rev": "7f816e1dc456647b60d27b054695782586577e90",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7f816e1d`](https://github.com/nix-community/NUR/commit/7f816e1dc456647b60d27b054695782586577e90) | `` automatic update `` |
| [`f57882ec`](https://github.com/nix-community/NUR/commit/f57882ec8f2111a447fc7e3b72d2aa72169f6631) | `` automatic update `` |
| [`309888c7`](https://github.com/nix-community/NUR/commit/309888c7260ba22a3d9be84937404fb0b8115b1e) | `` automatic update `` |
| [`2b09a899`](https://github.com/nix-community/NUR/commit/2b09a899b787fa159e8cc346e1038fac80011fb4) | `` automatic update `` |