### PR TITLE
chore(flake/git-hooks): `af8a16fe` -> `1864030e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -326,11 +326,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1730302582,
-        "narHash": "sha256-W1MIJpADXQCgosJZT8qBYLRuZls2KSiKdpnTVdKBuvU=",
+        "lastModified": 1730797577,
+        "narHash": "sha256-SrID5yVpyUfknUTGWgYkTyvdr9J1LxUym4om3SVGPkg=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "af8a16fe5c264f5e9e18bcee2859b40a656876cf",
+        "rev": "1864030ed24a2b8b4e4d386a5eeaf0c5369e50a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                 |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`04db8c18`](https://github.com/cachix/git-hooks.nix/commit/04db8c18ca4667986514ef81dc93d88998e9438d) | `` fix: poetry option is not defined `` |
| [`92495abe`](https://github.com/cachix/git-hooks.nix/commit/92495abe55afe79f1f7b23a0b304d8dc3fa29740) | `` fix: poetry option is not defined `` |