### PR TITLE
chore(flake/nur): `9434b37f` -> `95c0b37d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731954980,
-        "narHash": "sha256-O2qHxYy2+1FmSvvJHE2KPour6D4Bsv04XYl0RBCFvX4=",
+        "lastModified": 1731966377,
+        "narHash": "sha256-1UNYh2y7Z6iEPLic2zvHHXRoIwEgEbVYooAJGaPuxVE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9434b37f2ea5b934f5ea20a2540477d9679a60cc",
+        "rev": "95c0b37dcfd5594fc83cddee258f92b696349763",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`95c0b37d`](https://github.com/nix-community/NUR/commit/95c0b37dcfd5594fc83cddee258f92b696349763) | `` automatic update `` |
| [`2a71ed37`](https://github.com/nix-community/NUR/commit/2a71ed37a1dbd0ad80a33d52620ecea222ff99e2) | `` automatic update `` |
| [`de483fed`](https://github.com/nix-community/NUR/commit/de483fed9bf9cfe619d486df0429191f75d2e54b) | `` automatic update `` |
| [`885c8b8b`](https://github.com/nix-community/NUR/commit/885c8b8ba80ed5497f3bcbc17ffbd7f7fc3159c4) | `` automatic update `` |