### PR TITLE
chore(flake/darwin): `366b99ab` -> `158198a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730959354,
-        "narHash": "sha256-GX+YjVsamg03bliwcrqjsNufwguQdY9Jv5cewgaqoFQ=",
+        "lastModified": 1730963783,
+        "narHash": "sha256-I5l9aMkCQi0CHCrE4tol+31z74ZfnYDaeGoK1Bi9Qrk=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "366b99abfe07ebc0ab56f68b126394344cab00f5",
+        "rev": "158198a6e3690facf15718b24571789c0756d43a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                      |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
| [`79608947`](https://github.com/LnL7/nix-darwin/commit/79608947e27163a2e74b1bec0812ce7a942cbdb8) | `` buildkit-agents: don't use `mkdir -p -m` ``                               |
| [`3b738c76`](https://github.com/LnL7/nix-darwin/commit/3b738c765de1bb4ecc4993fa092b27dd46d495ed) | `` github-runner: replace `mkdir -p -m` with `umask` ``                      |
| [`cf130aa9`](https://github.com/LnL7/nix-darwin/commit/cf130aa9579fc1708ff4a265d2108eefa535e9b2) | `` users: don't generate `ensurePerms` when no users to manage ``            |
| [`32814a6e`](https://github.com/LnL7/nix-darwin/commit/32814a6eb1de3b564ff43e5b6453637b1eb25721) | `` users: replace runtime check to prevent deleting `root` with assertion `` |
| [`fd510a71`](https://github.com/LnL7/nix-darwin/commit/fd510a7122d49cc1cbd72b9e70b1ae6b3c76c990) | `` system: replace `for f in $(ls ...)` with `for f in .../*` ``             |
| [`04199680`](https://github.com/LnL7/nix-darwin/commit/041996803af5497fb000e3f79621fa5bb6995057) | `` treewide: fix shellcheck warnings and errors ``                           |
| [`9afef995`](https://github.com/LnL7/nix-darwin/commit/9afef9950f28780ff24908496c36f27826a601cf) | `` checks: move manual `/run` instructions to activation ``                  |
| [`3ea11449`](https://github.com/LnL7/nix-darwin/commit/3ea11449387edeac72fbd7791d106af7553be6e2) | `` system: run `shellcheck` on `activate` and `activate-user` scripts ``     |