### PR TITLE
chore(flake/nur): `c18781dd` -> `2fa8be0c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731357928,
-        "narHash": "sha256-RH0DWVggSrH0NjzfCr60lNfSpFvbjV+zcS4gIhk6irk=",
+        "lastModified": 1731361079,
+        "narHash": "sha256-pDgguZxBXKxLkZljiYCmJpWM341Cj52A41IdbNqlEWU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c18781dd9bfe715f59e5ece0c18a9e2959e22d1c",
+        "rev": "2fa8be0cf07b2ddcca3615f19e8d07e831bf4d40",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2fa8be0c`](https://github.com/nix-community/NUR/commit/2fa8be0cf07b2ddcca3615f19e8d07e831bf4d40) | `` automatic update `` |