### PR TITLE
chore(flake/sops-nix): `eee831aa` -> `6b85086b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -941,11 +941,11 @@
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
-        "lastModified": 1731824381,
-        "narHash": "sha256-Zluegq0O709V6tL1fhDkOyVUQsvVfI0jamDSb8NNYlw=",
+        "lastModified": 1731842579,
+        "narHash": "sha256-///x6/i73Tv6ZgXa+2IjwFRu5PbUGy0lCQzLa/57q7s=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "eee831aadbc25f72fa9d214d57bddfd847e026b2",
+        "rev": "6b85086bccc660291db1652cbe97462cc9f3cd58",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                         |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`6b85086b`](https://github.com/Mic92/sops-nix/commit/6b85086bccc660291db1652cbe97462cc9f3cd58) | `` reformat code base with nixfmt ``            |
| [`b05bdb26`](https://github.com/Mic92/sops-nix/commit/b05bdb2650aee87e90e76c38713f5e9fd5d35037) | `` nix-darwin: fix evaluation with templates `` |
| [`a7b8f0fe`](https://github.com/Mic92/sops-nix/commit/a7b8f0feb7f775c9467137180054ebd9474fc6ab) | `` define templates for home-manager ``         |