### PR TITLE
chore(flake/nur): `772488c3` -> `15a545f0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731157072,
-        "narHash": "sha256-EMAzOJa87/SAxuTvqFjFMKvFDV8Dd4JpZxhK7zuXlYE=",
+        "lastModified": 1731167095,
+        "narHash": "sha256-brs+6LRG3UN9+XA1ZM73N7wXkqhYoIyrsoolYoGs68U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "772488c38d694670e14af921fb6eb6fbf541cf8f",
+        "rev": "15a545f08fcd076b21f039998498e7f396e3f1cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`15a545f0`](https://github.com/nix-community/NUR/commit/15a545f08fcd076b21f039998498e7f396e3f1cb) | `` automatic update `` |