### PR TITLE
chore(flake/nur): `4ae1080f` -> `2647900a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731515340,
-        "narHash": "sha256-GE/kuwXQhmUynUPdRbWp3ccuqfFshF6oLMg7TGXgl+8=",
+        "lastModified": 1731522829,
+        "narHash": "sha256-LWkO4ks0y4A9LAlahNWC+ZY5nYjL6ylFT0gmvHStJsA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ae1080fdf68e0c54c05860030861a852439223a",
+        "rev": "2647900a849e6ca7929585515fa96c90572a59c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2647900a`](https://github.com/nix-community/NUR/commit/2647900a849e6ca7929585515fa96c90572a59c8) | `` automatic update `` |