### PR TITLE
chore(flake/nur): `13f83516` -> `50c118bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732099841,
-        "narHash": "sha256-XwpBKjFzkBhZJ//m+iAsvgO4XLuFoui9GRyE7R+PQ5Y=",
+        "lastModified": 1732103128,
+        "narHash": "sha256-ss6/TNvQgIHPxskSC5CrxuGEVWcq1g6Glh4mUqd01Ho=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "13f83516cdc2fd2fce2ee0f62d82ec698fb39184",
+        "rev": "50c118bb8b06e1a6a643b21a8522051cec0ee6c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`50c118bb`](https://github.com/nix-community/NUR/commit/50c118bb8b06e1a6a643b21a8522051cec0ee6c7) | `` automatic update `` |