### PR TITLE
chore(flake/emacs-overlay): `44d601ba` -> `adc9a8ca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1731374007,
-        "narHash": "sha256-06BnSHgnNeGe+HBETNJE5G0kihSt4v+GeJAY7LBUxbs=",
+        "lastModified": 1731376273,
+        "narHash": "sha256-eXLU6zf2FaIYvZNC/kFuNY89iaoZX+X6I1RH+KxHR/k=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "44d601ba4d251251e342d14ba3663a073c1b4aa4",
+        "rev": "adc9a8ca1ef06c1786f2a18dbd5e999b4e115e74",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`adc9a8ca`](https://github.com/nix-community/emacs-overlay/commit/adc9a8ca1ef06c1786f2a18dbd5e999b4e115e74) | `` Updated melpa `` |