### PR TITLE
chore(flake/nur): `b3f470a4` -> `a0ab966b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731851132,
-        "narHash": "sha256-qouQ1PepFte/ba/wmvixPTYgWjgTKKNadwJAmzyegSU=",
+        "lastModified": 1731854849,
+        "narHash": "sha256-ru5OBSnAxqbSoPA9WYwLUryWIxB9dgEH3w1FGeaKTyY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b3f470a406135cf67de31c3d47eb55774ee2b12f",
+        "rev": "a0ab966bfd6aba0931f8b3b739dafe6eff9ed349",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a0ab966b`](https://github.com/nix-community/NUR/commit/a0ab966bfd6aba0931f8b3b739dafe6eff9ed349) | `` automatic update `` |