### PR TITLE
chore(flake/nur): `ec161bd8` -> `86997491`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732358906,
-        "narHash": "sha256-edEgwPqfYFC/n/fwwi9ciu5IpCypCMKChax+z9n40v4=",
+        "lastModified": 1732361011,
+        "narHash": "sha256-dSAfd7wSrxd0GtwGRaW7MJv3OBNyw3XLM5AU+6mAKL4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ec161bd8bfdf11b6442febcd670ca31d8cd207af",
+        "rev": "86997491ed2896f76088abf22617a54a45f3d22e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`86997491`](https://github.com/nix-community/NUR/commit/86997491ed2896f76088abf22617a54a45f3d22e) | `` automatic update `` |