### PR TITLE
chore(flake/nixos-hardware): `184687ae` -> `f6581f1c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -605,11 +605,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1731332224,
-        "narHash": "sha256-0ctfVp27ingWtY7dbP5+QpSQ98HaOZleU0teyHQUAw0=",
+        "lastModified": 1731403644,
+        "narHash": "sha256-T9V7CTucjRZ4Qc6pUEV/kpgNGzQbHWfGcfK6JJLfUeI=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "184687ae1a3139faa4746168baf071f60d0310c8",
+        "rev": "f6581f1c3b137086e42a08a906bdada63045f991",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`f6581f1c`](https://github.com/NixOS/nixos-hardware/commit/f6581f1c3b137086e42a08a906bdada63045f991) | `` framework: workaround display issues on AMD GPUs `` |
| [`863e3ca9`](https://github.com/NixOS/nixos-hardware/commit/863e3ca9988f34c370bd660a5efc3e20eb7ad38b) | `` apple/t2: bump kernel from 6.11 to 6.11.7 ``        |