### PR TITLE
chore(flake/nur): `65bf722a` -> `eef51d29`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731126210,
-        "narHash": "sha256-Eo2ga0hRUOoJ5hNnQV/kXxgj1d9jiV5PoWHFNrtzO3s=",
+        "lastModified": 1731152693,
+        "narHash": "sha256-P2MIpNTNQq7EUPJrsNK1F/OTrqMzcaoVEwYMwuNt0w4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "65bf722ae8dcbd860e81c7e3b68bfeeff0b76b81",
+        "rev": "eef51d29faddf26d9c4eeddeebe7ab85dac4ad1b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`eef51d29`](https://github.com/nix-community/NUR/commit/eef51d29faddf26d9c4eeddeebe7ab85dac4ad1b) | `` automatic update `` |
| [`d2ac63cf`](https://github.com/nix-community/NUR/commit/d2ac63cfdbe5159c97c894657cdac3fe58a714ea) | `` automatic update `` |
| [`34a0b6ce`](https://github.com/nix-community/NUR/commit/34a0b6ced7cdbe44974f4b1119a9557dbd30832e) | `` automatic update `` |