### PR TITLE
chore(flake/nur): `a0ab966b` -> `748b7cfa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731854849,
-        "narHash": "sha256-ru5OBSnAxqbSoPA9WYwLUryWIxB9dgEH3w1FGeaKTyY=",
+        "lastModified": 1731861853,
+        "narHash": "sha256-svkgUDU7ETRIgLCRuI9PNPnxdiX/R2BbqV8/3HiaIJU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a0ab966bfd6aba0931f8b3b739dafe6eff9ed349",
+        "rev": "748b7cfaad6c60b788708533ea417f038e33e09c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`748b7cfa`](https://github.com/nix-community/NUR/commit/748b7cfaad6c60b788708533ea417f038e33e09c) | `` automatic update `` |
| [`90d9aaff`](https://github.com/nix-community/NUR/commit/90d9aaffa8531e9a5e05380de437a95ee4968c90) | `` automatic update `` |