### PR TITLE
chore(flake/nur): `47c654b6` -> `0e9772df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -739,11 +739,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732480006,
-        "narHash": "sha256-QscOabzgJq4vJm2joaJrmYneyvt1GWh+4JB+EEErm9Q=",
+        "lastModified": 1732492372,
+        "narHash": "sha256-0ZGZ/e4D2cTzX08DH4VjxQ2pxPYLItwFfn1+qvAyo3M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "47c654b6d4c461da43e1bdab4072af74da82529e",
+        "rev": "0e9772df263d96edd69448da3c8590bae7dd91f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0e9772df`](https://github.com/nix-community/NUR/commit/0e9772df263d96edd69448da3c8590bae7dd91f9) | `` automatic update `` |