### PR TITLE
chore(flake/nur): `c7dd9f07` -> `d222b47c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730552901,
-        "narHash": "sha256-K1v1CSzAnfL85MHY07S0BhVKae/ysZqowWdEapFcFJc=",
+        "lastModified": 1730565856,
+        "narHash": "sha256-B+0LTC2ofNwu1d2KP8EJOMSHGC436Mbcxqko4JkqXuY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c7dd9f07d3e3c2abf03aac70ebd21d658037f0c4",
+        "rev": "d222b47cb95ed657e013c38c8fb2b3bf8b65d51f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d222b47c`](https://github.com/nix-community/NUR/commit/d222b47cb95ed657e013c38c8fb2b3bf8b65d51f) | `` automatic update `` |
| [`dc8caf40`](https://github.com/nix-community/NUR/commit/dc8caf40c12843f335a1e9d79630d74466b09d65) | `` automatic update `` |