### PR TITLE
chore(flake/emacs-overlay): `95821bb1` -> `01a97b7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1731229046,
-        "narHash": "sha256-YhI4SCUrc/Kp2BZolTvPk/KToSlnVXmXBd026HW9lvA=",
+        "lastModified": 1731255573,
+        "narHash": "sha256-MfesV7uFUOHmaMWUDxRWhEOCgItGBNnmcGqyP0AOH74=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "95821bb1f52bac1f268a77898cc863ebdf3249b8",
+        "rev": "01a97b7d62e0a1063e98e042b9c5db5e04d37888",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`01a97b7d`](https://github.com/nix-community/emacs-overlay/commit/01a97b7d62e0a1063e98e042b9c5db5e04d37888) | `` Updated elpa ``   |
| [`21d609ea`](https://github.com/nix-community/emacs-overlay/commit/21d609eadcc0ec5ad9a7b3ac3ce8f41fa0466877) | `` Updated nongnu `` |