### PR TITLE
chore(flake/nur): `d82f229b` -> `8a658f7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731775831,
-        "narHash": "sha256-H0vUibnBuU/i8TP4C0j584KeoI/IzaLTk+THLg4w4So=",
+        "lastModified": 1731780121,
+        "narHash": "sha256-nlFmEF/AFus6iTN0ZTCUKEfg0hiiPOaJdW+nZ0Io3aE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d82f229b8bb0bf3f1bf43f01f3a9626467da27f5",
+        "rev": "8a658f7dd88bb3b3dbbdeea9dc5e268f4cf6e2e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8a658f7d`](https://github.com/nix-community/NUR/commit/8a658f7dd88bb3b3dbbdeea9dc5e268f4cf6e2e6) | `` automatic update `` |
| [`33b857d3`](https://github.com/nix-community/NUR/commit/33b857d30914d122eaf0328ced8effbc14714f6f) | `` automatic update `` |