### PR TITLE
chore(flake/nix-index-database): `0ef970b7` -> `bedc30c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -543,11 +543,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732419467,
-        "narHash": "sha256-TjuKScXbj4Ddr0L+kEOLFaYOhzbS/k/EFL543wkjN5E=",
+        "lastModified": 1732461762,
+        "narHash": "sha256-3SMxtkXlmzPmF4NXCt6lLF2IkdyAmO824PlScUKVhB0=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "0ef970b7021e0ee9ab93437d0e28296e86669b03",
+        "rev": "bedc30c64442579943c1c6e7579db263d810884f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                   |
| ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`bedc30c6`](https://github.com/nix-community/nix-index-database/commit/bedc30c64442579943c1c6e7579db263d810884f) | `` add missing include for home-manager ``                |
| [`af404206`](https://github.com/nix-community/nix-index-database/commit/af404206393ced55798b7fadb1959377cb0a02f6) | `` more defensivly seperate options from configuration `` |
| [`faa91659`](https://github.com/nix-community/nix-index-database/commit/faa91659deeb2257c41bbc32fa0eb7839a6798c1) | `` README: mention nix-darwin usage ``                    |