### PR TITLE
chore(flake/emacs-overlay): `6afb2183` -> `5201f36d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -149,11 +149,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1730513067,
-        "narHash": "sha256-0MHc5yR4qmQK4O8MzraisT3gnv907fn813Qb2J134CU=",
+        "lastModified": 1730567476,
+        "narHash": "sha256-vTNDUlry/9Xx5GQLRXBsw9Rm+YS8g3TlnKVdYIf0GB8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6afb2183cef03dcfce47c3bf22b2d44ded54ace0",
+        "rev": "5201f36d19505bc1cb8c253ea8e6379cdeb33252",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`5201f36d`](https://github.com/nix-community/emacs-overlay/commit/5201f36d19505bc1cb8c253ea8e6379cdeb33252) | `` Updated emacs ``  |
| [`5020b902`](https://github.com/nix-community/emacs-overlay/commit/5020b902f155be44b3bd0b5a394ba97f5c83690f) | `` Updated nongnu `` |
| [`77836f64`](https://github.com/nix-community/emacs-overlay/commit/77836f645ce80b186a337bce9793a870aa38f1bc) | `` Updated elpa ``   |