### PR TITLE
chore(flake/emacs-overlay): `83b6f973` -> `48f6fcd3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1730970854,
-        "narHash": "sha256-PvStjAOzvb3Ta9lUkPtbXKE3HJ+4/zsWvHJFO/mzD2o=",
+        "lastModified": 1730999633,
+        "narHash": "sha256-md+Ltm7/q3boudffL5Bes3TMN3Wd57UJzJSkh0XHbWg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "83b6f9732eaf48f94d8ad6baa5cc2bf82bc3d3ff",
+        "rev": "48f6fcd3e11fec064374d7a9df8dc026fd711094",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`48f6fcd3`](https://github.com/nix-community/emacs-overlay/commit/48f6fcd3e11fec064374d7a9df8dc026fd711094) | `` Updated emacs ``  |
| [`18264d45`](https://github.com/nix-community/emacs-overlay/commit/18264d45da2a551a74b282198dd785a4829d1889) | `` Updated melpa ``  |
| [`b6ad1cf5`](https://github.com/nix-community/emacs-overlay/commit/b6ad1cf5ce77aa5073af5d1d7c77e11e2a3005cb) | `` Updated elpa ``   |
| [`c0ec1dce`](https://github.com/nix-community/emacs-overlay/commit/c0ec1dce37be9bf3f4972fcad1191be29848bb75) | `` Updated nongnu `` |