### PR TITLE
chore(flake/nixos-hardware): `f372fa6c` -> `12ad8c1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -605,11 +605,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1730872171,
-        "narHash": "sha256-mKU222tf5Y3UTKj61FhQ5ChLyDsx0snfIjWDUJzYINY=",
+        "lastModified": 1730874081,
+        "narHash": "sha256-VK7LkfdcpUi8tqcgMIYY2jejDh4O3MNw9An0FcKveRQ=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "f372fa6cfa45eb24552a2c1bdba2de0f14cd5a0e",
+        "rev": "12ad8c1bf13ff15ffa6afe82c59b4af0b9226035",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                  |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`12ad8c1b`](https://github.com/NixOS/nixos-hardware/commit/12ad8c1bf13ff15ffa6afe82c59b4af0b9226035) | `` apple/macbook-pro/11-1: add comment why we include broadcom driver `` |
| [`7a9364e7`](https://github.com/NixOS/nixos-hardware/commit/7a9364e705e61d0c7fc25b3756457a6caf3b9db8) | `` apple: init MacBookPro11,1 ``                                         |