### PR TITLE
chore(flake/flake-compat): `0f9255e0` -> `9ed2ac15`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -199,11 +199,11 @@
     },
     "flake-compat": {
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1732722421,
+        "narHash": "sha256-HRJ/18p+WoXpWJkcdsk9St5ZiukCqSDgbOGFa8Okehg=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "9ed2ac151eada2306ca8c418ebd97807bb08f6ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                            |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ |
| [`a1b45cd4`](https://github.com/edolstra/flake-compat/commit/a1b45cd4a224023888702a60d6830bc0ab40c038) | `` Return all outputs ``                                           |
| [`3980b5e4`](https://github.com/edolstra/flake-compat/commit/3980b5e441bac46246f9f11c77085ed5a2c73912) | `` Expose revCount attribute for git inputs ``                     |
| [`520e73f6`](https://github.com/edolstra/flake-compat/commit/520e73f623ca5e1f61ee4b5f07a9a700e67c0e95) | `` Use builtins.fetchTree if available ``                          |
| [`baa7aa7b`](https://github.com/edolstra/flake-compat/commit/baa7aa7bd0a570b3b9edd0b8da859fee3ffaa4d4) | `` Check for pure eval mode before calling `builtins.storePath` `` |
| [`b7cd5940`](https://github.com/edolstra/flake-compat/commit/b7cd594063b9118c198bbdb4c22c19ca0919822a) | `` README: fix node name look-up ``                                |