### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `1889b7b6` -> `ba54beb3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -495,11 +495,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1730553087,
-        "narHash": "sha256-rb0eqWpnFFAWWXOTMefuNwW+eYRkRdnrxSLvGruUzlA=",
+        "lastModified": 1730622971,
+        "narHash": "sha256-hqBTj/DzVjGcPTaDWnRbtRE14D/GQOHTpkE2maYLfyg=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "1889b7b69f5e303dab138b87d7bbaed127e9e126",
+        "rev": "ba54beb3fabb9154440a25732a9894d1188b7930",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                                |
| ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`ba54beb3`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/ba54beb3fabb9154440a25732a9894d1188b7930) | `` Document macOS as supported ``      |
| [`e9eb3eee`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/e9eb3eee0d0385874e0541323eec63479cd6a75c) | `` CI: Run tests on MacOS ``           |
| [`b41fd0f6`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/b41fd0f6af008ad6607af23d78b3c65e9db946ce) | `` Explicitly run tests without GUI `` |