### PR TITLE
chore(flake/emacs-overlay): `865dd92d` -> `5264b3b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1731546886,
-        "narHash": "sha256-NUYCFZZh/OdvPEYbeyHOXWr29H2bjGhmBfH0rB2dUq0=",
+        "lastModified": 1731550026,
+        "narHash": "sha256-+vnzZV6TNHaJOs5h7AK+GtGP59wAAzMdrGZUGoFeqgw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "865dd92d2c7f46190b2063ffc6ec6af605d097bd",
+        "rev": "5264b3b1bc09532a103ea69a0747ae56fdb3a5ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`5264b3b1`](https://github.com/nix-community/emacs-overlay/commit/5264b3b1bc09532a103ea69a0747ae56fdb3a5ec) | `` Updated emacs `` |
| [`f5913f18`](https://github.com/nix-community/emacs-overlay/commit/f5913f1890a0cd11684666a77e363cc3b473d069) | `` Updated melpa `` |