### PR TITLE
chore(flake/nur): `9c6bc994` -> `32a091f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732380271,
-        "narHash": "sha256-8R1AP/no6UO6RYQq2cM7CDQieCfozdIAD0TipiTK58k=",
+        "lastModified": 1732387718,
+        "narHash": "sha256-qgOyvB5g41QCefVlK/6WjymS3D08+c+VekPsXL+VWi0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9c6bc9942ea16c3563c7c275d3274e1c314e88cc",
+        "rev": "32a091f99d7422427f383de2b3b699dfef718d41",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`32a091f9`](https://github.com/nix-community/NUR/commit/32a091f99d7422427f383de2b3b699dfef718d41) | `` automatic update `` |
| [`88a92e14`](https://github.com/nix-community/NUR/commit/88a92e149952c58ce6f6912322d7e25f80bb5dbe) | `` automatic update `` |
| [`137c0901`](https://github.com/nix-community/NUR/commit/137c090180032ce65a605e93987f4f0ae2eb6442) | `` automatic update `` |
| [`81f8dcf4`](https://github.com/nix-community/NUR/commit/81f8dcf40964207c91b1b7d11f0e6c270219361f) | `` automatic update `` |
| [`816f6e0f`](https://github.com/nix-community/NUR/commit/816f6e0f0434ee6025cfa5a143f1ba95f04b2c9d) | `` automatic update `` |