### PR TITLE
chore(flake/nur): `2c6a32ed` -> `3f335d1f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731170586,
-        "narHash": "sha256-KXi75VysPFOBAVoghxrWMpVcrg4+pvMB5KTelhDgHn4=",
+        "lastModified": 1731177199,
+        "narHash": "sha256-C99JI1nnLGEG6TWDlHTyxcuPTNNPakIcvUjlkFJA7rk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2c6a32edcf1da50be71b6ad96b8a3e99cbdeb744",
+        "rev": "3f335d1febbcea794cf5104725b4944d0d4b2066",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3f335d1f`](https://github.com/nix-community/NUR/commit/3f335d1febbcea794cf5104725b4944d0d4b2066) | `` automatic update `` |
| [`bd3de805`](https://github.com/nix-community/NUR/commit/bd3de80588b4805ac698a415b8a38e469b6488bf) | `` automatic update `` |