### PR TITLE
chore(flake/nur): `7b8c700e` -> `72bbb833`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732265322,
-        "narHash": "sha256-tJCil9hkF20WOvaJPfFRYlGqDasj5xmG88yxkVvRxhw=",
+        "lastModified": 1732285408,
+        "narHash": "sha256-+22r7TK3VgeY3LoPo2jqWywx8nZbKdM0uOIYCL5oJAg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7b8c700ea02f89344a6db506b91eaa64c39ee3f4",
+        "rev": "72bbb83380c2c743a11f09cdfeac5b6ea64d30b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                         |
| -------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`72bbb833`](https://github.com/nix-community/NUR/commit/72bbb83380c2c743a11f09cdfeac5b6ea64d30b4) | `` automatic update ``          |
| [`798a3758`](https://github.com/nix-community/NUR/commit/798a37580e4b253e8fbac518f35572ac49b767bb) | `` README: update maintainer `` |