### PR TITLE
chore(flake/nur): `f5b99f96` -> `fa620b67`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -842,11 +842,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1732980641,
-        "narHash": "sha256-YjDVJPL4f+d41TTEYF+aVTMJFvYMXcbMJbXFi7HBUvw=",
+        "lastModified": 1733039467,
+        "narHash": "sha256-6N65SlJSIP+DTziDuQbgaO5729AGOba+XIVidhCVzVQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f5b99f967e98d67f4fa48808c46976e55412618d",
+        "rev": "fa620b675ec04637aefcbae5749be4b0afdd6059",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fa620b67`](https://github.com/nix-community/NUR/commit/fa620b675ec04637aefcbae5749be4b0afdd6059) | `` automatic update `` |
| [`c557c64d`](https://github.com/nix-community/NUR/commit/c557c64d669731dd2a45dfc5d671faef169c8b60) | `` automatic update `` |
| [`068ea9dd`](https://github.com/nix-community/NUR/commit/068ea9dd050bef3c4b9572dbf80d8a028ed23363) | `` automatic update `` |
| [`13cdb732`](https://github.com/nix-community/NUR/commit/13cdb732e0e1b8ec8b3aac38972501d2fa0d605d) | `` automatic update `` |
| [`bddf3b72`](https://github.com/nix-community/NUR/commit/bddf3b72b641f9116c770ea5115d192f27c48f91) | `` automatic update `` |
| [`45959026`](https://github.com/nix-community/NUR/commit/45959026e0fa781181a41888ae47fd4acc2c308d) | `` automatic update `` |
| [`f3f64712`](https://github.com/nix-community/NUR/commit/f3f64712a1fe6441b10de9721f5a593d37ae2adc) | `` automatic update `` |
| [`d711073b`](https://github.com/nix-community/NUR/commit/d711073b26533360c2bc595b4e6a824b873f8e22) | `` automatic update `` |
| [`89dc6c69`](https://github.com/nix-community/NUR/commit/89dc6c69aa2593688246c0ac5b17d454c6520284) | `` automatic update `` |
| [`ec8a319c`](https://github.com/nix-community/NUR/commit/ec8a319ccb1fa71bab8ad5a9667ca11cc3afa592) | `` automatic update `` |
| [`72f2f9a2`](https://github.com/nix-community/NUR/commit/72f2f9a22a990715b1129ee53696c7bf48dee9d2) | `` automatic update `` |
| [`517b7cf8`](https://github.com/nix-community/NUR/commit/517b7cf8e7d9d90dc6b4fe7dcc3034f5757c20aa) | `` automatic update `` |
| [`13b32611`](https://github.com/nix-community/NUR/commit/13b3261117f4e10e808855eac6845a0a775fa9c5) | `` automatic update `` |
| [`d886a37e`](https://github.com/nix-community/NUR/commit/d886a37e34f46a1a5c3571b0e98c839f92a72715) | `` automatic update `` |
| [`340a00af`](https://github.com/nix-community/NUR/commit/340a00aff0daceaf1564c92ca93de3729e65b481) | `` automatic update `` |
| [`0c940759`](https://github.com/nix-community/NUR/commit/0c9407597f073e5589c2b2570d507afe4e773a04) | `` automatic update `` |
| [`dbe385cf`](https://github.com/nix-community/NUR/commit/dbe385cf42e0d496801e1c54f6d7d3e70d9d4d21) | `` automatic update `` |
| [`2d2f766e`](https://github.com/nix-community/NUR/commit/2d2f766ed38279db386926af2cf456300bc07f36) | `` automatic update `` |
| [`47864a24`](https://github.com/nix-community/NUR/commit/47864a2407f2a3caaadd007ae4187200f08ce61e) | `` automatic update `` |
| [`bdf00fe6`](https://github.com/nix-community/NUR/commit/bdf00fe66fab01b4a80c21995d31dbb68ce50fec) | `` automatic update `` |
| [`3bf72a07`](https://github.com/nix-community/NUR/commit/3bf72a07ced4187061498ef42dc6cfa901e80194) | `` automatic update `` |