### PR TITLE
chore(flake/nur): `4cde5b2e` -> `2aeeee17`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731815686,
-        "narHash": "sha256-6HPZVrwQOZzeaW5QseyXnghK76a3aDnRoQf+L+cpNms=",
+        "lastModified": 1731821709,
+        "narHash": "sha256-k4rLmODUcEs0wCh2wOtpRhZXO/wrI/26n9IBrHX+L9s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4cde5b2ea07d8c05570d7305738a9870b1a14700",
+        "rev": "2aeeee1797357b8ad88187a8671df63b1f53fa2b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2aeeee17`](https://github.com/nix-community/NUR/commit/2aeeee1797357b8ad88187a8671df63b1f53fa2b) | `` automatic update `` |
| [`103b02af`](https://github.com/nix-community/NUR/commit/103b02afb5fa6bebab9742bd94979326afd11371) | `` automatic update `` |
| [`59740d79`](https://github.com/nix-community/NUR/commit/59740d792bea5caa547c9bc7ce366802ecfafb7f) | `` automatic update `` |
| [`67df6abe`](https://github.com/nix-community/NUR/commit/67df6abee3d5fbb66e90b1da309dafc4413df9d0) | `` automatic update `` |