### PR TITLE
chore(flake/nur): `86ad5392` -> `5347bd2c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -811,11 +811,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732433005,
-        "narHash": "sha256-RX8r+frx4RLlz1scXVlw/7IH6uQz0u03krFRomkHntw=",
+        "lastModified": 1732438268,
+        "narHash": "sha256-5bhAbn8h2jv3HzlyaZ6nSypOlBLkfbbjXVsYueGSmvE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "86ad5392b8c1a579a06232bcc7e4e38f7f89b48f",
+        "rev": "5347bd2ceaa9e1698d6efc2cf0fdcc0b1fb16213",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5347bd2c`](https://github.com/nix-community/NUR/commit/5347bd2ceaa9e1698d6efc2cf0fdcc0b1fb16213) | `` automatic update `` |
| [`2b5ebecc`](https://github.com/nix-community/NUR/commit/2b5ebeccb7553de88e16c5749f5d0fc25f470716) | `` automatic update `` |