### PR TITLE
chore(flake/nur): `fa57a752` -> `3d50986f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731722968,
-        "narHash": "sha256-AorIcOjtBSpsWD16RW50Z+m8DBkoxdYkvSwQ/cgHyRk=",
+        "lastModified": 1731725645,
+        "narHash": "sha256-z15Z8UQFLt/K4k+uSzf7ahIA5w8+IswBh1zCWub8miA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fa57a75252006ee4f3e221bd9a4c90d8a0fbe885",
+        "rev": "3d50986f3cabedc642e10e7255ff69dd5ee8fd6b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3d50986f`](https://github.com/nix-community/NUR/commit/3d50986f3cabedc642e10e7255ff69dd5ee8fd6b) | `` automatic update `` |