### PR TITLE
chore(flake/nur): `4ad55c01` -> `2723e4e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730756809,
-        "narHash": "sha256-os3GysGFCfRxOztO99J7h4WLybRlvLtbmPw1u0SL2Zs=",
+        "lastModified": 1730760310,
+        "narHash": "sha256-jWW+1+YivuO9PLf4mmPOliqlFPPzkypEU0hnwBoQM2A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ad55c01c89c310302475c287e2d9602fb9edfab",
+        "rev": "2723e4e5073ac0ae4ec107cd75697df6b1165603",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2723e4e5`](https://github.com/nix-community/NUR/commit/2723e4e5073ac0ae4ec107cd75697df6b1165603) | `` automatic update `` |