### PR TITLE
chore(flake/nur): `5103d0ba` -> `13d3f7a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731253523,
-        "narHash": "sha256-b1/4ZL34f8SQPEEeewXFBxl4fGGEoLqdgxUF+OqI6AU=",
+        "lastModified": 1731257634,
+        "narHash": "sha256-kSRCKzCDM/8ZlqJDB27/rL8FHGzqi/ELaG6lgpl5ICg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5103d0ba9b445d72f0298f1d8c6eabb0cde1d69c",
+        "rev": "13d3f7a244413bb5154b9d3f355f5d5e2d0b6c15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`13d3f7a2`](https://github.com/nix-community/NUR/commit/13d3f7a244413bb5154b9d3f355f5d5e2d0b6c15) | `` automatic update `` |
| [`ca703617`](https://github.com/nix-community/NUR/commit/ca7036174b50850bd1e937bebeca5124f4eae172) | `` automatic update `` |