### PR TITLE
chore(flake/nur): `62b08a5f` -> `d0755633`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730958746,
-        "narHash": "sha256-m0PQQHA3jvdaieJ7Ced8zGdFu6FckIC7K57cnb7t51E=",
+        "lastModified": 1730965661,
+        "narHash": "sha256-UlNKg3Fa9csAEjCF2noQgK/t8bIQlKa+fQGZIkyd3VA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "62b08a5fc72f0c1f74af065a5ac3f96f01932afa",
+        "rev": "d0755633545e572d4b11993a6a0b3471d8f8d68e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d0755633`](https://github.com/nix-community/NUR/commit/d0755633545e572d4b11993a6a0b3471d8f8d68e) | `` automatic update `` |
| [`b630cb2d`](https://github.com/nix-community/NUR/commit/b630cb2de8071736233d82ca93c96e536d11311b) | `` automatic update `` |
| [`bc4d2a3b`](https://github.com/nix-community/NUR/commit/bc4d2a3b71c75d81cc247b1bf991b63f75358004) | `` automatic update `` |