### PR TITLE
chore(flake/nur): `6d05b830` -> `2258b6ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731899567,
-        "narHash": "sha256-x6dR7HdgZG0wCnJOZLwbJV/5Vwz98c5y1mCQ6GiF+BM=",
+        "lastModified": 1731902101,
+        "narHash": "sha256-ZBj8YIUFqCDbNvIlrJIFaZ+xq9T5482qXMaU8lWHSmQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6d05b8307231b06cb22d0ac7691dd1b10a18c447",
+        "rev": "2258b6ade3b7a0c69266126cdf1a8ec37765d4fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2258b6ad`](https://github.com/nix-community/NUR/commit/2258b6ade3b7a0c69266126cdf1a8ec37765d4fd) | `` automatic update `` |
| [`2bb1bfa3`](https://github.com/nix-community/NUR/commit/2bb1bfa3cd685165930638baecfa0a2b5d5939c8) | `` automatic update `` |