### PR TITLE
chore(flake/nur): `557c0ead` -> `1e663547`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731476497,
-        "narHash": "sha256-mOJooVeRALi61bQ2sWRCUliH2ouTH4yySqQeW39WNgM=",
+        "lastModified": 1731483916,
+        "narHash": "sha256-uwYcbNm9OuldhvHbcX98udjdXl10tpV7NtRZPMNx6Ko=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "557c0eadd9e2a3f76b1d0426641c2f8e597cf939",
+        "rev": "1e663547065b1c361863c201bbfdd664f6b94fee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1e663547`](https://github.com/nix-community/NUR/commit/1e663547065b1c361863c201bbfdd664f6b94fee) | `` automatic update `` |