### PR TITLE
chore(flake/nur): `b7d2ac25` -> `82fc0bfd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731948526,
-        "narHash": "sha256-OXvG3qPAKIRj/1wECJ89F/BhgiUpnwKooor2+5lZduE=",
+        "lastModified": 1731952383,
+        "narHash": "sha256-pPd0kDOqWphc47dmRKXjcjScLOp8xluDkNldsL/eysc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b7d2ac2549d5585daae9582ee6d98fb8a72a9084",
+        "rev": "82fc0bfdb50a81d2ce3edeea46487bc3c9a8dff8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`82fc0bfd`](https://github.com/nix-community/NUR/commit/82fc0bfdb50a81d2ce3edeea46487bc3c9a8dff8) | `` automatic update `` |