### PR TITLE
chore(flake/nur): `3c7a4532` -> `b73273c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730742119,
-        "narHash": "sha256-npA4wtBgm9s5C0ElDYkyiBXeBGsxDqT6e7sPGwtDLFc=",
+        "lastModified": 1730752943,
+        "narHash": "sha256-KGJpGaFpZdhrUJqXc3ZyI4ALcedW8Fm2zuFpDItj+ds=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3c7a45327b6a9f8b02df8d3acf213fd0616d59ef",
+        "rev": "b73273c89b6cd4f8d845ef0374647638c60496c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b73273c8`](https://github.com/nix-community/NUR/commit/b73273c89b6cd4f8d845ef0374647638c60496c3) | `` automatic update `` |
| [`27ef0fba`](https://github.com/nix-community/NUR/commit/27ef0fba0927d02c697a47d5f68658de1c9ac0b4) | `` automatic update `` |
| [`9047a1ea`](https://github.com/nix-community/NUR/commit/9047a1ea2401169b09e5b8914ab267f93f6df4a7) | `` automatic update `` |