### PR TITLE
chore(flake/sops-nix): `472741cf` -> `e39947d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -924,11 +924,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731862312,
-        "narHash": "sha256-NVUTFxKrJp/hjehlF1IvkPnlRYg/O9HFVutbxOM8zNM=",
+        "lastModified": 1731954233,
+        "narHash": "sha256-vvXx1m2Rsw7MkbKJdpcICzz4YPgZPApGKQGhNZfkhOI=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "472741cf3fee089241ac9ea705bb2b9e0bfa2978",
+        "rev": "e39947d0ee8e341fa7108bd02a33cdfa24a1360e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                   |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`e39947d0`](https://github.com/Mic92/sops-nix/commit/e39947d0ee8e341fa7108bd02a33cdfa24a1360e) | `` allow for missing switch-to-configuration directory `` |