### PR TITLE
chore(flake/nur): `340b8c3c` -> `6da1917b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730937175,
-        "narHash": "sha256-YDJ1R6NmTpGhLpXrlqp3p9H/ktr2BJD1GoG1WMagYRc=",
+        "lastModified": 1730945219,
+        "narHash": "sha256-5jd+97tWQBAYCaXp/tASBFGysNmKBjNh7vLRy2CTy7w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "340b8c3ca8a5fcfe8a2230a5e76442b36f68e2ca",
+        "rev": "6da1917b360136b4cd13028aaef86802b2307670",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6da1917b`](https://github.com/nix-community/NUR/commit/6da1917b360136b4cd13028aaef86802b2307670) | `` automatic update `` |