### PR TITLE
chore(flake/nur): `63160bf9` -> `9be12e84`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731052621,
-        "narHash": "sha256-YLpfieRDHfdk2yAorwigqCIHvXMXzHrizTMfZI9VQPY=",
+        "lastModified": 1731055713,
+        "narHash": "sha256-m8rkTfOKUtfkOvR29euF/+6iYPo75O3doU5D3eoqhpk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "63160bf9d6b901bf846464b888f427f5e6375f24",
+        "rev": "9be12e84548ea618d8c5ad2ffb9d6f5659d3a6f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9be12e84`](https://github.com/nix-community/NUR/commit/9be12e84548ea618d8c5ad2ffb9d6f5659d3a6f1) | `` automatic update `` |