### PR TITLE
chore(flake/nur): `6da1917b` -> `0e29ae68`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730945219,
-        "narHash": "sha256-5jd+97tWQBAYCaXp/tASBFGysNmKBjNh7vLRy2CTy7w=",
+        "lastModified": 1730947526,
+        "narHash": "sha256-JlX5aCFXpcVZum4w4SM20Fqx4bJxacl6XN9l1wQ2s8Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6da1917b360136b4cd13028aaef86802b2307670",
+        "rev": "0e29ae68c824d322a0e2475131439702cd58ae9f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0e29ae68`](https://github.com/nix-community/NUR/commit/0e29ae68c824d322a0e2475131439702cd58ae9f) | `` automatic update `` |