### PR TITLE
chore(flake/sops-nix): `fe630714` -> `60e1bce1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -941,11 +941,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1731008979,
-        "narHash": "sha256-yN1NxvmqV8UltLkqYBWTeZNgpD/eyh/7LM58caHiEfE=",
+        "lastModified": 1731047660,
+        "narHash": "sha256-iyp51lPWEQz4c5VH9bVbAuBcFP4crETU2QJYh5V0NYA=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "fe63071416471abdab06caa234122932a7c4b980",
+        "rev": "60e1bce1999f126e3b16ef45f89f72f0c3f8d16f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                              |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`60e1bce1`](https://github.com/Mic92/sops-nix/commit/60e1bce1999f126e3b16ef45f89f72f0c3f8d16f) | `` Add support for `restartUnits` and `reloadUnits` for templates `` |
| [`c9f6b151`](https://github.com/Mic92/sops-nix/commit/c9f6b151cc3578f6517a5dbd152f0e29cc6d875f) | `` fix: create `template.path` symlink ``                            |