### PR TITLE
chore(flake/nur): `a651207e` -> `a694577c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731447904,
-        "narHash": "sha256-mIAgTpMVs/Z71r2foD+CtwEpThdQzTvFeS7uMfYMC7E=",
+        "lastModified": 1731463670,
+        "narHash": "sha256-ymR6S/HfTVB7jS+Cnx2dTgmPCCdpHtOSvkvCY08fNLs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a651207e562a6ef6379f037dd4d8d953fe1b644b",
+        "rev": "a694577ccac1c786fbe702c9ec1b0f056156cd83",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a694577c`](https://github.com/nix-community/NUR/commit/a694577ccac1c786fbe702c9ec1b0f056156cd83) | `` automatic update `` |
| [`a180e646`](https://github.com/nix-community/NUR/commit/a180e6461d394d215b3645f068a070c7d9a6f7f6) | `` automatic update `` |