### PR TITLE
chore(flake/nur): `1990a3e6` -> `32892eee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -847,11 +847,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730655194,
-        "narHash": "sha256-B5/Ja3qDt4K5GhUr/l5kfgYEU+pNbqFOGfoAvI7bWd4=",
+        "lastModified": 1730661288,
+        "narHash": "sha256-o6mpqPB5FtbX/UiT012G0IgW1J9aXpL0g6eEPUXhshQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1990a3e6c45c9a85b239dca73f8b13ec2214806c",
+        "rev": "32892eee6299e1948ccc7708680f503359205432",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`32892eee`](https://github.com/nix-community/NUR/commit/32892eee6299e1948ccc7708680f503359205432) | `` automatic update `` |
| [`f9845334`](https://github.com/nix-community/NUR/commit/f984533422fba1872b8b4191bbb489ce83981d18) | `` automatic update `` |
| [`805e768e`](https://github.com/nix-community/NUR/commit/805e768e781baae448a5f7300e49ed7fc99257c4) | `` automatic update `` |