### PR TITLE
chore(flake/home-manager): `9ae941a4` -> `83002f18`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -333,11 +333,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732466726,
-        "narHash": "sha256-i+wpA5bHGzT9PXbyoi3hIeSvLI6eCEG5utlEvAu0jAQ=",
+        "lastModified": 1732472774,
+        "narHash": "sha256-nfD12L8mm1Zcg0keslWrQgaqj+ZSjQnK6Hf6ryIZA0c=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9ae941a4cff40575feb7a64eb6cce70f733b12ed",
+        "rev": "83002f18468c4471d5f8de8c542ed2422badbf8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`83002f18`](https://github.com/nix-community/home-manager/commit/83002f18468c4471d5f8de8c542ed2422badbf8f) | `` mopidy: restart the systemd service on failure `` |
| [`98bf8de6`](https://github.com/nix-community/home-manager/commit/98bf8de65dc1ed12c6443b18f6f24d36e9c438d6) | `` volnoti: use cfg.package instead of pkgs ``       |
| [`f9fd45c5`](https://github.com/nix-community/home-manager/commit/f9fd45c512ef02c69557823543bb04051a41fa37) | `` volnoti: add self to maintainers ``               |