### PR TITLE
chore(flake/nur): `7efb4610` -> `b2edbf77`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732290590,
-        "narHash": "sha256-5D23UhDnXUd+vMpULEqzNDxVgqN5s+5FWgCG+Ylf020=",
+        "lastModified": 1732294419,
+        "narHash": "sha256-f/m3NvGDXpYgi5RM/yJsRqF75B+mJmLdbdvGzFld8e0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7efb4610277ec246d7a1d37655f9471fc4defbfc",
+        "rev": "b2edbf772a9061600e1d2a0ba277b3989f03f4a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b2edbf77`](https://github.com/nix-community/NUR/commit/b2edbf772a9061600e1d2a0ba277b3989f03f4a2) | `` automatic update `` |
| [`38fa4a13`](https://github.com/nix-community/NUR/commit/38fa4a137017770646d2a59773796d29b1a70941) | `` automatic update `` |