### PR TITLE
chore(flake/nur): `ebdd24ac` -> `3199e01a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730570452,
-        "narHash": "sha256-QLw12qwcpw6hOZ1N05LLJiiGlQDABbfAV0t97HXZ+CY=",
+        "lastModified": 1730573567,
+        "narHash": "sha256-4N2g4+CzkN2wjTsDelKD67DEp4T0yUpsyoSDKieLYM4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ebdd24aca1f40c1462acac8186364d326a073e17",
+        "rev": "3199e01a7dc67e11dd0c175f0c6559fb5328c707",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3199e01a`](https://github.com/nix-community/NUR/commit/3199e01a7dc67e11dd0c175f0c6559fb5328c707) | `` automatic update `` |
| [`198ff483`](https://github.com/nix-community/NUR/commit/198ff48341da4b09852742195d664d13872c7a37) | `` automatic update `` |
| [`561a4453`](https://github.com/nix-community/NUR/commit/561a44537cc94620665ad8dfa36266d2851c99c3) | `` automatic update `` |
| [`74f094bc`](https://github.com/nix-community/NUR/commit/74f094bc4e8f7511f870a588b177dd656d6bfa2a) | `` automatic update `` |