### PR TITLE
chore(flake/nur): `9b866628` -> `6e804f70`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731557061,
-        "narHash": "sha256-Cyhuv1J1OgCX8xuhTdrjm+R9ZhYjWUciVbUNpcVz/8Q=",
+        "lastModified": 1731569820,
+        "narHash": "sha256-5i2hiBMnhqLVXpnmPwvLJKB5Tn816Z+9UmC5EcL2av4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9b86662869a3e52ba1545b737b489944baca6ae9",
+        "rev": "6e804f7059440328e36f002f6eead1fd9b8eef43",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6e804f70`](https://github.com/nix-community/NUR/commit/6e804f7059440328e36f002f6eead1fd9b8eef43) | `` automatic update `` |
| [`079b8eda`](https://github.com/nix-community/NUR/commit/079b8eda3a720dce65c8af244fb70bb88675ab5e) | `` automatic update `` |