### PR TITLE
chore(flake/emacs-overlay): `d902534f` -> `75b7551f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1732986626,
-        "narHash": "sha256-mm0VxNLhlcfX4to/Lv2tDPYWnQ+Py13Hq3cHc+RT9YI=",
+        "lastModified": 1733072333,
+        "narHash": "sha256-Vo/TVzPi58W8dC2a0fzpfdL1U7HgvCGd0/Q67UoZ3CI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d902534f27fea8439422e55c435d4b4bbf8a2472",
+        "rev": "75b7551fea3c131628fdba2bc03d0a398f07c75a",
         "type": "github"
       },
       "original": {
@@ -692,16 +692,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1732749044,
-        "narHash": "sha256-T38FQOg0BV5M8FN1712fovzNakSOENEYs+CSkg31C9Y=",
+        "lastModified": 1732981179,
+        "narHash": "sha256-F7thesZPvAMSwjRu0K8uFshTk3ZZSNAsXTIFvXBT+34=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c5b4ecbed5b155b705336aa96d878e55acd8685",
+        "rev": "62c435d93bf046a5396f3016472e8f7c8e2aed65",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }


### PR DESCRIPTION
| Commit                                                                                                       | Message                                              |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
| [`75b7551f`](https://github.com/nix-community/emacs-overlay/commit/75b7551fea3c131628fdba2bc03d0a398f07c75a) | `` Updated melpa ``                                  |
| [`e4632fae`](https://github.com/nix-community/emacs-overlay/commit/e4632fae7ef03a3cca85363a11a171e20f7a643d) | `` Updated elpa ``                                   |
| [`d620cb05`](https://github.com/nix-community/emacs-overlay/commit/d620cb053183a0150d85b423d8ecbf37b7636416) | `` Updated nongnu ``                                 |
| [`951ef3b9`](https://github.com/nix-community/emacs-overlay/commit/951ef3b904d452654ee8049440f628bca5dc1ff2) | `` Updated flake inputs ``                           |
| [`4ebaf4d0`](https://github.com/nix-community/emacs-overlay/commit/4ebaf4d0b6b8ab9bacd57f5db199da2d76eea8da) | `` Updated melpa ``                                  |
| [`483548ff`](https://github.com/nix-community/emacs-overlay/commit/483548ffef958bed56302a2d7938ec31dac8ddb1) | `` Updated flake inputs ``                           |
| [`1603799a`](https://github.com/nix-community/emacs-overlay/commit/1603799aa3105e4b737358710d88ea8078c0ebb7) | `` Updated melpa ``                                  |
| [`7a58ace1`](https://github.com/nix-community/emacs-overlay/commit/7a58ace151bf1939308680f37db100b00769c318) | `` flake: bump nixpkgs-stable from 24.05 to 24.11 `` |
| [`dfe29ae7`](https://github.com/nix-community/emacs-overlay/commit/dfe29ae7ac4a8bb5f1b993e32cfea336f78a0d82) | `` Updated elpa ``                                   |
| [`9354adf6`](https://github.com/nix-community/emacs-overlay/commit/9354adf670b5f5a787f32e7d1b1476e85015a44b) | `` Updated nongnu ``                                 |
| [`dcff3ac1`](https://github.com/nix-community/emacs-overlay/commit/dcff3ac1d9e6ad316c917d2425f1b3067f64f8a5) | `` Updated flake inputs ``                           |