### PR TITLE
chore(flake/nur): `eb5a832f` -> `20cab42a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732341601,
-        "narHash": "sha256-P476HKAnAwyrdgAJWT4RaLLPcjEKx9YXEnrVCm2J+v0=",
+        "lastModified": 1732345006,
+        "narHash": "sha256-JvryQ/d/yiDL249+dUIEnq6UYkq/74dJPfCqq5i+iyg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eb5a832f57d482ea8943fe84826dc6a08cd8d172",
+        "rev": "20cab42aa18252cfb95a76f4dd36ce11860eafa2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`20cab42a`](https://github.com/nix-community/NUR/commit/20cab42aa18252cfb95a76f4dd36ce11860eafa2) | `` automatic update `` |
| [`c8e9da44`](https://github.com/nix-community/NUR/commit/c8e9da446795da8eddf5923ebf1090482cdc1e0f) | `` automatic update `` |
| [`30afb181`](https://github.com/nix-community/NUR/commit/30afb181fed3f6f906ca4f543fec6ae6bcb7838e) | `` automatic update `` |