### PR TITLE
chore(flake/nur): `e8b75dfe` -> `9da996c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731594893,
-        "narHash": "sha256-FFczaWpORm8WrAxvQWNfEniJGkeBxglOwP1Cm5eAwZ0=",
+        "lastModified": 1731601888,
+        "narHash": "sha256-A+39SS2nFLaWbBdY4wdoJAYz22E4YQV7IXuGCAztLO4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e8b75dfea41e4bde46273bebdc618c54eae8af5a",
+        "rev": "9da996c73bdc1a439def9422217798395698ecbc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9da996c7`](https://github.com/nix-community/NUR/commit/9da996c73bdc1a439def9422217798395698ecbc) | `` automatic update `` |
| [`37b0dad2`](https://github.com/nix-community/NUR/commit/37b0dad212626ccf8baa666de2b16dd011ffbfa2) | `` automatic update `` |