### PR TITLE
chore(flake/home-manager): `ee8ff6d5` -> `35b05500`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -367,11 +367,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731534694,
-        "narHash": "sha256-KvMam8x7QsIhD+dbykfoYV/nU0u1LVRQPO0vfySDdDs=",
+        "lastModified": 1731535640,
+        "narHash": "sha256-2EckCJn4wxran/TsRiCOFcmVpep2m9EBKl99NBh2GnM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ee8ff6d53fca9adec60238f63eb632300d0dffa0",
+        "rev": "35b055009afd0107b69c286fca34d2ad98940d57",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                           |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`35b05500`](https://github.com/nix-community/home-manager/commit/35b055009afd0107b69c286fca34d2ad98940d57) | `` kanshi: add package to home.packages ``        |
| [`3c044aef`](https://github.com/nix-community/home-manager/commit/3c044aefe610ceeec9cf3e83e55fa62715df27e2) | `` git-sync: add example to repository option ``  |
| [`cd21d2e6`](https://github.com/nix-community/home-manager/commit/cd21d2e61b2da9cc5b96f848ac6fd3c4dc377a1b) | `` git-sync: fix crash when whitespace in path `` |