### PR TITLE
chore(flake/nur): `35d1aaf8` -> `7cfe2b47`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1731998533,
-        "narHash": "sha256-N1wSCSUEGyih79czO2cBw25WqgsgJztGQmYqSPQmynA=",
+        "lastModified": 1732006266,
+        "narHash": "sha256-cLTHyflXWDy90+lH8jWblDx6LVNDSlnVCGtuE/e6SWI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "35d1aaf81870bf5ed50644978c7a1e2c08c9027c",
+        "rev": "7cfe2b474e40ef9e605ba421e141640b0acc6ed0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7cfe2b47`](https://github.com/nix-community/NUR/commit/7cfe2b474e40ef9e605ba421e141640b0acc6ed0) | `` automatic update `` |