### PR TITLE
chore(flake/nur): `7a3e6d03` -> `e2a9a9fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -812,11 +812,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732405614,
-        "narHash": "sha256-Xi/S5NN8R75fy0SJmYfDv0ACGHqjL0Xc9fX7okOGt/g=",
+        "lastModified": 1732414488,
+        "narHash": "sha256-pdoqPZslw7gG3oFPbwLeVyIBQwoN4MG6AvU9ImR7TjY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7a3e6d03844e420619c76108379d012026a45d10",
+        "rev": "e2a9a9fccb6e4f442e58156d485d286919a710c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e2a9a9fc`](https://github.com/nix-community/NUR/commit/e2a9a9fccb6e4f442e58156d485d286919a710c9) | `` automatic update `` |
| [`9c0698b6`](https://github.com/nix-community/NUR/commit/9c0698b6797cfbb9e646a540c744572f960f9558) | `` automatic update `` |