### PR TITLE
chore(flake/nur): `7a975ef1` -> `571dc408`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732071189,
-        "narHash": "sha256-1l60xJ0owsJo6N9pS8UBn5ch/xiZPkujLtHaRvZcUlU=",
+        "lastModified": 1732074896,
+        "narHash": "sha256-QW2cBG34PkvfUXkWAGSSKPW4mn6Aq9GLmFoZCSNel2M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7a975ef1d200e79f6a7cfce127e37d41b610f9f4",
+        "rev": "571dc4087164290d2a31b5542e94d0e778a44c98",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`571dc408`](https://github.com/nix-community/NUR/commit/571dc4087164290d2a31b5542e94d0e778a44c98) | `` automatic update `` |
| [`a64fea55`](https://github.com/nix-community/NUR/commit/a64fea5568fd736a9c53708d57bbd0be8960e26b) | `` automatic update `` |
| [`e297c530`](https://github.com/nix-community/NUR/commit/e297c530119c60e9e882399565f84c4a976ab3c3) | `` automatic update `` |