### PR TITLE
chore(flake/emacs-overlay): `0c62adbb` -> `207f6791`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1731172058,
-        "narHash": "sha256-dn6EaE6IY8IgOnUTbapbhoyNp6n/jbmoV7o9praPNa0=",
+        "lastModified": 1731204630,
+        "narHash": "sha256-8ZaDHOEcO5MvPK8QPnY0P95KfHlVGpg/tCZPMEmabv4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0c62adbb149571711cea2dbadb4c2a0652dfc266",
+        "rev": "207f6791278638301f7783cff08d8c1e00e6703b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`207f6791`](https://github.com/nix-community/emacs-overlay/commit/207f6791278638301f7783cff08d8c1e00e6703b) | `` Updated emacs ``  |
| [`146c531a`](https://github.com/nix-community/emacs-overlay/commit/146c531addc9ad05d74a7310ddd9ad5a5cedb72a) | `` Updated melpa ``  |
| [`0c8598df`](https://github.com/nix-community/emacs-overlay/commit/0c8598df24a3877662d3374da33bfe4591442298) | `` Updated elpa ``   |
| [`616e686e`](https://github.com/nix-community/emacs-overlay/commit/616e686ed2dfd52003b92adadd72163db2636f37) | `` Updated nongnu `` |