### PR TITLE
chore(flake/nur): `dd54c732` -> `62b08a5f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730954132,
-        "narHash": "sha256-NCfsCKrQrBQGf6exWnc1aa+Q3TVeu3StrKvMp+WJhkc=",
+        "lastModified": 1730958746,
+        "narHash": "sha256-m0PQQHA3jvdaieJ7Ced8zGdFu6FckIC7K57cnb7t51E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dd54c7329afb995ef7d345f26100e03eb1b59dda",
+        "rev": "62b08a5fc72f0c1f74af065a5ac3f96f01932afa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`62b08a5f`](https://github.com/nix-community/NUR/commit/62b08a5fc72f0c1f74af065a5ac3f96f01932afa) | `` automatic update `` |
| [`036eb891`](https://github.com/nix-community/NUR/commit/036eb89179e44676b12b0b55a6416e79be2a4202) | `` automatic update `` |