### PR TITLE
chore(flake/emacs-overlay): `48f6fcd3` -> `7feb51a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1730999633,
-        "narHash": "sha256-md+Ltm7/q3boudffL5Bes3TMN3Wd57UJzJSkh0XHbWg=",
+        "lastModified": 1731028448,
+        "narHash": "sha256-6SOEfCj5pgJEH7pYulpbiiOH/qCK5U8d9gGf7N3GLvg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "48f6fcd3e11fec064374d7a9df8dc026fd711094",
+        "rev": "7feb51a8215d1d1004dd8ce5b780d64cc236d78d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`7feb51a8`](https://github.com/nix-community/emacs-overlay/commit/7feb51a8215d1d1004dd8ce5b780d64cc236d78d) | `` Updated elpa ``   |
| [`9412f6c4`](https://github.com/nix-community/emacs-overlay/commit/9412f6c45cf35b18a51cb713d836088d4a3157f0) | `` Updated nongnu `` |