### PR TITLE
chore(flake/nur): `34ea5361` -> `a1d4c79a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732134607,
-        "narHash": "sha256-vWkWJWMujimxIan8vSSXmB6ujov6SgQca3wD4c2EGIk=",
+        "lastModified": 1732140964,
+        "narHash": "sha256-OrmDjtdoUqsWE7DPwEgn+a3qcPMX21f7uCzMnDjxdFs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "34ea536162b11e0db2449bd2eb248dccce1bb9e6",
+        "rev": "a1d4c79a93b4a56127c152f4eec71eee63f8f5e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                          |
| -------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`a1d4c79a`](https://github.com/nix-community/NUR/commit/a1d4c79a93b4a56127c152f4eec71eee63f8f5e6) | `` automatic update ``           |
| [`d1ad84c9`](https://github.com/nix-community/NUR/commit/d1ad84c9b28e592e53688869f0b6b25072a47960) | `` add chillcicada repository `` |