### PR TITLE
chore(flake/nur): `88b6dea6` -> `004f4f8f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -850,11 +850,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730612615,
-        "narHash": "sha256-l5mlB45tLEcMGGEucbGs06CvsrXrxGM4NKueWh7Pkuo=",
+        "lastModified": 1730637657,
+        "narHash": "sha256-7AytYxxgajveX29o9LKKgEDR5VxOHJl1NtiZY0hNXQA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "88b6dea6f574d59dd0f3bd48d1da32d37118de34",
+        "rev": "004f4f8f2f56e8a649227638f1401d1e84697f04",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`004f4f8f`](https://github.com/nix-community/NUR/commit/004f4f8f2f56e8a649227638f1401d1e84697f04) | `` automatic update `` |
| [`b42ad644`](https://github.com/nix-community/NUR/commit/b42ad6446301efc53863515e875bcb0d3f58e4ba) | `` automatic update `` |
| [`28ff2235`](https://github.com/nix-community/NUR/commit/28ff223571435f32579d052ef3932edad83cf500) | `` automatic update `` |
| [`efc73c2c`](https://github.com/nix-community/NUR/commit/efc73c2c6fa2fe3721d64c8360ab70d29bb58663) | `` automatic update `` |
| [`c60087f3`](https://github.com/nix-community/NUR/commit/c60087f397c379f0f5efd14ee6d972fcaa9e9f1a) | `` automatic update `` |