### PR TITLE
chore(flake/emacs-overlay): `071670e5` -> `0c62adbb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1731142757,
-        "narHash": "sha256-Ve//ZdhxtvoQOhHGe1URgFG6rSTB4IWIOZ47e2kCx+8=",
+        "lastModified": 1731172058,
+        "narHash": "sha256-dn6EaE6IY8IgOnUTbapbhoyNp6n/jbmoV7o9praPNa0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "071670e5bfad91f90647c0961bdc38deee2219fb",
+        "rev": "0c62adbb149571711cea2dbadb4c2a0652dfc266",
         "type": "github"
       },
       "original": {
@@ -678,11 +678,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1730883749,
-        "narHash": "sha256-mwrFF0vElHJP8X3pFCByJR365Q2463ATp2qGIrDUdlE=",
+        "lastModified": 1730963269,
+        "narHash": "sha256-rz30HrFYCHiWEBCKHMffHbMdWJ35hEkcRVU0h7ms3x0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dba414932936fde69f0606b4f1d87c5bc0003ede",
+        "rev": "83fb6c028368e465cd19bb127b86f971a5e41ebc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`0c62adbb`](https://github.com/nix-community/emacs-overlay/commit/0c62adbb149571711cea2dbadb4c2a0652dfc266) | `` Updated emacs ``        |
| [`a03932a7`](https://github.com/nix-community/emacs-overlay/commit/a03932a70e735e9ca27097043105f32debd2c617) | `` Updated melpa ``        |
| [`79bc2328`](https://github.com/nix-community/emacs-overlay/commit/79bc2328f605ece415cb4c27e000eaa9e224aed2) | `` Updated elpa ``         |
| [`3370eff9`](https://github.com/nix-community/emacs-overlay/commit/3370eff942378b11c41da200b3e7225869920491) | `` Updated flake inputs `` |