### PR TITLE
chore(flake/darwin): `6c71c49e` -> `f86f158e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731454423,
-        "narHash": "sha256-TtwvgFxUa0wyptLhQbKaixgNW1UXf3+TDqfX3Kp63oM=",
+        "lastModified": 1731642829,
+        "narHash": "sha256-vG+O2RZRzYZ8BUMNNJ+BLSj6PUoGW7taDQbp6QNJ3Xo=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "6c71c49e2448e51ad830ed211024e6d0edc50116",
+        "rev": "f86f158efd4bab8dce3e207e4621f1df3a760b7a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                       |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------- |
| [`dae70299`](https://github.com/LnL7/nix-darwin/commit/dae702993d18c608f07e9d320ccba816e9bce064) | `` activate-system: remove `enable` option `` |