### PR TITLE
chore(flake/nur): `15a545f0` -> `2c6a32ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731167095,
-        "narHash": "sha256-brs+6LRG3UN9+XA1ZM73N7wXkqhYoIyrsoolYoGs68U=",
+        "lastModified": 1731170586,
+        "narHash": "sha256-KXi75VysPFOBAVoghxrWMpVcrg4+pvMB5KTelhDgHn4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "15a545f08fcd076b21f039998498e7f396e3f1cb",
+        "rev": "2c6a32edcf1da50be71b6ad96b8a3e99cbdeb744",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2c6a32ed`](https://github.com/nix-community/NUR/commit/2c6a32edcf1da50be71b6ad96b8a3e99cbdeb744) | `` automatic update `` |