### PR TITLE
chore(flake/nur): `4b2c6076` -> `c14d2d94`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731201619,
-        "narHash": "sha256-iZxHC4cC1fKYIq2a+XR9u1hSaBb9mbh/3PVX0XJO/sM=",
+        "lastModified": 1731204582,
+        "narHash": "sha256-XVcBaOEUvf89hBo/j9ZXvv2eLRUSXcJxMX64X/chVac=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4b2c607645799a478f4f6999d8241e84c4882671",
+        "rev": "c14d2d94eee4e0bf1eb8c68352bae17ef71707de",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c14d2d94`](https://github.com/nix-community/NUR/commit/c14d2d94eee4e0bf1eb8c68352bae17ef71707de) | `` automatic update `` |
| [`7a039a99`](https://github.com/nix-community/NUR/commit/7a039a997ab935048759516669e537cea1b97578) | `` automatic update `` |