### PR TITLE
chore(flake/nur): `aa23c513` -> `4cde5b2e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731811898,
-        "narHash": "sha256-geL+s2aoL3F+kiG4RtJFWzzlcUyrYJfo9zzhTr6LwSM=",
+        "lastModified": 1731815686,
+        "narHash": "sha256-6HPZVrwQOZzeaW5QseyXnghK76a3aDnRoQf+L+cpNms=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aa23c513a11e0c27172f76bb3fee41a1f1746e22",
+        "rev": "4cde5b2ea07d8c05570d7305738a9870b1a14700",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4cde5b2e`](https://github.com/nix-community/NUR/commit/4cde5b2ea07d8c05570d7305738a9870b1a14700) | `` automatic update `` |
| [`8b3ec1a5`](https://github.com/nix-community/NUR/commit/8b3ec1a5af4dc944dbafbe819e77f02774e54075) | `` automatic update `` |
| [`9ac57c18`](https://github.com/nix-community/NUR/commit/9ac57c183c77763e7f1e483b1f215d338cb2f9f4) | `` automatic update `` |