### PR TITLE
chore(flake/nur): `2258b6ad` -> `00714e6f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731902101,
-        "narHash": "sha256-ZBj8YIUFqCDbNvIlrJIFaZ+xq9T5482qXMaU8lWHSmQ=",
+        "lastModified": 1731907529,
+        "narHash": "sha256-FxwgwRQ5a+11yGUxDpFIrEg9XHmXEzFuXITuRaHejdw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2258b6ade3b7a0c69266126cdf1a8ec37765d4fd",
+        "rev": "00714e6fa82882ec4a6675a7a8bbf0a8b1c006d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`00714e6f`](https://github.com/nix-community/NUR/commit/00714e6fa82882ec4a6675a7a8bbf0a8b1c006d4) | `` automatic update `` |
| [`272278bd`](https://github.com/nix-community/NUR/commit/272278bd4b897a5e6f690c4c5be0a97e5ab340ad) | `` automatic update `` |