### PR TITLE
chore(flake/nur): `0e9772df` -> `71fe495a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -842,11 +842,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732492372,
-        "narHash": "sha256-0ZGZ/e4D2cTzX08DH4VjxQ2pxPYLItwFfn1+qvAyo3M=",
+        "lastModified": 1732531874,
+        "narHash": "sha256-+7zxHH7yCHhN293AcBKirSZNyNaq52VM4MbAmTW69bA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0e9772df263d96edd69448da3c8590bae7dd91f9",
+        "rev": "71fe495a8b1f9fe1576ba3343a81afd54dcff583",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`71fe495a`](https://github.com/nix-community/NUR/commit/71fe495a8b1f9fe1576ba3343a81afd54dcff583) | `` automatic update `` |
| [`97aa65a4`](https://github.com/nix-community/NUR/commit/97aa65a484880e38c9796b7baf1c5877557675d9) | `` automatic update `` |
| [`4e8d9b44`](https://github.com/nix-community/NUR/commit/4e8d9b4486040b543369539ffd9623ee317d65b9) | `` automatic update `` |
| [`5332a20c`](https://github.com/nix-community/NUR/commit/5332a20c102c371244638dfb30a9d853a1639567) | `` automatic update `` |
| [`3713e478`](https://github.com/nix-community/NUR/commit/3713e47855a644d534b556be42458326bef6cbe0) | `` automatic update `` |
| [`f79dcb09`](https://github.com/nix-community/NUR/commit/f79dcb095c70b1a47be933d4dda2ad931136e434) | `` automatic update `` |
| [`0c4a3592`](https://github.com/nix-community/NUR/commit/0c4a359234bcde0e7b75539cffcf9881a0e12adb) | `` automatic update `` |
| [`c2c1dbe8`](https://github.com/nix-community/NUR/commit/c2c1dbe8b2082709579b745a0d2a6e2680d31065) | `` automatic update `` |
| [`357f49c3`](https://github.com/nix-community/NUR/commit/357f49c348cf978ed40005a05171d4bccd64b13d) | `` automatic update `` |
| [`b1ce524c`](https://github.com/nix-community/NUR/commit/b1ce524cf4d295ac4a4493aaa08bb5fea4ba74bc) | `` automatic update `` |