### PR TITLE
chore(flake/nixpkgs): `23e89b7d` -> `4633a7c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -756,11 +756,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1732014248,
-        "narHash": "sha256-y/MEyuJ5oBWrWAic/14LaIr/u5E0wRVzyYsouYY3W6w=",
+        "lastModified": 1732521221,
+        "narHash": "sha256-2ThgXBUXAE1oFsVATK1ZX9IjPcS4nKFOAjhPNKuiMn0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+        "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
| [`6d404af7`](https://github.com/NixOS/nixpkgs/commit/6d404af7beee626c3c4c517b6485184eecbf933e) | `` glsl_analyzer: fix on x86_64-darwin ``                                                                                      |
| [`5c6f35fe`](https://github.com/NixOS/nixpkgs/commit/5c6f35fe6b6fa56fbfe7b28e233c3180c216a2d1) | `` Revert "limesctl: drop" ``                                                                                                  |
| [`03675716`](https://github.com/NixOS/nixpkgs/commit/03675716cf607867764e30c3a643dc009c762655) | `` litecoin{,d}: drop ``                                                                                                       |
| [`1635ae0b`](https://github.com/NixOS/nixpkgs/commit/1635ae0b386ed5d63dc233d5881ad002b45a2db3) | `` terraform-providers.project: 1.8.0 -> 1.9.1 ``                                                                              |
| [`76407ce9`](https://github.com/NixOS/nixpkgs/commit/76407ce99dcbbafbab38b7d4a87ab931b7a8be46) | `` terraform-providers.github: 6.3.1 -> 6.4.0 ``                                                                               |
| [`c4c06282`](https://github.com/NixOS/nixpkgs/commit/c4c062825da3263d775740d330c1f72cd09daa65) | `` terraform-providers.ns1: 2.4.4 -> 2.4.5 ``                                                                                  |
| [`cc15ead6`](https://github.com/NixOS/nixpkgs/commit/cc15ead64f3a8b5d581dcb9e1f0a91e7e3fce768) | `` terraform-providers.scaleway: 2.46.0 -> 2.47.0 ``                                                                           |
| [`0c2a7f81`](https://github.com/NixOS/nixpkgs/commit/0c2a7f8159ce0f2b5f59e05f5f82d9e69ae049fd) | `` OWNERS: add Java team as owner of Java module ``                                                                            |
| [`5bb480bf`](https://github.com/NixOS/nixpkgs/commit/5bb480bf8f0faa39fe0d1296d1b8fadb59c9ef07) | `` nixos/java: format with nixfmt-rfc-style ``                                                                                 |
| [`2fe2ad56`](https://github.com/NixOS/nixpkgs/commit/2fe2ad56a458ce26027ca86a2f66b615022827be) | `` lan-mouse: 0.9.1 → 0.10.0 ``                                                                                                |
| [`b2cfcea8`](https://github.com/NixOS/nixpkgs/commit/b2cfcea82a30e6150c45d45ad2ce0eb4decd6904) | `` svelte-language-server: 0.17.5 -> 0.17.7 ``                                                                                 |
| [`56ea7605`](https://github.com/NixOS/nixpkgs/commit/56ea76053d669f0dbae3f3669c13c9626bbdcd35) | `` mission-center: switch to using fetchCargoVendor ``                                                                         |
| [`705ae9b9`](https://github.com/NixOS/nixpkgs/commit/705ae9b92e70c3abd0668c58ecee298127db188c) | `` mautrix-signal: 0.7.2 -> 0.7.3 ``                                                                                           |
| [`576701ee`](https://github.com/NixOS/nixpkgs/commit/576701eebceed7402943fa82e02bbce136d2d61a) | `` libsignal-ffi: 0.58.3 -> 0.62.0 ``                                                                                          |
| [`211a5429`](https://github.com/NixOS/nixpkgs/commit/211a54292cfd75b7a893152fff7344fe300cd86b) | `` php81: 8.1.30 -> 8.1.31 ``                                                                                                  |
| [`4fdc3370`](https://github.com/NixOS/nixpkgs/commit/4fdc3370b7e1fef71679126aaecd8cb5c2c56357) | `` nvim-lsp-file-operations: init at 2024-10-24 ``                                                                             |
| [`6f6d0f28`](https://github.com/NixOS/nixpkgs/commit/6f6d0f283887fc8bcc466473e9d9bdc4997715cb) | `` php83: 8.3.13 -> 8.3.14 ``                                                                                                  |
| [`c9ac44d1`](https://github.com/NixOS/nixpkgs/commit/c9ac44d1f1a304a6e671d6be82d06dff6ae328c3) | `` php82: 8.2.25 -> 8.2.26 ``                                                                                                  |
| [`72809add`](https://github.com/NixOS/nixpkgs/commit/72809add269e95f4b6391cd0ae106575b5d9fc0d) | `` vault-tasks: 0.4.0 -> 0.5.0 ``                                                                                              |
| [`03a516ee`](https://github.com/NixOS/nixpkgs/commit/03a516ee2e3314c667759fe69c2285b85c5e9d63) | `` rigel-engine: init at 0-unstable-2024-05-26 ``                                                                              |
| [`df1bc649`](https://github.com/NixOS/nixpkgs/commit/df1bc6491a8c02bc93ca3e20e5c2113173ba0c37) | `` trayscale: 0.13.5 -> 0.14.0 ``                                                                                              |
| [`d11140fa`](https://github.com/NixOS/nixpkgs/commit/d11140fa35add4fc798643e9cd44b08bcbe23321) | `` neovim: add 'autoconfigure' setting (#356271) ``                                                                            |
| [`b6ef6fe5`](https://github.com/NixOS/nixpkgs/commit/b6ef6fe53aa9c7eddf710371dbd6cba940aea7f8) | `` arduino: fix fhsenv version ``                                                                                              |
| [`cd0c48f3`](https://github.com/NixOS/nixpkgs/commit/cd0c48f3f6633e474077c06b792bbd1399d7ac3f) | `` python312Packages.equinox: 0.11.8 -> 0.11.9 ``                                                                              |
| [`73450ebc`](https://github.com/NixOS/nixpkgs/commit/73450ebccf101dc7263106057af6fa90b8737e7a) | `` lan-mouse: reformat ``                                                                                                      |
| [`4e2ce1ba`](https://github.com/NixOS/nixpkgs/commit/4e2ce1ba944026460925a0f4271f6799a88a5417) | `` apptainer.tests.image-hello-cowsay: remove obsolete `rmdir "$out"` ``                                                       |
| [`26eba255`](https://github.com/NixOS/nixpkgs/commit/26eba25577388072ba13b1682860fe872ba39942) | `` runInLinuxVM: re-add sourcing of stdenv & .attrs.sh ``                                                                      |
| [`2e77b9b2`](https://github.com/NixOS/nixpkgs/commit/2e77b9b2b85c29fc8c88ec6fa3347b72f190a0bb) | `` typstyle: 0.12.1 -> 0.12.3 ``                                                                                               |
| [`ce7cc914`](https://github.com/NixOS/nixpkgs/commit/ce7cc9146eeee38df2b0160828b29b11c803bd45) | `` torq: drop ``                                                                                                               |
| [`ecf6e3cc`](https://github.com/NixOS/nixpkgs/commit/ecf6e3cc41db1eb4efd3f1578cc809e3891f75da) | `` protoc-gen-go: 1.35.1 -> 1.35.2 ``                                                                                          |
| [`a2c2ebc1`](https://github.com/NixOS/nixpkgs/commit/a2c2ebc1d1cb48397d97472e0080dbcae795600f) | `` haskellPackages.sym: mark broken on darwin ``                                                                               |
| [`5c999586`](https://github.com/NixOS/nixpkgs/commit/5c99958613ddf26480115c2ff2846f0a7ca02c86) | `` nixos/haka: fix assert ``                                                                                                   |
| [`9262fc48`](https://github.com/NixOS/nixpkgs/commit/9262fc48f95daf53b1cc6297f53eace38656aeb3) | `` nixos/mopidy: use lib.getExe ``                                                                                             |
| [`73ede0a4`](https://github.com/NixOS/nixpkgs/commit/73ede0a42d6aa6f133fc5574cf23b02b0338a7ff) | `` mopidy: fmt ``                                                                                                              |
| [`dddc9d80`](https://github.com/NixOS/nixpkgs/commit/dddc9d800a911d7bcb58bc379a6e0bcff972c49c) | `` nixos/mopidy: fmt ``                                                                                                        |
| [`8f6ffd06`](https://github.com/NixOS/nixpkgs/commit/8f6ffd06a4ec118c2d84d64b5c65d42482f2dac2) | `` nixos/mopidy: add test ``                                                                                                   |
| [`fba9ba64`](https://github.com/NixOS/nixpkgs/commit/fba9ba64b37a27c67268ce1db492c7b4ab423130) | `` nixos/mopidy: remove "with" statment ``                                                                                     |
| [`46c222a1`](https://github.com/NixOS/nixpkgs/commit/46c222a1211de03f03b034821644b55d142cce83) | `` aw-watcher-window-wayland: 6108ad3df8e157965a43566fa35cdaf144b1c51b -> 0-unstable-2024-10-08; switch to fetchCargoVendor `` |
| [`3469a7c9`](https://github.com/NixOS/nixpkgs/commit/3469a7c92fcab3cea7b84062935c1e0927b35c1c) | `` kubectl-gadget: 0.33.0 -> 0.34.0 ``                                                                                         |
| [`c74cfd90`](https://github.com/NixOS/nixpkgs/commit/c74cfd9030b5ddf041c54d95f8f35e32d028e0d7) | `` python312Packages.cantools: 39.4.8 -> 39.4.11 ``                                                                            |
| [`7235e907`](https://github.com/NixOS/nixpkgs/commit/7235e9075d7c4bf399f15ca2d51a3907ea901859) | `` blender : 4.2.3 -> 4.3.0 ``                                                                                                 |
| [`f7b82e06`](https://github.com/NixOS/nixpkgs/commit/f7b82e06e3f1cf971a996aa30a1a5bf7404051da) | `` alist: 3.39.2 -> 3.40.0 ``                                                                                                  |
| [`8ccddb64`](https://github.com/NixOS/nixpkgs/commit/8ccddb644140ac7d96149955b356d28bd28d519f) | `` alist: use fetchzip to get web dist ``                                                                                      |
| [`f32b5f99`](https://github.com/NixOS/nixpkgs/commit/f32b5f997fcd515dd7ab3b1335f40d4e56064688) | `` alist: split webVersion from version ``                                                                                     |
| [`041623d2`](https://github.com/NixOS/nixpkgs/commit/041623d2191493b172b2a261cbf545cdb5672f62) | `` python312Packages.yalexs-ble: 2.5.0 -> 2.5.1 ``                                                                             |
| [`1f5b080f`](https://github.com/NixOS/nixpkgs/commit/1f5b080fa9e0e5ca8394c7f424e02b1576d3f3bd) | `` python312Packages.py-aosmith: 1.0.10 -> 1.0.11 ``                                                                           |
| [`5883fb4a`](https://github.com/NixOS/nixpkgs/commit/5883fb4ab6d1eb012c52ba7dc15b02a959603c43) | `` code-cursor: 0.42.5 -> 0.43.0 ``                                                                                            |
| [`a91beb2d`](https://github.com/NixOS/nixpkgs/commit/a91beb2d34b6e92cfbb3831162ed33aadc3bd98c) | `` sqlite-utils: 3.37 -> 3.38 ``                                                                                               |
| [`ba1b15be`](https://github.com/NixOS/nixpkgs/commit/ba1b15be08b15e1b8368fb0e7a392b4fc7c88697) | `` squeak: fix build ``                                                                                                        |
| [`bc7d2a31`](https://github.com/NixOS/nixpkgs/commit/bc7d2a3129d526f82801febbe3be74df92e0b3d9) | `` typst: remove local `cargo.lock`, use `fetchCargoVendor` ``                                                                 |
| [`2cbf5b1c`](https://github.com/NixOS/nixpkgs/commit/2cbf5b1c4b125451c63baa13638ce7515daa4ce3) | `` suricata: link nixosTests.suricata to passthru.tests ``                                                                     |
| [`74a650ef`](https://github.com/NixOS/nixpkgs/commit/74a650ef9ca05c0ee487691d1e9382ea121bd787) | `` suricata: move to pkgs/by-name ``                                                                                           |
| [`77fffb09`](https://github.com/NixOS/nixpkgs/commit/77fffb09ec86138b2fd32297f7c1a3b39a31afeb) | `` suricata: take versioned params instead of overriding at top-level ``                                                       |
| [`147ecc75`](https://github.com/NixOS/nixpkgs/commit/147ecc75640b0dcdf85aa8dd8ad5b7036d3fe1e2) | `` python312Packages.bcc: 0.31.0 -> 0.32.0 ``                                                                                  |
| [`fe61d5b3`](https://github.com/NixOS/nixpkgs/commit/fe61d5b377bcd169d9dfe41398e2b2dbedf48ce5) | `` python312Packages.apollo-fpga: 1.1.0 -> 1.1.1 ``                                                                            |
| [`f9d6f677`](https://github.com/NixOS/nixpkgs/commit/f9d6f6774557503c3ad7ada48505be308185ffd7) | `` versitygw: init at 1.0.8 ``                                                                                                 |
| [`de716269`](https://github.com/NixOS/nixpkgs/commit/de716269153f26352da0d03e06383eb37cbd8af5) | `` heptabase: 1.41.1 -> 1.46.1 ``                                                                                              |
| [`dbd0c8dc`](https://github.com/NixOS/nixpkgs/commit/dbd0c8dcd0519058a384446758f5ce1ab8b06fb7) | `` terraform-providers.exoscale: 0.61.0 -> 0.62.0 ``                                                                           |
| [`3f631d65`](https://github.com/NixOS/nixpkgs/commit/3f631d658b122112629cbe5ea24aba609a5ca6ae) | `` ollama: 0.3.12 -> 0.4.4 ``                                                                                                  |
| [`13981dc9`](https://github.com/NixOS/nixpkgs/commit/13981dc98c5d6e020db03c408cb751637222bcb3) | `` python312Packages.skops: disable flaky test ``                                                                              |
| [`4a9e4b62`](https://github.com/NixOS/nixpkgs/commit/4a9e4b6299280f3c522beab76d4a3a7c630e76f4) | `` adwsteamgtk: 0.7.1 -> 0.7.2 ``                                                                                              |
| [`cf1bb0ec`](https://github.com/NixOS/nixpkgs/commit/cf1bb0ec9f292c51888b5595f4b5255b28e12a99) | `` cnquery: 11.19.1 -> 11.31.1 ``                                                                                              |