### PR TITLE
chore(flake/nur): `accde1d4` -> `47c654b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732477495,
-        "narHash": "sha256-sjJRKocfyZkYwnoeMVHELQdnLf1xZ/qf/7C+III2+PQ=",
+        "lastModified": 1732480006,
+        "narHash": "sha256-QscOabzgJq4vJm2joaJrmYneyvt1GWh+4JB+EEErm9Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "accde1d45e6d46475307d42b2e6ebf36db3bf228",
+        "rev": "47c654b6d4c461da43e1bdab4072af74da82529e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`47c654b6`](https://github.com/nix-community/NUR/commit/47c654b6d4c461da43e1bdab4072af74da82529e) | `` automatic update `` |