### PR TITLE
chore(flake/nur): `d239d9e4` -> `b6dfe07f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730818022,
-        "narHash": "sha256-65XWIVBMViT6fsyEKDdIXOE98UB1rq0PHIpFKH2bZGg=",
+        "lastModified": 1730823871,
+        "narHash": "sha256-MT1XsWcjs1KwTKW/sotRXbprpx2Iu1hA43pvXVWEC04=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d239d9e41525121dde6ff1a29cfad42f9681ac4c",
+        "rev": "b6dfe07fa068a474d6b3fffa1c83efc55a9c63dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b6dfe07f`](https://github.com/nix-community/NUR/commit/b6dfe07fa068a474d6b3fffa1c83efc55a9c63dc) | `` automatic update `` |