### PR TITLE
chore(flake/nur): `32892eee` -> `e8da0ed9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -847,11 +847,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730661288,
-        "narHash": "sha256-o6mpqPB5FtbX/UiT012G0IgW1J9aXpL0g6eEPUXhshQ=",
+        "lastModified": 1730677585,
+        "narHash": "sha256-P5UbHhsuw6/cmohi1UY2kNHcnvODHPnsr/NfsQWKCiw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "32892eee6299e1948ccc7708680f503359205432",
+        "rev": "e8da0ed9265ebaf94839d910a0c168b9941aa2ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e8da0ed9`](https://github.com/nix-community/NUR/commit/e8da0ed9265ebaf94839d910a0c168b9941aa2ed) | `` automatic update `` |