### PR TITLE
chore(flake/nur): `7cfe2b47` -> `c398af1c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732006266,
-        "narHash": "sha256-cLTHyflXWDy90+lH8jWblDx6LVNDSlnVCGtuE/e6SWI=",
+        "lastModified": 1732009877,
+        "narHash": "sha256-pVfRjybzUozkMI9szkH72JRfKrjJsOFJhRAw8zxP0QM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7cfe2b474e40ef9e605ba421e141640b0acc6ed0",
+        "rev": "c398af1c88ad4d1d9af66dcc4674089dead0df5b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c398af1c`](https://github.com/nix-community/NUR/commit/c398af1c88ad4d1d9af66dcc4674089dead0df5b) | `` automatic update `` |