### PR TITLE
chore(flake/nur): `eef51d29` -> `772488c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731152693,
-        "narHash": "sha256-P2MIpNTNQq7EUPJrsNK1F/OTrqMzcaoVEwYMwuNt0w4=",
+        "lastModified": 1731157072,
+        "narHash": "sha256-EMAzOJa87/SAxuTvqFjFMKvFDV8Dd4JpZxhK7zuXlYE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eef51d29faddf26d9c4eeddeebe7ab85dac4ad1b",
+        "rev": "772488c38d694670e14af921fb6eb6fbf541cf8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`772488c3`](https://github.com/nix-community/NUR/commit/772488c38d694670e14af921fb6eb6fbf541cf8f) | `` automatic update `` |
| [`ced23bd8`](https://github.com/nix-community/NUR/commit/ced23bd815138f9b5d3796c1532534318c876838) | `` automatic update `` |
| [`ed96a3f3`](https://github.com/nix-community/NUR/commit/ed96a3f3a9fb1c18cef3967c1aaf1c5c6b3d046f) | `` automatic update `` |