### PR TITLE
chore(flake/sops-nix): `e9b5eef9` -> `59d69883`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -941,11 +941,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1730605784,
-        "narHash": "sha256-1NveNAMLHbxOg0BpBMSVuZ2yW2PpDnZLbZ25wV50PMc=",
+        "lastModified": 1730746162,
+        "narHash": "sha256-ZGmI+3AbT8NkDdBQujF+HIxZ+sWXuyT6X8B49etWY2g=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "e9b5eef9b51cdf966c76143e13a9476725b2f760",
+        "rev": "59d6988329626132eaf107761643f55eb979eef1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                       |
| ----------------------------------------------------------------------------------------------- | ----------------------------- |
| [`59d69883`](https://github.com/Mic92/sops-nix/commit/59d6988329626132eaf107761643f55eb979eef1) | `` Fix module declarations `` |