### PR TITLE
chore(flake/nur): `e7395b0e` -> `5bfc920e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -842,11 +842,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732689435,
-        "narHash": "sha256-Fow7egJj3C8FC+TcKrM93g7t4rMeuSuU95D/8RPVuMY=",
+        "lastModified": 1732805641,
+        "narHash": "sha256-dt62iVgFbADlCT4j6XgUkwhejWU55kVQG5040HyA/bc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e7395b0e379646e0ea88b7d6f009684f13d97e62",
+        "rev": "5bfc920efdaa5044521000b95409a2594c1f3603",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5bfc920e`](https://github.com/nix-community/NUR/commit/5bfc920efdaa5044521000b95409a2594c1f3603) | `` automatic update `` |
| [`b297e0d5`](https://github.com/nix-community/NUR/commit/b297e0d5de898f0cf484838beeee86129c4806ed) | `` automatic update `` |
| [`73eac890`](https://github.com/nix-community/NUR/commit/73eac8907227b7cdd133887f903743c497108320) | `` automatic update `` |
| [`0d17923e`](https://github.com/nix-community/NUR/commit/0d17923e85b38080aaa128791483bf18e72a1655) | `` automatic update `` |
| [`76677bbf`](https://github.com/nix-community/NUR/commit/76677bbf3851a1bb02d79bfab500aec78545978e) | `` automatic update `` |
| [`9e179956`](https://github.com/nix-community/NUR/commit/9e179956844b328cd8b94a1573c49132a4b0f294) | `` automatic update `` |
| [`7c412613`](https://github.com/nix-community/NUR/commit/7c412613e5ed3d49f2e198c0b0187add6b897b3d) | `` automatic update `` |
| [`18a5a057`](https://github.com/nix-community/NUR/commit/18a5a057e380cf4f7966cc477a9a7f9e9eb9edb5) | `` automatic update `` |
| [`32a5ef01`](https://github.com/nix-community/NUR/commit/32a5ef0103a052676390074c2458bd8f517a4b4a) | `` automatic update `` |
| [`47a2c180`](https://github.com/nix-community/NUR/commit/47a2c1803967c16e5b4aaa86a3881fbfa52d9a0a) | `` automatic update `` |
| [`9170d486`](https://github.com/nix-community/NUR/commit/9170d4863051161157ff0ed3ea317e2473365a79) | `` automatic update `` |
| [`f1920ef7`](https://github.com/nix-community/NUR/commit/f1920ef7ed1d1870e6316bdaa4fec9d973b58d38) | `` automatic update `` |
| [`89686cf6`](https://github.com/nix-community/NUR/commit/89686cf60d3ab5ff3a753d4aa347077908ff21b9) | `` automatic update `` |
| [`d39a0fe1`](https://github.com/nix-community/NUR/commit/d39a0fe16b7a66f71ef2428e0e48fd4686e87302) | `` automatic update `` |
| [`bdd51cca`](https://github.com/nix-community/NUR/commit/bdd51cca30359d28c3b84721cde9ad367734d6b8) | `` automatic update `` |
| [`15c7a90a`](https://github.com/nix-community/NUR/commit/15c7a90a19b27248faa95c4194b154d427bf569f) | `` automatic update `` |
| [`a2077ee0`](https://github.com/nix-community/NUR/commit/a2077ee00cc07a7d15e9c163f05f77895d226dfe) | `` automatic update `` |
| [`a4550411`](https://github.com/nix-community/NUR/commit/a4550411793e78de0b74376fe4bfe5e261fcef45) | `` automatic update `` |
| [`fbe88c0d`](https://github.com/nix-community/NUR/commit/fbe88c0dba3181daf3ef9760e548329fcc320f9d) | `` automatic update `` |
| [`68a671a7`](https://github.com/nix-community/NUR/commit/68a671a7ae13e85260cd0b05a4213600dad1c050) | `` automatic update `` |
| [`59a1f165`](https://github.com/nix-community/NUR/commit/59a1f1655ea2d8a03088616eaa9156a7fd338572) | `` automatic update `` |
| [`a1eb092a`](https://github.com/nix-community/NUR/commit/a1eb092a0f03991fc9af0f2f6bdfa7da94158a92) | `` automatic update `` |
| [`776841ce`](https://github.com/nix-community/NUR/commit/776841ce4f9fde930b541439e118a2c967c407ee) | `` automatic update `` |
| [`afda7072`](https://github.com/nix-community/NUR/commit/afda70720b98c634ff26a92eb8a3a93297610638) | `` automatic update `` |
| [`c0c2a0ba`](https://github.com/nix-community/NUR/commit/c0c2a0ba50aeef3cd2fe46531699018b7ab6f128) | `` automatic update `` |
| [`f2a9aa0e`](https://github.com/nix-community/NUR/commit/f2a9aa0e0cff734ea2ee8528aa97c2f367b92647) | `` automatic update `` |
| [`31a30f08`](https://github.com/nix-community/NUR/commit/31a30f0862fd8b5f88a6597382bb09197356b19e) | `` automatic update `` |
| [`d86e9111`](https://github.com/nix-community/NUR/commit/d86e9111e430021c7c6cabae6694f5f01ad3cdd6) | `` automatic update `` |
| [`3423df0d`](https://github.com/nix-community/NUR/commit/3423df0d80d5894ccacb0d2f60c2d47e6bd7f4a9) | `` automatic update `` |