### PR TITLE
chore(flake/nur): `20cab42a` -> `0bdf92bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732345006,
-        "narHash": "sha256-JvryQ/d/yiDL249+dUIEnq6UYkq/74dJPfCqq5i+iyg=",
+        "lastModified": 1732345972,
+        "narHash": "sha256-dIoLOEpjtZ50X72WfvAPPCdsy3a6howazb43HDXqZmk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "20cab42aa18252cfb95a76f4dd36ce11860eafa2",
+        "rev": "0bdf92bb0dc880494de512232baba209e8e3342e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0bdf92bb`](https://github.com/nix-community/NUR/commit/0bdf92bb0dc880494de512232baba209e8e3342e) | `` automatic update `` |