### PR TITLE
chore(flake/emacs-overlay): `d1b497b5` -> `7c0720d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1732899654,
-        "narHash": "sha256-TEX9YXLt5aTrX5p6ZqLtoiWUKJM8J9rWsDvzZke78/k=",
+        "lastModified": 1732932542,
+        "narHash": "sha256-837KjsuR9UWt+H6eVOJ58bcNZ92Qf9L2R3TJeiVrMd0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d1b497b5b8b38353e749911a857b5c3c6da336b7",
+        "rev": "7c0720d624aae2b9ab356e3e858a2490bce1b822",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`7c0720d6`](https://github.com/nix-community/emacs-overlay/commit/7c0720d624aae2b9ab356e3e858a2490bce1b822) | `` Updated emacs ``  |
| [`60b9979f`](https://github.com/nix-community/emacs-overlay/commit/60b9979ff5649312fb41f1971f5def47373379c5) | `` Updated melpa ``  |
| [`90c48f72`](https://github.com/nix-community/emacs-overlay/commit/90c48f727fee87c31a442bb6cd7e68960c86e0be) | `` Updated elpa ``   |
| [`200afe61`](https://github.com/nix-community/emacs-overlay/commit/200afe61d314ab169ed46241560d20d2df09f7c6) | `` Updated nongnu `` |