### PR TITLE
chore(flake/nur): `6e17acc0` -> `fa57a752`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731695757,
-        "narHash": "sha256-w+bGxRbZpWc6SyBbtjW2ci2fw1zk0udTjFpQW0g0Pc8=",
+        "lastModified": 1731722968,
+        "narHash": "sha256-AorIcOjtBSpsWD16RW50Z+m8DBkoxdYkvSwQ/cgHyRk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6e17acc00a48253a4d25e5ee4e6c215b8950c039",
+        "rev": "fa57a75252006ee4f3e221bd9a4c90d8a0fbe885",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fa57a752`](https://github.com/nix-community/NUR/commit/fa57a75252006ee4f3e221bd9a4c90d8a0fbe885) | `` automatic update `` |