### PR TITLE
chore(flake/nur): `0fe9e1f9` -> `93581059`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731660398,
-        "narHash": "sha256-bAryoDx5AiJBSwo7qayyCwSFIS6gSmNnQ1ZWfXk+B9E=",
+        "lastModified": 1731678443,
+        "narHash": "sha256-WBltUhgsFFuBEesRJ6M6xChjfSRyB2bkpm5oZOktOZs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0fe9e1f974ce4c5f2d32a2e1d0346010da2c7ecd",
+        "rev": "93581059a8e8b5f7529752f74f1f7a5d8a9290eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`93581059`](https://github.com/nix-community/NUR/commit/93581059a8e8b5f7529752f74f1f7a5d8a9290eb) | `` automatic update `` |
| [`40254693`](https://github.com/nix-community/NUR/commit/40254693c3500191c5a375cb4a42d3f0128f8a09) | `` automatic update `` |