### PR TITLE
chore(flake/home-manager): `c7c25176` -> `1bd5616e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -367,11 +367,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731782173,
-        "narHash": "sha256-l0vlBmqQOJneVtvRjAJuYPGV5wtiqq1+OTkVti8b3CY=",
+        "lastModified": 1731786860,
+        "narHash": "sha256-130gQ5k8kZlxjBEeLpE+SvWFgSOFgQFeZlqIik7KgtQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c7c251761235282acfc681accf8d3deea6681cc0",
+        "rev": "1bd5616e33c0c54d7a5b37db94160635a9b27aeb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`1bd5616e`](https://github.com/nix-community/home-manager/commit/1bd5616e33c0c54d7a5b37db94160635a9b27aeb) | `` lib/file-type: Make `force` option visible (#6003) `` |