### PR TITLE
chore(flake/emacs-overlay): `6b78552e` -> `d1b497b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1732845489,
-        "narHash": "sha256-7DKGn0D915PZUr/NklO41WsITUfLr+RM/RJqQezKjUI=",
+        "lastModified": 1732899654,
+        "narHash": "sha256-TEX9YXLt5aTrX5p6ZqLtoiWUKJM8J9rWsDvzZke78/k=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6b78552e35d0a1b050091401ee9959070383ac36",
+        "rev": "d1b497b5b8b38353e749911a857b5c3c6da336b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`d1b497b5`](https://github.com/nix-community/emacs-overlay/commit/d1b497b5b8b38353e749911a857b5c3c6da336b7) | `` Updated melpa ``  |
| [`88d1137e`](https://github.com/nix-community/emacs-overlay/commit/88d1137e1b2b93dd6f65b47a61fc47a49a242b4f) | `` Updated elpa ``   |
| [`c038049f`](https://github.com/nix-community/emacs-overlay/commit/c038049f688ee3da6d4d2f7557c274a52ffaac9d) | `` Updated nongnu `` |
| [`ca218dbd`](https://github.com/nix-community/emacs-overlay/commit/ca218dbd42ae4b16bc4378a06f5f1310b69a32af) | `` Updated emacs ``  |
| [`4ab3a4f1`](https://github.com/nix-community/emacs-overlay/commit/4ab3a4f16671bdc5c61afa563a80b94a22e289f0) | `` Updated melpa ``  |