### PR TITLE
chore(flake/nur): `9ed42d53` -> `c18781dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731354313,
-        "narHash": "sha256-AEzoXzAJx09S7ADEaV9dFlPGgYedzua9DjANAC8qAxk=",
+        "lastModified": 1731357928,
+        "narHash": "sha256-RH0DWVggSrH0NjzfCr60lNfSpFvbjV+zcS4gIhk6irk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ed42d53fa81cc19986de870927e2760b37dfc8c",
+        "rev": "c18781dd9bfe715f59e5ece0c18a9e2959e22d1c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c18781dd`](https://github.com/nix-community/NUR/commit/c18781dd9bfe715f59e5ece0c18a9e2959e22d1c) | `` automatic update `` |
| [`bdfe967e`](https://github.com/nix-community/NUR/commit/bdfe967e541572864af778dba8cfb69aac4e6960) | `` automatic update `` |