### PR TITLE
chore(flake/nur): `a5548a41` -> `6f38da2c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731237216,
-        "narHash": "sha256-Cdhu4RjdEQA7WEIVvIwp6mMRDf3TNyoy9hs85I2urNc=",
+        "lastModified": 1731243617,
+        "narHash": "sha256-RBNhh7c6iG5/yechGlUArzqz2THHcxbSW3RSLSjTlZg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a5548a416de329b8b41aa61bf775f58dba858ff8",
+        "rev": "6f38da2cb8f7615f93e567f90b1af4abb4c240b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6f38da2c`](https://github.com/nix-community/NUR/commit/6f38da2cb8f7615f93e567f90b1af4abb4c240b0) | `` automatic update `` |