### PR TITLE
chore(flake/nur): `b7bc4517` -> `13f83516`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732096393,
-        "narHash": "sha256-v+JdHyTLo7Hm/qfgK6qURyCDnrkmIZsZDu4XevSeSp8=",
+        "lastModified": 1732099841,
+        "narHash": "sha256-XwpBKjFzkBhZJ//m+iAsvgO4XLuFoui9GRyE7R+PQ5Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b7bc4517f37638b7fd54b44ae5d55ac4473ecf39",
+        "rev": "13f83516cdc2fd2fce2ee0f62d82ec698fb39184",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`13f83516`](https://github.com/nix-community/NUR/commit/13f83516cdc2fd2fce2ee0f62d82ec698fb39184) | `` automatic update `` |
| [`ef47782a`](https://github.com/nix-community/NUR/commit/ef47782ab53cbcd82bb6fd8aca6c11ecb7b65829) | `` automatic update `` |