### PR TITLE
chore(flake/emacs-overlay): `17d58785` -> `071670e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1731117732,
-        "narHash": "sha256-G0GwyH/gaV1MvTKNirF35g4PovqIeeLGRCx8upHdTVw=",
+        "lastModified": 1731142757,
+        "narHash": "sha256-Ve//ZdhxtvoQOhHGe1URgFG6rSTB4IWIOZ47e2kCx+8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "17d58785e7a094bf329bd20c1632d6fd34a7af35",
+        "rev": "071670e5bfad91f90647c0961bdc38deee2219fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`071670e5`](https://github.com/nix-community/emacs-overlay/commit/071670e5bfad91f90647c0961bdc38deee2219fb) | `` Updated melpa `` |