### PR TITLE
chore(flake/nur): `de59ef73` -> `6e57af87`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731427820,
-        "narHash": "sha256-qETsjwJ7ICL6EpKU601AywtNMxmJCyjHMVaLsXkjXJc=",
+        "lastModified": 1731440712,
+        "narHash": "sha256-N5ZRH5EXERUX8N5sHnYvIOAQMoDt5z2luXjX6kmSQMI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "de59ef732179d203e15c01baad24559813360355",
+        "rev": "6e57af87397c6a40a212a69c3b224b44849a1c38",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6e57af87`](https://github.com/nix-community/NUR/commit/6e57af87397c6a40a212a69c3b224b44849a1c38) | `` automatic update `` |
| [`37d88266`](https://github.com/nix-community/NUR/commit/37d882663e9546df4024f7bc03254ba2ddef3787) | `` automatic update `` |