### PR TITLE
chore(flake/emacs-overlay): `96e0bac0` -> `f704f6f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1732724585,
-        "narHash": "sha256-pO5sNOYN1FHUw1/rUWamL+A3cktUG5ZOo3F3yMUCfMI=",
+        "lastModified": 1732759838,
+        "narHash": "sha256-bBghlNpHztnrUb1o7BAinp+rrWZMpaVNPrxnefhk1LY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "96e0bac0682868c890d4d36168024853e8dee174",
+        "rev": "f704f6f113bef121c7e38f807e3397f7dbe1aee0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`f704f6f1`](https://github.com/nix-community/emacs-overlay/commit/f704f6f113bef121c7e38f807e3397f7dbe1aee0) | `` Updated emacs ``  |
| [`ef4afd4f`](https://github.com/nix-community/emacs-overlay/commit/ef4afd4f603d68b83160107108123b0555295af1) | `` Updated melpa ``  |
| [`09e0f5d0`](https://github.com/nix-community/emacs-overlay/commit/09e0f5d0a4d0eae261ca598ad9a11c73c12d61ae) | `` Updated elpa ``   |
| [`5b1b438a`](https://github.com/nix-community/emacs-overlay/commit/5b1b438a780878b506e9a49d877ce27ab7c3a98b) | `` Updated nongnu `` |