### PR TITLE
chore(flake/nur): `feb10928` -> `0beb6102`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731616049,
-        "narHash": "sha256-aUIeHy2e2xYQdpRGe5y9zGgWUTc2qZL9zwt4ATUkXdo=",
+        "lastModified": 1731620698,
+        "narHash": "sha256-DiqPN2gSAQkJtBIyETu+aSetWnh6Ouq9xPuMxD/6oKA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "feb109282a7c4eaf3c810aa2e30f7b3b322b2091",
+        "rev": "0beb610276f6d7d8eab363cfe875c289de2dde3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0beb6102`](https://github.com/nix-community/NUR/commit/0beb610276f6d7d8eab363cfe875c289de2dde3e) | `` automatic update `` |