### PR TITLE
chore(flake/nur): `48d49a91` -> `1f664a85`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731754035,
-        "narHash": "sha256-EyZZwZMs+zfI/NSOVPRh8kW1qljNJsPC11Y7fXLg9Gs=",
+        "lastModified": 1731757514,
+        "narHash": "sha256-zIAq7IBDJF+w6W+LBeKmOdaalIteCZST9IQGnX2fCxk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "48d49a916e13bcb6363d8d3ac4c5c862aea21b7c",
+        "rev": "1f664a85a1fbca8a5f73cdbe62ac3c08068ea683",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1f664a85`](https://github.com/nix-community/NUR/commit/1f664a85a1fbca8a5f73cdbe62ac3c08068ea683) | `` automatic update `` |
| [`05f16f37`](https://github.com/nix-community/NUR/commit/05f16f37bd82395d5a0e252f7181c8af2b27e758) | `` automatic update `` |