### PR TITLE
chore(flake/nur): `0e75739b` -> `62d4b402`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731383031,
-        "narHash": "sha256-J1UvJl/ZjAhRk/uIro607ZOyNoJokBSGSlP8cXo9Ec4=",
+        "lastModified": 1731386824,
+        "narHash": "sha256-1NHwj7QbQZvyz2qw+8C84r6bMF/QN6cIlsxszZQd77c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0e75739bbe7d3ffbbd421886bc7e0881556ef93c",
+        "rev": "62d4b40295f0c4a068b5e5dbbc66589938b18983",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`62d4b402`](https://github.com/nix-community/NUR/commit/62d4b40295f0c4a068b5e5dbbc66589938b18983) | `` automatic update `` |
| [`9e3d808b`](https://github.com/nix-community/NUR/commit/9e3d808be97edf034d83f4c869ec0a1d3ef47c69) | `` automatic update `` |
| [`0d685930`](https://github.com/nix-community/NUR/commit/0d685930c99ad305fe3f4cd7c97f50e351738052) | `` automatic update `` |