### PR TITLE
chore(flake/emacs-overlay): `72c506de` -> `a84dc7f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1732468280,
-        "narHash": "sha256-z04IEIYlO/KMeXQCt7neM/WDlIVtQjy+QGDrTwDNwHc=",
+        "lastModified": 1732499882,
+        "narHash": "sha256-+BWeuEH70v193zbGjil9vTyXFomixVWKwg+C6F4aYnI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "72c506de74f90bc47bfe62627844b973b493a377",
+        "rev": "a84dc7f9b8a43f089d094a7d9af8340d21f0d5f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`a84dc7f9`](https://github.com/nix-community/emacs-overlay/commit/a84dc7f9b8a43f089d094a7d9af8340d21f0d5f0) | `` Updated melpa ``  |
| [`11cfcdb5`](https://github.com/nix-community/emacs-overlay/commit/11cfcdb5c90289fda42fe7088981f35c4fb75dfb) | `` Updated elpa ``   |
| [`e5f8205e`](https://github.com/nix-community/emacs-overlay/commit/e5f8205e44e676fbd182dac5484fc843a3c81f56) | `` Updated nongnu `` |