### PR TITLE
chore(flake/nur): `786ca6dd` -> `d82f229b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731768294,
-        "narHash": "sha256-z1KwCt5OXySmHw+rvz42CRGfMNJMwUWs0rM26cWYCTk=",
+        "lastModified": 1731775831,
+        "narHash": "sha256-H0vUibnBuU/i8TP4C0j584KeoI/IzaLTk+THLg4w4So=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "786ca6dd40c35a7b7fed696ad1901822cf160ef2",
+        "rev": "d82f229b8bb0bf3f1bf43f01f3a9626467da27f5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d82f229b`](https://github.com/nix-community/NUR/commit/d82f229b8bb0bf3f1bf43f01f3a9626467da27f5) | `` automatic update `` |
| [`4e8351d5`](https://github.com/nix-community/NUR/commit/4e8351d51a548c5ef2a759a2a1cc95c0a98a6d2b) | `` automatic update `` |
| [`564dae74`](https://github.com/nix-community/NUR/commit/564dae7415d2c37073a0a002a8d92f1cbcee4556) | `` automatic update `` |
| [`9dfc5d8e`](https://github.com/nix-community/NUR/commit/9dfc5d8e282e15731aa75ea83b497eddfba97a8f) | `` automatic update `` |
| [`e76f99ed`](https://github.com/nix-community/NUR/commit/e76f99ed67f82634c6a07acdc859ededdbd8a43f) | `` automatic update `` |
| [`f708e36f`](https://github.com/nix-community/NUR/commit/f708e36f58b5afb70115e7242cd1770302f04ddf) | `` automatic update `` |