### PR TITLE
chore(flake/nur): `044a4b96` -> `eaa739d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731840438,
-        "narHash": "sha256-tEVbT7JSMqebBvTyFolN7gkxdX/qtfMuT0uZFNLQvt4=",
+        "lastModified": 1731846017,
+        "narHash": "sha256-w9fc4d6JA30xhzfK+CQtEVffuQIZ0iWS+rAeQ9+4OK0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "044a4b96cdc20eb6aad109d432a239e7048f1a84",
+        "rev": "eaa739d1ab855017f848ea80f780feadbf819959",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`eaa739d1`](https://github.com/nix-community/NUR/commit/eaa739d1ab855017f848ea80f780feadbf819959) | `` automatic update `` |