### PR TITLE
chore(flake/nur): `f2d57e74` -> `786ca6dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731764218,
-        "narHash": "sha256-mZ7J8j+K2tMPD2Y6aEgBOE8JuEJ63gbOx1aDbSxuN24=",
+        "lastModified": 1731768294,
+        "narHash": "sha256-z1KwCt5OXySmHw+rvz42CRGfMNJMwUWs0rM26cWYCTk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f2d57e74172aa03f87bd520b8778ef880f58af3c",
+        "rev": "786ca6dd40c35a7b7fed696ad1901822cf160ef2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`786ca6dd`](https://github.com/nix-community/NUR/commit/786ca6dd40c35a7b7fed696ad1901822cf160ef2) | `` automatic update `` |