### PR TITLE
chore(flake/nur): `5bfc920e` -> `3e4ad626`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -842,11 +842,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732805641,
-        "narHash": "sha256-dt62iVgFbADlCT4j6XgUkwhejWU55kVQG5040HyA/bc=",
+        "lastModified": 1732867503,
+        "narHash": "sha256-E8/tbKB7KP2cGBUkXVj9Ft1A/UsliKZgNzmQs4Zp7Uw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5bfc920efdaa5044521000b95409a2594c1f3603",
+        "rev": "3e4ad62655801e127c48f79360dd1abd9a118680",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                         |
| -------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`3e4ad626`](https://github.com/nix-community/NUR/commit/3e4ad62655801e127c48f79360dd1abd9a118680) | `` automatic update ``          |
| [`b3a6ab11`](https://github.com/nix-community/NUR/commit/b3a6ab1123d0523cdb4c2ad3dd5e97c6a8619483) | `` thaumy: enable submodules `` |
| [`71cb9f84`](https://github.com/nix-community/NUR/commit/71cb9f84b908d987b49a971a389cd1c1f3fd7d77) | `` automatic update ``          |
| [`1f44f8ea`](https://github.com/nix-community/NUR/commit/1f44f8ea1e6feffe3fa3908a6b74c6f97f161a7d) | `` automatic update ``          |
| [`6c24a672`](https://github.com/nix-community/NUR/commit/6c24a67268a58dabd7de27f386d8a822bcc6cc68) | `` automatic update ``          |
| [`d2663258`](https://github.com/nix-community/NUR/commit/d2663258532075556f449dc6fed76fae13cba9c6) | `` automatic update ``          |
| [`cc2a3158`](https://github.com/nix-community/NUR/commit/cc2a3158b6a714b98a8b891d6dcfc3a43039051f) | `` automatic update ``          |
| [`db56ca86`](https://github.com/nix-community/NUR/commit/db56ca866d8481ea85c89562eb83948174eba54b) | `` automatic update ``          |
| [`6cc17a35`](https://github.com/nix-community/NUR/commit/6cc17a35ab465d89dc8c647eb7e889a9cead63ae) | `` automatic update ``          |
| [`db729fbb`](https://github.com/nix-community/NUR/commit/db729fbba845a0bc1197f2283568231e1a90863e) | `` automatic update ``          |
| [`aa8a1e90`](https://github.com/nix-community/NUR/commit/aa8a1e906eea2a7acc5bfdd0aa735a5cfdc1a037) | `` automatic update ``          |
| [`afe4a4b4`](https://github.com/nix-community/NUR/commit/afe4a4b45f0a34cc5647c57f203d84faa6ea52d1) | `` automatic update ``          |
| [`e07f9f52`](https://github.com/nix-community/NUR/commit/e07f9f520bf17ad16ee14d4559cf8ae227cf85ff) | `` automatic update ``          |
| [`512b9991`](https://github.com/nix-community/NUR/commit/512b99913ad8d4a84310dfedbfb52bfff82ee748) | `` automatic update ``          |
| [`0de175b5`](https://github.com/nix-community/NUR/commit/0de175b59e2583aa1a76fcaa22fe3d79a413d749) | `` automatic update ``          |
| [`a560b464`](https://github.com/nix-community/NUR/commit/a560b464020a55581d1cbde8d9f34581228dbfcc) | `` automatic update ``          |
| [`98462a96`](https://github.com/nix-community/NUR/commit/98462a96c46ee1696f17d83948ebe44112406db5) | `` automatic update ``          |
| [`e0c8b90b`](https://github.com/nix-community/NUR/commit/e0c8b90b675ac514ca8ec4d5856e18090d1ce6ac) | `` automatic update ``          |
| [`e4332b67`](https://github.com/nix-community/NUR/commit/e4332b67530a0c25876741ed85107188c2fc9051) | `` automatic update ``          |
| [`2a8ddcb9`](https://github.com/nix-community/NUR/commit/2a8ddcb9238bf6b0c17d23a2298072373e86d18c) | `` automatic update ``          |
| [`16d48de9`](https://github.com/nix-community/NUR/commit/16d48de939f7d2e4f4e11c1f3826aeeaf49c9c7f) | `` automatic update ``          |
| [`dc348a6b`](https://github.com/nix-community/NUR/commit/dc348a6b3171c9e4cb9e470d12627f967438a9a4) | `` automatic update ``          |
| [`19e15bd2`](https://github.com/nix-community/NUR/commit/19e15bd28b2cb20cb1bef8a0df39b12b0094c0c3) | `` automatic update ``          |
| [`be678675`](https://github.com/nix-community/NUR/commit/be678675e55edea3756c130f363944a08f7fa68c) | `` automatic update ``          |
| [`45f2b3e6`](https://github.com/nix-community/NUR/commit/45f2b3e69d1996bd3332d4140f8b275cd08bf575) | `` automatic update ``          |
| [`81e45637`](https://github.com/nix-community/NUR/commit/81e45637b88bcea6dda07896f0237d04f774c3b9) | `` automatic update ``          |
| [`98db167b`](https://github.com/nix-community/NUR/commit/98db167b9d4e00f7acfb49a52edbbb707209c7c1) | `` automatic update ``          |