### PR TITLE
chore(flake/emacs-overlay): `0c0c0dba` -> `1febd5c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1730798123,
-        "narHash": "sha256-olT8nqVIOx5A3F1qrO+lQtiJY55gtKGt0bUzkEwEyVE=",
+        "lastModified": 1730826798,
+        "narHash": "sha256-QE7sHcAIolvAMbHSWZQ5nB2R17C2R/9YB5Q6CR70Hug=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0c0c0dba05690c02ea7d508fd59389052c5f6438",
+        "rev": "1febd5c1ad7e798543c886756c598e0fb8d473fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`1febd5c1`](https://github.com/nix-community/emacs-overlay/commit/1febd5c1ad7e798543c886756c598e0fb8d473fd) | `` Updated emacs ``  |
| [`fdbf7efb`](https://github.com/nix-community/emacs-overlay/commit/fdbf7efbc9f7cfefd3f8429120f60d9ae78708e3) | `` Updated melpa ``  |
| [`f283ea8e`](https://github.com/nix-community/emacs-overlay/commit/f283ea8ea3c82e0ffc29a12615a947a9a410f213) | `` Updated elpa ``   |
| [`a05b1f74`](https://github.com/nix-community/emacs-overlay/commit/a05b1f74147d1b4d9997c58f802bcfe50c007e38) | `` Updated nongnu `` |