### PR TITLE
chore(flake/nur): `75c995f1` -> `e6d25da5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732398387,
-        "narHash": "sha256-QYeXbTMAdisNl7AgeTbtDR7aeDSR5E4C/oRenQqdM+8=",
+        "lastModified": 1732401282,
+        "narHash": "sha256-QfgTI3RuSbrvpReVcilHkkMegLZAblq6w8S8yCv6QFs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "75c995f1d4e1297e4ffd45a20bf71440bbc7aa3e",
+        "rev": "e6d25da53d3cd2da4bdf0e2bb7592f4180790008",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e6d25da5`](https://github.com/nix-community/NUR/commit/e6d25da53d3cd2da4bdf0e2bb7592f4180790008) | `` automatic update `` |
| [`4f3debc2`](https://github.com/nix-community/NUR/commit/4f3debc21ed61c12f0a76d3776b8f0b26fe85d33) | `` automatic update `` |
| [`0630a772`](https://github.com/nix-community/NUR/commit/0630a772afa933969aaec73047077cd657b6a19e) | `` automatic update `` |