### PR TITLE
chore(flake/sops-nix): `4c91d52d` -> `d2bd7f43`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -941,11 +941,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1731364708,
-        "narHash": "sha256-HC0anOL+KmUQ2hdRl0AtunbAckasxrkn4VLmxbW/WaA=",
+        "lastModified": 1731748189,
+        "narHash": "sha256-Zd/Uukvpcu26M6YGhpbsgqm6LUSLz+Q8mDZ5LOEGdiE=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "4c91d52db103e757fc25b58998b0576ae702d659",
+        "rev": "d2bd7f433b28db6bc7ae03d5eca43564da0af054",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                    |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`d2bd7f43`](https://github.com/Mic92/sops-nix/commit/d2bd7f433b28db6bc7ae03d5eca43564da0af054) | `` Implement darwin module for sops-nix `` |