### PR TITLE
chore(flake/nur): `7323015d` -> `0b9690db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731589619,
-        "narHash": "sha256-acZbTxMpyGLSUdYoKBr84XtpYkzks2PS9gQ9QIwucZw=",
+        "lastModified": 1731591848,
+        "narHash": "sha256-J9Jag7FB/srXfxTC32ivhl1TZTdvnuKZ7SET/cJ6fT4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7323015da884c35a111b408b376cdba0f30d8ed4",
+        "rev": "0b9690db18637a69b40bb78ba5cbaa5ab2bd9c6e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0b9690db`](https://github.com/nix-community/NUR/commit/0b9690db18637a69b40bb78ba5cbaa5ab2bd9c6e) | `` automatic update `` |