### PR TITLE
chore(flake/nur): `0dff6424` -> `1844924b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -842,11 +842,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1733082301,
-        "narHash": "sha256-KcolIV1v74HskhQephwtcHJHl0hkl2tnJrTcUowfvG0=",
+        "lastModified": 1733125101,
+        "narHash": "sha256-C8f6ekiZ4kP84JWLDrMigvnSK6RXQoxLEDoteXMx1yc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0dff642460311c4dde8000a93a99822d28766099",
+        "rev": "1844924bf1e7e5a98198eca17b6c27cc9a363b05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1844924b`](https://github.com/nix-community/NUR/commit/1844924bf1e7e5a98198eca17b6c27cc9a363b05) | `` automatic update `` |
| [`e73b5097`](https://github.com/nix-community/NUR/commit/e73b5097cba00c81310081db06bcc0cc71a8fb40) | `` automatic update `` |
| [`c9e5dec1`](https://github.com/nix-community/NUR/commit/c9e5dec149daabcae8d723122085771696c8a804) | `` automatic update `` |
| [`d4965c44`](https://github.com/nix-community/NUR/commit/d4965c44223dd6effe3ad7316646dd3a51095cf1) | `` automatic update `` |
| [`6e00a547`](https://github.com/nix-community/NUR/commit/6e00a547d384955dc46f5389e7497bfc067e7ec6) | `` automatic update `` |
| [`ec9d4e3b`](https://github.com/nix-community/NUR/commit/ec9d4e3b7df86b994c3af1dc21726377c0558934) | `` automatic update `` |
| [`2055e4cd`](https://github.com/nix-community/NUR/commit/2055e4cd3899efb5f7e81251177f85eaec10994a) | `` automatic update `` |
| [`08805821`](https://github.com/nix-community/NUR/commit/0880582154a04791e75b298b7640d8b65e00d5b8) | `` automatic update `` |
| [`5e926ea2`](https://github.com/nix-community/NUR/commit/5e926ea2b652ad0bedff0ba8d0d51f8975cadffe) | `` automatic update `` |
| [`7ef71f9e`](https://github.com/nix-community/NUR/commit/7ef71f9e709f3980cd95f43c31e2122ff208105c) | `` automatic update `` |
| [`47d7b9c4`](https://github.com/nix-community/NUR/commit/47d7b9c47623126a212fe027033151ad014b43a5) | `` automatic update `` |
| [`3eadec3d`](https://github.com/nix-community/NUR/commit/3eadec3d7610126b12d3896935f9250a86e2718e) | `` automatic update `` |