### PR TITLE
chore(flake/nixos-hardware): `90642a0d` -> `912e5b8a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -605,11 +605,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1730886862,
-        "narHash": "sha256-wCZtRGM1NGxq6VG4+TMzfsa4cuG2VJVtowtYuWW5W3g=",
+        "lastModified": 1730915391,
+        "narHash": "sha256-TQtgzB3LXwhQFowmdalLCQ+KwadZxKvaYIQ03LIEYa4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "90642a0deae927fa911d49d4f7c5616257105141",
+        "rev": "912e5b8a0023898a2f025084e99fa31734a9c465",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`912e5b8a`](https://github.com/NixOS/nixos-hardware/commit/912e5b8a0023898a2f025084e99fa31734a9c465) | `` tuxedo/aura/15-gen1: migrate renamed option `` |
| [`36ed775c`](https://github.com/NixOS/nixos-hardware/commit/36ed775c1e10ab120f0629676c61369881a109fc) | `` tests: update flake lock ``                    |