### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `ba54beb3` -> `98931388`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -495,11 +495,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1730622971,
-        "narHash": "sha256-hqBTj/DzVjGcPTaDWnRbtRE14D/GQOHTpkE2maYLfyg=",
+        "lastModified": 1730637309,
+        "narHash": "sha256-jgDzuxBZwfSnr3VYNmzI6UGoxO5MrRMFv1cUrA4y/lQ=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "ba54beb3fabb9154440a25732a9894d1188b7930",
+        "rev": "989313881155b308a2e72a9444d269e9a6508a07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message              |
| ---------------------------------------------------------------------------------------------------------------------- | -------------------- |
| [`98931388`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/989313881155b308a2e72a9444d269e9a6508a07) | `` Pin Doom input `` |