### PR TITLE
chore(flake/emacs-overlay): `9538b0c1` -> `d902534f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1732957172,
-        "narHash": "sha256-m2ZPNfgRsC7JE2yZBdfSV8o5qq4sZkmS2f5m2yd0RX4=",
+        "lastModified": 1732986626,
+        "narHash": "sha256-mm0VxNLhlcfX4to/Lv2tDPYWnQ+Py13Hq3cHc+RT9YI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9538b0c14fad28b9a9edf69d34916f476699ad45",
+        "rev": "d902534f27fea8439422e55c435d4b4bbf8a2472",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`d902534f`](https://github.com/nix-community/emacs-overlay/commit/d902534f27fea8439422e55c435d4b4bbf8a2472) | `` Updated emacs ``  |
| [`a7757632`](https://github.com/nix-community/emacs-overlay/commit/a7757632e104a3164d194809924187cd0d06f868) | `` Updated melpa ``  |
| [`2c93365b`](https://github.com/nix-community/emacs-overlay/commit/2c93365bf4a9c1a02da39db93a5c693112904bef) | `` Updated elpa ``   |
| [`e1345151`](https://github.com/nix-community/emacs-overlay/commit/e13451512d7ad3adad894c39299748f024c0e884) | `` Updated nongnu `` |