### PR TITLE
chore(flake/nur): `b7fc2b10` -> `706e00a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730860149,
-        "narHash": "sha256-dBt0jt/EWGRXpHqJ3pcc4aqCRaZkvRRISk+HOinbXhg=",
+        "lastModified": 1730864891,
+        "narHash": "sha256-OE6c+baQQPTrtCLQtLY5E/V9TXsEl6/i1JolZjhQ61Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b7fc2b100096a696181e485fe2dfd57c43dcb108",
+        "rev": "706e00a40d3e36f128f5a82b14dabccec522c26a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`706e00a4`](https://github.com/nix-community/NUR/commit/706e00a40d3e36f128f5a82b14dabccec522c26a) | `` automatic update `` |
| [`14db4ff8`](https://github.com/nix-community/NUR/commit/14db4ff87ca0be03d72d85eb3eaa6849a55f2ec2) | `` automatic update `` |
| [`ac25210c`](https://github.com/nix-community/NUR/commit/ac25210ce8d293b6373ae9524208e826b4f4f8cb) | `` automatic update `` |