### PR TITLE
chore(flake/nur): `c68e686c` -> `dee01da6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730832632,
-        "narHash": "sha256-S4drRHRb42uqXfYLHl+oZsvFdo2LSJFXFhNtqGfumDI=",
+        "lastModified": 1730846050,
+        "narHash": "sha256-G7z96CG11PVoBwZFFaak5jmXLY+z6d9Y1/aJBvy0YeI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c68e686c8d16ab2e89996f3cac9b3a14b52aa342",
+        "rev": "dee01da6357dd27c51d5a59237affd11eaee4a75",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dee01da6`](https://github.com/nix-community/NUR/commit/dee01da6357dd27c51d5a59237affd11eaee4a75) | `` automatic update `` |
| [`428b7e32`](https://github.com/nix-community/NUR/commit/428b7e320ba46639bd454dcad8567691731cbf0e) | `` automatic update `` |