### PR TITLE
chore(flake/nur): `367e6892` -> `83c71996`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731091775,
-        "narHash": "sha256-9sfHDWgRZes3DrJE3faONoeKEZZ2SrFzLzkHUScA0RU=",
+        "lastModified": 1731095563,
+        "narHash": "sha256-RSs7ajVH6EukqYho5bSaBTdm8gbfCeNSM4mlkm5FqQ4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "367e68920e3f1dfb183c651378433661fd6b5426",
+        "rev": "83c719962467e34652f223a7761ba9f7860ffbcc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`83c71996`](https://github.com/nix-community/NUR/commit/83c719962467e34652f223a7761ba9f7860ffbcc) | `` automatic update `` |
| [`52f1bda9`](https://github.com/nix-community/NUR/commit/52f1bda909b9bbcb834508499d4bc4b2ba4b5545) | `` automatic update `` |