### PR TITLE
chore(flake/sops-nix): `60e1bce1` -> `f1675e3b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -941,11 +941,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1731047660,
-        "narHash": "sha256-iyp51lPWEQz4c5VH9bVbAuBcFP4crETU2QJYh5V0NYA=",
+        "lastModified": 1731213149,
+        "narHash": "sha256-jR8i6nFLmSmm0cIoeRQ8Q4EBARa3oGaAtEER/OMMxus=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "60e1bce1999f126e3b16ef45f89f72f0c3f8d16f",
+        "rev": "f1675e3b0e1e663a4af49be67ecbc9e749f85eb7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                          |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`f1675e3b`](https://github.com/Mic92/sops-nix/commit/f1675e3b0e1e663a4af49be67ecbc9e749f85eb7) | `` home-manager: Add support for Split GPG on Qubes OS (#657) `` |