### PR TITLE
chore(flake/nur): `b6dfe07f` -> `c68e686c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730823871,
-        "narHash": "sha256-MT1XsWcjs1KwTKW/sotRXbprpx2Iu1hA43pvXVWEC04=",
+        "lastModified": 1730832632,
+        "narHash": "sha256-S4drRHRb42uqXfYLHl+oZsvFdo2LSJFXFhNtqGfumDI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b6dfe07fa068a474d6b3fffa1c83efc55a9c63dc",
+        "rev": "c68e686c8d16ab2e89996f3cac9b3a14b52aa342",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c68e686c`](https://github.com/nix-community/NUR/commit/c68e686c8d16ab2e89996f3cac9b3a14b52aa342) | `` automatic update `` |
| [`19c98c09`](https://github.com/nix-community/NUR/commit/19c98c09e3061f8dca5510412a2995e78a6f1bad) | `` automatic update `` |
| [`3c952762`](https://github.com/nix-community/NUR/commit/3c952762b854563826531e925260350a6aad79a7) | `` automatic update `` |