### PR TITLE
chore(flake/nur): `d4f7c93b` -> `c3ee535c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731988544,
-        "narHash": "sha256-5b9tkOL5T4XKGeWxhG0G1sm6X5gecaf8PVB2TpFFAbY=",
+        "lastModified": 1731989548,
+        "narHash": "sha256-R8R1zo6wNi9awwRgoQ5wKlvgSXW/PrYF9vs8eLGvxtU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d4f7c93b27982d9112c94af23badeef1ab07ac65",
+        "rev": "c3ee535c374f56110be3d1f4c219f3c45b14664b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c3ee535c`](https://github.com/nix-community/NUR/commit/c3ee535c374f56110be3d1f4c219f3c45b14664b) | `` automatic update `` |
| [`0f93d39c`](https://github.com/nix-community/NUR/commit/0f93d39c3f8a72e07867cae9d3bcf86cb7c36d3f) | `` automatic update `` |