### PR TITLE
chore(flake/darwin): `f86f158e` -> `2bcef10f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731642829,
-        "narHash": "sha256-vG+O2RZRzYZ8BUMNNJ+BLSj6PUoGW7taDQbp6QNJ3Xo=",
+        "lastModified": 1731768170,
+        "narHash": "sha256-9Zj2baKY3KaKzs5+nqZgIwr/o/iibhENFxjOnpU+IOU=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "f86f158efd4bab8dce3e207e4621f1df3a760b7a",
+        "rev": "2bcef10f4319f34ddebadb5f37eaa81ca2510730",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                        |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
| [`ec5fce60`](https://github.com/LnL7/nix-darwin/commit/ec5fce6061c26095f6de3a9cb9398171aa3b8c86) | `` uninstaller: check `nix-daemon` works after restoring ``                    |
| [`e07f08c0`](https://github.com/LnL7/nix-darwin/commit/e07f08c0dcbf2f10a51f76ac2910c25e25ff4d84) | `` uninstaller: fix restoring nix-daemon launchd daemon ``                     |
| [`6d20de4e`](https://github.com/LnL7/nix-darwin/commit/6d20de4ed606846230f766cc059bf01b47b8e2d4) | `` nix: remove outdated note requiring managed daemon for distributedBuilds `` |
| [`7918e24e`](https://github.com/LnL7/nix-darwin/commit/7918e24e5b999e36c923573e9d6ac183b0c00f38) | `` treewide: remove `nix.package` example ``                                   |
| [`6d794390`](https://github.com/LnL7/nix-darwin/commit/6d794390fa48afbe5d8b0020392f55bc1d800cb6) | `` checks: check single user installs don't have the `nix-daemon` enabled ``   |
| [`5d1b7ac6`](https://github.com/LnL7/nix-darwin/commit/5d1b7ac696c2c9cf4206d7fbd3ebe3daa3b9bbd2) | `` treewide: remove mentions of `services.nix-daemon.enable = true;` ``        |
| [`698414e4`](https://github.com/LnL7/nix-darwin/commit/698414e4091d919cc1b3af622f29bd594d3c21c3) | `` nix-daemon: enable by default ``                                            |
| [`d2498644`](https://github.com/LnL7/nix-darwin/commit/d2498644fd84360e46ad90de3029066ad441e15a) | `` nix-daemon: remove `with lib;` ``                                           |