### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `98931388` -> `560a3e44`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730513067,
-        "narHash": "sha256-0MHc5yR4qmQK4O8MzraisT3gnv907fn813Qb2J134CU=",
+        "lastModified": 1730626539,
+        "narHash": "sha256-gAivT/gAHhzdRpB+4hBYhLBF51KIj+hvo9J9tbJ6VDU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6afb2183cef03dcfce47c3bf22b2d44ded54ace0",
+        "rev": "7cd35bfbe2fbb2906bc85803eab0bdc499b6f253",
         "type": "github"
       },
       "original": {
@@ -495,11 +495,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1730637309,
-        "narHash": "sha256-jgDzuxBZwfSnr3VYNmzI6UGoxO5MrRMFv1cUrA4y/lQ=",
+        "lastModified": 1730637497,
+        "narHash": "sha256-ld35QzRuabhDwmL9SH0U3ektDFZqkOgPxNN6VpJZIic=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "989313881155b308a2e72a9444d269e9a6508a07",
+        "rev": "560a3e44c4aa3e51727192eef3a9dd93c574dcdb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                  |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`560a3e44`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/560a3e44c4aa3e51727192eef3a9dd93c574dcdb) | `` flake.lock: Update `` |