### PR TITLE
chore(flake/nur): `79c7e2e5` -> `9268a3c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -811,11 +811,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732445289,
-        "narHash": "sha256-I11rJ+2M9kO6mWsMPhEEGQlg/1u9cCCjoY/9pTAKpOg=",
+        "lastModified": 1732454251,
+        "narHash": "sha256-pGuDkPu16Paye5X/ctdXQ1DgWGgSJDCh981dKe7peEQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "79c7e2e562346749551db0d1350d49c74721216a",
+        "rev": "9268a3c103594c1ef76267597caf742a68e56b7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9268a3c1`](https://github.com/nix-community/NUR/commit/9268a3c103594c1ef76267597caf742a68e56b7f) | `` automatic update `` |
| [`6f56404a`](https://github.com/nix-community/NUR/commit/6f56404a371d10850097bc761f51980f0b67a520) | `` automatic update `` |