### PR TITLE
chore(flake/nur): `ac57ca5a` -> `0539e57b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730898299,
-        "narHash": "sha256-8eMf0sYUR1monzhVxlArKI8EZBz0ZZlGwHOlgmR/6/M=",
+        "lastModified": 1730904390,
+        "narHash": "sha256-KvJvhPYmAOqaXAWOP9444RobnT2aOcvBRfaTd2K3k74=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ac57ca5ad5b19388a63c58d337b47ad51ac73ddc",
+        "rev": "0539e57b47455bcf07b0be39d789af1a36117a5c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0539e57b`](https://github.com/nix-community/NUR/commit/0539e57b47455bcf07b0be39d789af1a36117a5c) | `` automatic update `` |