### PR TITLE
chore(flake/nixos-hardware): `1b0b9278` -> `2e78b1af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -605,11 +605,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1730797322,
-        "narHash": "sha256-cH9emjYIbDYTde/CKOmU97rh7sKuyfedzPcTz4OTJkE=",
+        "lastModified": 1730828750,
+        "narHash": "sha256-XrnZLkLiBYNlwV5gus/8DT7nncF1TS5la6Be7rdVOpI=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "1b0b927860d7eb367ee6a3123ddeb7a8e24bd836",
+        "rev": "2e78b1af8025108ecd6edaa3ab09695b8a4d3d55",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                            |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`df8450fa`](https://github.com/NixOS/nixos-hardware/commit/df8450fa268551003c0b29abc455cd9a5c494d9d) | `` microsoft/surface: Remove old kernel version `` |
| [`097c476b`](https://github.com/NixOS/nixos-hardware/commit/097c476b076300e0f44e2a804ad472ca3da395d4) | `` microsoft/surface: Update to kernel 6.11.4 ``   |