### PR TITLE
chore(flake/emacs-overlay): `d066ff0e` -> `fe2312ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1731085910,
-        "narHash": "sha256-Pd3FGq1gqMKmzC2vTpnLKfbgZjgfJkjUj3CZYjBMJIw=",
+        "lastModified": 1731114737,
+        "narHash": "sha256-zJK4Y9FVqhgF8qZPgNNrClhgZdTxmI0Yirxhvvwth8c=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d066ff0e61cfb9819514d124a7d256d6d05e33ac",
+        "rev": "fe2312ed21dca3e2b9a28916988eaae5e03af943",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`fe2312ed`](https://github.com/nix-community/emacs-overlay/commit/fe2312ed21dca3e2b9a28916988eaae5e03af943) | `` Updated elpa ``   |
| [`565547e7`](https://github.com/nix-community/emacs-overlay/commit/565547e79ce1c07dbac337c86bf6962ae3e69e04) | `` Updated nongnu `` |