### PR TITLE
chore(flake/darwin): `edabc790` -> `698a62c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732229547,
-        "narHash": "sha256-vtUhSQFgDfyyNM6rgmn35A2T+L5PXBS0H89cxWK9N2A=",
+        "lastModified": 1732324260,
+        "narHash": "sha256-0xzQvoId/P008QkTSAdFVv465P9rL9nYkIOWXL5pdsY=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "edabc790a834326dcb5810e2698fa743483510d0",
+        "rev": "698a62c628c2ec423aa770d8ec0e1d0bcf4fca1a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                 |
| ------------------------------------------------------------------------------------------------ | --------------------------------------- |
| [`caa23e87`](https://github.com/LnL7/nix-darwin/commit/caa23e878f7f6fecb978bb91c1d208bf94a62c43) | `` github-runner: make `umask` quiet `` |
| [`23f312e4`](https://github.com/LnL7/nix-darwin/commit/23f312e48a252e348fc8884f2abc7975f976aac0) | `` nix-tools: set `meta.mainProgram` `` |