### PR TITLE
chore(flake/home-manager): `83002f18` -> `a9953635`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -333,11 +333,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732472774,
-        "narHash": "sha256-nfD12L8mm1Zcg0keslWrQgaqj+ZSjQnK6Hf6ryIZA0c=",
+        "lastModified": 1732482255,
+        "narHash": "sha256-GUffLwzawz5WRVfWaWCg78n/HrBJrOG7QadFY6rtV8A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "83002f18468c4471d5f8de8c542ed2422badbf8f",
+        "rev": "a9953635d7f34e7358d5189751110f87e3ac17da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`a9953635`](https://github.com/nix-community/home-manager/commit/a9953635d7f34e7358d5189751110f87e3ac17da) | `` mopidy: restart service on config changes `` |
| [`4d8d8c38`](https://github.com/nix-community/home-manager/commit/4d8d8c385e78f5f744e2e2f81f5c56fade6ca4eb) | `` zed-editor: add extraPackages option ``      |