### PR TITLE
chore(flake/home-manager): `16fe7818` -> `92fef254`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -367,11 +367,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732383377,
-        "narHash": "sha256-FnTC1Eycct/oD1I0ZUuy9FmQFfBeuymbVD2ptlQWaGc=",
+        "lastModified": 1732397793,
+        "narHash": "sha256-2jaf/zkug22hzlldm1PKdKJLVKgdjVXbf47SF+5mroU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "16fe78182e924c9a2b0cffa1f343efea80945ef2",
+        "rev": "92fef254a9071fa41a13908281284e6a62b9c92e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`92fef254`](https://github.com/nix-community/home-manager/commit/92fef254a9071fa41a13908281284e6a62b9c92e) | `` podman: install package and create config files `` |
| [`ba9367b5`](https://github.com/nix-community/home-manager/commit/ba9367b5a98402fb3d2afe7aa58c432c43996720) | `` emacs: add darwin service ``                       |