### PR TITLE
chore(flake/nur): `0e29ae68` -> `dd54c732`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730947526,
-        "narHash": "sha256-JlX5aCFXpcVZum4w4SM20Fqx4bJxacl6XN9l1wQ2s8Y=",
+        "lastModified": 1730954132,
+        "narHash": "sha256-NCfsCKrQrBQGf6exWnc1aa+Q3TVeu3StrKvMp+WJhkc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0e29ae68c824d322a0e2475131439702cd58ae9f",
+        "rev": "dd54c7329afb995ef7d345f26100e03eb1b59dda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dd54c732`](https://github.com/nix-community/NUR/commit/dd54c7329afb995ef7d345f26100e03eb1b59dda) | `` automatic update `` |
| [`85d7a493`](https://github.com/nix-community/NUR/commit/85d7a493624f35e370ced2963b7041e532eec9c2) | `` automatic update `` |
| [`18d96e63`](https://github.com/nix-community/NUR/commit/18d96e633e709eca0a662d5b858d2c5c90e20dc9) | `` automatic update `` |
| [`140a598a`](https://github.com/nix-community/NUR/commit/140a598a731189a068ccbb08817c5b9ae112a7cb) | `` automatic update `` |