### PR TITLE
chore(flake/nur): `6e804f70` -> `da115e2e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731569820,
-        "narHash": "sha256-5i2hiBMnhqLVXpnmPwvLJKB5Tn816Z+9UmC5EcL2av4=",
+        "lastModified": 1731571649,
+        "narHash": "sha256-StGVrpFI6dKODTLNAW1SRDxdttnukjLTW8UmR3Nx6es=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6e804f7059440328e36f002f6eead1fd9b8eef43",
+        "rev": "da115e2e9d97361d93b0d0d0f4a0b22641658907",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`da115e2e`](https://github.com/nix-community/NUR/commit/da115e2e9d97361d93b0d0d0f4a0b22641658907) | `` automatic update `` |