### PR TITLE
chore(flake/srvos): `8896d33c` -> `be4533b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -944,11 +944,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732011996,
-        "narHash": "sha256-AO+RnQGN9Jz3Qor2XTy+U1iIli9O8X2p8QRw9Qohkv8=",
+        "lastModified": 1732050592,
+        "narHash": "sha256-WuGCnlt1xhHJfsHpPXdV3gH9Khe4gJ1+abWCHFcddvM=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "8896d33c8147763c6a6342a6256990d17e1ac357",
+        "rev": "be4533b50ac69cd871ab73d4101c47b397b8c143",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                         |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`be4533b5`](https://github.com/nix-community/srvos/commit/be4533b50ac69cd871ab73d4101c47b397b8c143) | `` chore(nix): make the project usable without flakes (#560) `` |