### PR TITLE
chore(flake/home-manager): `0918bb02` -> `f3a2ff69`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -367,11 +367,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731882691,
-        "narHash": "sha256-lJX1EJZSrITQAfN7hiBQh3EJ4U9uayWVHdwtFiJkmwE=",
+        "lastModified": 1731887066,
+        "narHash": "sha256-uw7K/RsYioJicV79Nl39yjtfhdfTDU2aRxnBgvFhkZ8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0918bb02385a6897e7a0180d23ee4587491eb0d4",
+        "rev": "f3a2ff69586f3a54b461526e5702b1a2f81e740a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`f3a2ff69`](https://github.com/nix-community/home-manager/commit/f3a2ff69586f3a54b461526e5702b1a2f81e740a) | `` zsh-abbr: update source path (#6084) `` |
| [`05d3b621`](https://github.com/nix-community/home-manager/commit/05d3b6215afa733fed6f025a59a562f98330acc3) | `` home-manager: prepare 25.05-pre ``      |