### PR TITLE
chore(flake/nur): `c71d4648` -> `5103d0ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731246289,
-        "narHash": "sha256-KmUDaLo9jwFYMtYH9Zsr/cLXT/CnoslsXeuuVAJVDvk=",
+        "lastModified": 1731253523,
+        "narHash": "sha256-b1/4ZL34f8SQPEEeewXFBxl4fGGEoLqdgxUF+OqI6AU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c71d4648258014fb7b1c1d9e89161fc58d2612ea",
+        "rev": "5103d0ba9b445d72f0298f1d8c6eabb0cde1d69c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5103d0ba`](https://github.com/nix-community/NUR/commit/5103d0ba9b445d72f0298f1d8c6eabb0cde1d69c) | `` automatic update `` |
| [`b5c4a327`](https://github.com/nix-community/NUR/commit/b5c4a327633feff78ac83e350bee2ee858004cc5) | `` automatic update `` |
| [`6e365688`](https://github.com/nix-community/NUR/commit/6e3656883c5007b8e4618627e3b138158e12dd13) | `` automatic update `` |