### PR TITLE
chore(flake/nur): `d6500750` -> `dc45934d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730706378,
-        "narHash": "sha256-p9Gk1m2mi76JUV2Q2O0Z47N2CFhu68qsCgSsr1nFT04=",
+        "lastModified": 1730724255,
+        "narHash": "sha256-bAXc/H2ox+lfN/J0eCdrPPV1g+0a2GIjy2Tn/1NPUTs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d6500750bf0cf8133ed0c13fe897fed623dac703",
+        "rev": "dc45934dd2561c26c65c6a6fb6917ed773803ead",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dc45934d`](https://github.com/nix-community/NUR/commit/dc45934dd2561c26c65c6a6fb6917ed773803ead) | `` automatic update `` |
| [`4a9ef04e`](https://github.com/nix-community/NUR/commit/4a9ef04ed3048a17b50a11499e7f08d2ff00080c) | `` automatic update `` |
| [`ebaba584`](https://github.com/nix-community/NUR/commit/ebaba584d46e6df580964968200011b3c8972910) | `` automatic update `` |
| [`12c84364`](https://github.com/nix-community/NUR/commit/12c84364e498caa394eaad290591f19eb5264f74) | `` automatic update `` |
| [`0aa65807`](https://github.com/nix-community/NUR/commit/0aa65807dd2381ae681ae4e3d43829c4fdad0f39) | `` automatic update `` |
| [`9e23637c`](https://github.com/nix-community/NUR/commit/9e23637c9d10e9445d4920b8f9626f7fdada7c48) | `` automatic update `` |
| [`6720812c`](https://github.com/nix-community/NUR/commit/6720812cce88e6bcd4fd20a081d2c48303e0388c) | `` automatic update `` |
| [`ceed636a`](https://github.com/nix-community/NUR/commit/ceed636ae6821c166f2d53a8adcd9d56a9e143c5) | `` automatic update `` |