### PR TITLE
chore(flake/nur): `13b44543` -> `34ea5361`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732131502,
-        "narHash": "sha256-kWc3mjgEUh+2xzaluNxLMvEHRkfJ37pRBtXcwekKefM=",
+        "lastModified": 1732134607,
+        "narHash": "sha256-vWkWJWMujimxIan8vSSXmB6ujov6SgQca3wD4c2EGIk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "13b44543c4e5d20bb2976ddde846c7341e4c41dd",
+        "rev": "34ea536162b11e0db2449bd2eb248dccce1bb9e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`34ea5361`](https://github.com/nix-community/NUR/commit/34ea536162b11e0db2449bd2eb248dccce1bb9e6) | `` automatic update `` |