### PR TITLE
chore(flake/nur): `b806a341` -> `147809ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732311919,
-        "narHash": "sha256-MTAo4cQrO98MRs95/Mq70N3lEoStemPSy0eAy5/rBYg=",
+        "lastModified": 1732320236,
+        "narHash": "sha256-FZjRONrxwAcrkVaFeLDpiYVTHnM3S+ksFp9vkeQHCHM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b806a34190e57aa4b77e019603b2be97d3a545a9",
+        "rev": "147809cef614fe3d0132ac6b872ffa12734afe26",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`147809ce`](https://github.com/nix-community/NUR/commit/147809cef614fe3d0132ac6b872ffa12734afe26) | `` automatic update `` |
| [`70cb6ce6`](https://github.com/nix-community/NUR/commit/70cb6ce63f7da98980487cdb1b47f10c479df00a) | `` automatic update `` |