### PR TITLE
chore(flake/nur): `91466f09` -> `46724e2f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731469923,
-        "narHash": "sha256-2n36aoUsi2x31L1jpcdy38jDyVbnaYQh8FO8HNyNA7I=",
+        "lastModified": 1731472408,
+        "narHash": "sha256-pO0AdDTDV+Hmy/UHsLlueyeCU0wvNuYHM01JgXipm4E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "91466f0979b3b026c76fd8396742f97d89621139",
+        "rev": "46724e2fb0997446979be05d13b2798f17706d1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`46724e2f`](https://github.com/nix-community/NUR/commit/46724e2fb0997446979be05d13b2798f17706d1e) | `` automatic update `` |
| [`723fa8c1`](https://github.com/nix-community/NUR/commit/723fa8c1a77aefb6a68693322045f3979c40dd6d) | `` automatic update `` |
| [`02d80ed1`](https://github.com/nix-community/NUR/commit/02d80ed1179fca2ca58adc9d4ba6c4c6c6c6ccc7) | `` automatic update `` |
| [`8061e402`](https://github.com/nix-community/NUR/commit/8061e40260a85634329bb70b6493f4b4275a481b) | `` automatic update `` |