### PR TITLE
chore(flake/nur): `62d4b402` -> `fd60b581`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731386824,
-        "narHash": "sha256-1NHwj7QbQZvyz2qw+8C84r6bMF/QN6cIlsxszZQd77c=",
+        "lastModified": 1731392722,
+        "narHash": "sha256-sf0ACyQBI5ozKG75oRCb1I2Hha6j06jsXinE37rot8U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "62d4b40295f0c4a068b5e5dbbc66589938b18983",
+        "rev": "fd60b581ea818ebd6c9d181a198074fd9f73f734",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fd60b581`](https://github.com/nix-community/NUR/commit/fd60b581ea818ebd6c9d181a198074fd9f73f734) | `` automatic update `` |