### PR TITLE
chore(flake/nur): `62fa5dcf` -> `0fdefeac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730582014,
-        "narHash": "sha256-uDmIIdv5Hft2Az2UUwKbb5QweYwkw25e6Y8mCLrF9QI=",
+        "lastModified": 1730599867,
+        "narHash": "sha256-sjDrezjrAICqxXS1GvuElbYoo932zGeD2YMW0LFk1Po=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "62fa5dcf74c3d2cae2d207926572614489e78815",
+        "rev": "0fdefeac8566f50d09ec998231f5afe04c56f845",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0fdefeac`](https://github.com/nix-community/NUR/commit/0fdefeac8566f50d09ec998231f5afe04c56f845) | `` automatic update `` |
| [`9adbb33c`](https://github.com/nix-community/NUR/commit/9adbb33c44edf2cd11591d3e6a4fe0624c22ab5f) | `` automatic update `` |