### PR TITLE
chore(flake/nur): `c3ee535c` -> `35d1aaf8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731989548,
-        "narHash": "sha256-R8R1zo6wNi9awwRgoQ5wKlvgSXW/PrYF9vs8eLGvxtU=",
+        "lastModified": 1731998533,
+        "narHash": "sha256-N1wSCSUEGyih79czO2cBw25WqgsgJztGQmYqSPQmynA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c3ee535c374f56110be3d1f4c219f3c45b14664b",
+        "rev": "35d1aaf81870bf5ed50644978c7a1e2c08c9027c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`35d1aaf8`](https://github.com/nix-community/NUR/commit/35d1aaf81870bf5ed50644978c7a1e2c08c9027c) | `` automatic update `` |
| [`63f22919`](https://github.com/nix-community/NUR/commit/63f2291958b594107cabf1f7a564b4bdec22983e) | `` automatic update `` |