### PR TITLE
chore(flake/emacs-overlay): `395675b2` -> `98672e89`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1731463490,
-        "narHash": "sha256-AtyI66bBn9IX9s+rXQEJHrkAQv3430urS6IxK5m1Uzs=",
+        "lastModified": 1731489158,
+        "narHash": "sha256-xxhjjRBM9P6536SATfoGkKcMBKPZxcgs3yx/cyQxbb0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "395675b281ab1aea12ab75a6296b83e3b3152f13",
+        "rev": "98672e8948813f132851fb6768fa1265a8cab324",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`98672e89`](https://github.com/nix-community/emacs-overlay/commit/98672e8948813f132851fb6768fa1265a8cab324) | `` Updated emacs `` |
| [`feaebd62`](https://github.com/nix-community/emacs-overlay/commit/feaebd62bd3960aa559413470986ca0b15d2ddf5) | `` Updated melpa `` |