### PR TITLE
chore(flake/nur): `2dacadbb` -> `ac345298`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731217493,
-        "narHash": "sha256-uNalHWxMOfzigziTWBb4LuZW2C5W0Crdf7npegbuqCg=",
+        "lastModified": 1731222045,
+        "narHash": "sha256-3hCQpuP5KPtXPYMzrFjNICYmXlKFgEJ9zI3OPUwr56M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2dacadbb32bca2aae9e64160a600ac07eeb9f05a",
+        "rev": "ac345298360b23eadc961f84aad40deace5fa6c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ac345298`](https://github.com/nix-community/NUR/commit/ac345298360b23eadc961f84aad40deace5fa6c4) | `` automatic update `` |
| [`1148f164`](https://github.com/nix-community/NUR/commit/1148f164220c9e15ff94fe1e80c92c369a0efabd) | `` automatic update `` |