### PR TITLE
chore(flake/nix-index-database): `bedc30c6` -> `f4a5ca57`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -543,11 +543,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732461762,
-        "narHash": "sha256-3SMxtkXlmzPmF4NXCt6lLF2IkdyAmO824PlScUKVhB0=",
+        "lastModified": 1732519917,
+        "narHash": "sha256-AGXhwHdJV0q/WNgqwrR2zriubLr785b02FphaBtyt1Q=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "bedc30c64442579943c1c6e7579db263d810884f",
+        "rev": "f4a5ca5771ba9ca31ad24a62c8d511a405303436",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                       |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`fdc58afc`](https://github.com/nix-community/nix-index-database/commit/fdc58afcc31a59b679b676071b94442b3f83bbec) | `` darwin-module: stop setting unused comma.package option `` |