### PR TITLE
chore(flake/nur): `9867e0b8` -> `73f4ff37`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731919745,
-        "narHash": "sha256-2uL5cMPnLhyB4dbgjgfRjhzZy3NArFZraYwdl0iYXPc=",
+        "lastModified": 1731927078,
+        "narHash": "sha256-x64xr5KNFZld7zs2bGBrGSQwlij3SGsp+DwL/YhqnGc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9867e0b895d5e871427dc731883dcee5c0c462a6",
+        "rev": "73f4ff378c43a5a26b3e994009e92d662f136577",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`73f4ff37`](https://github.com/nix-community/NUR/commit/73f4ff378c43a5a26b3e994009e92d662f136577) | `` automatic update `` |