### PR TITLE
chore(flake/nur): `25e6cfc7` -> `495fc9ea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731872711,
-        "narHash": "sha256-2vj0E55Ckfo8eiPqImADvBEHwtIoOx8ufiRnXElQf0w=",
+        "lastModified": 1731896641,
+        "narHash": "sha256-TnCM+tqrRtAH06F3AH6dsJlyBNEc+T0Ei/MpXWyLkMw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "25e6cfc7d6260864f5f5dfe2617b39a6afb6ea5e",
+        "rev": "495fc9ea2801122dc14ac0bbd8ffa13293ac76b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`495fc9ea`](https://github.com/nix-community/NUR/commit/495fc9ea2801122dc14ac0bbd8ffa13293ac76b6) | `` automatic update `` |
| [`9c9b53b1`](https://github.com/nix-community/NUR/commit/9c9b53b1e00af6fa1297e2bf3d757f2589624116) | `` automatic update `` |
| [`64e1cb66`](https://github.com/nix-community/NUR/commit/64e1cb66cbca34ca2970d57094c342c73bd99fad) | `` automatic update `` |
| [`b90a6ac4`](https://github.com/nix-community/NUR/commit/b90a6ac45909d866b185630be378f623e21a88e7) | `` automatic update `` |
| [`74a9029b`](https://github.com/nix-community/NUR/commit/74a9029b6599457a623e03f116f90ac6b49aae31) | `` automatic update `` |
| [`70f09dea`](https://github.com/nix-community/NUR/commit/70f09deab2aa18e82bc92fc545199850a68ea475) | `` automatic update `` |