### PR TITLE
chore(flake/nixos-hardware): `0c657fd1` -> `c2c275fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -605,11 +605,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1731740063,
-        "narHash": "sha256-6ErGxO5PdrVAfTCb8FBNcYx3AjAlCyOyGcZLo+tknKs=",
+        "lastModified": 1731740897,
+        "narHash": "sha256-teFd31vsE/0Z0WR6XVeKhKPw6Eyb2gXGpG0tjpMfBDM=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "0c657fd1342d7996874a19c6e5540fd6ab3cf876",
+        "rev": "c2c275fbb2e656948ba6e1f67b8ddd430f158c5f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`c2c275fb`](https://github.com/NixOS/nixos-hardware/commit/c2c275fbb2e656948ba6e1f67b8ddd430f158c5f) | `` Add information on Gigabyte B650M Aorus Elite AX `` |