### PR TITLE
chore(flake/nur): `3613297c` -> `d6500750`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -847,11 +847,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730695599,
-        "narHash": "sha256-0pkVFO2ogrIPAsS14UcPOTKXk4fzek0iXBlG542p9P8=",
+        "lastModified": 1730706378,
+        "narHash": "sha256-p9Gk1m2mi76JUV2Q2O0Z47N2CFhu68qsCgSsr1nFT04=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3613297c9973e78120e3bbb776d47874dfcd11ac",
+        "rev": "d6500750bf0cf8133ed0c13fe897fed623dac703",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d6500750`](https://github.com/nix-community/NUR/commit/d6500750bf0cf8133ed0c13fe897fed623dac703) | `` automatic update `` |
| [`6c339fda`](https://github.com/nix-community/NUR/commit/6c339fda9e3b3926672748f5c48fc3fd1b6746c4) | `` automatic update `` |
| [`2b06cac2`](https://github.com/nix-community/NUR/commit/2b06cac2a490c2b524090aac35864a4d5bf9b033) | `` automatic update `` |
| [`fa8a677e`](https://github.com/nix-community/NUR/commit/fa8a677ed025fd4130efcd4dec0bcb39b6432758) | `` automatic update `` |
| [`ed22981b`](https://github.com/nix-community/NUR/commit/ed22981bf479b8e03d8a9a86a844cf7fb3cc5a89) | `` automatic update `` |