### PR TITLE
chore(flake/nur): `d222b47c` -> `ebdd24ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730565856,
-        "narHash": "sha256-B+0LTC2ofNwu1d2KP8EJOMSHGC436Mbcxqko4JkqXuY=",
+        "lastModified": 1730570452,
+        "narHash": "sha256-QLw12qwcpw6hOZ1N05LLJiiGlQDABbfAV0t97HXZ+CY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d222b47cb95ed657e013c38c8fb2b3bf8b65d51f",
+        "rev": "ebdd24aca1f40c1462acac8186364d326a073e17",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ebdd24ac`](https://github.com/nix-community/NUR/commit/ebdd24aca1f40c1462acac8186364d326a073e17) | `` automatic update `` |
| [`d576297e`](https://github.com/nix-community/NUR/commit/d576297e3aec2033503d4e570a04745e10e23d93) | `` automatic update `` |