### PR TITLE
chore(flake/nur): `e71e64fa` -> `b016b006`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731071029,
-        "narHash": "sha256-CobEKm1ePwZzJqBCaBUEarSUYU4tpBqUz8FdQqjhq6g=",
+        "lastModified": 1731074503,
+        "narHash": "sha256-1a/dIzqToBgMwPgtXl+s4+eFUo99yzn5BHhF3aFRgOQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e71e64fa768ceddd7e80493fa2c52233e1c87703",
+        "rev": "b016b006a07be73115fbebba5e96225fb497804b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b016b006`](https://github.com/nix-community/NUR/commit/b016b006a07be73115fbebba5e96225fb497804b) | `` automatic update `` |