### PR TITLE
chore(flake/nur): `2ae1a03a` -> `e256ca80`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732214595,
-        "narHash": "sha256-z68VxpGpowy+2TChnCKrtSo0QAG6D37CZTedCP3tKDs=",
+        "lastModified": 1732218405,
+        "narHash": "sha256-+aw2RvxAoGc5FgnQSpLlt+QNcnRPFfp4/Vts7cfo6rE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2ae1a03a03110fd95c56a51d495f04cfe979b17b",
+        "rev": "e256ca80ae399c3eea5e0cbe47f9a641877286c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e256ca80`](https://github.com/nix-community/NUR/commit/e256ca80ae399c3eea5e0cbe47f9a641877286c5) | `` automatic update `` |