### PR TITLE
chore(flake/home-manager): `bd58a113` -> `9ae941a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732453510,
-        "narHash": "sha256-mAOaLu++YRwOxCJ135Bhgf78WYhIKWHL2aGWCAoXoBg=",
+        "lastModified": 1732466726,
+        "narHash": "sha256-i+wpA5bHGzT9PXbyoi3hIeSvLI6eCEG5utlEvAu0jAQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bd58a1132e9b7f121f65313bc662ad6c8a05f878",
+        "rev": "9ae941a4cff40575feb7a64eb6cce70f733b12ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`9ae941a4`](https://github.com/nix-community/home-manager/commit/9ae941a4cff40575feb7a64eb6cce70f733b12ed) | `` abook: remove platform linux assertion ``    |
| [`5e2f47c5`](https://github.com/nix-community/home-manager/commit/5e2f47c5a52707d250364401091e88021ba052a1) | `` hypridle: fix service when no config file `` |