### PR TITLE
chore(flake/treefmt): `37f8f47c` -> `705df926`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1024,11 +1024,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732187120,
-        "narHash": "sha256-XdW2mYXvPHYtZ8oQqO3tRYtxx7kI0Hs3NU64IwAtD68=",
+        "lastModified": 1732292307,
+        "narHash": "sha256-5WSng844vXt8uytT5djmqBCkopyle6ciFgteuA9bJpw=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "37f8f47cb618eddee0c0dd31a582b1cd3013c7f6",
+        "rev": "705df92694af7093dfbb27109ce16d828a79155f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message              |
| ---------------------------------------------------------------------------------------------------- | -------------------- |
| [`705df926`](https://github.com/numtide/treefmt-nix/commit/705df92694af7093dfbb27109ce16d828a79155f) | `` doc fix (#264) `` |