### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `8f41e765` -> `f42213c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -495,11 +495,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1730342415,
-        "narHash": "sha256-UwDiZMZZlbyzclbbfexNo8PQiWD6rK5MHUiqmMp6ogo=",
+        "lastModified": 1730542549,
+        "narHash": "sha256-v6iwYZ+YpI2u9Zcig8H9YfYJS3mpg0PKxRkeBK2GSzY=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "8f41e765138b0d94fd42f67bec5791a7f3a5e81c",
+        "rev": "f42213c85926350c31be8c37f162d05a5d7b1240",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                                       |
| ---------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`f42213c8`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/f42213c85926350c31be8c37f162d05a5d7b1240) | `` Exclude "emacs" when building repoToPin `` |