### PR TITLE
chore(flake/nur): `2beaf55f` -> `0fe9e1f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731653227,
-        "narHash": "sha256-Oy7VEPB0jTjWy/MexmMWu0MQq1asYCLgwuMiYpejfbU=",
+        "lastModified": 1731660398,
+        "narHash": "sha256-bAryoDx5AiJBSwo7qayyCwSFIS6gSmNnQ1ZWfXk+B9E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2beaf55f518df124a7fd9d1269617effee23869d",
+        "rev": "0fe9e1f974ce4c5f2d32a2e1d0346010da2c7ecd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0fe9e1f9`](https://github.com/nix-community/NUR/commit/0fe9e1f974ce4c5f2d32a2e1d0346010da2c7ecd) | `` automatic update `` |