### PR TITLE
chore(flake/home-manager): `8cf9cb2e` -> `16fe7818`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -367,11 +367,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732303962,
-        "narHash": "sha256-5Umjb5AdtxV5jSJd5jxoCckh5mlg+FBQDsyAilu637g=",
+        "lastModified": 1732383377,
+        "narHash": "sha256-FnTC1Eycct/oD1I0ZUuy9FmQFfBeuymbVD2ptlQWaGc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8cf9cb2ee78aa129e5b8220135a511a2be254c0c",
+        "rev": "16fe78182e924c9a2b0cffa1f343efea80945ef2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`16fe7818`](https://github.com/nix-community/home-manager/commit/16fe78182e924c9a2b0cffa1f343efea80945ef2) | `` conky: update systemd exec path to config package `` |
| [`445d721e`](https://github.com/nix-community/home-manager/commit/445d721ecfbd92d83f857f12f1f99f5c8fa79951) | `` home-cursor: add hyprcursor support ``               |