### PR TITLE
chore(flake/nur): `c61a86d2` -> `61618110`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732173138,
-        "narHash": "sha256-20AnQRqEtdwP1YIWkgaziJEnSzbXPWBxulCEOtD8BZ0=",
+        "lastModified": 1732178928,
+        "narHash": "sha256-9nYatC+xsG9PvYXS1Gh372Xb0CmXu2yYMOhK/BPp86c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c61a86d2d02cd45549d5f3b0b9da27b2ae1d710b",
+        "rev": "61618110365507b1308972f05764766cfad2d97f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`61618110`](https://github.com/nix-community/NUR/commit/61618110365507b1308972f05764766cfad2d97f) | `` automatic update `` |
| [`5eb8ad0a`](https://github.com/nix-community/NUR/commit/5eb8ad0a754cb74786eacb7c339e180154f6eba5) | `` automatic update `` |