### PR TITLE
chore(flake/nur): `18153db3` -> `5e67f474`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732182439,
-        "narHash": "sha256-XCoRiukCZ7Tvr5KhuWOGX88XblaHQTmszOyCGNfxD0Y=",
+        "lastModified": 1732193657,
+        "narHash": "sha256-l4YncGn8Ee2v8DW3WqtKI4qHeGk7aUc3KoAPvwunC+o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "18153db391b7a6cf5c496984f74f78875a382ee3",
+        "rev": "5e67f4745975ab2e5111ca7ff6c3ae02e9a555b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5e67f474`](https://github.com/nix-community/NUR/commit/5e67f4745975ab2e5111ca7ff6c3ae02e9a555b8) | `` automatic update `` |