### PR TITLE
chore(flake/nur): `dee01da6` -> `b7fc2b10`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730846050,
-        "narHash": "sha256-G7z96CG11PVoBwZFFaak5jmXLY+z6d9Y1/aJBvy0YeI=",
+        "lastModified": 1730860149,
+        "narHash": "sha256-dBt0jt/EWGRXpHqJ3pcc4aqCRaZkvRRISk+HOinbXhg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dee01da6357dd27c51d5a59237affd11eaee4a75",
+        "rev": "b7fc2b100096a696181e485fe2dfd57c43dcb108",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b7fc2b10`](https://github.com/nix-community/NUR/commit/b7fc2b100096a696181e485fe2dfd57c43dcb108) | `` automatic update `` |
| [`a594d91f`](https://github.com/nix-community/NUR/commit/a594d91f20acd78c52d5725741c08aac408dde1f) | `` automatic update `` |
| [`02d13964`](https://github.com/nix-community/NUR/commit/02d13964dc99bac6e32005b87ee618d08d7ffd87) | `` automatic update `` |
| [`61dab23c`](https://github.com/nix-community/NUR/commit/61dab23cbfec1301817dbd5d6dc247e064c94831) | `` automatic update `` |
| [`caba193f`](https://github.com/nix-community/NUR/commit/caba193fb0db2b71403f015344923c7028f1267c) | `` automatic update `` |
| [`4df3089e`](https://github.com/nix-community/NUR/commit/4df3089e56a9627be7dda84ff467252add280b1a) | `` automatic update `` |
| [`f18a0b0b`](https://github.com/nix-community/NUR/commit/f18a0b0b6eb6094f642f6e5c5cc2ba80c0adb202) | `` automatic update `` |