### PR TITLE
chore(flake/treefmt): `62003fda` -> `37f8f47c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1024,11 +1024,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732111664,
-        "narHash": "sha256-XWHuPWcP59QnHEewdZJXBX1TA2lAP78Vz4daG6tfIr4=",
+        "lastModified": 1732187120,
+        "narHash": "sha256-XdW2mYXvPHYtZ8oQqO3tRYtxx7kI0Hs3NU64IwAtD68=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "62003fdad7a5ab7b6af3ea9bd7290e4c220277d0",
+        "rev": "37f8f47cb618eddee0c0dd31a582b1cd3013c7f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                         |
| ---------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`37f8f47c`](https://github.com/numtide/treefmt-nix/commit/37f8f47cb618eddee0c0dd31a582b1cd3013c7f6) | `` README: new format (#259) `` |