### PR TITLE
chore(flake/nur): `e82af675` -> `b806a341`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732306673,
-        "narHash": "sha256-CUF43khwTIQ9x05SMLCpW8T0Y17rBdfp2uLhpwmBbBA=",
+        "lastModified": 1732311919,
+        "narHash": "sha256-MTAo4cQrO98MRs95/Mq70N3lEoStemPSy0eAy5/rBYg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e82af6753b655ff4caf19df25a49f76d70b5ad1b",
+        "rev": "b806a34190e57aa4b77e019603b2be97d3a545a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b806a341`](https://github.com/nix-community/NUR/commit/b806a34190e57aa4b77e019603b2be97d3a545a9) | `` automatic update `` |