### PR TITLE
chore(flake/nix-index-database): `0e3a8778` -> `cc2ddbf2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -566,11 +566,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729999765,
-        "narHash": "sha256-LYsavZXitFjjyETZoij8usXjTa7fa9AIF3Sk3MJSX+Y=",
+        "lastModified": 1730604744,
+        "narHash": "sha256-/MK6QU4iOozJ4oHTfZipGtOgaT/uy/Jm4foCqHQeYR4=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "0e3a8778c2ee218eff8de6aacf3d2fa6c33b2d4f",
+        "rev": "cc2ddbf2df8ef7cc933543b1b42b845ee4772318",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`cc2ddbf2`](https://github.com/nix-community/nix-index-database/commit/cc2ddbf2df8ef7cc933543b1b42b845ee4772318) | `` update generated.nix to release 2024-11-03-031757 `` |
| [`6ac0329a`](https://github.com/nix-community/nix-index-database/commit/6ac0329a7fcd811439df5150b25faeabbef58bec) | `` flake.lock: Update ``                                |