### PR TITLE
chore(flake/nur): `a59251d9` -> `bff6cb44`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732106864,
-        "narHash": "sha256-5RWkCir5qDXRbWHQz83bgN0MHadFuReyfYPXUYcQeOs=",
+        "lastModified": 1732112841,
+        "narHash": "sha256-FmcXWdWwEoRgAjBner5ys7w+w3PegCACZ34VgoNJFWM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a59251d9f044e153825700bdb65c1a5abd092600",
+        "rev": "bff6cb443d467bc395acc575e54c85f7abc4fe77",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bff6cb44`](https://github.com/nix-community/NUR/commit/bff6cb443d467bc395acc575e54c85f7abc4fe77) | `` automatic update `` |
| [`93c993b5`](https://github.com/nix-community/NUR/commit/93c993b588f3b676310d501d1a736c24bde44eb9) | `` automatic update `` |