### PR TITLE
chore(flake/nur): `6f38da2c` -> `c71d4648`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731243617,
-        "narHash": "sha256-RBNhh7c6iG5/yechGlUArzqz2THHcxbSW3RSLSjTlZg=",
+        "lastModified": 1731246289,
+        "narHash": "sha256-KmUDaLo9jwFYMtYH9Zsr/cLXT/CnoslsXeuuVAJVDvk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6f38da2cb8f7615f93e567f90b1af4abb4c240b0",
+        "rev": "c71d4648258014fb7b1c1d9e89161fc58d2612ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c71d4648`](https://github.com/nix-community/NUR/commit/c71d4648258014fb7b1c1d9e89161fc58d2612ea) | `` automatic update `` |