### PR TITLE
chore(flake/nur): `3d50986f` -> `cfdc33bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731725645,
-        "narHash": "sha256-z15Z8UQFLt/K4k+uSzf7ahIA5w8+IswBh1zCWub8miA=",
+        "lastModified": 1731729003,
+        "narHash": "sha256-zRS3aqzK0e00U061KmR3MEmxB0fISHB9XFm+V8EfDsQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3d50986f3cabedc642e10e7255ff69dd5ee8fd6b",
+        "rev": "cfdc33bb6211739aae2ace32c71db27450d709e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cfdc33bb`](https://github.com/nix-community/NUR/commit/cfdc33bb6211739aae2ace32c71db27450d709e9) | `` automatic update `` |
| [`be2664b2`](https://github.com/nix-community/NUR/commit/be2664b26e2c661b5053239f9f4d8a9b458e5dca) | `` automatic update `` |