### PR TITLE
chore(flake/emacs-overlay): `ca2129b1` -> `8d1826ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1730711584,
-        "narHash": "sha256-7XpfL6x0or0qH3NjtiujcyUzFrZu72b/pyLCbwk0+2s=",
+        "lastModified": 1730739613,
+        "narHash": "sha256-UNwS+2868c7B1CcInYTZfCKj+DlChm6BbEL5m/VtbDY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ca2129b1d5afb32e46299dc48e03467522352bd5",
+        "rev": "8d1826ba7648bd2704c6beed35a9e9e3327178d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`8d1826ba`](https://github.com/nix-community/emacs-overlay/commit/8d1826ba7648bd2704c6beed35a9e9e3327178d1) | `` Updated melpa ``  |
| [`71531b9b`](https://github.com/nix-community/emacs-overlay/commit/71531b9ba1ca6eb5ae812c5f85c0c932d2fd8de4) | `` Updated elpa ``   |
| [`14649cb9`](https://github.com/nix-community/emacs-overlay/commit/14649cb9b85ff80801214c8fe080009bbd8dc383) | `` Updated nongnu `` |