### PR TITLE
chore(flake/emacs-overlay): `f6c94b95` -> `188269c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1731604406,
-        "narHash": "sha256-CUkO4CXaDcGyUqQ+/ArvekL3hlfgass7LjrnG6m2+g8=",
+        "lastModified": 1731633562,
+        "narHash": "sha256-KTXzYymofBU99GFr+Q+O3ceX/14kYKxhTOuOjrOVSBk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f6c94b95f529cfbd29848c12816111a2471a5293",
+        "rev": "188269c44cde3363a8b8afd04565bc079b989d95",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`188269c4`](https://github.com/nix-community/emacs-overlay/commit/188269c44cde3363a8b8afd04565bc079b989d95) | `` Updated elpa ``   |
| [`dfda8a5b`](https://github.com/nix-community/emacs-overlay/commit/dfda8a5b8586c88309f7efa1cfe85b735be1cd0b) | `` Updated nongnu `` |