### PR TITLE
chore(flake/nur): `7f816e1d` -> `c72ac480`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730537575,
-        "narHash": "sha256-UUtvjcWyn3nHm3yNzSlt2KZAO2p1mMZld4CAPMBwLI8=",
+        "lastModified": 1730548313,
+        "narHash": "sha256-J35s2jRvbI7Gk6L3h9AjRZm2KSNpOb8E+Gy2VYgjjH8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7f816e1dc456647b60d27b054695782586577e90",
+        "rev": "c72ac480b25888ae3c918ea69aa18b7240b0162b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c72ac480`](https://github.com/nix-community/NUR/commit/c72ac480b25888ae3c918ea69aa18b7240b0162b) | `` automatic update `` |
| [`95a1b1a4`](https://github.com/nix-community/NUR/commit/95a1b1a4ba69e9fb84029ca7b9220221fa94f31d) | `` automatic update `` |
| [`57df81c2`](https://github.com/nix-community/NUR/commit/57df81c2bcabc503171defb232a0e11710ddaaf9) | `` automatic update `` |