### PR TITLE
chore(flake/nur): `407d7258` -> `9251bb3e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731291424,
-        "narHash": "sha256-zm6hIsPKo5z8SaZFgs9Y4H9NagYOHTC0LdLHg2yjDDw=",
+        "lastModified": 1731297840,
+        "narHash": "sha256-eWA297on+n2DXa5HFOjO3yLabjTJcfCOJ2yzTnZLQFY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "407d7258ccccab7d06c57b239573587dddf8a52b",
+        "rev": "9251bb3e482b0726081d5a03702341cb3d8180ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9251bb3e`](https://github.com/nix-community/NUR/commit/9251bb3e482b0726081d5a03702341cb3d8180ef) | `` automatic update `` |
| [`862dd4ea`](https://github.com/nix-community/NUR/commit/862dd4eae6d3a7ff70169afc1e69a96644100c68) | `` automatic update `` |