### PR TITLE
chore(flake/nur): `8439fca0` -> `3cfb142e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732220928,
-        "narHash": "sha256-OOFqnjTax0132/mBsRpVD1QTMlZUCbVexKgKUVUxJNg=",
+        "lastModified": 1732244899,
+        "narHash": "sha256-q1GrPmkj1tFHoUkFxH5pl7Af7Oi2mlYk/k58FXAQeHw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8439fca0da7f67b331edcca08eb2a47249be72f4",
+        "rev": "3cfb142ee4fe5cb519af5ef0246cda79087fef1a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3cfb142e`](https://github.com/nix-community/NUR/commit/3cfb142ee4fe5cb519af5ef0246cda79087fef1a) | `` automatic update `` |
| [`23d8babf`](https://github.com/nix-community/NUR/commit/23d8babf3a6baca864f0597dfc98c1cb3509bf0c) | `` automatic update `` |