### PR TITLE
chore(flake/nur): `159109d4` -> `07604fb3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732163411,
-        "narHash": "sha256-SPVZNI5PWoIuQSTwxs51EI3JHNBbLvJTYIHpmqfavQw=",
+        "lastModified": 1732170883,
+        "narHash": "sha256-FfYCst+60CLt25T0c/ubmp5l/wn2hqKZdckNqRJvNgg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "159109d408ff0eec3fe9a4c60073481aa21f9b6a",
+        "rev": "07604fb30702be45f8b2e380effde59914ee7ce5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`07604fb3`](https://github.com/nix-community/NUR/commit/07604fb30702be45f8b2e380effde59914ee7ce5) | `` automatic update `` |
| [`19aa599e`](https://github.com/nix-community/NUR/commit/19aa599e5e632668ce7b8fdcb80293362ef4fd3e) | `` automatic update `` |