### PR TITLE
chore(flake/emacs-overlay): `75b7551f` -> `51d6aafb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1733072333,
-        "narHash": "sha256-Vo/TVzPi58W8dC2a0fzpfdL1U7HgvCGd0/Q67UoZ3CI=",
+        "lastModified": 1733127808,
+        "narHash": "sha256-UJUFsa1jmYSgAhrii1HVEl//ggT3Nzaw6kDN6TnkGXM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "75b7551fea3c131628fdba2bc03d0a398f07c75a",
+        "rev": "51d6aafb5e3bbf10a29bd8ff417b617e35b14d0e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`51d6aafb`](https://github.com/nix-community/emacs-overlay/commit/51d6aafb5e3bbf10a29bd8ff417b617e35b14d0e) | `` Updated flake inputs `` |
| [`9a75ee95`](https://github.com/nix-community/emacs-overlay/commit/9a75ee9552e74f9652920cf2bbf8f1c9270876bf) | `` Updated emacs ``        |
| [`fe46c999`](https://github.com/nix-community/emacs-overlay/commit/fe46c9992f9a8e7302afe92af6b5c8b0838e00ab) | `` Updated melpa ``        |
| [`a0720262`](https://github.com/nix-community/emacs-overlay/commit/a0720262d8eae367c90d08e510eddfb7049455fa) | `` Updated elpa ``         |
| [`dda85b36`](https://github.com/nix-community/emacs-overlay/commit/dda85b369ea696041ce1ac4fe923fe2be6b666cb) | `` Updated nongnu ``       |