### PR TITLE
chore(flake/nur): `b2949998` -> `65bf722a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731119600,
-        "narHash": "sha256-Asx9nXJBdRN4AvuA8+etlQWY8PrqrXXvPb1uNFveV8k=",
+        "lastModified": 1731126210,
+        "narHash": "sha256-Eo2ga0hRUOoJ5hNnQV/kXxgj1d9jiV5PoWHFNrtzO3s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b29499982ee565c8dab5ca5c7be8d2ebfc267d87",
+        "rev": "65bf722ae8dcbd860e81c7e3b68bfeeff0b76b81",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`65bf722a`](https://github.com/nix-community/NUR/commit/65bf722ae8dcbd860e81c7e3b68bfeeff0b76b81) | `` automatic update `` |
| [`df28023b`](https://github.com/nix-community/NUR/commit/df28023b5384418533403182d1c312ea5e3cd262) | `` automatic update `` |