### PR TITLE
chore(flake/nur): `ccd20884` -> `ab9fa7cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731102846,
-        "narHash": "sha256-oDy3utx0+Cwo1aoxMgqlH1A7TbU1AW4DQFPld18FPXU=",
+        "lastModified": 1731103882,
+        "narHash": "sha256-R79Ri+1LlW9t9eYkhUvktxIGikuXIXmPSrEkCVv5Vsw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ccd208848f807bdbc7c48b70151d1a860c67fbeb",
+        "rev": "ab9fa7cfb78ae777bdf44bbaf3b023932e2f743b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ab9fa7cf`](https://github.com/nix-community/NUR/commit/ab9fa7cfb78ae777bdf44bbaf3b023932e2f743b) | `` automatic update `` |