### PR TITLE
chore(flake/nur): `9251bb3e` -> `82617a64`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731297840,
-        "narHash": "sha256-eWA297on+n2DXa5HFOjO3yLabjTJcfCOJ2yzTnZLQFY=",
+        "lastModified": 1731310589,
+        "narHash": "sha256-rK9JrR2XOSfg3kW5SabthbSnzJqP7oMuflfZ45q6Sdc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9251bb3e482b0726081d5a03702341cb3d8180ef",
+        "rev": "82617a6413ea5b5ebd7c2790c358e3059c7f6efd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`82617a64`](https://github.com/nix-community/NUR/commit/82617a6413ea5b5ebd7c2790c358e3059c7f6efd) | `` automatic update `` |