### PR TITLE
chore(flake/nur): `d4d63749` -> `e7395b0e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -842,11 +842,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732664804,
-        "narHash": "sha256-59kFHhZXuXZJnY008XuGgtNhMrQlV21X/tWJn8KzqgI=",
+        "lastModified": 1732689435,
+        "narHash": "sha256-Fow7egJj3C8FC+TcKrM93g7t4rMeuSuU95D/8RPVuMY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d4d637492fd5aa3c0bc15b034423a947d5a41c69",
+        "rev": "e7395b0e379646e0ea88b7d6f009684f13d97e62",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e7395b0e`](https://github.com/nix-community/NUR/commit/e7395b0e379646e0ea88b7d6f009684f13d97e62) | `` automatic update `` |
| [`7dc3519a`](https://github.com/nix-community/NUR/commit/7dc3519a301b3de73c508665651835df1d7e3fc7) | `` automatic update `` |
| [`6b7ba2de`](https://github.com/nix-community/NUR/commit/6b7ba2dea537e242e55a80dc57e286a1bd7e916f) | `` automatic update `` |
| [`88ae6efb`](https://github.com/nix-community/NUR/commit/88ae6efbef9e363539f46e46058bbf15e6703abb) | `` automatic update `` |
| [`4d05809a`](https://github.com/nix-community/NUR/commit/4d05809aaf41633073e5a0af073253905e681f76) | `` automatic update `` |
| [`4a455ecb`](https://github.com/nix-community/NUR/commit/4a455ecb20e3f2654bea0039f91860a2f6762ed6) | `` automatic update `` |
| [`da4069f1`](https://github.com/nix-community/NUR/commit/da4069f1ffdb811aafa1a068f636b6fbe7e4e14f) | `` automatic update `` |
| [`36de6640`](https://github.com/nix-community/NUR/commit/36de664047dd308eacfad70c0fed04d2d840687b) | `` automatic update `` |
| [`5221d584`](https://github.com/nix-community/NUR/commit/5221d58402a9f823c851baa809deb46cfc74537c) | `` automatic update `` |
| [`18c08bf8`](https://github.com/nix-community/NUR/commit/18c08bf854d7d6d6bbdaf56d6716f43e995cc792) | `` automatic update `` |