### PR TITLE
chore(flake/nur): `46724e2f` -> `557c0ead`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731472408,
-        "narHash": "sha256-pO0AdDTDV+Hmy/UHsLlueyeCU0wvNuYHM01JgXipm4E=",
+        "lastModified": 1731476497,
+        "narHash": "sha256-mOJooVeRALi61bQ2sWRCUliH2ouTH4yySqQeW39WNgM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "46724e2fb0997446979be05d13b2798f17706d1e",
+        "rev": "557c0eadd9e2a3f76b1d0426641c2f8e597cf939",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`557c0ead`](https://github.com/nix-community/NUR/commit/557c0eadd9e2a3f76b1d0426641c2f8e597cf939) | `` automatic update `` |