### PR TITLE
chore(flake/emacs-overlay): `31dd8e84` -> `c459524b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1732638272,
-        "narHash": "sha256-GVU6mT/HDC7DRWYgyrJw2c23PGnb7nAWoVbc3JtbCoo=",
+        "lastModified": 1732670452,
+        "narHash": "sha256-iD1di4nIZ7Ab1KYwYEnIaCAKxNBCfG63xUHTW/Z5ch0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "31dd8e842483b14a334409530b966a196c52f254",
+        "rev": "c459524b98ca355ef06f272034267cbe8f3e28f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`c459524b`](https://github.com/nix-community/emacs-overlay/commit/c459524b98ca355ef06f272034267cbe8f3e28f0) | `` Updated elpa ``         |
| [`76b9b210`](https://github.com/nix-community/emacs-overlay/commit/76b9b210ee8d6012b464e23a56123bfca902d2a2) | `` Updated nongnu ``       |
| [`68655ab2`](https://github.com/nix-community/emacs-overlay/commit/68655ab2998b748db2691c8bbead41051a4862b9) | `` Updated flake inputs `` |