### PR TITLE
chore(flake/nur): `2d49d25e` -> `a8697e4c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731639254,
-        "narHash": "sha256-nk4PQXuPmKxLhLtuq5BYYtN6bGzEv72HsP/N3a/IjMc=",
+        "lastModified": 1731643669,
+        "narHash": "sha256-W0FXB6ErqWHW7LFhph+IAGrSlteOfL5yzmc1GOOS+bs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2d49d25e4f529756b72cc8f88faacdfc528f5b30",
+        "rev": "a8697e4c4ea67d9d98d6d99716823c3346be8462",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a8697e4c`](https://github.com/nix-community/NUR/commit/a8697e4c4ea67d9d98d6d99716823c3346be8462) | `` automatic update `` |
| [`911d289c`](https://github.com/nix-community/NUR/commit/911d289c5bba2942e418b984149603454dd7b915) | `` automatic update `` |