### PR TITLE
chore(flake/nur): `706e00a4` -> `de6fddc4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730864891,
-        "narHash": "sha256-OE6c+baQQPTrtCLQtLY5E/V9TXsEl6/i1JolZjhQ61Y=",
+        "lastModified": 1730879823,
+        "narHash": "sha256-TuxdbJ4dlAfHcJljE76jSeAY/RnlLo46F+/TB2w2s40=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "706e00a40d3e36f128f5a82b14dabccec522c26a",
+        "rev": "de6fddc4a6172ebe07539c83a35b2d284e6eee2a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`de6fddc4`](https://github.com/nix-community/NUR/commit/de6fddc4a6172ebe07539c83a35b2d284e6eee2a) | `` automatic update `` |
| [`0025554e`](https://github.com/nix-community/NUR/commit/0025554e8661788c0a8f06d4821c30cb0d6a3ed8) | `` automatic update `` |
| [`d92cc32a`](https://github.com/nix-community/NUR/commit/d92cc32aaa59284afc4e447440c48a4767499e60) | `` automatic update `` |
| [`c8c67f0f`](https://github.com/nix-community/NUR/commit/c8c67f0f9c4cc16ba52273e7613d87c828dbd320) | `` automatic update `` |
| [`29eb3f49`](https://github.com/nix-community/NUR/commit/29eb3f494d46f9e13db348533242f38a1d2d7676) | `` automatic update `` |
| [`74878fdf`](https://github.com/nix-community/NUR/commit/74878fdfff8d8a3fccca942288c73d6ca3372b4b) | `` automatic update `` |
| [`4b4ee2f1`](https://github.com/nix-community/NUR/commit/4b4ee2f18701ab82b3d7546bb0e185550da8b3bf) | `` automatic update `` |
| [`60583e48`](https://github.com/nix-community/NUR/commit/60583e487c0f910e2c67d48b78935d29b09f61a5) | `` automatic update `` |