### PR TITLE
chore(flake/sops-nix): `6b85086b` -> `0ec0d5d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -724,22 +724,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable_4": {
-      "locked": {
-        "lastModified": 1731797254,
-        "narHash": "sha256-df3dJApLPhd11AlueuoN0Q4fHo/hagP75LlM5K1sz9g=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e8c38b73aeb218e27163376a2d617e61a2ad9b59",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "release-24.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1731139594,
@@ -937,15 +921,14 @@
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable_4"
+        ]
       },
       "locked": {
-        "lastModified": 1731842579,
-        "narHash": "sha256-///x6/i73Tv6ZgXa+2IjwFRu5PbUGy0lCQzLa/57q7s=",
+        "lastModified": 1731854022,
+        "narHash": "sha256-lgOoC3t5Wp3LWgzIwhK0d6xfPgF6TaAzFzu9O4xVxpo=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "6b85086bccc660291db1652cbe97462cc9f3cd58",
+        "rev": "0ec0d5d3c58ccafc622cb273e5458471931c65b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                       |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`0ec0d5d3`](https://github.com/Mic92/sops-nix/commit/0ec0d5d3c58ccafc622cb273e5458471931c65b6) | `` remove obsolete sops-pgp-hook alias ``                     |
| [`799b572e`](https://github.com/Mic92/sops-nix/commit/799b572ef1ce4c6ed8efa806b9b542ae8d9cfe6e) | `` move checks out of pkgs ``                                 |
| [`42073729`](https://github.com/Mic92/sops-nix/commit/420737291e2ec58a40c4a392bc4d1e29d87f1bb9) | `` load devshell from flake ``                                |
| [`793c07f3`](https://github.com/Mic92/sops-nix/commit/793c07f331a831e4321038e3e8ac2e503167af8b) | `` nix-darwin: fix shellcheck warning of activation script `` |
| [`1c75c1c1`](https://github.com/Mic92/sops-nix/commit/1c75c1c13aea0b05981b6254fe1cf01c9e1dce6e) | `` fix darwin evaluation ``                                   |
| [`fe6a1bb9`](https://github.com/Mic92/sops-nix/commit/fe6a1bb9229253f2f7b8405bb87f57543e423ad1) | `` add home-manager and sops-nix to ci ``                     |
| [`dfcebb55`](https://github.com/Mic92/sops-nix/commit/dfcebb55c8e8165208c4a802335353d2e7517341) | `` only export nixos tests on Linux ``                        |
| [`5f3869df`](https://github.com/Mic92/sops-nix/commit/5f3869dfd2cdaf78d0fe48d0ac10949ee7534a27) | `` update github action to also update private flake ``       |
| [`77697276`](https://github.com/Mic92/sops-nix/commit/77697276340fbfa7244cafb58ffe3b28e1002572) | `` move nixpkgs-stable to private flake inputs ``             |
| [`d76a2f00`](https://github.com/Mic92/sops-nix/commit/d76a2f002f46ed68a061961c063aeb1c47e040f6) | `` nix-darwin: remove unused variable ``                      |