### PR TITLE
chore(flake/emacs-overlay): `4f2af1a9` -> `395675b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1731460487,
-        "narHash": "sha256-2mCGfgaYMJmBfnh6/1yZiw9KLf8bLD3xQ8MtvKtViXI=",
+        "lastModified": 1731463490,
+        "narHash": "sha256-AtyI66bBn9IX9s+rXQEJHrkAQv3430urS6IxK5m1Uzs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4f2af1a9f2ad8cedcced602fd0ef30c7a496aa2d",
+        "rev": "395675b281ab1aea12ab75a6296b83e3b3152f13",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`395675b2`](https://github.com/nix-community/emacs-overlay/commit/395675b281ab1aea12ab75a6296b83e3b3152f13) | `` Updated emacs `` |
| [`8c899159`](https://github.com/nix-community/emacs-overlay/commit/8c8991591e48d03735b488fe0ad72a69fe00d188) | `` Updated melpa `` |