### PR TITLE
chore(flake/nur): `a8697e4c` -> `2beaf55f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731643669,
-        "narHash": "sha256-W0FXB6ErqWHW7LFhph+IAGrSlteOfL5yzmc1GOOS+bs=",
+        "lastModified": 1731653227,
+        "narHash": "sha256-Oy7VEPB0jTjWy/MexmMWu0MQq1asYCLgwuMiYpejfbU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a8697e4c4ea67d9d98d6d99716823c3346be8462",
+        "rev": "2beaf55f518df124a7fd9d1269617effee23869d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2beaf55f`](https://github.com/nix-community/NUR/commit/2beaf55f518df124a7fd9d1269617effee23869d) | `` automatic update `` |
| [`92b13b6a`](https://github.com/nix-community/NUR/commit/92b13b6a47a46a7dcdf21bd9162d90cfdb31086c) | `` automatic update `` |