### PR TITLE
chore(flake/srvos): `a9f2ae9f` -> `dabae9d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -961,11 +961,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730682372,
-        "narHash": "sha256-GU8ghhVS7ctcV4Cy1W3X/N6KtmJNVptirIzkA7NMxp8=",
+        "lastModified": 1730940990,
+        "narHash": "sha256-FyRDs/jlmaBDL1ryf3tM9rFaOrlYn5wSa1VUr4k2w+4=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "a9f2ae9fb213b6175c71cd6aecfdb366979d2e0c",
+        "rev": "dabae9d2062afd45f343d13d819eea1029d08162",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`dabae9d2`](https://github.com/nix-community/srvos/commit/dabae9d2062afd45f343d13d819eea1029d08162) | `` Revert "darwin/mixins/terminfo: disable termite" `` |
| [`c6bd578f`](https://github.com/nix-community/srvos/commit/c6bd578f11d4cd55953e2f5e34844edd51d9f163) | `` dev/private/flake.lock: Update ``                   |
| [`378cf815`](https://github.com/nix-community/srvos/commit/378cf815dbb8254bd9a979d21b19116fd88f2cc7) | `` flake.lock: Update ``                               |