### PR TITLE
chore(flake/nur): `5c00c003` -> `b2bfcd53`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731930207,
-        "narHash": "sha256-Tjnsu6V5uyFhq6/gf5leBi2x1MHlcZ3OaZMWHgDHm3A=",
+        "lastModified": 1731935357,
+        "narHash": "sha256-5+Q84V0hfMnwu67U/uWsw8cA62ppFBIKbwxjz0pIKRc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5c00c003b3d0c84db5ec3b863a5da6fff60d6d5f",
+        "rev": "b2bfcd53e1ad7e3864788aa80a15a4004292a2c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b2bfcd53`](https://github.com/nix-community/NUR/commit/b2bfcd53e1ad7e3864788aa80a15a4004292a2c2) | `` automatic update `` |