### PR TITLE
chore(flake/nix-doom-emacs-unstraightened): `a78d26b4` -> `28b62eda`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -124,11 +124,11 @@
     "doomemacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1730548076,
-        "narHash": "sha256-NQdv5gWYsckwPoh00Lr6VN4IGERH/T08nHbzBhRadN4=",
+        "lastModified": 1732368874,
+        "narHash": "sha256-ketdYl75drmTQZRUvUDcVswUXGi0vKonzqopX8Maja8=",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "97c0dcc2c328fcc791333e149418c26096043758",
+        "rev": "9c8cfaadde1ccc96a780d713d2a096f0440b9483",
         "type": "github"
       },
       "original": {
@@ -168,11 +168,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730683519,
-        "narHash": "sha256-JsaxXQEI76Lq6c5KVAzcAvNox0qEzJfC5+bYZqtySCk=",
+        "lastModified": 1732583978,
+        "narHash": "sha256-dh0RQSLyVCNwzW+r7O/QEFvdZUGwbiyhJzvEssYjWfc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3cbb531951b8abd4413ebc04a4e06d214de3cf04",
+        "rev": "b537c6adc150f4517eb9025c4101cf9ab15f4902",
         "type": "github"
       },
       "original": {
@@ -472,11 +472,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1730717277,
-        "narHash": "sha256-01K4n9V96nG4jM0tpkRJe/Vwq6LiA0DJzBI8zyMIbHM=",
+        "lastModified": 1732610459,
+        "narHash": "sha256-/lD1FDtKFFwA1SVnVgDHS51IDW8441jM67r8rveMfS4=",
         "owner": "marienz",
         "repo": "nix-doom-emacs-unstraightened",
-        "rev": "a78d26b4f344c1b44d8891343149a73717e8b8a1",
+        "rev": "28b62eda45dee33eacf81c44924bbf5eabe7fe88",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                                 | Message                                                |
| ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`28b62eda`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/28b62eda45dee33eacf81c44924bbf5eabe7fe88) | `` flake.lock: Update ``                               |
| [`392bee85`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/392bee851623da313e59d163dd51653009c733db) | `` flake.lock: Update ``                               |
| [`96fcfaa6`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/96fcfaa685323335cd2dd337cc5ba6a06fa65ab4) | `` Stop building org-roam-v1 (require `org +roam2`) `` |
| [`4a5f45b4`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/4a5f45b41a619608b6106d57ea924e9d035133a7) | `` Revert "Pin Doom input" ``                          |
| [`07aa2a81`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/07aa2a814d582da98a58871d00fe3570c1d31d4f) | `` Leave the user init.el alone ``                     |
| [`fe642df7`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/fe642df7f314189b44bcfa7b838de622c5431da4) | `` Initialize profile in intended order ``             |
| [`af2a616a`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/af2a616a78285705c388b12fd841bed7f353c717) | `` Tweak how straight-base-dir is set ``               |
| [`e73e398b`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/e73e398b501df0c54ad3345d1b52cbf52ebb76bd) | `` Use byte-compiled profile loader ``                 |
| [`ff9ea909`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/ff9ea9099a224d49064bf27c5ba85dcad7060694) | `` Update Doom and emacs-overlay ``                    |
| [`f9302e9c`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/f9302e9c4aa42e45284200ba7e073d5238141ec3) | `` Update Doom, adjusting to initializating changes `` |
| [`e5ef895d`](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/e5ef895d37a77805256a0f5a79d0eef01dbb1444) | `` BREAKING CHANGE: drop noProfileHack ``              |