### PR TITLE
chore(flake/nur): `7aecd6ae` -> `4d35e312`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732247641,
-        "narHash": "sha256-tpCPWk+SHvd6JS8N+R6ppYr4est3whrf2ZeZBekJsy0=",
+        "lastModified": 1732249882,
+        "narHash": "sha256-1lSlNTt+NHWGVsY7nsuhJAjF3DlciOuTBM1kZDVn518=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7aecd6aef7d72348a8854bae980a41cf813bab87",
+        "rev": "4d35e3120802e505d822195dba0ab130f5ac480c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4d35e312`](https://github.com/nix-community/NUR/commit/4d35e3120802e505d822195dba0ab130f5ac480c) | `` automatic update `` |
| [`160b15bc`](https://github.com/nix-community/NUR/commit/160b15bcaa040e3b8db64cb368433bea8020ee0c) | `` automatic update `` |