### PR TITLE
chore(flake/nur): `11478f4d` -> `407d7258`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731283053,
-        "narHash": "sha256-v8nHXQGB9qvisk4wyfQRgY0IUergaDLTBhZu3B6zuDQ=",
+        "lastModified": 1731291424,
+        "narHash": "sha256-zm6hIsPKo5z8SaZFgs9Y4H9NagYOHTC0LdLHg2yjDDw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "11478f4dfdaf639e1a4df8b26de9cdaca9a883c8",
+        "rev": "407d7258ccccab7d06c57b239573587dddf8a52b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`407d7258`](https://github.com/nix-community/NUR/commit/407d7258ccccab7d06c57b239573587dddf8a52b) | `` automatic update `` |
| [`c8cbc575`](https://github.com/nix-community/NUR/commit/c8cbc5757362a8276cc1ef32d0cb1b0247068d9e) | `` automatic update `` |