### PR TITLE
chore(flake/nur): `46be5a46` -> `340b8c3c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730933176,
-        "narHash": "sha256-N2V87GGg47YeGQ6J6MeEHSp6eOrP72wN+YPilNsURyw=",
+        "lastModified": 1730937175,
+        "narHash": "sha256-YDJ1R6NmTpGhLpXrlqp3p9H/ktr2BJD1GoG1WMagYRc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "46be5a462eda50885e180ebb7acb8bc9faf3dc8a",
+        "rev": "340b8c3ca8a5fcfe8a2230a5e76442b36f68e2ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`340b8c3c`](https://github.com/nix-community/NUR/commit/340b8c3ca8a5fcfe8a2230a5e76442b36f68e2ca) | `` automatic update `` |
| [`45e3d34f`](https://github.com/nix-community/NUR/commit/45e3d34f269cdb867036aa0f32bfb6aa6cffabbd) | `` automatic update `` |
| [`fbf6963d`](https://github.com/nix-community/NUR/commit/fbf6963dbc561c45112fa6910099996c153b05ec) | `` automatic update `` |