### PR TITLE
chore(flake/nur): `6b4e7eb3` -> `c711f117`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732200980,
-        "narHash": "sha256-I7iT9Pvfvwdn/HwduB0iypeZ0ZLe2S7ISeoOVu5MuWE=",
+        "lastModified": 1732206859,
+        "narHash": "sha256-iTNypEsXq4C9Mtio2n3G+SYdvR9v+Gq0pgrO1e/sccs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6b4e7eb30278bbf9fda14859347035fe3fc45eea",
+        "rev": "c711f117ec0c8cc7bf1edcb7c238d8b5b963ffce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c711f117`](https://github.com/nix-community/NUR/commit/c711f117ec0c8cc7bf1edcb7c238d8b5b963ffce) | `` automatic update `` |