### PR TITLE
chore(flake/emacs-overlay): `94734b1b` -> `6fcec249`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1732525371,
-        "narHash": "sha256-CZ1vywFlUYAoUVWfc8IcYRgK8CLM8RCMx2QHYCGkhsI=",
+        "lastModified": 1732554899,
+        "narHash": "sha256-c4ai2tbi0fdeoxu4zaHjyDxgBo5X3tClF6ccU7cmMPk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "94734b1bf571b12202fa1298f6bf200372b40170",
+        "rev": "6fcec24914230d0fd047cfe2b4428fe03d779f99",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`6fcec249`](https://github.com/nix-community/emacs-overlay/commit/6fcec24914230d0fd047cfe2b4428fe03d779f99) | `` Updated emacs ``  |
| [`74b9722e`](https://github.com/nix-community/emacs-overlay/commit/74b9722ee2ff0a5dce45a5f45acf97a4aa6d5b42) | `` Updated melpa ``  |
| [`4c13a6fc`](https://github.com/nix-community/emacs-overlay/commit/4c13a6fcbabc424b48ab3a5e8a30119ecf33df7d) | `` Updated nongnu `` |