### PR TITLE
chore(flake/nur): `495fc9ea` -> `6d05b830`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731896641,
-        "narHash": "sha256-TnCM+tqrRtAH06F3AH6dsJlyBNEc+T0Ei/MpXWyLkMw=",
+        "lastModified": 1731899567,
+        "narHash": "sha256-x6dR7HdgZG0wCnJOZLwbJV/5Vwz98c5y1mCQ6GiF+BM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "495fc9ea2801122dc14ac0bbd8ffa13293ac76b6",
+        "rev": "6d05b8307231b06cb22d0ac7691dd1b10a18c447",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6d05b830`](https://github.com/nix-community/NUR/commit/6d05b8307231b06cb22d0ac7691dd1b10a18c447) | `` automatic update `` |