### PR TITLE
chore(flake/nixos-cosmic): `db397534` -> `9ae6f201`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -609,11 +609,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1730597759,
-        "narHash": "sha256-DStWygV/fV3aU8VWN4wIG4Mjpq7s540gUD4A103u+Zo=",
+        "lastModified": 1730690910,
+        "narHash": "sha256-iojrqmdTxd4ywibCdZYltMEqedlmz6cCF4H5GOOSxMk=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "db3975340480a6c2532398991f3a47f74df17eed",
+        "rev": "9ae6f20152e5b850886d26c5ce5f167aa51cd52f",
         "type": "github"
       },
       "original": {
@@ -761,11 +761,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1730200266,
-        "narHash": "sha256-l253w0XMT8nWHGXuXqyiIC/bMvh1VRszGXgdpQlfhvU=",
+        "lastModified": 1730531603,
+        "narHash": "sha256-Dqg6si5CqIzm87sp57j5nTaeBbWhHFaVyG7V6L8k3lY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "807e9154dcb16384b1b765ebe9cd2bba2ac287fd",
+        "rev": "7ffd9ae656aec493492b44d0ddfb28e79a1ea25d",
         "type": "github"
       },
       "original": {
@@ -923,11 +923,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730514457,
-        "narHash": "sha256-cjFX208s9pyaOfMvF9xI6WyafyXINqdhMF7b1bMQpLI=",
+        "lastModified": 1730601085,
+        "narHash": "sha256-Sgax33jGuvVHTjl1P78IwzlhAGyOxtx5Q26inKja8S4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "1ff38ca26eb31858e4dfe7fe738b6b3ce5d74922",
+        "rev": "8d1b40f8dfd7539aaa3de56e207e22b3cc451825",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                         |
| ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`9ae6f201`](https://github.com/lilyinstarlight/nixos-cosmic/commit/9ae6f20152e5b850886d26c5ce5f167aa51cd52f) | `` flake: update inputs (#460) ``                               |
| [`5a8893df`](https://github.com/lilyinstarlight/nixos-cosmic/commit/5a8893df05ebb4e5eae6e188228ea9be9628dd9a) | `` cosmic-wallpapers: update licenses after upstream changes `` |
| [`5716def4`](https://github.com/lilyinstarlight/nixos-cosmic/commit/5716def4259f0061735590cffe7aea5d9caa7424) | `` vm: add gnome-keyring for testing ``                         |
| [`37da426d`](https://github.com/lilyinstarlight/nixos-cosmic/commit/37da426d2a8395f37b1e45dc647364abc58460e8) | `` pkgs: update cosmic (#455) ``                                |