### PR TITLE
chore(flake/nur): `b14d4df7` -> `44c21d20`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -811,11 +811,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732460309,
-        "narHash": "sha256-AkfZgFl43g/ZXvsRb5/SIfPxl2ocIsTXgKELphZh65U=",
+        "lastModified": 1732470384,
+        "narHash": "sha256-h9mGcHzO8FdAfBIYcqeDlEOK6JZKo5C9w81CSeuRdDM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b14d4df78665d47cf8b95a31740a3990472cc39d",
+        "rev": "44c21d2005ffbc206138afa6c327d7fafa5712bf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`44c21d20`](https://github.com/nix-community/NUR/commit/44c21d2005ffbc206138afa6c327d7fafa5712bf) | `` automatic update `` |
| [`f1401684`](https://github.com/nix-community/NUR/commit/f140168402706b583d44524256e6e81485679c21) | `` automatic update `` |
| [`775b3b61`](https://github.com/nix-community/NUR/commit/775b3b6153a60ce681c0ac61ee4fe885dc2676f2) | `` automatic update `` |
| [`3ced67d5`](https://github.com/nix-community/NUR/commit/3ced67d5dc15f27269906ce7c5431f8bc665b321) | `` automatic update `` |
| [`5951bcd8`](https://github.com/nix-community/NUR/commit/5951bcd835d728eb0db62425dba44a79d83c75d0) | `` automatic update `` |