### PR TITLE
chore(flake/nur): `60812ab7` -> `9b866628`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731550038,
-        "narHash": "sha256-xwKPQbbcyMGJf04Ke6+1JDg+3LPBKq28hMNsuBz151M=",
+        "lastModified": 1731557061,
+        "narHash": "sha256-Cyhuv1J1OgCX8xuhTdrjm+R9ZhYjWUciVbUNpcVz/8Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "60812ab70dd415c05dce56ed03076821138589cd",
+        "rev": "9b86662869a3e52ba1545b737b489944baca6ae9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9b866628`](https://github.com/nix-community/NUR/commit/9b86662869a3e52ba1545b737b489944baca6ae9) | `` automatic update `` |
| [`84cfcca3`](https://github.com/nix-community/NUR/commit/84cfcca371a71efa450575e202ecd6b1ae404615) | `` automatic update `` |