### PR TITLE
chore(flake/nur): `2fa8be0c` -> `02bf2693`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731361079,
-        "narHash": "sha256-pDgguZxBXKxLkZljiYCmJpWM341Cj52A41IdbNqlEWU=",
+        "lastModified": 1731365127,
+        "narHash": "sha256-nLtHRaEG/MIMmU+5H29GWTi2B8RsQ/BMi6XU4YD2Su0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2fa8be0cf07b2ddcca3615f19e8d07e831bf4d40",
+        "rev": "02bf26939ee7b23e1ec45a33372b42fcefdd59cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`02bf2693`](https://github.com/nix-community/NUR/commit/02bf26939ee7b23e1ec45a33372b42fcefdd59cd) | `` automatic update `` |
| [`69bbd5a3`](https://github.com/nix-community/NUR/commit/69bbd5a3228632e6afdfeba09cdc353125ef9381) | `` automatic update `` |
| [`baaf5d4c`](https://github.com/nix-community/NUR/commit/baaf5d4cc68a9f177e75168fe925586438de116b) | `` automatic update `` |