### PR TITLE
chore(flake/nur): `295cc9ee` -> `48d49a91`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731730181,
-        "narHash": "sha256-uCyImsva4NYsRywcT+U6cr+MZrXx/e4Gu8SqTujrCBY=",
+        "lastModified": 1731754035,
+        "narHash": "sha256-EyZZwZMs+zfI/NSOVPRh8kW1qljNJsPC11Y7fXLg9Gs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "295cc9ee333bda9e7d58daae4d1c25fcdef3e5a6",
+        "rev": "48d49a916e13bcb6363d8d3ac4c5c862aea21b7c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`48d49a91`](https://github.com/nix-community/NUR/commit/48d49a916e13bcb6363d8d3ac4c5c862aea21b7c) | `` automatic update `` |