### PR TITLE
chore(flake/nur): `3df4b04f` -> `a651207e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731444045,
-        "narHash": "sha256-3Svsq7ffXPXdLMMnKCynYGypqgAMd55MrdvSN2wbebk=",
+        "lastModified": 1731447904,
+        "narHash": "sha256-mIAgTpMVs/Z71r2foD+CtwEpThdQzTvFeS7uMfYMC7E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3df4b04fe7df925a7e089526fac66dcb95fa128c",
+        "rev": "a651207e562a6ef6379f037dd4d8d953fe1b644b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a651207e`](https://github.com/nix-community/NUR/commit/a651207e562a6ef6379f037dd4d8d953fe1b644b) | `` automatic update `` |