### PR TITLE
chore(flake/nur): `1f664a85` -> `8965d9b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731757514,
-        "narHash": "sha256-zIAq7IBDJF+w6W+LBeKmOdaalIteCZST9IQGnX2fCxk=",
+        "lastModified": 1731760389,
+        "narHash": "sha256-2jw0lEc4VtEP4VawPn/DQdJDa9P3diXR2jWtdTUh8TI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1f664a85a1fbca8a5f73cdbe62ac3c08068ea683",
+        "rev": "8965d9b4b1d1685908bc30771fc2bdd77baf23ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                       |
| -------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`8965d9b4`](https://github.com/nix-community/NUR/commit/8965d9b4b1d1685908bc30771fc2bdd77baf23ff) | `` automatic update ``        |
| [`a6719e65`](https://github.com/nix-community/NUR/commit/a6719e656cd3dd606a3b387a4b3f6ebd5b85983b) | `` add mbekkomo repository `` |