### PR TITLE
chore(flake/nur): `d1fc85fa` -> `51420b39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730907825,
-        "narHash": "sha256-5j+hT+S/h/1ecslabfrmfppk4ZNPt6p++ZhQPetKIrk=",
+        "lastModified": 1730923063,
+        "narHash": "sha256-QSy8CAkCkDImoLEyICxXtPW9N4rSC9QXcPE83OLXc1c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d1fc85fa53cacd8b3aa4f47ff14e8ad36d724709",
+        "rev": "51420b39807738ce2e8c43f034c35cd6bc920076",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`51420b39`](https://github.com/nix-community/NUR/commit/51420b39807738ce2e8c43f034c35cd6bc920076) | `` automatic update `` |
| [`1bf55365`](https://github.com/nix-community/NUR/commit/1bf55365b72536ea4722936b860bf912a43fa85c) | `` automatic update `` |