### PR TITLE
chore(flake/nixpkgs): `76612b17` -> `dc460ec7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -758,11 +758,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1731139594,
-        "narHash": "sha256-IigrKK3vYRpUu+HEjPL/phrfh7Ox881er1UEsZvw9Q4=",
+        "lastModified": 1731319897,
+        "narHash": "sha256-PbABj4tnbWFMfBp6OcUK5iGy1QY+/Z96ZcLpooIbuEI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "76612b17c0ce71689921ca12d9ffdc9c23ce40b2",
+        "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                    |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`6c3d0282`](https://github.com/NixOS/nixpkgs/commit/6c3d0282c8392a414b4675cc91dc7689860d8f3e) | `` netbird: 0.30.2 -> 0.31.0 (#354756) ``                                                  |
| [`b3057fce`](https://github.com/NixOS/nixpkgs/commit/b3057fce636d941c6da247268cc96b94c7452e49) | `` niri: add patch for scrolling without mouse config ``                                   |
| [`f0b14e4f`](https://github.com/NixOS/nixpkgs/commit/f0b14e4fb4be96242f3e1f8f20db213b2a977148) | `` niri: install dinit service files ``                                                    |
| [`4c3539c7`](https://github.com/NixOS/nixpkgs/commit/4c3539c70b796baae64fc9cd682531b26d1752a6) | `` linux-firmware: 20241017 -> 20241110 ``                                                 |
| [`7d424672`](https://github.com/NixOS/nixpkgs/commit/7d4246729b4466e8b8a7385815e711420c9f4b45) | `` vaultwarden: 1.32.3 -> 1.32.4 ``                                                        |
| [`8feb5e84`](https://github.com/NixOS/nixpkgs/commit/8feb5e84c9e98ab540a953ad62576093148ef01b) | `` libskk: fix parse error (#355005) ``                                                    |
| [`f94a3e0c`](https://github.com/NixOS/nixpkgs/commit/f94a3e0cd12e244f3cc495aea294b83acceea29d) | `` nix-unit: 2.24.0 -> 2.24.1 ``                                                           |
| [`b3c4bada`](https://github.com/NixOS/nixpkgs/commit/b3c4badad7e20ca2a8bd7d9134a0cad8ac709468) | `` roboto-flex: init at 3.200 ``                                                           |
| [`dac96aac`](https://github.com/NixOS/nixpkgs/commit/dac96aac49afc5f0ace869355491a9614dcb721d) | `` nixos/frigate: Set SyslogIdentifier for better log entries ``                           |
| [`6b593553`](https://github.com/NixOS/nixpkgs/commit/6b59355398832f8041bc9530325a82fc03a0a4b5) | `` texlivePackages.xetex: force XeTeX to use fontconfig on Darwin (#354963) ``             |
| [`32e064f4`](https://github.com/NixOS/nixpkgs/commit/32e064f48c2b13025a7481db482600c089abbd59) | `` evcc: 0.131.4 -> 0.131.5 ``                                                             |
| [`5b74eb9b`](https://github.com/NixOS/nixpkgs/commit/5b74eb9b909e652fb27452074c071bb18c588e4e) | `` scopehal-apps: darwin support ``                                                        |
| [`8f0c9853`](https://github.com/NixOS/nixpkgs/commit/8f0c9853d54987e50134164a80f7715025bcca4d) | `` pypy3Packages.home-assistant-chip-clusters: fix the eval ``                             |
| [`e8062217`](https://github.com/NixOS/nixpkgs/commit/e8062217822110cc018ccb33c49279f7a40102fc) | `` niri: 0.1.9 -> 0.1.10 ``                                                                |
| [`0198cfb7`](https://github.com/NixOS/nixpkgs/commit/0198cfb7673af48efe46e594228f5ad63acf20c7) | `` hyprlandPlugins.hyprsplit: 0.44.1 -> 0.45.0 ``                                          |
| [`f3f9fcf9`](https://github.com/NixOS/nixpkgs/commit/f3f9fcf93c8dbe5df26fc77fa07fda9680b1c80e) | `` hyprlandPlugins.hyprspace: 0-unstable-2024-09-16 -> 0-unstable-2024-11-02 ``            |
| [`cbc60c36`](https://github.com/NixOS/nixpkgs/commit/cbc60c36101f10f4dbb54506ccfca066c3900ef9) | `` hyprlandPlugins.hyprscroller: 0-unstable-2024-10-10 -> 0-unstable-2024-11-09 ``         |
| [`d9e2143b`](https://github.com/NixOS/nixpkgs/commit/d9e2143b3e56d0b755eb1b6e4488bfe4c5d3c502) | `` hyprlandPlugins.hyprgrass: 0.8.2 -> 0.8.2-unstable-2024-10-30 ``                        |
| [`9739ac3a`](https://github.com/NixOS/nixpkgs/commit/9739ac3afe9546dd1d9c7f75af86a20298bcbc0f) | `` hyprlandPlugins.hyprfocus: 0-unstable-2024-05-30 -> 0-unstable-2024-10-09 ``            |
| [`7804dcce`](https://github.com/NixOS/nixpkgs/commit/7804dcce6c5bcefd659101d5bc80d79feb722e41) | `` hyprlandPlugins.hypr-dynamic-cursors: 0-unstable-2024-10-10 -> 0-unstable-2024-11-10 `` |
| [`7c6c0482`](https://github.com/NixOS/nixpkgs/commit/7c6c04825999a72822697dc4de5313c8a730dd44) | `` hyprlandPlugins/hyprland-plugins: 0.44.0 -> 0.45.0 ``                                   |
| [`e2b798c5`](https://github.com/NixOS/nixpkgs/commit/e2b798c525ac96dbc6a9b272d9a76c20e8966658) | `` hyprlandPlugins.hy3: 0.44.0 -> 0.45.0 ``                                                |
| [`62d3c4fb`](https://github.com/NixOS/nixpkgs/commit/62d3c4fb592bf4c07db38a1183dcefa6fd273213) | `` netsurf.browser: fix darwin builds ``                                                   |
| [`6b0d4d7f`](https://github.com/NixOS/nixpkgs/commit/6b0d4d7f4e8ef278ff7142f4d09145b754e43bc5) | `` aquamarine: 0.4.3 -> 0.4.4 ``                                                           |
| [`fa1ebbee`](https://github.com/NixOS/nixpkgs/commit/fa1ebbeeff0a9ca5a780224325e04713b4579064) | `` python312Packages.wordcloud: 1.9.3 -> 1.9.4 ``                                          |
| [`9bd781e7`](https://github.com/NixOS/nixpkgs/commit/9bd781e733017b31816e5b0bd87bb1cab875a04b) | `` linux/hardened/patches/6.6: v6.6.59-hardened1 -> v6.6.60-hardened1 ``                   |
| [`3b3ea3ac`](https://github.com/NixOS/nixpkgs/commit/3b3ea3ac4b03e0f464e31dc26cf1a01201cd36d7) | `` linux/hardened/patches/6.11: v6.11.6-hardened1 -> v6.11.7-hardened1 ``                  |
| [`d9b6a745`](https://github.com/NixOS/nixpkgs/commit/d9b6a745b2652374612e2ea4f1bf29a3b2135c29) | `` linux/hardened/patches/6.1: v6.1.115-hardened1 -> v6.1.116-hardened1 ``                 |
| [`c367b19a`](https://github.com/NixOS/nixpkgs/commit/c367b19a22b7af697c1ad1058423a04dd5951553) | `` linux/hardened/patches/5.4: v5.4.284-hardened1 -> v5.4.285-hardened1 ``                 |
| [`fc908992`](https://github.com/NixOS/nixpkgs/commit/fc9089929ad513141d94459e4b9a4f26c3391112) | `` linux/hardened/patches/5.15: v5.15.170-hardened1 -> v5.15.171-hardened1 ``              |
| [`edb9a963`](https://github.com/NixOS/nixpkgs/commit/edb9a963e6ea47566662771784e510467455d03d) | `` linux/hardened/patches/5.10: v5.10.228-hardened1 -> v5.10.229-hardened1 ``              |
| [`2544da75`](https://github.com/NixOS/nixpkgs/commit/2544da75c5bfcfed05b8cab336fc2f3c1290eb93) | `` home-assistant-custom-lovelace-modules.dirigera_platform: init at 2.6.4 (#350542) ``    |
| [`8339db67`](https://github.com/NixOS/nixpkgs/commit/8339db676638e022d21f667f517c796bd3f73a30) | `` home-assistant-custom-components.better_thermostat: 1.6.0 -> 1.6.1 ``                   |
| [`6977c6b6`](https://github.com/NixOS/nixpkgs/commit/6977c6b6c48e89c50352222fb690a66f071ef3b9) | `` piano-rs: init at 0.2.0 ``                                                              |
| [`e4c62c1f`](https://github.com/NixOS/nixpkgs/commit/e4c62c1fc494808c7c6cfdcddf31644cfb1f9479) | `` pylyzer: 0.0.69 -> 0.0.70 ``                                                            |
| [`fd214590`](https://github.com/NixOS/nixpkgs/commit/fd214590b6ac2a38a440a5c856537c218c5eec18) | `` rime-zhwiki: init at 20240909 ``                                                        |
| [`08e65e66`](https://github.com/NixOS/nixpkgs/commit/08e65e669ae380e7a25846e2f2a7125581926f5c) | `` python312Packages.tensorflow-probability: 0.24.0 -> 0.25.0 ``                           |
| [`60190159`](https://github.com/NixOS/nixpkgs/commit/60190159408fb3aeadae4a54d013ecd260320af0) | `` gfn-electron: init at 2.1.2 ``                                                          |
| [`77c379fc`](https://github.com/NixOS/nixpkgs/commit/77c379fc15b189d19fd665d01b91ab500fe92683) | `` maintainers/README: add guidelines for committers ``                                    |
| [`57fa2393`](https://github.com/NixOS/nixpkgs/commit/57fa239369669a5404140eded78283bd9b487069) | `` python3Packages.globus-sdk: fix test ``                                                 |
| [`4b239e8f`](https://github.com/NixOS/nixpkgs/commit/4b239e8fff1895c70a60f5179779ea2f00156ec2) | `` python3Packages.globus-sdk: add bot-wxt1221 as maintainers ``                           |
| [`1d294155`](https://github.com/NixOS/nixpkgs/commit/1d2941554a1091d0aa57cf10a03096ad7297f5f7) | `` dbmate: 2.21.0 -> 2.22.0 ``                                                             |
| [`a7fcea08`](https://github.com/NixOS/nixpkgs/commit/a7fcea08bca8615ab9165954c1a7dd2be81f2eb8) | `` miriway: 24.09 -> 24.10.1 ``                                                            |
| [`8025d6d1`](https://github.com/NixOS/nixpkgs/commit/8025d6d17bcdde234a3edb621f32ba47c3780c3b) | `` typos: 1.26.0 -> 1.27.3 ``                                                              |
| [`da975704`](https://github.com/NixOS/nixpkgs/commit/da9757048d7dea2c24a7aa3c9baca1bd298908b2) | `` buck2: Use stdenvNoCC ``                                                                |
| [`982ff0b0`](https://github.com/NixOS/nixpkgs/commit/982ff0b08e25e028da30697ad378e1722b363c91) | `` buck2: Install completions for bash and zsh ``                                          |
| [`8213a8a5`](https://github.com/NixOS/nixpkgs/commit/8213a8a557f80086dac25ae2c613794ce9f0b4eb) | `` surreal-engine: init at 0-unstable-2024-11-08 (#337069) ``                              |
| [`494908f0`](https://github.com/NixOS/nixpkgs/commit/494908f0fe86d07a31a77ae48a49ee8be876606f) | `` python312Packages.localstack: fix build and refactor ``                                 |
| [`54394a0c`](https://github.com/NixOS/nixpkgs/commit/54394a0c0b713f74e13603613027ea76a4ad91bd) | `` python312Packages.localstack-ext: fix build and refactor ``                             |
| [`822590d0`](https://github.com/NixOS/nixpkgs/commit/822590d062486876765c1c988eae739d5d19148e) | `` python3Packages.protobuf4: disable tests that fail on 32bit ``                          |
| [`551bd11c`](https://github.com/NixOS/nixpkgs/commit/551bd11c42de32a031f980bbbf0f76e2543a0b7f) | `` python312Packages.pyftgl: refactor and modenize ``                                      |
| [`beceecb5`](https://github.com/NixOS/nixpkgs/commit/beceecb51336d5a52e71a744f9d5f24b63c8f3b8) | `` python312Packages.pyftgl: fix source ``                                                 |
| [`8618fe6f`](https://github.com/NixOS/nixpkgs/commit/8618fe6f96b9daecc98e7d7978bda6feac067191) | `` python312Packages.pyftgl: fix build on darwin ``                                        |
| [`9828bad6`](https://github.com/NixOS/nixpkgs/commit/9828bad63a499f7e710196bf93f05da28d25d050) | `` completely: 0.5.2 -> 0.6.3 ``                                                           |
| [`8f8f60be`](https://github.com/NixOS/nixpkgs/commit/8f8f60bee8e5a8fbaefb49b5ea7767daff961336) | `` cvise: 2.10.0 -> 2.11.0 ``                                                              |
| [`66c47da4`](https://github.com/NixOS/nixpkgs/commit/66c47da4338cb5159e17b6a997b374b96c69d2bd) | `` prettypst: unstable-2023-12-06 -> unstable-2024-10-20 ``                                |
| [`88b620a7`](https://github.com/NixOS/nixpkgs/commit/88b620a72b65e28523f5509809806b5e4766acf0) | `` completely: move to by-name ``                                                          |
| [`e065e550`](https://github.com/NixOS/nixpkgs/commit/e065e550b153d8b50b72d78c54e33f1bac93be41) | `` python3Packages.us: add bot-wxt1221 as maintainers ``                                   |
| [`ef21cc74`](https://github.com/NixOS/nixpkgs/commit/ef21cc74e2f16da0cf71a496b6b5f5a889729bc1) | `` python3Packages.us: switch to pyproject ``                                              |
| [`46bbcb7e`](https://github.com/NixOS/nixpkgs/commit/46bbcb7efef5e9a38f7cdb28da717f05984a5c4d) | `` vgmtrans: init at 1.2 ``                                                                |
| [`fc94ad90`](https://github.com/NixOS/nixpkgs/commit/fc94ad90fb0ee66ec8301aa67fa3ab2532ab797f) | `` phonemizer: add bot-wxt1221 as maintainers ``                                           |
| [`42be8c49`](https://github.com/NixOS/nixpkgs/commit/42be8c49fb89a1d9c7dc1cdf03cf0d3894e95c6f) | `` phonemizer: fix build ``                                                                |
| [`e19b3c8c`](https://github.com/NixOS/nixpkgs/commit/e19b3c8cd386d3f4eec5f04ad3fc192981698644) | `` python312Packages.netifaces2: init at 0.0.22 (#354736) ``                               |
| [`fc1d5620`](https://github.com/NixOS/nixpkgs/commit/fc1d56201e179be978dfe7922633c9789b5ce603) | `` openlibm: 0.8.3 -> 0.8.4 ``                                                             |
| [`eee079f7`](https://github.com/NixOS/nixpkgs/commit/eee079f7e129c398f594716c1ca1fa0b3ea82eab) | `` xcodes: nix-rfc-format ``                                                               |
| [`b45f6140`](https://github.com/NixOS/nixpkgs/commit/b45f61402b8af4c8d18251c179630646dbfc0859) | `` xcodes: with lib; cleanup ``                                                            |
| [`7531c8e0`](https://github.com/NixOS/nixpkgs/commit/7531c8e01dc8de6a7e22912680da58290fc2e85c) | `` xcodes: 1.5.0 -> 1.6.0 ``                                                               |
| [`3912015f`](https://github.com/NixOS/nixpkgs/commit/3912015f1d0d30a9427dada9bcd6922166f7390e) | `` python312Packages.androidtv: 0.0.74 -> 0.0.75 ``                                        |
| [`647624dc`](https://github.com/NixOS/nixpkgs/commit/647624dca6a1641eccaef1c8c26ec8e35975132b) | `` wine-discord-ipc-bridge: unstable-2023-08-09 -> 0.0.3 (#353900) ``                      |
| [`01ddc696`](https://github.com/NixOS/nixpkgs/commit/01ddc69668f55020a52a0b4c4aa4708ad399b5aa) | `` obsidian: remove white background from icons ``                                         |
| [`c188d417`](https://github.com/NixOS/nixpkgs/commit/c188d417cf0718ee7beebbb5fb66dcf613de50b3) | `` python312Packages.soco: 0.30.5 -> 0.30.6 ``                                             |
| [`96e67743`](https://github.com/NixOS/nixpkgs/commit/96e67743abd9c95ddea96a4be83f151df334808a) | `` ox: switch to the new darwin sdk pattern ``                                             |
| [`992c80c0`](https://github.com/NixOS/nixpkgs/commit/992c80c02e1fc883008ce15cc51acd522748011d) | `` ox: 0.6.7 -> 0.6.10 ``                                                                  |
| [`757df4a1`](https://github.com/NixOS/nixpkgs/commit/757df4a1b42e13b93c849dd3b3866f426a11d1b4) | `` xcodes: move to by-name ``                                                              |
| [`ae21c33f`](https://github.com/NixOS/nixpkgs/commit/ae21c33fafab312d7bbb48231478a30c97f8ae29) | `` python312Packages.debugpy: 1.8.7 -> 1.8.8 ``                                            |
| [`1bd58487`](https://github.com/NixOS/nixpkgs/commit/1bd58487d015f6281f1156d32c06eea0a3d1fe0c) | `` python312Packages.scikit-rf: 1.3.0 -> 1.4.1 ``                                          |
| [`27235e1e`](https://github.com/NixOS/nixpkgs/commit/27235e1e6da67804cea38f1feb3f6830b3d76bfc) | `` python312Packages.google-generativeai: 0.8.2 -> 0.8.3 ``                                |
| [`1e6362fe`](https://github.com/NixOS/nixpkgs/commit/1e6362fe068f7b7aa3482d64b9a1024cae14786a) | `` python312Packages.google-ai-generativelanguage: 0.6.10 -> 0.6.12 ``                     |
| [`9e960c97`](https://github.com/NixOS/nixpkgs/commit/9e960c976873758289981b4daac611466c726c04) | `` python312Packages.google-cloud-bigquery-logging: 1.4.5 -> 1.5.0 ``                      |
| [`6ffb12c9`](https://github.com/NixOS/nixpkgs/commit/6ffb12c9f9c38813725f27ab9da91d1df60b950b) | `` kine: 0.13.2 -> 0.13.3 ``                                                               |
| [`ab244d13`](https://github.com/NixOS/nixpkgs/commit/ab244d13144a43dad7bbe4d7128acb6cdfb12830) | `` python312Packages.aiogram: update disabled ``                                           |
| [`bb00b359`](https://github.com/NixOS/nixpkgs/commit/bb00b359cce792fd072a6e9daa46fb6c5dd68397) | `` ggshield: 1.32.2 -> 1.33.0 ``                                                           |
| [`b39ea623`](https://github.com/NixOS/nixpkgs/commit/b39ea623743c4874c1e72eaee59b732186d8b8b8) | `` python312Packages.tencentcloud-sdk-python: 3.0.1262 -> 3.0.1263 ``                      |
| [`4c4420b2`](https://github.com/NixOS/nixpkgs/commit/4c4420b29b660c52bd27ff7536806a8b14a34aaa) | `` python312Packages.pyswitchbot: add pytest-asyncio ``                                    |
| [`b1d0a1aa`](https://github.com/NixOS/nixpkgs/commit/b1d0a1aafff5aa7e74afbb33639ec1f76856a19c) | `` python312Packages.reolink-aio: 0.10.4 -> 0.11.0b1 ``                                    |
| [`652fd511`](https://github.com/NixOS/nixpkgs/commit/652fd5119056af072b4c060c0bd8993b5707d242) | `` pik: 0.9.0 -> 0.10.0 ``                                                                 |