### PR TITLE
chore(flake/nix-index-database): `bdba2469` -> `0ef970b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -544,11 +544,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731814505,
-        "narHash": "sha256-l9ryrx1Twh08a+gxrMGM9O/aZKEimZfa6sZVyPCImgI=",
+        "lastModified": 1732419467,
+        "narHash": "sha256-TjuKScXbj4Ddr0L+kEOLFaYOhzbS/k/EFL543wkjN5E=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "bdba246946fb079b87b4cada4df9b1cdf1c06132",
+        "rev": "0ef970b7021e0ee9ab93437d0e28296e86669b03",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`0ef970b7`](https://github.com/nix-community/nix-index-database/commit/0ef970b7021e0ee9ab93437d0e28296e86669b03) | `` update generated.nix to release 2024-11-24-032503 `` |
| [`6a79fb11`](https://github.com/nix-community/nix-index-database/commit/6a79fb11d1dda460b5e869ed44eb388e41042112) | `` flake.lock: Update ``                                |