### PR TITLE
chore(flake/srvos): `dabae9d2` -> `e26a8147`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -944,11 +944,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730940990,
-        "narHash": "sha256-FyRDs/jlmaBDL1ryf3tM9rFaOrlYn5wSa1VUr4k2w+4=",
+        "lastModified": 1731891382,
+        "narHash": "sha256-rRREuHCR3k6/g+F9sToP2Cf05qVlWQbl2c7dRRhcqTI=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "dabae9d2062afd45f343d13d819eea1029d08162",
+        "rev": "e26a814735f50034e35dff637efad2d502698d09",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`e26a8147`](https://github.com/nix-community/srvos/commit/e26a814735f50034e35dff637efad2d502698d09) | `` dev/private/flake.lock: Update `` |
| [`32c1d08b`](https://github.com/nix-community/srvos/commit/32c1d08b3e7227bd2c229891f9b520955acc14c9) | `` flake.lock: Update ``             |