### PR TITLE
chore(flake/sops-nix): `c5ae1e21` -> `fe630714`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -941,11 +941,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1730883027,
-        "narHash": "sha256-pvXMOJIqRW0trsW+FzRMl6d5PbsM4rWfD5lcKCOrrwI=",
+        "lastModified": 1731008979,
+        "narHash": "sha256-yN1NxvmqV8UltLkqYBWTeZNgpD/eyh/7LM58caHiEfE=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c5ae1e214ff935f2d3593187a131becb289ea639",
+        "rev": "fe63071416471abdab06caa234122932a7c4b980",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                            |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`fe630714`](https://github.com/Mic92/sops-nix/commit/fe63071416471abdab06caa234122932a7c4b980) | `` Improve activation messages about rendered templates ``                         |
| [`33f18b40`](https://github.com/Mic92/sops-nix/commit/33f18b404eb8ebf1485256fa832cb59c63d72dfa) | `` Rework `restart-and-reload` to assert more strictly on the activation output `` |