### PR TITLE
chore(flake/nur): `fac45f20` -> `9af895e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732301975,
-        "narHash": "sha256-EWSXyZ6MNDHKPIv1xtbqd+kuwfPORROvgGtCmoY/4FQ=",
+        "lastModified": 1732305275,
+        "narHash": "sha256-aMcvh0+sulxnnql2eIRFldHQaX1IUkRJZYDykR1Lla4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fac45f20ffc9584d3f8ac50d98b880d55036fbbc",
+        "rev": "9af895e71584810564b3758bd4791aa27160028f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                |
| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`9af895e7`](https://github.com/nix-community/NUR/commit/9af895e71584810564b3758bd4791aa27160028f) | `` automatic update ``                                 |
| [`715ed0d5`](https://github.com/nix-community/NUR/commit/715ed0d5339fd5f7c3b0d449704691cfa11bcd68) | `` .github/workflows: Add check-nix-format workflow `` |
| [`4021fa3c`](https://github.com/nix-community/NUR/commit/4021fa3c833984eddcdf8bb5b0b58e99942d53c5) | `` treewide: nixfmt ``                                 |
| [`4f4dec9f`](https://github.com/nix-community/NUR/commit/4f4dec9f659a0cbd7984d9fe759a20d367ba6244) | `` automatic update ``                                 |