### PR TITLE
chore(flake/darwin): `3c52583b` -> `6ab87b7c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -66,11 +66,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732420287,
-        "narHash": "sha256-CzvYF4x6jUh/+NEEIFrIY5t1W/N3IA2bNZJiMXu9GTo=",
+        "lastModified": 1732603785,
+        "narHash": "sha256-AEjWTJwOmSnVYsSJCojKgoguGfFfwel6z/6ud6UFMU8=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "3c52583b99666a349a6219dc1f0dd07d75c82d6a",
+        "rev": "6ab87b7c84d4ee873e937108c4ff80c015a40c7a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                          |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
| [`25e0b606`](https://github.com/LnL7/nix-darwin/commit/25e0b6064eed7a4ffeca7bacbba9dcca6fa8cc86) | `` system: fix detection and ownership of /etc/synthetic.conf `` |