### PR TITLE
chore(flake/nur): `3cfb142e` -> `7aecd6ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732244899,
-        "narHash": "sha256-q1GrPmkj1tFHoUkFxH5pl7Af7Oi2mlYk/k58FXAQeHw=",
+        "lastModified": 1732247641,
+        "narHash": "sha256-tpCPWk+SHvd6JS8N+R6ppYr4est3whrf2ZeZBekJsy0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3cfb142ee4fe5cb519af5ef0246cda79087fef1a",
+        "rev": "7aecd6aef7d72348a8854bae980a41cf813bab87",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7aecd6ae`](https://github.com/nix-community/NUR/commit/7aecd6aef7d72348a8854bae980a41cf813bab87) | `` automatic update `` |
| [`e70e22d3`](https://github.com/nix-community/NUR/commit/e70e22d36d660883f4b7a0eaf27c3202a21d277b) | `` automatic update `` |