### PR TITLE
chore(flake/nur): `2723e4e5` -> `50bb1583`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730760310,
-        "narHash": "sha256-jWW+1+YivuO9PLf4mmPOliqlFPPzkypEU0hnwBoQM2A=",
+        "lastModified": 1730778547,
+        "narHash": "sha256-G8sV7J82k1dCiy4eU5ieq94iZVkCLeD8tIR3Zcd/ocY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2723e4e5073ac0ae4ec107cd75697df6b1165603",
+        "rev": "50bb158324a38d1c306e7b31fa0e96e585110e1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`50bb1583`](https://github.com/nix-community/NUR/commit/50bb158324a38d1c306e7b31fa0e96e585110e1f) | `` automatic update `` |
| [`1a0e2122`](https://github.com/nix-community/NUR/commit/1a0e212254c7c720f2f9b3759c706d15f9193288) | `` automatic update `` |
| [`585392c4`](https://github.com/nix-community/NUR/commit/585392c41497111219603a7cb3077817f184a860) | `` automatic update `` |
| [`0a3b6703`](https://github.com/nix-community/NUR/commit/0a3b6703e3a15b50254a058d6108948e7a0ae764) | `` automatic update `` |
| [`4f733717`](https://github.com/nix-community/NUR/commit/4f73371746aa590d640b2e9654c8b821c913bada) | `` automatic update `` |
| [`ec55b248`](https://github.com/nix-community/NUR/commit/ec55b248ec616c3546ff6b84e559fe48efde0ca5) | `` automatic update `` |
| [`98ac4ac9`](https://github.com/nix-community/NUR/commit/98ac4ac90433498454568d7d177670fd4b2ee2b0) | `` automatic update `` |