### PR TITLE
chore(flake/emacs-overlay): `10001900` -> `39ef0684`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1731257787,
-        "narHash": "sha256-QmijaEOYVhmj8V1bUtCQUQyanEHZ2n9HMCcMXveJMuI=",
+        "lastModified": 1731287789,
+        "narHash": "sha256-/XdD6CFTHoTR/Ug5jMJ+IVKVarcusIG9F34q91kVVa4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "10001900f78be46ab8642edde7455aa5f0d54a6a",
+        "rev": "39ef0684eb1fb83060e4badca01352ea904c7e89",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`39ef0684`](https://github.com/nix-community/emacs-overlay/commit/39ef0684eb1fb83060e4badca01352ea904c7e89) | `` Updated elpa ``         |
| [`dc4dc7d3`](https://github.com/nix-community/emacs-overlay/commit/dc4dc7d31acb43b66ff2a5f001936e7ba541de9f) | `` Updated nongnu ``       |
| [`9c43c3f7`](https://github.com/nix-community/emacs-overlay/commit/9c43c3f77c7c46fb4b15dd4a3274f7979a94439c) | `` Updated flake inputs `` |