### PR TITLE
chore(flake/nur): `3ab52f28` -> `53f87962`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732370327,
-        "narHash": "sha256-lGy8sDtok/RKoE+Ghe0yUuZigESbmxedLcckg5+Je5I=",
+        "lastModified": 1732373269,
+        "narHash": "sha256-VFLPL2k9u3hTcmsjKGrUJ5nHn/SZlKRbXujIeT/Xpfk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3ab52f2809610c0f6242504c57464f4816600849",
+        "rev": "53f8796289b8fd6fa5bb8a66a11e5c5ed4b7cab9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`53f87962`](https://github.com/nix-community/NUR/commit/53f8796289b8fd6fa5bb8a66a11e5c5ed4b7cab9) | `` automatic update `` |
| [`1f1cc469`](https://github.com/nix-community/NUR/commit/1f1cc4692331a456ce1b9dca6737333ddadd6dea) | `` automatic update `` |