### PR TITLE
chore(flake/emacs-overlay): `cbd63433` -> `881e7b58`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1730912409,
-        "narHash": "sha256-GbMAKWzvb9lRyQYEYuDPjGJIVrfNcRs+fjQwPrCA1kU=",
+        "lastModified": 1730913294,
+        "narHash": "sha256-OZjABHdKGwqjWMgMovRN0RTlJHwsPnGlma1KDKT4WiQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cbd63433a850b999169dd08f8b6ac34e91629d75",
+        "rev": "881e7b588330736320f2a6496225e729156cbcde",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`881e7b58`](https://github.com/nix-community/emacs-overlay/commit/881e7b588330736320f2a6496225e729156cbcde) | `` Updated emacs `` |