### PR TITLE
chore(flake/nur): `d91a1375` -> `159109d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732160898,
-        "narHash": "sha256-a/4CRduNQB9nJ/h9FdsavCjj+NL63cSymMLrA5xwVqU=",
+        "lastModified": 1732163411,
+        "narHash": "sha256-SPVZNI5PWoIuQSTwxs51EI3JHNBbLvJTYIHpmqfavQw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d91a137575bd6166c68bf4e5f7214942756647ce",
+        "rev": "159109d408ff0eec3fe9a4c60073481aa21f9b6a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`159109d4`](https://github.com/nix-community/NUR/commit/159109d408ff0eec3fe9a4c60073481aa21f9b6a) | `` automatic update `` |
| [`33e7f04b`](https://github.com/nix-community/NUR/commit/33e7f04b6197743887ca22bbd008f8e94468cd86) | `` automatic update `` |