### PR TITLE
chore(flake/emacs-overlay): `881e7b58` -> `b83a78c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1730913294,
-        "narHash": "sha256-OZjABHdKGwqjWMgMovRN0RTlJHwsPnGlma1KDKT4WiQ=",
+        "lastModified": 1730945088,
+        "narHash": "sha256-1lvYUy3CvszNYHb+SEfZgzoVZTa+xaJlzp49ORks6Yo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "881e7b588330736320f2a6496225e729156cbcde",
+        "rev": "b83a78c62a3d9be32671dae83b7cb8b2cce52725",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`b83a78c6`](https://github.com/nix-community/emacs-overlay/commit/b83a78c62a3d9be32671dae83b7cb8b2cce52725) | `` Updated emacs ``  |
| [`89ca3331`](https://github.com/nix-community/emacs-overlay/commit/89ca3331d0faf728c6f169b85d07e1589c8e7048) | `` Updated melpa ``  |
| [`79d50f29`](https://github.com/nix-community/emacs-overlay/commit/79d50f29766d521dff062b038efd15c1fd4a9739) | `` Updated elpa ``   |
| [`0b79f991`](https://github.com/nix-community/emacs-overlay/commit/0b79f99128badd14e5ab525c44b3052bdb91d38b) | `` Updated nongnu `` |