### PR TITLE
chore(flake/nur): `35f7c817` -> `75c995f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732395429,
-        "narHash": "sha256-bUQydpSHjYIcnA1JI+wDBUsnBtyIAGo9e/39O5M6Awg=",
+        "lastModified": 1732398387,
+        "narHash": "sha256-QYeXbTMAdisNl7AgeTbtDR7aeDSR5E4C/oRenQqdM+8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "35f7c817fe8f28c5983d8833128e3881f8092519",
+        "rev": "75c995f1d4e1297e4ffd45a20bf71440bbc7aa3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`75c995f1`](https://github.com/nix-community/NUR/commit/75c995f1d4e1297e4ffd45a20bf71440bbc7aa3e) | `` automatic update `` |
| [`692f6808`](https://github.com/nix-community/NUR/commit/692f68082780b6c7bc42ba42e9a51bffb5637f5f) | `` automatic update `` |
| [`340acc6c`](https://github.com/nix-community/NUR/commit/340acc6c450969b3422d23f2ed705e777d7f3208) | `` automatic update `` |
| [`dcc9c86c`](https://github.com/nix-community/NUR/commit/dcc9c86c6c4dedb0c25a7bbfaa583c5b184044cc) | `` automatic update `` |