### PR TITLE
chore(flake/nur): `004f4f8f` -> `1990a3e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -847,11 +847,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730637657,
-        "narHash": "sha256-7AytYxxgajveX29o9LKKgEDR5VxOHJl1NtiZY0hNXQA=",
+        "lastModified": 1730655194,
+        "narHash": "sha256-B5/Ja3qDt4K5GhUr/l5kfgYEU+pNbqFOGfoAvI7bWd4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "004f4f8f2f56e8a649227638f1401d1e84697f04",
+        "rev": "1990a3e6c45c9a85b239dca73f8b13ec2214806c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1990a3e6`](https://github.com/nix-community/NUR/commit/1990a3e6c45c9a85b239dca73f8b13ec2214806c) | `` automatic update `` |