### PR TITLE
chore(flake/home-manager): `35b05500` -> `1d0862ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -367,11 +367,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731535640,
-        "narHash": "sha256-2EckCJn4wxran/TsRiCOFcmVpep2m9EBKl99NBh2GnM=",
+        "lastModified": 1731604581,
+        "narHash": "sha256-Qq2YZZaDTB3FZLWU/Hgh1uuWlUBl3cMLGB99bm7rFUM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "35b055009afd0107b69c286fca34d2ad98940d57",
+        "rev": "1d0862ee2d7c6f6cd720d6f32213fa425004be10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                              |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`1d0862ee`](https://github.com/nix-community/home-manager/commit/1d0862ee2d7c6f6cd720d6f32213fa425004be10) | `` feh: add themes option (#6074) `` |