### PR TITLE
chore(flake/nur): `d0b443a4` -> `7a975ef1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732068686,
-        "narHash": "sha256-t4odoZ4MWl7YCdSJenncbKG3Xad6PUJTzNb4XgZdOrE=",
+        "lastModified": 1732071189,
+        "narHash": "sha256-1l60xJ0owsJo6N9pS8UBn5ch/xiZPkujLtHaRvZcUlU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d0b443a475148595fac59110e19410f9a3f2ae28",
+        "rev": "7a975ef1d200e79f6a7cfce127e37d41b610f9f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7a975ef1`](https://github.com/nix-community/NUR/commit/7a975ef1d200e79f6a7cfce127e37d41b610f9f4) | `` automatic update `` |