### PR TITLE
chore(flake/catppuccin): `85f8c778` -> `a817009e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1732918371,
-        "narHash": "sha256-S6IHjHmystPgL9La4wgrJvlb58rfd/wtKHckxpF+O0k=",
+        "lastModified": 1733001911,
+        "narHash": "sha256-uX/9m0TbdhEzuWA0muM5mI/AaWcLiDLjCCyu5Qr9MRk=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "85f8c7784e8be03d12846cea35738be181e09497",
+        "rev": "a817009ebfd2cca7f70a77884e5098d0a8c83f8e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                   |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`a817009e`](https://github.com/catppuccin/nix/commit/a817009ebfd2cca7f70a77884e5098d0a8c83f8e) | `` docs: fix new redirects (#394) ``      |
| [`44dce3c3`](https://github.com/catppuccin/nix/commit/44dce3c368680e78f9ac5a903c42268b2867dd26) | `` docs: add nicer redirects (#393) ``    |
| [`7a6e695b`](https://github.com/catppuccin/nix/commit/7a6e695bbf6220af2b1a6941613d9df1160a32cd) | `` chore(modules): update ports (#379) `` |