### PR TITLE
chore(flake/nur): `0fdefeac` -> `88b6dea6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730599867,
-        "narHash": "sha256-sjDrezjrAICqxXS1GvuElbYoo932zGeD2YMW0LFk1Po=",
+        "lastModified": 1730612615,
+        "narHash": "sha256-l5mlB45tLEcMGGEucbGs06CvsrXrxGM4NKueWh7Pkuo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0fdefeac8566f50d09ec998231f5afe04c56f845",
+        "rev": "88b6dea6f574d59dd0f3bd48d1da32d37118de34",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`88b6dea6`](https://github.com/nix-community/NUR/commit/88b6dea6f574d59dd0f3bd48d1da32d37118de34) | `` automatic update `` |
| [`b2e6cb78`](https://github.com/nix-community/NUR/commit/b2e6cb78849086ca691645357f103ca38f8ac7c9) | `` automatic update `` |
| [`182d354d`](https://github.com/nix-community/NUR/commit/182d354da5ea1bc4a45d057cd4fc0b6dccc8637d) | `` automatic update `` |
| [`9d661fbc`](https://github.com/nix-community/NUR/commit/9d661fbc5d1a5eef6877dfc482af3a2e86f5ee77) | `` automatic update `` |
| [`591fdb68`](https://github.com/nix-community/NUR/commit/591fdb68dbe68fbd6b819ef4d9111b66727edb65) | `` automatic update `` |
| [`0d79a413`](https://github.com/nix-community/NUR/commit/0d79a4134d8e73080c4084b5ea2f0bb15f12e1e1) | `` automatic update `` |
| [`3fdddf4f`](https://github.com/nix-community/NUR/commit/3fdddf4ffdb49adadeb9d4ec9e01602385c1f460) | `` automatic update `` |