### PR TITLE
chore(flake/emacs-overlay): `d7618a5f` -> `d0ff8cfc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1731662022,
-        "narHash": "sha256-Q6AmDWc3N9pLtUO90bvOafGDMhFfb+BSHSgz40LD/7o=",
+        "lastModified": 1731690821,
+        "narHash": "sha256-rSDrN5h+gES/wTN5+Bsvg6U14KNGafr+3PzZBTqfEf8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d7618a5f8b29ca9c573df4532631b621b2a763fa",
+        "rev": "d0ff8cfc00bed7ae7a9f9e4cacea031443d295bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`d0ff8cfc`](https://github.com/nix-community/emacs-overlay/commit/d0ff8cfc00bed7ae7a9f9e4cacea031443d295bb) | `` Updated emacs ``  |
| [`e242de3c`](https://github.com/nix-community/emacs-overlay/commit/e242de3cdffc62319a3caba2ab9f491c4b8f51c1) | `` Updated melpa ``  |
| [`6d296e5f`](https://github.com/nix-community/emacs-overlay/commit/6d296e5f93348504d669a2a377fb16c7548239c2) | `` Updated elpa ``   |
| [`9689a1f9`](https://github.com/nix-community/emacs-overlay/commit/9689a1f90e9dc315f460a626dec4d7f27e4e623b) | `` Updated nongnu `` |