### PR TITLE
chore(flake/nur): `2f9af08f` -> `dc5cb760`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731002468,
-        "narHash": "sha256-UTUk0waC6FMNRmjU06ENAXS0pDc77K070TpqSK8x9cw=",
+        "lastModified": 1731008709,
+        "narHash": "sha256-RBUutTfh/bcvWHzjnqybjB50evgMYGngOG1Iosxbs0E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2f9af08f428e3b4b7f87eb72697ddd51adbe2fc9",
+        "rev": "dc5cb7606d6359297287945f6908ddf9d60e20f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dc5cb760`](https://github.com/nix-community/NUR/commit/dc5cb7606d6359297287945f6908ddf9d60e20f3) | `` automatic update `` |
| [`62d61350`](https://github.com/nix-community/NUR/commit/62d61350cb361bea61275ba33bdf580f4e063c1c) | `` automatic update `` |