### PR TITLE
chore(flake/nur): `93581059` -> `dd830ca2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731678443,
-        "narHash": "sha256-WBltUhgsFFuBEesRJ6M6xChjfSRyB2bkpm5oZOktOZs=",
+        "lastModified": 1731682507,
+        "narHash": "sha256-1gZCrmPQ3mWwXl3b3KM53DuS0SVpvZB+qwJcMT1qDB8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "93581059a8e8b5f7529752f74f1f7a5d8a9290eb",
+        "rev": "dd830ca21979e6566596d7acaa5d761d4421c278",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dd830ca2`](https://github.com/nix-community/NUR/commit/dd830ca21979e6566596d7acaa5d761d4421c278) | `` automatic update `` |
| [`45c59093`](https://github.com/nix-community/NUR/commit/45c59093d7666eff6dea16f2318a912f672287ef) | `` automatic update `` |