### PR TITLE
chore(flake/nur): `689c78bc` -> `d239d9e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730795826,
-        "narHash": "sha256-5eUMYntBzgV2EPdPWY4acON2vc4zWrRR7rOJifTqrIE=",
+        "lastModified": 1730818022,
+        "narHash": "sha256-65XWIVBMViT6fsyEKDdIXOE98UB1rq0PHIpFKH2bZGg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "689c78bc78b5a3aa0e86a2f5cd25a266015791ee",
+        "rev": "d239d9e41525121dde6ff1a29cfad42f9681ac4c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d239d9e4`](https://github.com/nix-community/NUR/commit/d239d9e41525121dde6ff1a29cfad42f9681ac4c) | `` automatic update `` |
| [`6a60b7ee`](https://github.com/nix-community/NUR/commit/6a60b7eecf957eff338a7af89e84b692d4b6019a) | `` automatic update `` |
| [`5561a0fc`](https://github.com/nix-community/NUR/commit/5561a0fc7aeef14f2b47dc880aefe0e758c547a6) | `` automatic update `` |
| [`ca44a5d7`](https://github.com/nix-community/NUR/commit/ca44a5d7c23565c5aae7bab98ba08e121401e0f6) | `` automatic update `` |
| [`e356541e`](https://github.com/nix-community/NUR/commit/e356541e9a30c987e72f994011770c385322ad67) | `` automatic update `` |
| [`ca7969ff`](https://github.com/nix-community/NUR/commit/ca7969ff2ec6ffc542dcf37c9fff09068938be1a) | `` automatic update `` |