### PR TITLE
chore(flake/nur): `fd60b581` -> `f35697ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731392722,
-        "narHash": "sha256-sf0ACyQBI5ozKG75oRCb1I2Hha6j06jsXinE37rot8U=",
+        "lastModified": 1731398215,
+        "narHash": "sha256-x4amgQdW2vZ7Tres4Hlytr/YOKP4phEC5jQKQIr9JGw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fd60b581ea818ebd6c9d181a198074fd9f73f734",
+        "rev": "f35697ee6272523f8f9737058b605aa3c38f845e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f35697ee`](https://github.com/nix-community/NUR/commit/f35697ee6272523f8f9737058b605aa3c38f845e) | `` automatic update `` |