### PR TITLE
chore(flake/nur): `a694577c` -> `91466f09`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731463670,
-        "narHash": "sha256-ymR6S/HfTVB7jS+Cnx2dTgmPCCdpHtOSvkvCY08fNLs=",
+        "lastModified": 1731469923,
+        "narHash": "sha256-2n36aoUsi2x31L1jpcdy38jDyVbnaYQh8FO8HNyNA7I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a694577ccac1c786fbe702c9ec1b0f056156cd83",
+        "rev": "91466f0979b3b026c76fd8396742f97d89621139",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`91466f09`](https://github.com/nix-community/NUR/commit/91466f0979b3b026c76fd8396742f97d89621139) | `` automatic update `` |
| [`0e330d45`](https://github.com/nix-community/NUR/commit/0e330d45c6a96d52fc2285682526f62eb8ab396c) | `` automatic update `` |