### PR TITLE
chore(flake/nur): `e2a9a9fc` -> `86ad5392`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -811,11 +811,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732414488,
-        "narHash": "sha256-pdoqPZslw7gG3oFPbwLeVyIBQwoN4MG6AvU9ImR7TjY=",
+        "lastModified": 1732433005,
+        "narHash": "sha256-RX8r+frx4RLlz1scXVlw/7IH6uQz0u03krFRomkHntw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e2a9a9fccb6e4f442e58156d485d286919a710c9",
+        "rev": "86ad5392b8c1a579a06232bcc7e4e38f7f89b48f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`86ad5392`](https://github.com/nix-community/NUR/commit/86ad5392b8c1a579a06232bcc7e4e38f7f89b48f) | `` automatic update `` |
| [`86dd7c6c`](https://github.com/nix-community/NUR/commit/86dd7c6cbc3f3994e3e04c46bd9fce3898745d12) | `` automatic update `` |
| [`4741eb6c`](https://github.com/nix-community/NUR/commit/4741eb6cae950dfdb103a8ff4e3831f207523169) | `` automatic update `` |
| [`c8cf0a41`](https://github.com/nix-community/NUR/commit/c8cf0a412909464e53abdcacee673ce09adb43f1) | `` automatic update `` |