### PR TITLE
chore(flake/nur): `2aeeee17` -> `fd679aae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731821709,
-        "narHash": "sha256-k4rLmODUcEs0wCh2wOtpRhZXO/wrI/26n9IBrHX+L9s=",
+        "lastModified": 1731828968,
+        "narHash": "sha256-bE5CnDQXWSDgyWU3/dKs3NEFInk8sHsrZ0zZust+1G4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2aeeee1797357b8ad88187a8671df63b1f53fa2b",
+        "rev": "fd679aaea16414301993b3e3adbfe7853212e750",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fd679aae`](https://github.com/nix-community/NUR/commit/fd679aaea16414301993b3e3adbfe7853212e750) | `` automatic update `` |