### PR TITLE
chore(flake/nixos-hardware): `45348ad6` -> `c6c90887`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -559,11 +559,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1732483221,
-        "narHash": "sha256-kF6rDeCshoCgmQz+7uiuPdREVFuzhIorGOoPXMalL2U=",
+        "lastModified": 1733139194,
+        "narHash": "sha256-PVQW9ovo0CJbhuhCsrhFJGGdD1euwUornspKpBIgdok=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "45348ad6fb8ac0e8415f6e5e96efe47dd7f39405",
+        "rev": "c6c90887f84c02ce9ebf33b95ca79ef45007bf88",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                  |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`c6c90887`](https://github.com/NixOS/nixos-hardware/commit/c6c90887f84c02ce9ebf33b95ca79ef45007bf88) | `` drop acpi_call from nixos-hardware ``                                                 |
| [`fe01780d`](https://github.com/NixOS/nixos-hardware/commit/fe01780d356d70fd119a19277bff71d3e78dad00) | `` Update flake.nix ``                                                                   |
| [`93183259`](https://github.com/NixOS/nixos-hardware/commit/9318325957572aae826cc37d4378412b0d49d5dc) | `` 「✨」 feat(Dell Precision 5530): Added Nvidia support and some other feature (#1254) `` |
| [`acdc2cd8`](https://github.com/NixOS/nixos-hardware/commit/acdc2cd8153ddefab79d2bd31ed5690cdf2d6314) | `` Fix typo in Lenovo IdeaPad 16AHP9 URL ``                                              |