### PR TITLE
chore(flake/nur): `ac345298` -> `49e37f06`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731222045,
-        "narHash": "sha256-3hCQpuP5KPtXPYMzrFjNICYmXlKFgEJ9zI3OPUwr56M=",
+        "lastModified": 1731223828,
+        "narHash": "sha256-LHinTrepUdqIC+uOJB9qJIpznzrjJ/1/JR+ArXPvFYI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ac345298360b23eadc961f84aad40deace5fa6c4",
+        "rev": "49e37f0694b0b2469912ff7147e7881d241e1e6a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`49e37f06`](https://github.com/nix-community/NUR/commit/49e37f0694b0b2469912ff7147e7881d241e1e6a) | `` automatic update `` |