### PR TITLE
chore(flake/nur): `dc45934d` -> `07201e5c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730724255,
-        "narHash": "sha256-bAXc/H2ox+lfN/J0eCdrPPV1g+0a2GIjy2Tn/1NPUTs=",
+        "lastModified": 1730728169,
+        "narHash": "sha256-t9SjIrqQqXql1vTE6LzDs2xzKWOwYe/EXuAB+wMvhZ8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dc45934dd2561c26c65c6a6fb6917ed773803ead",
+        "rev": "07201e5cd4833c1fbc0b7dd95e68615a98c1d31d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`07201e5c`](https://github.com/nix-community/NUR/commit/07201e5cd4833c1fbc0b7dd95e68615a98c1d31d) | `` automatic update `` |
| [`a8c7e68a`](https://github.com/nix-community/NUR/commit/a8c7e68a5f863b049a71b0327b70d4f51ab8b3aa) | `` automatic update `` |