### PR TITLE
chore(flake/nur): `9237df2e` -> `d4d63749`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -842,11 +842,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732619635,
-        "narHash": "sha256-YtCxUM9xaVUOVBl7SuyAujWj3iA914RukauPC2RYGvE=",
+        "lastModified": 1732664804,
+        "narHash": "sha256-59kFHhZXuXZJnY008XuGgtNhMrQlV21X/tWJn8KzqgI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9237df2ebc03bc6c19dc78bb3c8365f9af503bf6",
+        "rev": "d4d637492fd5aa3c0bc15b034423a947d5a41c69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d4d63749`](https://github.com/nix-community/NUR/commit/d4d637492fd5aa3c0bc15b034423a947d5a41c69) | `` automatic update `` |
| [`ab69d18f`](https://github.com/nix-community/NUR/commit/ab69d18f7ef18b5ab23a727b5b7f7f2ce35361ff) | `` automatic update `` |
| [`cd638d8b`](https://github.com/nix-community/NUR/commit/cd638d8bb0246139c2a5b5b50fb41894b8db311e) | `` automatic update `` |
| [`4f0cd6ee`](https://github.com/nix-community/NUR/commit/4f0cd6ee46dda00e199e9f8db13c03bcf61ebe91) | `` automatic update `` |
| [`0bec2bcc`](https://github.com/nix-community/NUR/commit/0bec2bcc5ec0b5ef794080d75284b7bb0da4a401) | `` automatic update `` |
| [`083abf8c`](https://github.com/nix-community/NUR/commit/083abf8c3b52200f2f73bea8b9b1c711b4d02459) | `` automatic update `` |
| [`f09c471e`](https://github.com/nix-community/NUR/commit/f09c471e523111eb684a48d4308f53c922311ad1) | `` automatic update `` |
| [`0524c0e3`](https://github.com/nix-community/NUR/commit/0524c0e39883d29c380bc115fc6e51a67f92fd0c) | `` automatic update `` |
| [`50620137`](https://github.com/nix-community/NUR/commit/50620137cc6ab40826289b2f2dc3fac0ab2caf44) | `` automatic update `` |
| [`94219442`](https://github.com/nix-community/NUR/commit/94219442ba266743e1d2aa9bc2111129aa4ae03f) | `` automatic update `` |
| [`59175b06`](https://github.com/nix-community/NUR/commit/59175b069af6584904600c436a47589f08f17307) | `` automatic update `` |