### PR TITLE
chore(flake/emacs-overlay): `188269c4` -> `aad0ad26`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1731633562,
-        "narHash": "sha256-KTXzYymofBU99GFr+Q+O3ceX/14kYKxhTOuOjrOVSBk=",
+        "lastModified": 1731636611,
+        "narHash": "sha256-NbrIfH/rY58V7rNv9h3Imc42rO/RtlWqZxBm5K1F+70=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "188269c44cde3363a8b8afd04565bc079b989d95",
+        "rev": "aad0ad26e710b4b1f575ed5895592ba8835e2c9e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`aad0ad26`](https://github.com/nix-community/emacs-overlay/commit/aad0ad26e710b4b1f575ed5895592ba8835e2c9e) | `` Updated emacs `` |
| [`35ae580c`](https://github.com/nix-community/emacs-overlay/commit/35ae580c2592be7467285353d27fb5ae684c7816) | `` Updated melpa `` |