### PR TITLE
chore(flake/emacs-overlay): `8bb826ff` -> `1cfaed17`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1731315605,
-        "narHash": "sha256-a38eEP2aWC/XtiIAuR3yX3mXnxBb2C/QCRhWqwlLajQ=",
+        "lastModified": 1731344419,
+        "narHash": "sha256-3psamTsRkKbTofK5FhuxP9wSl5VB9Vz8e7lXcAXcUxI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8bb826ff3ad7dd473f69c518272ae56d5f917a52",
+        "rev": "1cfaed170f85e2b31e0c5b9e1459dfa9d43e7db6",
         "type": "github"
       },
       "original": {
@@ -678,11 +678,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1730963269,
-        "narHash": "sha256-rz30HrFYCHiWEBCKHMffHbMdWJ35hEkcRVU0h7ms3x0=",
+        "lastModified": 1731239293,
+        "narHash": "sha256-q2yjIWFFcTzp5REWQUOU9L6kHdCDmFDpqeix86SOvDc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "83fb6c028368e465cd19bb127b86f971a5e41ebc",
+        "rev": "9256f7c71a195ebe7a218043d9f93390d49e6884",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`1cfaed17`](https://github.com/nix-community/emacs-overlay/commit/1cfaed170f85e2b31e0c5b9e1459dfa9d43e7db6) | `` Updated melpa ``        |
| [`5d6ad034`](https://github.com/nix-community/emacs-overlay/commit/5d6ad034c85e9647f1d6dc2bf0b214014b844411) | `` Updated elpa ``         |
| [`84fd4cdf`](https://github.com/nix-community/emacs-overlay/commit/84fd4cdfe15eee56c4f42043829ef6e6b7da3312) | `` Updated nongnu ``       |
| [`cfc32faf`](https://github.com/nix-community/emacs-overlay/commit/cfc32faff41ea05592a0425be92bf33d40744a42) | `` Updated flake inputs `` |