### PR TITLE
chore(flake/nur): `0539e57b` -> `d1fc85fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730904390,
-        "narHash": "sha256-KvJvhPYmAOqaXAWOP9444RobnT2aOcvBRfaTd2K3k74=",
+        "lastModified": 1730907825,
+        "narHash": "sha256-5j+hT+S/h/1ecslabfrmfppk4ZNPt6p++ZhQPetKIrk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0539e57b47455bcf07b0be39d789af1a36117a5c",
+        "rev": "d1fc85fa53cacd8b3aa4f47ff14e8ad36d724709",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d1fc85fa`](https://github.com/nix-community/NUR/commit/d1fc85fa53cacd8b3aa4f47ff14e8ad36d724709) | `` automatic update `` |
| [`3e6d8763`](https://github.com/nix-community/NUR/commit/3e6d87632039ebe45f06f578ff970a0c784d83e1) | `` automatic update `` |