### PR TITLE
chore(flake/darwin): `fa7b46fa` -> `4b3c0d35`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730980823,
-        "narHash": "sha256-nUSlnYSeg4N18LByLw8luEvrV+8Hwgddh9Bp13mo3wA=",
+        "lastModified": 1731023924,
+        "narHash": "sha256-VPdPD23r7EdJXLDYslfa2un8BNFfqEsFWpgMj8MNo8Y=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "fa7b46fa7716d0ff1abaa59ee2472ab25ad07188",
+        "rev": "4b3c0d353b1de3ea480718f15a6a97113a168178",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                      |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
| [`222c3cb5`](https://github.com/LnL7/nix-darwin/commit/222c3cb558f4e56e3f9e84bb65fe23034f7f9c79) | `` ci: fix uninstaller failing to run in `install-against-unstable` ``       |
| [`3a89b614`](https://github.com/LnL7/nix-darwin/commit/3a89b614321ab8dad3962d79fc3a29bace9a8486) | `` uninstaller: check `nix-daemon` was correctly reinstalled ``              |
| [`7bbc7c5d`](https://github.com/LnL7/nix-darwin/commit/7bbc7c5db686f4e57a29c82a185596f53d110647) | `` ci: test uninstallation of nix-darwin using flakes ``                     |
| [`ebca0c23`](https://github.com/LnL7/nix-darwin/commit/ebca0c23c95cc2d2c75b3c3a290fa99a886b9738) | `` uninstaller: switch to `writeShellApplication` ``                         |
| [`c3b406bd`](https://github.com/LnL7/nix-darwin/commit/c3b406bd1c6e60a69996dbbd529328e40d298bd7) | `` uninstaller: restore `*.before-nix-darwin` files ``                       |
| [`9cd45289`](https://github.com/LnL7/nix-darwin/commit/9cd45289c9200b5adf29ed4faaf8e00a8c06da9c) | `` uninstaller: reset any shells pointing to `/run/current-system/sw/bin` `` |
| [`1b5fa6be`](https://github.com/LnL7/nix-darwin/commit/1b5fa6be405425ae5040d68c4a3bfff14fdf2100) | `` uninstaller: remove unnecessary attempt to delete `nix-daemon` ``         |
| [`84ad3a2d`](https://github.com/LnL7/nix-darwin/commit/84ad3a2d7ea74cabd7f71261ca4a191585d47beb) | `` uninstaller: remove `/run` symlink ``                                     |