### PR TITLE
chore(flake/nur): `cbbf744e` -> `11478f4d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731275204,
-        "narHash": "sha256-g54hkRM0SfYOyAADwaJ5XuZyEoNSWLBWiB2pYBmj8q8=",
+        "lastModified": 1731283053,
+        "narHash": "sha256-v8nHXQGB9qvisk4wyfQRgY0IUergaDLTBhZu3B6zuDQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cbbf744eff5a0cb1c8504170989d003abdd08510",
+        "rev": "11478f4dfdaf639e1a4df8b26de9cdaca9a883c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`11478f4d`](https://github.com/nix-community/NUR/commit/11478f4dfdaf639e1a4df8b26de9cdaca9a883c8) | `` automatic update `` |
| [`8865f25d`](https://github.com/nix-community/NUR/commit/8865f25d1dca23673bea5e1d77c40bd5a26c4a8c) | `` automatic update `` |
| [`8c5862c7`](https://github.com/nix-community/NUR/commit/8c5862c75cfb5ab29bfec8141ae715fe4e751cee) | `` automatic update `` |
| [`61e0a384`](https://github.com/nix-community/NUR/commit/61e0a38438f8f41f540a36cdd0eadc3776fe2045) | `` automatic update `` |