### PR TITLE
chore(flake/emacs-overlay): `8d1826ba` -> `426cb9df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1730739613,
-        "narHash": "sha256-UNwS+2868c7B1CcInYTZfCKj+DlChm6BbEL5m/VtbDY=",
+        "lastModified": 1730771469,
+        "narHash": "sha256-23QaKZ8/sYuLXXvuePSFOXGl48oKebUO2ePm+bV88Ik=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8d1826ba7648bd2704c6beed35a9e9e3327178d1",
+        "rev": "426cb9df18290e06fe1820da6cb716a2599839f3",
         "type": "github"
       },
       "original": {
@@ -678,11 +678,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1730327045,
-        "narHash": "sha256-xKel5kd1AbExymxoIfQ7pgcX6hjw9jCgbiBjiUfSVJ8=",
+        "lastModified": 1730602179,
+        "narHash": "sha256-efgLzQAWSzJuCLiCaQUCDu4NudNlHdg2NzGLX5GYaEY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "080166c15633801df010977d9d7474b4a6c549d7",
+        "rev": "3c2f1c4ca372622cb2f9de8016c9a0b1cbd0f37c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`426cb9df`](https://github.com/nix-community/emacs-overlay/commit/426cb9df18290e06fe1820da6cb716a2599839f3) | `` Updated melpa ``        |
| [`b704abc3`](https://github.com/nix-community/emacs-overlay/commit/b704abc3cd77700ae76d7e50b518d36231113649) | `` Updated elpa ``         |
| [`d063bcd7`](https://github.com/nix-community/emacs-overlay/commit/d063bcd7962998e302fcf567ac50376d1d0646a2) | `` Updated nongnu ``       |
| [`7d5f5d41`](https://github.com/nix-community/emacs-overlay/commit/7d5f5d41bf8eaf301b845ea056cba808573bee98) | `` Updated flake inputs `` |