### PR TITLE
chore(flake/nur): `b657d937` -> `eb5a832f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732334681,
-        "narHash": "sha256-Enfvh3ZFikJua3raZIUXqh+NHXnv9khx0tn5f1xgDG8=",
+        "lastModified": 1732341601,
+        "narHash": "sha256-P476HKAnAwyrdgAJWT4RaLLPcjEKx9YXEnrVCm2J+v0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b657d937257e899c8103f8d7c68d83aa5f23b16e",
+        "rev": "eb5a832f57d482ea8943fe84826dc6a08cd8d172",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`eb5a832f`](https://github.com/nix-community/NUR/commit/eb5a832f57d482ea8943fe84826dc6a08cd8d172) | `` automatic update `` |
| [`80dc9d44`](https://github.com/nix-community/NUR/commit/80dc9d444a86f4b8f52d43645e8e1631d053b877) | `` automatic update `` |