### PR TITLE
chore(flake/nur): `f00b0903` -> `3c7a4532`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730731540,
-        "narHash": "sha256-RuLmeGqZV+k2Qa/QlZiAybEqFlDB/S4GmeD/7grU13w=",
+        "lastModified": 1730742119,
+        "narHash": "sha256-npA4wtBgm9s5C0ElDYkyiBXeBGsxDqT6e7sPGwtDLFc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f00b0903212956dff694732c646cc4255e73c2ab",
+        "rev": "3c7a45327b6a9f8b02df8d3acf213fd0616d59ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3c7a4532`](https://github.com/nix-community/NUR/commit/3c7a45327b6a9f8b02df8d3acf213fd0616d59ef) | `` automatic update `` |
| [`a893a2fe`](https://github.com/nix-community/NUR/commit/a893a2fe687bb69c267d5ae7fa3f42b8d735ecbd) | `` automatic update `` |