### PR TITLE
chore(flake/darwin): `e30d226a` -> `839fd2a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731424394,
-        "narHash": "sha256-J+POQgWQdjhuF1pEnkVKWPJ+dM62FTepk6TmJdj3O5U=",
+        "lastModified": 1731450320,
+        "narHash": "sha256-7QroOhMptfA6Pz5/Ig/apHdxF3+zvlZV8D3NMc6aEiM=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "e30d226a24e4079d068321f935dbf30626f08dc8",
+        "rev": "839fd2a2b5bb60a6c15f2347a92269d57d51012f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                      |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
| [`2bacd8db`](https://github.com/LnL7/nix-darwin/commit/2bacd8db310f479fab713829663d4b36913553cf) | `` environment: fix `lowPrio` support in `environment.systemPackages` ``     |
| [`8b27551e`](https://github.com/LnL7/nix-darwin/commit/8b27551e094666e6beb273c484392fa205bb0c97) | `` users: warn users to use `pkgs.bashInteractive` instead of `pkgs.bash` `` |
| [`5eb88645`](https://github.com/LnL7/nix-darwin/commit/5eb88645f74396d4b80fdf736ddd63afbe8320d5) | `` users: assert that `programs.<shell>.enable = true;` for users' shells `` |
| [`c2c88ae9`](https://github.com/LnL7/nix-darwin/commit/c2c88ae983c236839c24f547a0047310f8c69647) | `` users: remove `lib.` ``                                                   |