### PR TITLE
chore(flake/treefmt): `579b9a2f` -> `675d4a7f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1024,11 +1024,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731944360,
-        "narHash": "sha256-sJxPh+V0vUkBhlA58ok/y0o96AtfqiEF0O8qsdolI6o=",
+        "lastModified": 1731959974,
+        "narHash": "sha256-AsuUJfILHGteNuQgCuiWPzWOVgzBsbetUHRAVwW7FCw=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "579b9a2fd0020cd9cd81a4ef4eab2dca4d20c94c",
+        "rev": "675d4a7fc531799ae8dfca1986b79be7660559e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                       |
| ---------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`675d4a7f`](https://github.com/numtide/treefmt-nix/commit/675d4a7fc531799ae8dfca1986b79be7660559e2) | `` dnscontrol: init (#262) `` |