### PR TITLE
chore(flake/nur): `c9dd4848` -> `9ed42d53`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731347056,
-        "narHash": "sha256-LJr8SQWMGstlN25QEoz3t2TOFdDabvcPxWoU0VBF6MM=",
+        "lastModified": 1731354313,
+        "narHash": "sha256-AEzoXzAJx09S7ADEaV9dFlPGgYedzua9DjANAC8qAxk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c9dd484837f7874e86ee20741f1876f833f9cc6e",
+        "rev": "9ed42d53fa81cc19986de870927e2760b37dfc8c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9ed42d53`](https://github.com/nix-community/NUR/commit/9ed42d53fa81cc19986de870927e2760b37dfc8c) | `` automatic update `` |
| [`805985e0`](https://github.com/nix-community/NUR/commit/805985e00d71b467b1af5491d4c04eff182f70f8) | `` automatic update `` |
| [`4d77b647`](https://github.com/nix-community/NUR/commit/4d77b647a89d6405bfd2a6a2fecf613a3520683b) | `` automatic update `` |
| [`1271e8fb`](https://github.com/nix-community/NUR/commit/1271e8fb9f786c99614821493fca7e88f72602c2) | `` automatic update `` |