### PR TITLE
chore(flake/emacs-overlay): `c626c28c` -> `92793983`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1730857873,
-        "narHash": "sha256-XvZhPCECx8MVK3wgJ/EXAIclEkzyA4WIALOIeommFDE=",
+        "lastModified": 1730883635,
+        "narHash": "sha256-ncm1rzHPlXJ78vdkk6i3LsBX6dMIn3WlwcL4ofqluVU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c626c28c864722e20b7e9b507ccb1ca48d4328af",
+        "rev": "92793983cce95f76479982fdd2f4f27979854cc2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`92793983`](https://github.com/nix-community/emacs-overlay/commit/92793983cce95f76479982fdd2f4f27979854cc2) | `` Updated melpa ``        |
| [`3f4a91fb`](https://github.com/nix-community/emacs-overlay/commit/3f4a91fb88fbfca216c74a10edbde6ad93684474) | `` Updated flake inputs `` |