### PR TITLE
chore(flake/nur): `c711f117` -> `2ae1a03a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732206859,
-        "narHash": "sha256-iTNypEsXq4C9Mtio2n3G+SYdvR9v+Gq0pgrO1e/sccs=",
+        "lastModified": 1732214595,
+        "narHash": "sha256-z68VxpGpowy+2TChnCKrtSo0QAG6D37CZTedCP3tKDs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c711f117ec0c8cc7bf1edcb7c238d8b5b963ffce",
+        "rev": "2ae1a03a03110fd95c56a51d495f04cfe979b17b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2ae1a03a`](https://github.com/nix-community/NUR/commit/2ae1a03a03110fd95c56a51d495f04cfe979b17b) | `` automatic update `` |
| [`8f2cd33e`](https://github.com/nix-community/NUR/commit/8f2cd33e212164715043b60fdf432b29e0d6748c) | `` automatic update `` |