### PR TITLE
chore(flake/nur): `de6fddc4` -> `52212ee7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730879823,
-        "narHash": "sha256-TuxdbJ4dlAfHcJljE76jSeAY/RnlLo46F+/TB2w2s40=",
+        "lastModified": 1730893588,
+        "narHash": "sha256-Q7d6Nt95aSV7443czdKG7I8pQ45pao59HDeCZhMNCx8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "de6fddc4a6172ebe07539c83a35b2d284e6eee2a",
+        "rev": "52212ee79e1edfccb3096dcfe87a1bb4314abfa1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`52212ee7`](https://github.com/nix-community/NUR/commit/52212ee79e1edfccb3096dcfe87a1bb4314abfa1) | `` automatic update `` |
| [`c0d88286`](https://github.com/nix-community/NUR/commit/c0d8828600ef47d475e6ec33513bf9af6eb6b991) | `` automatic update `` |
| [`4ea95941`](https://github.com/nix-community/NUR/commit/4ea959419682bf08afc11b12d73bc2c58994686d) | `` automatic update `` |