### PR TITLE
chore(flake/emacs-overlay): `d0ff8cfc` -> `9c2da4a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1731690821,
-        "narHash": "sha256-rSDrN5h+gES/wTN5+Bsvg6U14KNGafr+3PzZBTqfEf8=",
+        "lastModified": 1731719850,
+        "narHash": "sha256-7czVGDJLLw6E0hQAD8LUHiBv0eNXO75dZJ5eRBa8o+Y=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d0ff8cfc00bed7ae7a9f9e4cacea031443d295bb",
+        "rev": "9c2da4a0bf2e6bd0ce99c37b60c19cfe38e99dcb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`9c2da4a0`](https://github.com/nix-community/emacs-overlay/commit/9c2da4a0bf2e6bd0ce99c37b60c19cfe38e99dcb) | `` Updated elpa ``   |
| [`489d5749`](https://github.com/nix-community/emacs-overlay/commit/489d5749b9782320f89e628e9e9caa515150e1e1) | `` Updated nongnu `` |