### PR TITLE
chore(flake/nur): `7a90da52` -> `c9dd4848`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731336490,
-        "narHash": "sha256-hoH/MuM9TDJgxFt2HeHWiF2NOSxSYH7ImFpRvivJkfA=",
+        "lastModified": 1731347056,
+        "narHash": "sha256-LJr8SQWMGstlN25QEoz3t2TOFdDabvcPxWoU0VBF6MM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7a90da52e605c22684cedc506e02d574042baa72",
+        "rev": "c9dd484837f7874e86ee20741f1876f833f9cc6e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c9dd4848`](https://github.com/nix-community/NUR/commit/c9dd484837f7874e86ee20741f1876f833f9cc6e) | `` automatic update `` |
| [`c27319f3`](https://github.com/nix-community/NUR/commit/c27319f3dc6cb6ca41fe0257f5c383f68524a369) | `` automatic update `` |