### PR TITLE
chore(flake/nur): `a1400ee4` -> `3613297c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -847,11 +847,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730692040,
-        "narHash": "sha256-uq54Ul4d0GpVCN7N3wITXeyJ6oID85qEbwvGSlyeA9I=",
+        "lastModified": 1730695599,
+        "narHash": "sha256-0pkVFO2ogrIPAsS14UcPOTKXk4fzek0iXBlG542p9P8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a1400ee460a8a2663c2c1597b144be300cc393d6",
+        "rev": "3613297c9973e78120e3bbb776d47874dfcd11ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3613297c`](https://github.com/nix-community/NUR/commit/3613297c9973e78120e3bbb776d47874dfcd11ac) | `` automatic update `` |
| [`c09c9720`](https://github.com/nix-community/NUR/commit/c09c972084cb9367f3b61fd4968b14f329c7b7bf) | `` automatic update `` |