### PR TITLE
chore(flake/nur): `708bdb18` -> `52598f7f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731040049,
-        "narHash": "sha256-uubOZgj2q0uclj4tWqmzIYKBzEzzDz1n+9Jbj+ivQwg=",
+        "lastModified": 1731046912,
+        "narHash": "sha256-6179UmFKew/FkNVNbsafu7UAkA/UGw7+wD8oG3pCC5A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "708bdb183869f9b5e6611f306a1f092cd14a9cf0",
+        "rev": "52598f7f9f9fac06c47150a19550fb7fea88346d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`52598f7f`](https://github.com/nix-community/NUR/commit/52598f7f9f9fac06c47150a19550fb7fea88346d) | `` automatic update `` |