### PR TITLE
chore(flake/nur): `71fe495a` -> `4e13d471`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -842,11 +842,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732531874,
-        "narHash": "sha256-+7zxHH7yCHhN293AcBKirSZNyNaq52VM4MbAmTW69bA=",
+        "lastModified": 1732564082,
+        "narHash": "sha256-uOb3GT/g5ak9nxe3EEWNFia33dasVEHnwmutzJtGE/o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "71fe495a8b1f9fe1576ba3343a81afd54dcff583",
+        "rev": "4e13d47128b0970305f76ad70d2253a277e56181",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4e13d471`](https://github.com/nix-community/NUR/commit/4e13d47128b0970305f76ad70d2253a277e56181) | `` automatic update `` |
| [`c7671b50`](https://github.com/nix-community/NUR/commit/c7671b5065be1516c799ab0d1ba01f36538501e2) | `` automatic update `` |
| [`13ec1ea3`](https://github.com/nix-community/NUR/commit/13ec1ea392fcc86f2139d47b0445c71df36ece51) | `` automatic update `` |
| [`62b691b5`](https://github.com/nix-community/NUR/commit/62b691b5792d5e5785c044588c66e05531411fb1) | `` automatic update `` |
| [`84e254f7`](https://github.com/nix-community/NUR/commit/84e254f778c59ee04c00f2abcea09cb34cd82527) | `` automatic update `` |
| [`9fd100a9`](https://github.com/nix-community/NUR/commit/9fd100a96b92553f87b866965ac9113e787028f8) | `` automatic update `` |
| [`bdd3c946`](https://github.com/nix-community/NUR/commit/bdd3c9465129b14b148cdc98e152433347b9b974) | `` automatic update `` |
| [`365f3e06`](https://github.com/nix-community/NUR/commit/365f3e06f11f32048f6b57cbf01928bc31c69ed1) | `` automatic update `` |
| [`d9fa99c8`](https://github.com/nix-community/NUR/commit/d9fa99c8761acc21942b61fed1ef94da60994c40) | `` automatic update `` |
| [`35ddaa1f`](https://github.com/nix-community/NUR/commit/35ddaa1fae8af5cc5be00bcfbb80023dbfa95298) | `` automatic update `` |
| [`362af7d4`](https://github.com/nix-community/NUR/commit/362af7d418a6db57287df12f565aadcc0d93f150) | `` automatic update `` |