### PR TITLE
chore(flake/nur): `481bba9a` -> `60812ab7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731530667,
-        "narHash": "sha256-/EBYF3f2kAPX3IOwxcjP/KTvXeX9b2cZyxgxGvp+XWI=",
+        "lastModified": 1731550038,
+        "narHash": "sha256-xwKPQbbcyMGJf04Ke6+1JDg+3LPBKq28hMNsuBz151M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "481bba9ab4c2054b7cac86ee3be24f67e5256820",
+        "rev": "60812ab70dd415c05dce56ed03076821138589cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`60812ab7`](https://github.com/nix-community/NUR/commit/60812ab70dd415c05dce56ed03076821138589cd) | `` automatic update `` |
| [`7a921478`](https://github.com/nix-community/NUR/commit/7a9214781148bf3587a67eeebbb372caca50d00e) | `` automatic update `` |
| [`bd5ead04`](https://github.com/nix-community/NUR/commit/bd5ead048fb2a5bb3635111761d2d75f1f19debc) | `` automatic update `` |