### PR TITLE
chore(flake/emacs-overlay): `7a8b2d88` -> `af086b3e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1731401995,
-        "narHash": "sha256-znB/vZLqh69rMncsIritz6cty204n8xknzeHiTsvVI0=",
+        "lastModified": 1731431553,
+        "narHash": "sha256-lpC1jVxInrschdB8E9ps7SAe6UmnnDBpZN7i63lWf28=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7a8b2d8879986e79d9271f85f6559e8a74f5b6cf",
+        "rev": "af086b3eaccec54cb18c6d3cf376d8f94b81d482",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`af086b3e`](https://github.com/nix-community/emacs-overlay/commit/af086b3eaccec54cb18c6d3cf376d8f94b81d482) | `` Updated emacs ``  |
| [`dfa8f663`](https://github.com/nix-community/emacs-overlay/commit/dfa8f663d2b95fd9ad891b9363e7d41bad0cd05a) | `` Updated melpa ``  |
| [`cf308e1c`](https://github.com/nix-community/emacs-overlay/commit/cf308e1caa9533a9c01cc28020d0dea5134b546a) | `` Updated elpa ``   |
| [`96fb09e8`](https://github.com/nix-community/emacs-overlay/commit/96fb09e8711fbe18347cb44290e2082d7bb8f6fa) | `` Updated nongnu `` |