### PR TITLE
chore(flake/nur): `c93a8b80` -> `a1400ee4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -847,11 +847,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730689544,
-        "narHash": "sha256-FomWwCfdau6KMCEpDv0M/+m2CWUh8+5qDTzYuKl29f4=",
+        "lastModified": 1730692040,
+        "narHash": "sha256-uq54Ul4d0GpVCN7N3wITXeyJ6oID85qEbwvGSlyeA9I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c93a8b8003a9ca7a559cab8271437ba4a885c61a",
+        "rev": "a1400ee460a8a2663c2c1597b144be300cc393d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a1400ee4`](https://github.com/nix-community/NUR/commit/a1400ee460a8a2663c2c1597b144be300cc393d6) | `` automatic update `` |
| [`54ba0152`](https://github.com/nix-community/NUR/commit/54ba0152a14c9268fcebfa582a006a95deb4a7ec) | `` automatic update `` |