### PR TITLE
chore(flake/darwin): `2fbf4a84` -> `3224bb2f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731032247,
-        "narHash": "sha256-OjLft7fwkmiRLXQsGAudGFZxEYXOT0nHwrQ9GbsBqJ4=",
+        "lastModified": 1731140526,
+        "narHash": "sha256-lPCTS5Jvypptq//q86G1BoggCXSWEMwDw1C1ky8P2vs=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "2fbf4a8417c28cf45bae6e6e97248cbbd9b78632",
+        "rev": "3224bb2f7c998448e4eb9b5df93195af2e268a30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                      |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
| [`5fbb7b76`](https://github.com/LnL7/nix-darwin/commit/5fbb7b7637307c89e52d7e73ed6c848353bda6a0) | `` zsh: only run shell initialization in /etc/zshenv when RCs are enabled `` |