### PR TITLE
chore(flake/nur): `82fc0bfd` -> `9434b37f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731952383,
-        "narHash": "sha256-pPd0kDOqWphc47dmRKXjcjScLOp8xluDkNldsL/eysc=",
+        "lastModified": 1731954980,
+        "narHash": "sha256-O2qHxYy2+1FmSvvJHE2KPour6D4Bsv04XYl0RBCFvX4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "82fc0bfdb50a81d2ce3edeea46487bc3c9a8dff8",
+        "rev": "9434b37f2ea5b934f5ea20a2540477d9679a60cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9434b37f`](https://github.com/nix-community/NUR/commit/9434b37f2ea5b934f5ea20a2540477d9679a60cc) | `` automatic update `` |