### PR TITLE
chore(flake/nur): `ab9fa7cf` -> `5e6755e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731103882,
-        "narHash": "sha256-R79Ri+1LlW9t9eYkhUvktxIGikuXIXmPSrEkCVv5Vsw=",
+        "lastModified": 1731109624,
+        "narHash": "sha256-XB22qkKLUi0cxH5y+f38BzFIJlb/Z5B/R7Rcl+urM/Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ab9fa7cfb78ae777bdf44bbaf3b023932e2f743b",
+        "rev": "5e6755e038226196809096a0ad58e9eae7347f8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5e6755e0`](https://github.com/nix-community/NUR/commit/5e6755e038226196809096a0ad58e9eae7347f8f) | `` automatic update `` |