### PR TITLE
chore(flake/nur): `4b0e599b` -> `1a1b06c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731494868,
-        "narHash": "sha256-gFzX+e1ATJmhjOMvbBmqf1v4WgMz770dZhtGN4dZtng=",
+        "lastModified": 1731509589,
+        "narHash": "sha256-ttUjj+kvn2xJpGHRZT2zclb+BVAFAnUZv6wGs9XoUGk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4b0e599bebf4bdf6725cdf8036a335096bf13097",
+        "rev": "1a1b06c26adeea38215a9955ffd5a9fb677a9b92",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1a1b06c2`](https://github.com/nix-community/NUR/commit/1a1b06c26adeea38215a9955ffd5a9fb677a9b92) | `` automatic update `` |
| [`ce861b4f`](https://github.com/nix-community/NUR/commit/ce861b4f99968fd26b93534f5d86c4f9df99964f) | `` automatic update `` |