### PR TITLE
chore(flake/darwin): `158198a6` -> `fa7b46fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730963783,
-        "narHash": "sha256-I5l9aMkCQi0CHCrE4tol+31z74ZfnYDaeGoK1Bi9Qrk=",
+        "lastModified": 1730980823,
+        "narHash": "sha256-nUSlnYSeg4N18LByLw8luEvrV+8Hwgddh9Bp13mo3wA=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "158198a6e3690facf15718b24571789c0756d43a",
+        "rev": "fa7b46fa7716d0ff1abaa59ee2472ab25ad07188",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                        |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
| [`110d49af`](https://github.com/LnL7/nix-darwin/commit/110d49af637c3da025b6b42a0caa81c1d63b2aed) | `` github-runner: Fix labels for different nixpkgs versions `` |