### PR TITLE
chore(flake/emacs-overlay): `4639038b` -> `f6c94b95`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1731574827,
-        "narHash": "sha256-QneOtCpfBNkgJCs32Y8LaKDpontw7W9ATQxIW4qb6qc=",
+        "lastModified": 1731604406,
+        "narHash": "sha256-CUkO4CXaDcGyUqQ+/ArvekL3hlfgass7LjrnG6m2+g8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4639038b0f5e66e7d0f3d103b8e44ded3ab7e337",
+        "rev": "f6c94b95f529cfbd29848c12816111a2471a5293",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`f6c94b95`](https://github.com/nix-community/emacs-overlay/commit/f6c94b95f529cfbd29848c12816111a2471a5293) | `` Updated emacs `` |
| [`2edb10c7`](https://github.com/nix-community/emacs-overlay/commit/2edb10c787461d3514475230bb83238752aacbff) | `` Updated melpa `` |
| [`e599f2aa`](https://github.com/nix-community/emacs-overlay/commit/e599f2aa6d4d9c706506aaae12e3d7a1d82fa2be) | `` Updated elpa ``  |