### PR TITLE
chore(flake/darwin): `f203352c` -> `146629a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730586190,
-        "narHash": "sha256-OWGw7LsffScfxocmMTtLTRZDABvzOnK3FavqnDqeBao=",
+        "lastModified": 1730589595,
+        "narHash": "sha256-QI//TRTTmkUM0bz+KhdanRcwzlYib6PjMTvhC3dwUWA=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "f203352cc035dad4a49242d9296ce4272badcefa",
+        "rev": "146629a54364f6b54e7f3d15c44fea69ed0bf476",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                 |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
| [`21809c42`](https://github.com/LnL7/nix-darwin/commit/21809c4261a421eb06b2d7b3ccd18ebadd921f96) | `` Allow configuring the fn key action ``               |
| [`0dacfdea`](https://github.com/LnL7/nix-darwin/commit/0dacfdea635b664812b8065e6b5449c43bf1a586) | `` Configure the folder that new Finder windows open `` |