### PR TITLE
chore(flake/nur): `a1d4c79a` -> `d91a1375`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732140964,
-        "narHash": "sha256-OrmDjtdoUqsWE7DPwEgn+a3qcPMX21f7uCzMnDjxdFs=",
+        "lastModified": 1732160898,
+        "narHash": "sha256-a/4CRduNQB9nJ/h9FdsavCjj+NL63cSymMLrA5xwVqU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a1d4c79a93b4a56127c152f4eec71eee63f8f5e6",
+        "rev": "d91a137575bd6166c68bf4e5f7214942756647ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d91a1375`](https://github.com/nix-community/NUR/commit/d91a137575bd6166c68bf4e5f7214942756647ce) | `` automatic update `` |