### PR TITLE
chore(flake/nur): `1bfee5e5` -> `b657d937`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732327684,
-        "narHash": "sha256-LRTG/8HXNAN5atBJGao43KRa13xTp5S6VGCaIF+UyPE=",
+        "lastModified": 1732334681,
+        "narHash": "sha256-Enfvh3ZFikJua3raZIUXqh+NHXnv9khx0tn5f1xgDG8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1bfee5e55992301948598f3bb5192e58dfb53cc2",
+        "rev": "b657d937257e899c8103f8d7c68d83aa5f23b16e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b657d937`](https://github.com/nix-community/NUR/commit/b657d937257e899c8103f8d7c68d83aa5f23b16e) | `` automatic update `` |