### PR TITLE
chore(flake/nur): `ac3ca33b` -> `25e6cfc7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731863972,
-        "narHash": "sha256-E3QBnpoTVvKY8HZH99qIxRfoSgvJQuo5GbA8Tsmt2es=",
+        "lastModified": 1731872711,
+        "narHash": "sha256-2vj0E55Ckfo8eiPqImADvBEHwtIoOx8ufiRnXElQf0w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ac3ca33bee0460cd09d79288aada1f29e6f6aacf",
+        "rev": "25e6cfc7d6260864f5f5dfe2617b39a6afb6ea5e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`25e6cfc7`](https://github.com/nix-community/NUR/commit/25e6cfc7d6260864f5f5dfe2617b39a6afb6ea5e) | `` automatic update `` |
| [`f50dcc1d`](https://github.com/nix-community/NUR/commit/f50dcc1d1f6518e3198a72ee5ccb5994f1eaa47d) | `` automatic update `` |