### PR TITLE
chore(flake/nur): `fd679aae` -> `d74d2f53`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731828968,
-        "narHash": "sha256-bE5CnDQXWSDgyWU3/dKs3NEFInk8sHsrZ0zZust+1G4=",
+        "lastModified": 1731837142,
+        "narHash": "sha256-K/HmwS80joHeKXSVDIDuRMRHsWR4+YPuxi/XCYntUzU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fd679aaea16414301993b3e3adbfe7853212e750",
+        "rev": "d74d2f539e825b77e3dac80dfe6d041679c801fc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d74d2f53`](https://github.com/nix-community/NUR/commit/d74d2f539e825b77e3dac80dfe6d041679c801fc) | `` automatic update `` |
| [`4faf510c`](https://github.com/nix-community/NUR/commit/4faf510c4c0252a803d6d052cf2dd7905daefce0) | `` automatic update `` |