### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `0e06177a` -> `a78d26b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -473,11 +473,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1730709541,
-        "narHash": "sha256-v3DX2wuwDvSjTLCuBWDX0o38TojyG8PGzXoF/p6stLA=",
+        "lastModified": 1730717277,
+        "narHash": "sha256-01K4n9V96nG4jM0tpkRJe/Vwq6LiA0DJzBI8zyMIbHM=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "0e06177aa5ff1392b6e57ce62ef99ebaae5798bc",
+        "rev": "a78d26b4f344c1b44d8891343149a73717e8b8a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message              |
| ---------------------------------------------------------------------------------------------------------------------- | -------------------- |
| [`a78d26b4`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/a78d26b4f344c1b44d8891343149a73717e8b8a1) | `` Drop forge pin `` |