### PR TITLE
chore(flake/treefmt): `746901bb` -> `579b9a2f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1024,11 +1024,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730321837,
-        "narHash": "sha256-vK+a09qq19QNu2MlLcvN4qcRctJbqWkX7ahgPZ/+maI=",
+        "lastModified": 1731944360,
+        "narHash": "sha256-sJxPh+V0vUkBhlA58ok/y0o96AtfqiEF0O8qsdolI6o=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "746901bb8dba96d154b66492a29f5db0693dbfcc",
+        "rev": "579b9a2fd0020cd9cd81a4ef4eab2dca4d20c94c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                     |
| ---------------------------------------------------------------------------------------------------- | --------------------------- |
| [`579b9a2f`](https://github.com/numtide/treefmt-nix/commit/579b9a2fd0020cd9cd81a4ef4eab2dca4d20c94c) | `` typstyle: init (#261) `` |