### PR TITLE
chore(flake/emacs-overlay): `fb81e751` -> `6b78552e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1732784553,
-        "narHash": "sha256-S3PiqgTS8ST07ihFDL2cPExoxHcd9I8ITecpgMz+s4M=",
+        "lastModified": 1732845489,
+        "narHash": "sha256-7DKGn0D915PZUr/NklO41WsITUfLr+RM/RJqQezKjUI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fb81e75180369a888db920df8f6097fbf2f603e9",
+        "rev": "6b78552e35d0a1b050091401ee9959070383ac36",
         "type": "github"
       },
       "original": {
@@ -692,11 +692,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1732632634,
-        "narHash": "sha256-+G7n/ZD635aN0sEXQLynU7pWMd3PKDM7yBIXvYmjABQ=",
+        "lastModified": 1732749044,
+        "narHash": "sha256-T38FQOg0BV5M8FN1712fovzNakSOENEYs+CSkg31C9Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6f6076c37180ea3a916f84928cf3a714c5207a30",
+        "rev": "0c5b4ecbed5b155b705336aa96d878e55acd8685",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`6b78552e`](https://github.com/nix-community/emacs-overlay/commit/6b78552e35d0a1b050091401ee9959070383ac36) | `` Updated melpa ``        |
| [`48849491`](https://github.com/nix-community/emacs-overlay/commit/48849491de34805d5802910c7f538cea7c378967) | `` Updated elpa ``         |
| [`62fe29fb`](https://github.com/nix-community/emacs-overlay/commit/62fe29fb26c5e5e375a9f3a5c8bed246ba2f65e7) | `` Updated nongnu ``       |
| [`ceb935b7`](https://github.com/nix-community/emacs-overlay/commit/ceb935b70d456dffe6a8a2b7ffefc5b5be5a1818) | `` Updated emacs ``        |
| [`07a864eb`](https://github.com/nix-community/emacs-overlay/commit/07a864eb40960450d6fa07aca8947f048a5eee4e) | `` Updated melpa ``        |
| [`bda2c918`](https://github.com/nix-community/emacs-overlay/commit/bda2c918fa6366cbdfc29c5307de9cecfa142bbe) | `` Updated elpa ``         |
| [`af0bb4d6`](https://github.com/nix-community/emacs-overlay/commit/af0bb4d679641b1d96ee366c0198642e4666f044) | `` Updated flake inputs `` |