### PR TITLE
chore(flake/nur): `d74d2f53` -> `044a4b96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731837142,
-        "narHash": "sha256-K/HmwS80joHeKXSVDIDuRMRHsWR4+YPuxi/XCYntUzU=",
+        "lastModified": 1731840438,
+        "narHash": "sha256-tEVbT7JSMqebBvTyFolN7gkxdX/qtfMuT0uZFNLQvt4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d74d2f539e825b77e3dac80dfe6d041679c801fc",
+        "rev": "044a4b96cdc20eb6aad109d432a239e7048f1a84",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`044a4b96`](https://github.com/nix-community/NUR/commit/044a4b96cdc20eb6aad109d432a239e7048f1a84) | `` automatic update `` |
| [`7abaf30e`](https://github.com/nix-community/NUR/commit/7abaf30ef30d253a5cd7bf7609a8fef6d707df5d) | `` automatic update `` |