### PR TITLE
chore(flake/sops-nix): `f1675e3b` -> `4c91d52d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -941,11 +941,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1731213149,
-        "narHash": "sha256-jR8i6nFLmSmm0cIoeRQ8Q4EBARa3oGaAtEER/OMMxus=",
+        "lastModified": 1731364708,
+        "narHash": "sha256-HC0anOL+KmUQ2hdRl0AtunbAckasxrkn4VLmxbW/WaA=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "f1675e3b0e1e663a4af49be67ecbc9e749f85eb7",
+        "rev": "4c91d52db103e757fc25b58998b0576ae702d659",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                                          |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`4c91d52d`](https://github.com/Mic92/sops-nix/commit/4c91d52db103e757fc25b58998b0576ae702d659) | `` build(deps): bump golang.org/x/crypto from 0.28.0 to 0.29.0 (#663) ``                         |
| [`e4f36d56`](https://github.com/Mic92/sops-nix/commit/e4f36d56ebe16f928e65e69ff321d9fa1514231b) | `` build(deps): bump github.com/ProtonMail/go-crypto from 1.1.0-beta.0-proton to 1.1.2 (#662) `` |
| [`58f41afc`](https://github.com/Mic92/sops-nix/commit/58f41afcc7d6d3682df547178cc19103dfff11e1) | `` build(deps): bump golang.org/x/sys from 0.26.0 to 0.27.0 (#661) ``                            |