### PR TITLE
chore(flake/nur): `070ef495` -> `ec161bd8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732355290,
-        "narHash": "sha256-HfCjkQKVjo77x6bLNqj2gkP8zrzt34Lo2grrLrLv26c=",
+        "lastModified": 1732358906,
+        "narHash": "sha256-edEgwPqfYFC/n/fwwi9ciu5IpCypCMKChax+z9n40v4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "070ef49521a45778e57778dc1c91907735ad0e28",
+        "rev": "ec161bd8bfdf11b6442febcd670ca31d8cd207af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                            |
| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`ec161bd8`](https://github.com/nix-community/NUR/commit/ec161bd8bfdf11b6442febcd670ca31d8cd207af) | `` automatic update ``                                             |
| [`7157696d`](https://github.com/nix-community/NUR/commit/7157696d339786020c39077ba12bef77d4873794) | `` automatic update ``                                             |
| [`cfda02e2`](https://github.com/nix-community/NUR/commit/cfda02e2d83044990613713793e78b7b62f9d149) | `` .github/renovate: configure renovate to supercede dependabot `` |
| [`45f11fea`](https://github.com/nix-community/NUR/commit/45f11fea6c502a91d0cf56c663d700cca94fec11) | `` automatic update ``                                             |
| [`a8e116d5`](https://github.com/nix-community/NUR/commit/a8e116d5644472bf1b0f7467e55ce54b7fb0eaf1) | `` add devmegablaster repository ``                                |