### PR TITLE
chore(flake/nur): `1aca2021` -> `feb10928`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731606289,
-        "narHash": "sha256-EuIVMbbItl54PYMy50E68Ie1rMz8XTjB7i47ov0p6PI=",
+        "lastModified": 1731616049,
+        "narHash": "sha256-aUIeHy2e2xYQdpRGe5y9zGgWUTc2qZL9zwt4ATUkXdo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1aca2021f991063b63370ca083de14219daf9f37",
+        "rev": "feb109282a7c4eaf3c810aa2e30f7b3b322b2091",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`feb10928`](https://github.com/nix-community/NUR/commit/feb109282a7c4eaf3c810aa2e30f7b3b322b2091) | `` automatic update `` |
| [`9ba55006`](https://github.com/nix-community/NUR/commit/9ba550061eafa7c09d91ffbd2e88a8372b3191d9) | `` automatic update `` |