### PR TITLE
chore(flake/nur): `0bdf92bb` -> `070ef495`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732345972,
-        "narHash": "sha256-dIoLOEpjtZ50X72WfvAPPCdsy3a6howazb43HDXqZmk=",
+        "lastModified": 1732355290,
+        "narHash": "sha256-HfCjkQKVjo77x6bLNqj2gkP8zrzt34Lo2grrLrLv26c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0bdf92bb0dc880494de512232baba209e8e3342e",
+        "rev": "070ef49521a45778e57778dc1c91907735ad0e28",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`070ef495`](https://github.com/nix-community/NUR/commit/070ef49521a45778e57778dc1c91907735ad0e28) | `` automatic update `` |