### PR TITLE
chore(flake/nur): `73f4ff37` -> `5c00c003`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731927078,
-        "narHash": "sha256-x64xr5KNFZld7zs2bGBrGSQwlij3SGsp+DwL/YhqnGc=",
+        "lastModified": 1731930207,
+        "narHash": "sha256-Tjnsu6V5uyFhq6/gf5leBi2x1MHlcZ3OaZMWHgDHm3A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "73f4ff378c43a5a26b3e994009e92d662f136577",
+        "rev": "5c00c003b3d0c84db5ec3b863a5da6fff60d6d5f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5c00c003`](https://github.com/nix-community/NUR/commit/5c00c003b3d0c84db5ec3b863a5da6fff60d6d5f) | `` automatic update `` |
| [`4b2e0ce3`](https://github.com/nix-community/NUR/commit/4b2e0ce300daec3f65d2bca81d0b1c02baed3cd2) | `` automatic update `` |