### PR TITLE
chore(flake/nur): `01e07687` -> `2f9af08f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730995869,
-        "narHash": "sha256-cNCYuTa8zmA7YsdsrA+SQldAUHtXekZY3+CMwPqhwMU=",
+        "lastModified": 1731002468,
+        "narHash": "sha256-UTUk0waC6FMNRmjU06ENAXS0pDc77K070TpqSK8x9cw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "01e07687addc49f631bc62295a5af16d3f10e389",
+        "rev": "2f9af08f428e3b4b7f87eb72697ddd51adbe2fc9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2f9af08f`](https://github.com/nix-community/NUR/commit/2f9af08f428e3b4b7f87eb72697ddd51adbe2fc9) | `` automatic update `` |