### PR TITLE
chore(flake/nur): `8a658f7d` -> `5b1a95e3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731780121,
-        "narHash": "sha256-nlFmEF/AFus6iTN0ZTCUKEfg0hiiPOaJdW+nZ0Io3aE=",
+        "lastModified": 1731789015,
+        "narHash": "sha256-WPdauhhD4ZdQ35p3WU8p95P6tN73K6s3w/MkBVW8+tI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8a658f7dd88bb3b3dbbdeea9dc5e268f4cf6e2e6",
+        "rev": "5b1a95e38d7c29f980061561cdbd793aa9596b08",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5b1a95e3`](https://github.com/nix-community/NUR/commit/5b1a95e38d7c29f980061561cdbd793aa9596b08) | `` automatic update `` |
| [`b10a6ef3`](https://github.com/nix-community/NUR/commit/b10a6ef36e9a7b37e8f375ff13fbddd7d4429816) | `` automatic update `` |
| [`d2fbc739`](https://github.com/nix-community/NUR/commit/d2fbc739c3ca6f05731c221495a57925a5bc6f2a) | `` automatic update `` |