### PR TITLE
chore(flake/emacs-overlay): `b537c6ad` -> `31dd8e84`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1732583978,
-        "narHash": "sha256-dh0RQSLyVCNwzW+r7O/QEFvdZUGwbiyhJzvEssYjWfc=",
+        "lastModified": 1732638272,
+        "narHash": "sha256-GVU6mT/HDC7DRWYgyrJw2c23PGnb7nAWoVbc3JtbCoo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b537c6adc150f4517eb9025c4101cf9ab15f4902",
+        "rev": "31dd8e842483b14a334409530b966a196c52f254",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`31dd8e84`](https://github.com/nix-community/emacs-overlay/commit/31dd8e842483b14a334409530b966a196c52f254) | `` Updated elpa ``   |
| [`174d1ea0`](https://github.com/nix-community/emacs-overlay/commit/174d1ea0c1d96834c18fe615274adad8a00705f2) | `` Updated nongnu `` |