### PR TITLE
chore(flake/nur): `571dc408` -> `1ca9b5eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732074896,
-        "narHash": "sha256-QW2cBG34PkvfUXkWAGSSKPW4mn6Aq9GLmFoZCSNel2M=",
+        "lastModified": 1732077794,
+        "narHash": "sha256-az/0HX58rF3xLqW349OujjNSJt3Zjzw+GymTwR55sGE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "571dc4087164290d2a31b5542e94d0e778a44c98",
+        "rev": "1ca9b5eb76462e8b5f507ef72569ce8244c50157",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1ca9b5eb`](https://github.com/nix-community/NUR/commit/1ca9b5eb76462e8b5f507ef72569ce8244c50157) | `` automatic update `` |
| [`c3a5bc7e`](https://github.com/nix-community/NUR/commit/c3a5bc7eabd84b6c8f13f4807c162f8d315734dd) | `` automatic update `` |