### PR TITLE
chore(flake/nur): `86997491` -> `3ab52f28`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732361011,
-        "narHash": "sha256-dSAfd7wSrxd0GtwGRaW7MJv3OBNyw3XLM5AU+6mAKL4=",
+        "lastModified": 1732370327,
+        "narHash": "sha256-lGy8sDtok/RKoE+Ghe0yUuZigESbmxedLcckg5+Je5I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "86997491ed2896f76088abf22617a54a45f3d22e",
+        "rev": "3ab52f2809610c0f6242504c57464f4816600849",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3ab52f28`](https://github.com/nix-community/NUR/commit/3ab52f2809610c0f6242504c57464f4816600849) | `` automatic update `` |