### PR TITLE
chore(flake/nur): `e8da0ed9` -> `c93a8b80`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -847,11 +847,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730677585,
-        "narHash": "sha256-P5UbHhsuw6/cmohi1UY2kNHcnvODHPnsr/NfsQWKCiw=",
+        "lastModified": 1730689544,
+        "narHash": "sha256-FomWwCfdau6KMCEpDv0M/+m2CWUh8+5qDTzYuKl29f4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e8da0ed9265ebaf94839d910a0c168b9941aa2ed",
+        "rev": "c93a8b8003a9ca7a559cab8271437ba4a885c61a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c93a8b80`](https://github.com/nix-community/NUR/commit/c93a8b8003a9ca7a559cab8271437ba4a885c61a) | `` automatic update `` |
| [`b418bdcc`](https://github.com/nix-community/NUR/commit/b418bdcc469c326a5d9513ca15f83266cf473e5d) | `` automatic update `` |
| [`a8e20c8f`](https://github.com/nix-community/NUR/commit/a8e20c8f534b7b74443ef7270430e36e60e81380) | `` automatic update `` |
| [`b8e44313`](https://github.com/nix-community/NUR/commit/b8e443136be2f650ed7b79b4562367f50712bf6d) | `` automatic update `` |
| [`1884e8eb`](https://github.com/nix-community/NUR/commit/1884e8eb3bb31d58624c203c31e75643bfb8699d) | `` automatic update `` |