### PR TITLE
chore(flake/sops-nix): `53c853fb` -> `3433ea14`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -956,11 +956,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732186149,
-        "narHash": "sha256-N9JGWe/T8BC0Tss2Cv30plvZUYoiRmykP7ZdY2on2b0=",
+        "lastModified": 1732575825,
+        "narHash": "sha256-xtt95+c7OUMoqZf4OvA/7AemiH3aVuWHQbErYQoPwFk=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "53c853fb1a7e4f25f68805ee25c83d5de18dc699",
+        "rev": "3433ea14fbd9e6671d0ff0dd45ed15ee4c156ffa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                     |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`3433ea14`](https://github.com/Mic92/sops-nix/commit/3433ea14fbd9e6671d0ff0dd45ed15ee4c156ffa) | `` update vendorHash ``                                                     |
| [`6ecde343`](https://github.com/Mic92/sops-nix/commit/6ecde343ef558861da82936283dd4523478b30e8) | `` build(deps): bump github.com/ProtonMail/go-crypto from 1.1.2 to 1.1.3 `` |