### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `f42213c8` -> `1889b7b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,11 +125,11 @@
     "doomemacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1729806236,
-        "narHash": "sha256-JtT5QzZCxii4X+AZI6fGkhABs2cK9/iMbU4YWpQ/lLY=",
+        "lastModified": 1730548076,
+        "narHash": "sha256-NQdv5gWYsckwPoh00Lr6VN4IGERH/T08nHbzBhRadN4=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "dea6552ef97d8d1b731bef17548d492e8b15566c",
+        "rev": "97c0dcc2c328fcc791333e149418c26096043758",
         "type": "github"
       },
       "original": {
@@ -173,11 +173,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730276721,
-        "narHash": "sha256-8nHuYwZ/fSpF9ne1Pws8PdP8xQB1ykV7+38fUluPRrM=",
+        "lastModified": 1730513067,
+        "narHash": "sha256-0MHc5yR4qmQK4O8MzraisT3gnv907fn813Qb2J134CU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "67374cbdb8400967ef6aba113e6d5815a13bf7bb",
+        "rev": "6afb2183cef03dcfce47c3bf22b2d44ded54ace0",
         "type": "github"
       },
       "original": {
@@ -495,11 +495,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1730542549,
-        "narHash": "sha256-v6iwYZ+YpI2u9Zcig8H9YfYJS3mpg0PKxRkeBK2GSzY=",
+        "lastModified": 1730553087,
+        "narHash": "sha256-rb0eqWpnFFAWWXOTMefuNwW+eYRkRdnrxSLvGruUzlA=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "f42213c85926350c31be8c37f162d05a5d7b1240",
+        "rev": "1889b7b69f5e303dab138b87d7bbaed127e9e126",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`1889b7b6`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/1889b7b69f5e303dab138b87d7bbaed127e9e126) | `` flake.lock: Update `` |
| [`8626f468`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/8626f4684eefc1b3976a39092b4d69c653bfa7ac) | `` Pin forge ``          |