### PR TITLE
chore(flake/darwin): `3224bb2f` -> `3c4a2b11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731140526,
-        "narHash": "sha256-lPCTS5Jvypptq//q86G1BoggCXSWEMwDw1C1ky8P2vs=",
+        "lastModified": 1731146817,
+        "narHash": "sha256-6feGOQfjgmntR67eqeL9RuAxd8WfBsRGHWF+wgLuGPo=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "3224bb2f7c998448e4eb9b5df93195af2e268a30",
+        "rev": "3c4a2b1150d2ffc3a37826c9f5bdaa64da13d56b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                       |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
| [`a89c8519`](https://github.com/LnL7/nix-darwin/commit/a89c85192354229d9fc0adfe11f3f89620eb9487) | `` ci: don't override nixpkgs when building the manual ``     |
| [`2ff55ab1`](https://github.com/LnL7/nix-darwin/commit/2ff55ab1c5c238181c3b6f1bd78156e7d77812bb) | `` manual: get revision information when called from flake `` |
| [`a82d72d2`](https://github.com/LnL7/nix-darwin/commit/a82d72d25f67dff02afbd6fb72cd16e2ec040a68) | `` flake: expose docs on Linux as well ``                     |