### PR TITLE
chore(flake/emacs-overlay): `693875f2` -> `7cd35bfb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -149,11 +149,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1730596928,
-        "narHash": "sha256-M1IOq+i/RpnBUjgq+q3AvvKNVjxZ82h3V/JwouWVM9o=",
+        "lastModified": 1730626539,
+        "narHash": "sha256-gAivT/gAHhzdRpB+4hBYhLBF51KIj+hvo9J9tbJ6VDU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "693875f2cf5cf94e520dbd0bca4711e4540b864c",
+        "rev": "7cd35bfbe2fbb2906bc85803eab0bdc499b6f253",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`7cd35bfb`](https://github.com/nix-community/emacs-overlay/commit/7cd35bfbe2fbb2906bc85803eab0bdc499b6f253) | `` Updated emacs ``        |
| [`c1235165`](https://github.com/nix-community/emacs-overlay/commit/c12351656d70d7a52ddfdf760d062e98da933845) | `` Updated elpa ``         |
| [`7a0f9b6c`](https://github.com/nix-community/emacs-overlay/commit/7a0f9b6cd046e4f35bf5d5fb59e25fa486594cb4) | `` Updated flake inputs `` |