### PR TITLE
chore(flake/nur): `3f6157ce` -> `09f375be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731575915,
-        "narHash": "sha256-nSbj83pXsHXUkd/bqc2hlCFhn4b580R4yKgPLURdq5Q=",
+        "lastModified": 1731585420,
+        "narHash": "sha256-y4VprnlzWwZzh+kQNRVYzld8VavLXEEm81RLctMkkL4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3f6157ceb966a93bf67c669780cde85e53b8d484",
+        "rev": "09f375beaece1d509a1289c145b3ba651f5192a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`09f375be`](https://github.com/nix-community/NUR/commit/09f375beaece1d509a1289c145b3ba651f5192a2) | `` automatic update `` |
| [`0b52d5e4`](https://github.com/nix-community/NUR/commit/0b52d5e4307c0b9bed8c438a2a0300356cede857) | `` automatic update `` |