### PR TITLE
chore(flake/nur): `13d3f7a2` -> `00516a12`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731257634,
-        "narHash": "sha256-kSRCKzCDM/8ZlqJDB27/rL8FHGzqi/ELaG6lgpl5ICg=",
+        "lastModified": 1731264423,
+        "narHash": "sha256-DTWprnE/7Oud9JpJL1LOGVJP9CFod7YeArsb0U3yXWo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "13d3f7a244413bb5154b9d3f355f5d5e2d0b6c15",
+        "rev": "00516a12c8792c11daa0982b8285b54c9a4e3c5e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`00516a12`](https://github.com/nix-community/NUR/commit/00516a12c8792c11daa0982b8285b54c9a4e3c5e) | `` automatic update `` |
| [`5b5350f1`](https://github.com/nix-community/NUR/commit/5b5350f16cefe83e1a3ed3f30d69b6af654f0d52) | `` automatic update `` |