### PR TITLE
chore(flake/nur): `a9e250ac` -> `b7bc4517`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732092587,
-        "narHash": "sha256-oMTbdAxXPJHzV5KomDKm9sdmYv/Z1Fcy8KEyd8VrCe8=",
+        "lastModified": 1732096393,
+        "narHash": "sha256-v+JdHyTLo7Hm/qfgK6qURyCDnrkmIZsZDu4XevSeSp8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a9e250ac37ac812feb565d3a7488db88cfaa61d3",
+        "rev": "b7bc4517f37638b7fd54b44ae5d55ac4473ecf39",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b7bc4517`](https://github.com/nix-community/NUR/commit/b7bc4517f37638b7fd54b44ae5d55ac4473ecf39) | `` automatic update `` |