### PR TITLE
chore(flake/nur): `80896fda` -> `689c78bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730792058,
-        "narHash": "sha256-3FCgErecf85iO1bqdz0Xe6OxphoS1Gr6DfFjYyUivo0=",
+        "lastModified": 1730795826,
+        "narHash": "sha256-5eUMYntBzgV2EPdPWY4acON2vc4zWrRR7rOJifTqrIE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "80896fda85c394da208104807fc00866aecf06a9",
+        "rev": "689c78bc78b5a3aa0e86a2f5cd25a266015791ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`689c78bc`](https://github.com/nix-community/NUR/commit/689c78bc78b5a3aa0e86a2f5cd25a266015791ee) | `` automatic update `` |
| [`9a7f8a8c`](https://github.com/nix-community/NUR/commit/9a7f8a8c1aebf5e762e74d876dbbb0cfa6b57544) | `` automatic update `` |