### PR TITLE
chore(flake/nur): `83c71996` -> `e1329e6e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731095563,
-        "narHash": "sha256-RSs7ajVH6EukqYho5bSaBTdm8gbfCeNSM4mlkm5FqQ4=",
+        "lastModified": 1731099277,
+        "narHash": "sha256-awyZHE1VCuIvDWEF5Dr4f61XBsrmgpDFyyLNW7q4Kdc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "83c719962467e34652f223a7761ba9f7860ffbcc",
+        "rev": "e1329e6e44454be6948b0fac74976a9e3ba53311",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e1329e6e`](https://github.com/nix-community/NUR/commit/e1329e6e44454be6948b0fac74976a9e3ba53311) | `` automatic update `` |