### PR TITLE
chore(flake/nur): `b2bfcd53` -> `b7d2ac25`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731935357,
-        "narHash": "sha256-5+Q84V0hfMnwu67U/uWsw8cA62ppFBIKbwxjz0pIKRc=",
+        "lastModified": 1731948526,
+        "narHash": "sha256-OXvG3qPAKIRj/1wECJ89F/BhgiUpnwKooor2+5lZduE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b2bfcd53e1ad7e3864788aa80a15a4004292a2c2",
+        "rev": "b7d2ac2549d5585daae9582ee6d98fb8a72a9084",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b7d2ac25`](https://github.com/nix-community/NUR/commit/b7d2ac2549d5585daae9582ee6d98fb8a72a9084) | `` automatic update `` |
| [`81041938`](https://github.com/nix-community/NUR/commit/81041938c7f8e36c9e31947e7ba3baf098ffdaf8) | `` automatic update `` |
| [`23a30a84`](https://github.com/nix-community/NUR/commit/23a30a846dc89a997f42f2d7e64d6f38564014ae) | `` automatic update `` |