### PR TITLE
chore(flake/nur): `c14d2d94` -> `2dacadbb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731204582,
-        "narHash": "sha256-XVcBaOEUvf89hBo/j9ZXvv2eLRUSXcJxMX64X/chVac=",
+        "lastModified": 1731217493,
+        "narHash": "sha256-uNalHWxMOfzigziTWBb4LuZW2C5W0Crdf7npegbuqCg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c14d2d94eee4e0bf1eb8c68352bae17ef71707de",
+        "rev": "2dacadbb32bca2aae9e64160a600ac07eeb9f05a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2dacadbb`](https://github.com/nix-community/NUR/commit/2dacadbb32bca2aae9e64160a600ac07eeb9f05a) | `` automatic update `` |
| [`371a00f5`](https://github.com/nix-community/NUR/commit/371a00f5ccdd038a5bef2e22360b550249afd3e9) | `` automatic update `` |
| [`8b6c4fe1`](https://github.com/nix-community/NUR/commit/8b6c4fe118dfc5039d79b18f1b3c7ef565bd5f6c) | `` automatic update `` |
| [`42fdddd4`](https://github.com/nix-community/NUR/commit/42fdddd40d148da49976b1d2353889c63b91de8e) | `` automatic update `` |
| [`fce02a6a`](https://github.com/nix-community/NUR/commit/fce02a6a15d94ae4e585f4447cc084b4700f1f9f) | `` automatic update `` |
| [`b4fef94a`](https://github.com/nix-community/NUR/commit/b4fef94a4b2b08fd64fca6535b89e629dc8d0995) | `` automatic update `` |