### PR TITLE
chore(flake/srvos): `b80b3ffa` -> `a9f2ae9f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -980,11 +980,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730335989,
-        "narHash": "sha256-hG7H+EcNZfNa5tsUzMX+NBYpG4viCTvfRp5t7ZUnKW8=",
+        "lastModified": 1730682372,
+        "narHash": "sha256-GU8ghhVS7ctcV4Cy1W3X/N6KtmJNVptirIzkA7NMxp8=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "b80b3ffabd20e39b579f45a33e638bbb1b297b60",
+        "rev": "a9f2ae9fb213b6175c71cd6aecfdb366979d2e0c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                       |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`a9f2ae9f`](https://github.com/nix-community/srvos/commit/a9f2ae9fb213b6175c71cd6aecfdb366979d2e0c) | `` darwin/mixins/terminfo: disable termite `` |
| [`ea727370`](https://github.com/nix-community/srvos/commit/ea72737047c4c7755864fdc8edcd6299aa3cb5bc) | `` dev/private/flake.lock: Update ``          |
| [`b20dc8c0`](https://github.com/nix-community/srvos/commit/b20dc8c05bd4f9bcd6d2be4597d55112f498680e) | `` flake.lock: Update ``                      |