### PR TITLE
chore(flake/nur): `83139931` -> `a2712ed4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732011692,
-        "narHash": "sha256-IesXtImeFNuZmWRSlmNHeq9ZhDv4SQqRashNry/NNJ4=",
+        "lastModified": 1732034903,
+        "narHash": "sha256-83fCcCsW/f1DIBQoQfSvnp95L4WADvKTC+xMQFQ0RRI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "83139931be39e5cb4deb85f3a86ff17d04a12928",
+        "rev": "a2712ed4e2e98c0e86ebc074acb2af8248941cc8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a2712ed4`](https://github.com/nix-community/NUR/commit/a2712ed4e2e98c0e86ebc074acb2af8248941cc8) | `` automatic update `` |
| [`91774e8c`](https://github.com/nix-community/NUR/commit/91774e8cd2e89b1858a98f0dc656f2de7cc63c14) | `` automatic update `` |
| [`5128049b`](https://github.com/nix-community/NUR/commit/5128049be5e7a1cc3cad4b2b7bbcefc08af20eef) | `` automatic update `` |
| [`104167fd`](https://github.com/nix-community/NUR/commit/104167fd6ba1b00d07fbbcba66cf36ad2763d12c) | `` automatic update `` |