### PR TITLE
chore(flake/nur): `53f87962` -> `6f31ab1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732373269,
-        "narHash": "sha256-VFLPL2k9u3hTcmsjKGrUJ5nHn/SZlKRbXujIeT/Xpfk=",
+        "lastModified": 1732376696,
+        "narHash": "sha256-jtyN+D7xA9ai7GrdrXrvMGuf9wYDTegnUwrQPJH8BKA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "53f8796289b8fd6fa5bb8a66a11e5c5ed4b7cab9",
+        "rev": "6f31ab1bc688575f436a4a4d2796f204e4c592eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6f31ab1b`](https://github.com/nix-community/NUR/commit/6f31ab1bc688575f436a4a4d2796f204e4c592eb) | `` automatic update `` |