### PR TITLE
chore(flake/home-manager): `819f6822` -> `c1fee8d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732884235,
-        "narHash": "sha256-r8j6R3nrvwbT1aUp4EPQ1KC7gm0pu9VcV1aNaB+XG6Q=",
+        "lastModified": 1733085484,
+        "narHash": "sha256-dVmNuUajnU18oHzBQWZm1BQtANCHaqNuxTHZQ+GN0r8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "819f682269f4e002884702b87e445c82840c68f2",
+        "rev": "c1fee8d4a60b89cae12b288ba9dbc608ff298163",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`c1fee8d4`](https://github.com/nix-community/home-manager/commit/c1fee8d4a60b89cae12b288ba9dbc608ff298163) | `` alot: make package used by module configurable `` |
| [`86327350`](https://github.com/nix-community/home-manager/commit/863273505016a1e88e4ffaec48d1b767104c5652) | `` kubecolor: add module ``                          |
| [`e71e678d`](https://github.com/nix-community/home-manager/commit/e71e678d18d1a24e01d823ccb72df13f9e82f65b) | `` nix-your-shell: add module ``                     |
| [`7f78e2d1`](https://github.com/nix-community/home-manager/commit/7f78e2d1c6a9db76444e02a73f0669ebb79f8833) | `` yazi: update keymap config ``                     |
| [`441fae84`](https://github.com/nix-community/home-manager/commit/441fae847ddfe20f9f9a4c47345691a205bb772c) | `` zsh-abbr: add package option ``                   |
| [`4964f3c6`](https://github.com/nix-community/home-manager/commit/4964f3c6fc17ae4578e762d3dc86b10fe890860e) | `` home-manager: prepare 24.11 release ``            |
| [`8eeda281`](https://github.com/nix-community/home-manager/commit/8eeda281e70cbadabb7f0095c5f34e354e85f307) | `` flake.lock: Update ``                             |