### PR TITLE
chore(flake/nixos-facter-modules): `d0e205ea` -> `86264858`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -604,11 +604,11 @@
     },
     "nixos-facter-modules": {
       "locked": {
-        "lastModified": 1730798058,
-        "narHash": "sha256-2KexAe17KRg2191SdBxVXqJKwV6MxKzlE35DDcAX+Ds=",
+        "lastModified": 1732288619,
+        "narHash": "sha256-zSQ2cR+NRJfHUVfkv+O6Wi53wXfzX8KHiO8fRfnvc0M=",
         "owner": "numtide",
         "repo": "nixos-facter-modules",
-        "rev": "d0e205eafca7091caad3925ff82a46fea08351e1",
+        "rev": "862648589993a96480c2255197a28feea712f68f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                            |
| ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`98193b2a`](https://github.com/numtide/nixos-facter-modules/commit/98193b2af5042b594c57f55f8d09395043a1f209) | `` chore: fmt ``                                                   |
| [`49e2f4dd`](https://github.com/numtide/nixos-facter-modules/commit/49e2f4dd1148afd0dcd008e6d518eae3fd1df063) | `` ci(mergify): upgrade configuration to current format ``         |
| [`5a1c2a28`](https://github.com/numtide/nixos-facter-modules/commit/5a1c2a28589e34f8a44d46dd1909cfacf928cb1a) | `` don't re-import nixpkgs for tests ``                            |
| [`cbbb0f78`](https://github.com/numtide/nixos-facter-modules/commit/cbbb0f780bddc5648ca4ee33a6c788e07c971776) | `` networking: fix incorrect report path for network_interfaces `` |