### PR TITLE
chore(flake/nur): `52598f7f` -> `63160bf9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731046912,
-        "narHash": "sha256-6179UmFKew/FkNVNbsafu7UAkA/UGw7+wD8oG3pCC5A=",
+        "lastModified": 1731052621,
+        "narHash": "sha256-YLpfieRDHfdk2yAorwigqCIHvXMXzHrizTMfZI9VQPY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "52598f7f9f9fac06c47150a19550fb7fea88346d",
+        "rev": "63160bf9d6b901bf846464b888f427f5e6375f24",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`63160bf9`](https://github.com/nix-community/NUR/commit/63160bf9d6b901bf846464b888f427f5e6375f24) | `` automatic update `` |
| [`507e6be0`](https://github.com/nix-community/NUR/commit/507e6be0db9eb6e9d84096447731bbeefd944af7) | `` automatic update `` |
| [`9b2b9f7a`](https://github.com/nix-community/NUR/commit/9b2b9f7a2338c672ac3ef54de87a1808c811afdb) | `` automatic update `` |