### PR TITLE
chore(flake/nur): `07201e5c` -> `f00b0903`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730728169,
-        "narHash": "sha256-t9SjIrqQqXql1vTE6LzDs2xzKWOwYe/EXuAB+wMvhZ8=",
+        "lastModified": 1730731540,
+        "narHash": "sha256-RuLmeGqZV+k2Qa/QlZiAybEqFlDB/S4GmeD/7grU13w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "07201e5cd4833c1fbc0b7dd95e68615a98c1d31d",
+        "rev": "f00b0903212956dff694732c646cc4255e73c2ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f00b0903`](https://github.com/nix-community/NUR/commit/f00b0903212956dff694732c646cc4255e73c2ab) | `` automatic update `` |
| [`94b7b475`](https://github.com/nix-community/NUR/commit/94b7b475e604b4aafb454a75ed22a72017c29462) | `` automatic update `` |
| [`990ebc38`](https://github.com/nix-community/NUR/commit/990ebc38acfabc59fc612017b6be19101d235a89) | `` automatic update `` |
| [`ddf24a95`](https://github.com/nix-community/NUR/commit/ddf24a953cf4d33e208c1ac62dc25f13ccf3a5bd) | `` automatic update `` |