### PR TITLE
chore(flake/flake-utils): `c1dfcf08` -> `11707dc2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -252,11 +252,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                           |
| ---------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`11707dc2`](https://github.com/numtide/flake-utils/commit/11707dc2f618dd54ca8739b309ec4fc024de578b) | `` README: add new logo (#120) `` |