### PR TITLE
chore(flake/sops-nix): `0ec0d5d3` -> `472741cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -924,11 +924,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731854022,
-        "narHash": "sha256-lgOoC3t5Wp3LWgzIwhK0d6xfPgF6TaAzFzu9O4xVxpo=",
+        "lastModified": 1731862312,
+        "narHash": "sha256-NVUTFxKrJp/hjehlF1IvkPnlRYg/O9HFVutbxOM8zNM=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "0ec0d5d3c58ccafc622cb273e5458471931c65b6",
+        "rev": "472741cf3fee089241ac9ea705bb2b9e0bfa2978",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                        |
| ----------------------------------------------------------------------------------------------- | ------------------------------ |
| [`472741cf`](https://github.com/Mic92/sops-nix/commit/472741cf3fee089241ac9ea705bb2b9e0bfa2978) | `` fix eval of tests (#674) `` |