### PR TITLE
chore(flake/nur): `c1a6861b` -> `708bdb18`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731016021,
-        "narHash": "sha256-79YweXOAVbC2I9XkMBb1AxosqIRa9rCTmT96aaMxomk=",
+        "lastModified": 1731040049,
+        "narHash": "sha256-uubOZgj2q0uclj4tWqmzIYKBzEzzDz1n+9Jbj+ivQwg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c1a6861b77c746081873cb3f006773a67302ed47",
+        "rev": "708bdb183869f9b5e6611f306a1f092cd14a9cf0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`708bdb18`](https://github.com/nix-community/NUR/commit/708bdb183869f9b5e6611f306a1f092cd14a9cf0) | `` automatic update `` |
| [`3472dad0`](https://github.com/nix-community/NUR/commit/3472dad0669d53a570ab92249307b40e98f417a1) | `` automatic update `` |
| [`b06263dc`](https://github.com/nix-community/NUR/commit/b06263dc99c62e62b659e20f77f640ce1ab6b5b9) | `` automatic update `` |
| [`6d1948f9`](https://github.com/nix-community/NUR/commit/6d1948f924be234a19d5ba2b48f43aff2900f92f) | `` automatic update `` |
| [`3fa07da3`](https://github.com/nix-community/NUR/commit/3fa07da3641c5e3050e5373d8fed6059aae7faeb) | `` automatic update `` |
| [`3f3971ae`](https://github.com/nix-community/NUR/commit/3f3971aef49cfc8f1a3f31742264317b3f975d4a) | `` automatic update `` |
| [`04afb838`](https://github.com/nix-community/NUR/commit/04afb83863f00e8895718af17972634df93700bd) | `` automatic update `` |