### PR TITLE
chore(flake/emacs-overlay): `98672e89` -> `e074a4f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1731489158,
-        "narHash": "sha256-xxhjjRBM9P6536SATfoGkKcMBKPZxcgs3yx/cyQxbb0=",
+        "lastModified": 1731517933,
+        "narHash": "sha256-j59F8M6LBre2Cc3QzxiYRlNe4wX/Jw1ziqPnbbmE3+Y=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "98672e8948813f132851fb6768fa1265a8cab324",
+        "rev": "e074a4f54d88af0db5284d77e0b80bb1a8d2c80f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`e074a4f5`](https://github.com/nix-community/emacs-overlay/commit/e074a4f54d88af0db5284d77e0b80bb1a8d2c80f) | `` Updated emacs ``  |
| [`8905d10a`](https://github.com/nix-community/emacs-overlay/commit/8905d10ac833fbebaefbeeb012f7af3cb147c391) | `` Updated melpa ``  |
| [`a81df221`](https://github.com/nix-community/emacs-overlay/commit/a81df221fef98954bba1869e7648ec650928a584) | `` Updated nongnu `` |
| [`3debd608`](https://github.com/nix-community/emacs-overlay/commit/3debd608803681bfab013d6eb2a8095dec8b1b95) | `` Updated elpa ``   |