### PR TITLE
chore(flake/nur): `fa620b67` -> `0dff6424`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -842,11 +842,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1733039467,
-        "narHash": "sha256-6N65SlJSIP+DTziDuQbgaO5729AGOba+XIVidhCVzVQ=",
+        "lastModified": 1733082301,
+        "narHash": "sha256-KcolIV1v74HskhQephwtcHJHl0hkl2tnJrTcUowfvG0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fa620b675ec04637aefcbae5749be4b0afdd6059",
+        "rev": "0dff642460311c4dde8000a93a99822d28766099",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0dff6424`](https://github.com/nix-community/NUR/commit/0dff642460311c4dde8000a93a99822d28766099) | `` automatic update `` |
| [`a56df007`](https://github.com/nix-community/NUR/commit/a56df0070bac25cddbf6b3c177f68d606f0bfd7c) | `` automatic update `` |
| [`2b3136c2`](https://github.com/nix-community/NUR/commit/2b3136c2f2b55f97424a6ffe5926e811e14b3c71) | `` automatic update `` |
| [`f8b0ea23`](https://github.com/nix-community/NUR/commit/f8b0ea2397ade560f9e9639d5ad14559f8f3b2cb) | `` automatic update `` |
| [`c5a4d6a9`](https://github.com/nix-community/NUR/commit/c5a4d6a9e18e55769beb00b9c20e74940a11de10) | `` automatic update `` |
| [`32064614`](https://github.com/nix-community/NUR/commit/3206461459b9ff22533ace5abd6f051b5effb9b8) | `` automatic update `` |
| [`79ce276f`](https://github.com/nix-community/NUR/commit/79ce276f39f4e8eed45549919a328dd40f0266a1) | `` automatic update `` |
| [`6882f316`](https://github.com/nix-community/NUR/commit/6882f3160f00684110f462bc882bd1bbb057b844) | `` automatic update `` |
| [`7d4007f6`](https://github.com/nix-community/NUR/commit/7d4007f69a37be43cbdd420d8d0659f8ae70fcbf) | `` automatic update `` |
| [`70753b1a`](https://github.com/nix-community/NUR/commit/70753b1a09c393de4450510255c5edd4e7f22e75) | `` automatic update `` |
| [`bea7fdcc`](https://github.com/nix-community/NUR/commit/bea7fdcc849a9a8b9309c029268298162ecb9e3e) | `` automatic update `` |
| [`0cccbcb3`](https://github.com/nix-community/NUR/commit/0cccbcb30ee67c0b28c67ae33486118031a82b09) | `` automatic update `` |
| [`9d101031`](https://github.com/nix-community/NUR/commit/9d1010316997b38f36f28824d95821e63b305657) | `` automatic update `` |
| [`22a70220`](https://github.com/nix-community/NUR/commit/22a702207667b663fb1e31720457daade0580312) | `` automatic update `` |
| [`386f8bff`](https://github.com/nix-community/NUR/commit/386f8bff4355bbe685e2f063a6e6e82666477665) | `` automatic update `` |
| [`58c7a1f1`](https://github.com/nix-community/NUR/commit/58c7a1f186e7d2bf80705cd56deab9f29c8a3fef) | `` automatic update `` |