### PR TITLE
chore(flake/nur): `e1329e6e` -> `ccd20884`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731099277,
-        "narHash": "sha256-awyZHE1VCuIvDWEF5Dr4f61XBsrmgpDFyyLNW7q4Kdc=",
+        "lastModified": 1731102846,
+        "narHash": "sha256-oDy3utx0+Cwo1aoxMgqlH1A7TbU1AW4DQFPld18FPXU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e1329e6e44454be6948b0fac74976a9e3ba53311",
+        "rev": "ccd208848f807bdbc7c48b70151d1a860c67fbeb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ccd20884`](https://github.com/nix-community/NUR/commit/ccd208848f807bdbc7c48b70151d1a860c67fbeb) | `` automatic update `` |
| [`aa67e54e`](https://github.com/nix-community/NUR/commit/aa67e54e73d5f45c5f9533065ebe3b1adbc53585) | `` automatic update `` |