### PR TITLE
chore(flake/emacs-overlay): `92793983` -> `cbd63433`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1730883635,
-        "narHash": "sha256-ncm1rzHPlXJ78vdkk6i3LsBX6dMIn3WlwcL4ofqluVU=",
+        "lastModified": 1730912409,
+        "narHash": "sha256-GbMAKWzvb9lRyQYEYuDPjGJIVrfNcRs+fjQwPrCA1kU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "92793983cce95f76479982fdd2f4f27979854cc2",
+        "rev": "cbd63433a850b999169dd08f8b6ac34e91629d75",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`cbd63433`](https://github.com/nix-community/emacs-overlay/commit/cbd63433a850b999169dd08f8b6ac34e91629d75) | `` Updated melpa ``  |
| [`7f59c301`](https://github.com/nix-community/emacs-overlay/commit/7f59c301454d2a3908819f16e2d6bcfd3667e9b7) | `` Updated elpa ``   |
| [`4635854f`](https://github.com/nix-community/emacs-overlay/commit/4635854f5ebe3f201346a80731d1cc8775d7e3ee) | `` Updated nongnu `` |