### PR TITLE
chore(flake/darwin): `3c4a2b11` -> `5c74ab86`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731146817,
-        "narHash": "sha256-6feGOQfjgmntR67eqeL9RuAxd8WfBsRGHWF+wgLuGPo=",
+        "lastModified": 1731153869,
+        "narHash": "sha256-3Ftf9oqOypcEyyrWJ0baVkRpvQqroK/SVBFLvU3nPuc=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "3c4a2b1150d2ffc3a37826c9f5bdaa64da13d56b",
+        "rev": "5c74ab862c8070cbf6400128a1b56abb213656da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                        |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
| [`5a1ae6a6`](https://github.com/LnL7/nix-darwin/commit/5a1ae6a6e41362fb52a682fd3d5f19585131d5de) | `` readme: add prerequisites section ``                                        |
| [`050b7db4`](https://github.com/LnL7/nix-darwin/commit/050b7db4451bbca9798d09661f098cb0033779b5) | `` installer: don't tell users to source bashrc ``                             |
| [`2fe3de58`](https://github.com/LnL7/nix-darwin/commit/2fe3de580e02a3d867134d6632525cf93ffaf0cb) | `` readme: fix badge ``                                                        |
| [`ae09d7ba`](https://github.com/LnL7/nix-darwin/commit/ae09d7ba528760f9c9b4f92d905d35c46d50ddca) | `` readme: remove outdated instructions for manually managing `/etc/bashrc` `` |
| [`534ca069`](https://github.com/LnL7/nix-darwin/commit/534ca06930039a616934b6d9dd8316e8df799622) | `` docs: use `nix-darwin` instead of `Darwin` ``                               |
| [`29358906`](https://github.com/LnL7/nix-darwin/commit/293589065dd0f6bbfd6f83fcdc4f2d74543337c9) | `` ci: fix manual not being regenerated when non-Nix files are updated ``      |