### PR TITLE
chore(flake/nur): `b2edbf77` -> `fac45f20`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732294419,
-        "narHash": "sha256-f/m3NvGDXpYgi5RM/yJsRqF75B+mJmLdbdvGzFld8e0=",
+        "lastModified": 1732301975,
+        "narHash": "sha256-EWSXyZ6MNDHKPIv1xtbqd+kuwfPORROvgGtCmoY/4FQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b2edbf772a9061600e1d2a0ba277b3989f03f4a2",
+        "rev": "fac45f20ffc9584d3f8ac50d98b880d55036fbbc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                                    |
| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`fac45f20`](https://github.com/nix-community/NUR/commit/fac45f20ffc9584d3f8ac50d98b880d55036fbbc) | `` pyproject.toml: Move relevant pyproject entries into lint subsection `` |
| [`7563379e`](https://github.com/nix-community/NUR/commit/7563379e93208a6e7cda6b935beeec97a3f17de5) | `` automatic update ``                                                     |
| [`c9252a63`](https://github.com/nix-community/NUR/commit/c9252a63fd5c4817f182943e5dd2f1334dfafddc) | `` .mergify.yml: Update mergify configuration due to rename ``             |
| [`459a9888`](https://github.com/nix-community/NUR/commit/459a9888ce2112bf8f51672cea7a17093d5afd54) | `` automatic update ``                                                     |
| [`8d807e74`](https://github.com/nix-community/NUR/commit/8d807e746a079e6a52e035cf4608f8dfabf607a2) | `` docs: add a simple example for using a single package in a devshell ``  |
| [`c1a1e27c`](https://github.com/nix-community/NUR/commit/c1a1e27c83251b8fe927abb1d3f6d451721e119d) | `` automatic update ``                                                     |
| [`843723ce`](https://github.com/nix-community/NUR/commit/843723ce9c75817db415d2617ee18fafffd73d2e) | `` automatic update ``                                                     |
| [`5cb3f089`](https://github.com/nix-community/NUR/commit/5cb3f08973469e46d5dd7a546db80c591ca451c1) | `` add fuyu-no-nur repository ``                                           |
| [`c88855e9`](https://github.com/nix-community/NUR/commit/c88855e91289671acd6b3ed2c040888a589a7918) | `` automatic update ``                                                     |
| [`51b734ef`](https://github.com/nix-community/NUR/commit/51b734efb87de2ab507c84a65642397bd2228efe) | `` automatic update ``                                                     |
| [`bf6f5acc`](https://github.com/nix-community/NUR/commit/bf6f5acc7352ee95286fa033e5f0d17a277c79f5) | `` add repos: wyzdwdz ``                                                   |