### PR TITLE
chore(flake/treefmt): `705df926` -> `84637a7a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1057,11 +1057,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732292307,
-        "narHash": "sha256-5WSng844vXt8uytT5djmqBCkopyle6ciFgteuA9bJpw=",
+        "lastModified": 1732643199,
+        "narHash": "sha256-uI7TXEb231o8dkwB5AUCecx3AQtosRmL6hKgnckvjps=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "705df92694af7093dfbb27109ce16d828a79155f",
+        "rev": "84637a7ab04179bdc42aa8fd0af1909fba76ad0c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                      |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`84637a7a`](https://github.com/numtide/treefmt-nix/commit/84637a7ab04179bdc42aa8fd0af1909fba76ad0c) | `` options: default projectRootFile to .git/config (#267) `` |