### PR TITLE
chore(flake/nur): `908451fa` -> `aa23c513`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731793520,
-        "narHash": "sha256-Axw4wfIcG1m8/kAb3k4LCBJKfNCpdXUCtjPsXEzSMWk=",
+        "lastModified": 1731811898,
+        "narHash": "sha256-geL+s2aoL3F+kiG4RtJFWzzlcUyrYJfo9zzhTr6LwSM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "908451fa847a4e3f74c409dff4721465de695253",
+        "rev": "aa23c513a11e0c27172f76bb3fee41a1f1746e22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`aa23c513`](https://github.com/nix-community/NUR/commit/aa23c513a11e0c27172f76bb3fee41a1f1746e22) | `` automatic update `` |
| [`6d78575b`](https://github.com/nix-community/NUR/commit/6d78575b22179cc5a0d599ce213e5b9fd64a7239) | `` automatic update `` |