### PR TITLE
chore(flake/emacs-overlay): `0cfc0c58` -> `3cbb5319`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1730653844,
-        "narHash": "sha256-1eSSNp/OeLD//sAEHSvc4MRERiNjpG71/iVXHVPKf/A=",
+        "lastModified": 1730683519,
+        "narHash": "sha256-JsaxXQEI76Lq6c5KVAzcAvNox0qEzJfC5+bYZqtySCk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0cfc0c58951dba55ad311ebc8bc5b29cda76eb47",
+        "rev": "3cbb531951b8abd4413ebc04a4e06d214de3cf04",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                               |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
| [`3cbb5319`](https://github.com/nix-community/emacs-overlay/commit/3cbb531951b8abd4413ebc04a4e06d214de3cf04) | `` Updated emacs ``                                   |
| [`adb0aaf9`](https://github.com/nix-community/emacs-overlay/commit/adb0aaf917ad499dcce27eb90a207e2f19a4cc4c) | `` Updated melpa ``                                   |
| [`8aa36a59`](https://github.com/nix-community/emacs-overlay/commit/8aa36a5940db29645a01036dbaedfef785b04524) | `` melpa: Hack update script not to use broken nix `` |
| [`9251d6e1`](https://github.com/nix-community/emacs-overlay/commit/9251d6e1366dfa5f9efebb3d4dc62fbb964b7e29) | `` Updated elpa ``                                    |
| [`b6133350`](https://github.com/nix-community/emacs-overlay/commit/b613335061c4e924ac6aa2704e9af5a001f19b55) | `` Updated nongnu ``                                  |
| [`c9f00a77`](https://github.com/nix-community/emacs-overlay/commit/c9f00a771906077a8c41272a6c38af7a2ed7df41) | `` ci: Pin Nix to 2.18.9 ``                           |