### PR TITLE
chore(flake/nur): `aef03b5f` -> `d4f7c93b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731975709,
-        "narHash": "sha256-RM+TIlxOjvlmlmrELbwARC4natVPH7K2Kx7DGVsRxQQ=",
+        "lastModified": 1731988544,
+        "narHash": "sha256-5b9tkOL5T4XKGeWxhG0G1sm6X5gecaf8PVB2TpFFAbY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aef03b5f200b77db492a656f9c5718371f6ebdc6",
+        "rev": "d4f7c93b27982d9112c94af23badeef1ab07ac65",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d4f7c93b`](https://github.com/nix-community/NUR/commit/d4f7c93b27982d9112c94af23badeef1ab07ac65) | `` automatic update `` |