### PR TITLE
chore(flake/nur): `4e13d471` -> `9237df2e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -842,11 +842,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732564082,
-        "narHash": "sha256-uOb3GT/g5ak9nxe3EEWNFia33dasVEHnwmutzJtGE/o=",
+        "lastModified": 1732619635,
+        "narHash": "sha256-YtCxUM9xaVUOVBl7SuyAujWj3iA914RukauPC2RYGvE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4e13d47128b0970305f76ad70d2253a277e56181",
+        "rev": "9237df2ebc03bc6c19dc78bb3c8365f9af503bf6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9237df2e`](https://github.com/nix-community/NUR/commit/9237df2ebc03bc6c19dc78bb3c8365f9af503bf6) | `` automatic update `` |
| [`76c36f54`](https://github.com/nix-community/NUR/commit/76c36f5443bac2445ce4b498d92f8c6d250afa4d) | `` automatic update `` |
| [`51acf239`](https://github.com/nix-community/NUR/commit/51acf239bbd8e8b127ce5fb0de6611bbe049364d) | `` automatic update `` |
| [`3ad24c22`](https://github.com/nix-community/NUR/commit/3ad24c2233fae10fcdc7b88d288eee4d66eeca89) | `` automatic update `` |
| [`04cb99d8`](https://github.com/nix-community/NUR/commit/04cb99d879ad7a3581bbb4463351afd8b8565eab) | `` automatic update `` |
| [`8e2badf2`](https://github.com/nix-community/NUR/commit/8e2badf277132b4616778976bed686b3ca3f9ee1) | `` automatic update `` |
| [`983b7553`](https://github.com/nix-community/NUR/commit/983b755396bd606cfa28f6eaeca37289bdebc929) | `` automatic update `` |
| [`26ebf2b1`](https://github.com/nix-community/NUR/commit/26ebf2b17993103cca1a65bdda765c9f7d3a40ab) | `` automatic update `` |
| [`f3747a14`](https://github.com/nix-community/NUR/commit/f3747a145c4d3e6cc9164ea102b50be481929d39) | `` automatic update `` |
| [`da65641d`](https://github.com/nix-community/NUR/commit/da65641dbeb35ed433596ecb7bb8bf7466376040) | `` automatic update `` |
| [`a4b110ca`](https://github.com/nix-community/NUR/commit/a4b110cab45c9a73411f5aa37ae175d5cab28984) | `` automatic update `` |
| [`3cbca17d`](https://github.com/nix-community/NUR/commit/3cbca17d9007c96dd07bdd313da221f455899446) | `` automatic update `` |
| [`f82e8ba2`](https://github.com/nix-community/NUR/commit/f82e8ba200b6b2c6619dfce29c909faaf15387c0) | `` automatic update `` |
| [`065287ab`](https://github.com/nix-community/NUR/commit/065287ab2e7c6fb0260da732dd650df7ef4f71a9) | `` automatic update `` |
| [`4103150b`](https://github.com/nix-community/NUR/commit/4103150b3bddc069646bd67f6dd8dc6f3266c5a1) | `` automatic update `` |
| [`e359a38a`](https://github.com/nix-community/NUR/commit/e359a38a02b982b41dc611e6dd37f1091d2e0cb6) | `` automatic update `` |
| [`7c2020a0`](https://github.com/nix-community/NUR/commit/7c2020a0fac81021d503aa5e32fef92ca4623178) | `` automatic update `` |
| [`128c41e7`](https://github.com/nix-community/NUR/commit/128c41e7a6670fae6d61ab812abf8cbfa21279d6) | `` automatic update `` |