### PR TITLE
chore(flake/nix-index-database): `896019f0` -> `40d882b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -544,11 +544,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731209121,
-        "narHash": "sha256-BF7FBh1hIYPDihdUlImHGsQzaJZVLLfYqfDx41wjuF0=",
+        "lastModified": 1731593150,
+        "narHash": "sha256-FvksinoI2Y6kuwH+cKBu1oDA8uPGfoRqgtQV6O8GDc4=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "896019f04b22ce5db4c0ee4f89978694f44345c3",
+        "rev": "40d882b55e89add1ded379cc99edaab24983d6d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                               |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`cda5c362`](https://github.com/nix-community/nix-index-database/commit/cda5c362dfee069a8cd42b412687a9f29b582113) | `` Update nix-index link in README `` |