### PR TITLE
chore(flake/nur): `cfdc33bb` -> `295cc9ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731729003,
-        "narHash": "sha256-zRS3aqzK0e00U061KmR3MEmxB0fISHB9XFm+V8EfDsQ=",
+        "lastModified": 1731730181,
+        "narHash": "sha256-uCyImsva4NYsRywcT+U6cr+MZrXx/e4Gu8SqTujrCBY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cfdc33bb6211739aae2ace32c71db27450d709e9",
+        "rev": "295cc9ee333bda9e7d58daae4d1c25fcdef3e5a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`295cc9ee`](https://github.com/nix-community/NUR/commit/295cc9ee333bda9e7d58daae4d1c25fcdef3e5a6) | `` automatic update `` |