### PR TITLE
chore(flake/nur): `6e57af87` -> `3df4b04f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731440712,
-        "narHash": "sha256-N5ZRH5EXERUX8N5sHnYvIOAQMoDt5z2luXjX6kmSQMI=",
+        "lastModified": 1731444045,
+        "narHash": "sha256-3Svsq7ffXPXdLMMnKCynYGypqgAMd55MrdvSN2wbebk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6e57af87397c6a40a212a69c3b224b44849a1c38",
+        "rev": "3df4b04fe7df925a7e089526fac66dcb95fa128c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3df4b04f`](https://github.com/nix-community/NUR/commit/3df4b04fe7df925a7e089526fac66dcb95fa128c) | `` automatic update `` |
| [`8bc7aa7b`](https://github.com/nix-community/NUR/commit/8bc7aa7be71d22254b2b4e85af58e4e061df733c) | `` automatic update `` |