### PR TITLE
chore(flake/nur): `50bb1583` -> `d17cb4d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730778547,
-        "narHash": "sha256-G8sV7J82k1dCiy4eU5ieq94iZVkCLeD8tIR3Zcd/ocY=",
+        "lastModified": 1730779796,
+        "narHash": "sha256-5J3jgJ923OdtEjyt3xFLyLkxGqGdn6oYUiC+dDCDL44=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "50bb158324a38d1c306e7b31fa0e96e585110e1f",
+        "rev": "d17cb4d177a40e5cedc04719af56571e7ef643a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d17cb4d1`](https://github.com/nix-community/NUR/commit/d17cb4d177a40e5cedc04719af56571e7ef643a7) | `` automatic update `` |