### PR TITLE
chore(flake/nixos-cosmic): `9ae6f201` -> `c62f5e8c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -590,11 +590,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1730690910,
-        "narHash": "sha256-iojrqmdTxd4ywibCdZYltMEqedlmz6cCF4H5GOOSxMk=",
+        "lastModified": 1730776371,
+        "narHash": "sha256-qLH/qtoBoKZJ5I2Ry312jCVJTfXu6XcCdcXPPAyJhBM=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "9ae6f20152e5b850886d26c5ce5f167aa51cd52f",
+        "rev": "c62f5e8c7a9a1ebc4013b617e0e054011c747d49",
         "type": "github"
       },
       "original": {
@@ -710,11 +710,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1730327045,
-        "narHash": "sha256-xKel5kd1AbExymxoIfQ7pgcX6hjw9jCgbiBjiUfSVJ8=",
+        "lastModified": 1730602179,
+        "narHash": "sha256-efgLzQAWSzJuCLiCaQUCDu4NudNlHdg2NzGLX5GYaEY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "080166c15633801df010977d9d7474b4a6c549d7",
+        "rev": "3c2f1c4ca372622cb2f9de8016c9a0b1cbd0f37c",
         "type": "github"
       },
       "original": {
@@ -904,11 +904,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730601085,
-        "narHash": "sha256-Sgax33jGuvVHTjl1P78IwzlhAGyOxtx5Q26inKja8S4=",
+        "lastModified": 1730687492,
+        "narHash": "sha256-xQVadjquBA/tFxDt5A55LJ1D1AvkVWsnrKC2o+pr8F4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8d1b40f8dfd7539aaa3de56e207e22b3cc451825",
+        "rev": "41814763a2c597755b0755dbe3e721367a5e420f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                                     |
| ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`c62f5e8c`](https://github.com/lilyinstarlight/nixos-cosmic/commit/c62f5e8c7a9a1ebc4013b617e0e054011c747d49) | `` pkgs: update cosmic (#459) ``                                            |
| [`b279b477`](https://github.com/lilyinstarlight/nixos-cosmic/commit/b279b477ba7c5342054d43f3bad4776f267871ef) | `` flake: update inputs (#462) ``                                           |
| [`ae6260b9`](https://github.com/lilyinstarlight/nixos-cosmic/commit/ae6260b9048edb4159c3dd0983eead49bcef19e2) | `` ci: bump DeterminateSystems/nix-installer-action from 14 to 15 (#461) `` |