### PR TITLE
chore(flake/emacs-overlay): `6fcec249` -> `b537c6ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1732554899,
-        "narHash": "sha256-c4ai2tbi0fdeoxu4zaHjyDxgBo5X3tClF6ccU7cmMPk=",
+        "lastModified": 1732583978,
+        "narHash": "sha256-dh0RQSLyVCNwzW+r7O/QEFvdZUGwbiyhJzvEssYjWfc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6fcec24914230d0fd047cfe2b4428fe03d779f99",
+        "rev": "b537c6adc150f4517eb9025c4101cf9ab15f4902",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`b537c6ad`](https://github.com/nix-community/emacs-overlay/commit/b537c6adc150f4517eb9025c4101cf9ab15f4902) | `` Updated elpa ``   |
| [`c401d6e4`](https://github.com/nix-community/emacs-overlay/commit/c401d6e4170885d110ecbf0322ecaa7fe9d59f6c) | `` Updated nongnu `` |