### PR TITLE
chore(flake/emacs-overlay): `e074a4f5` -> `865dd92d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1731517933,
-        "narHash": "sha256-j59F8M6LBre2Cc3QzxiYRlNe4wX/Jw1ziqPnbbmE3+Y=",
+        "lastModified": 1731546886,
+        "narHash": "sha256-NUYCFZZh/OdvPEYbeyHOXWr29H2bjGhmBfH0rB2dUq0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e074a4f54d88af0db5284d77e0b80bb1a8d2c80f",
+        "rev": "865dd92d2c7f46190b2063ffc6ec6af605d097bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message            |
| ------------------------------------------------------------------------------------------------------------ | ------------------ |
| [`865dd92d`](https://github.com/nix-community/emacs-overlay/commit/865dd92d2c7f46190b2063ffc6ec6af605d097bd) | `` Updated elpa `` |