### PR TITLE
chore(flake/emacs-overlay): `914e8cd4` -> `44d601ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1731345267,
-        "narHash": "sha256-mT7dmNszhVg2LbWWW+4qZIiS4d6WxrdJZYWvnB1K4Zs=",
+        "lastModified": 1731374007,
+        "narHash": "sha256-06BnSHgnNeGe+HBETNJE5G0kihSt4v+GeJAY7LBUxbs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "914e8cd43c10d41f6bba21abaf0d8b29554d69c9",
+        "rev": "44d601ba4d251251e342d14ba3663a073c1b4aa4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`44d601ba`](https://github.com/nix-community/emacs-overlay/commit/44d601ba4d251251e342d14ba3663a073c1b4aa4) | `` Updated elpa ``   |
| [`bc39ae24`](https://github.com/nix-community/emacs-overlay/commit/bc39ae24a1fe1762896d1ac235e519cf5d69e58b) | `` Updated nongnu `` |