### PR TITLE
chore(flake/nur): `1e663547` -> `1ff747c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731483916,
-        "narHash": "sha256-uwYcbNm9OuldhvHbcX98udjdXl10tpV7NtRZPMNx6Ko=",
+        "lastModified": 1731487580,
+        "narHash": "sha256-B3o8BWXVwe5KsFbex9L9JUFVwPeaV1graBjzhOP6nOg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1e663547065b1c361863c201bbfdd664f6b94fee",
+        "rev": "1ff747c93fa45f3f1a90e1740d48efe1de3051c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1ff747c9`](https://github.com/nix-community/NUR/commit/1ff747c93fa45f3f1a90e1740d48efe1de3051c6) | `` automatic update `` |