### PR TITLE
chore(flake/nur): `e256ca80` -> `8439fca0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732218405,
-        "narHash": "sha256-+aw2RvxAoGc5FgnQSpLlt+QNcnRPFfp4/Vts7cfo6rE=",
+        "lastModified": 1732220928,
+        "narHash": "sha256-OOFqnjTax0132/mBsRpVD1QTMlZUCbVexKgKUVUxJNg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e256ca80ae399c3eea5e0cbe47f9a641877286c5",
+        "rev": "8439fca0da7f67b331edcca08eb2a47249be72f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8439fca0`](https://github.com/nix-community/NUR/commit/8439fca0da7f67b331edcca08eb2a47249be72f4) | `` automatic update `` |