### PR TITLE
chore(flake/srvos): `ce61f716` -> `7d46a1fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -915,11 +915,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732791727,
-        "narHash": "sha256-E3ki8879tKii42pjibenRpJSDVW0mJFfSWHbci5Ck0s=",
+        "lastModified": 1733137728,
+        "narHash": "sha256-ichY2vLnuNfUJGgr8QmPEaU0CwFDhMbt9F9KNKN9VVs=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "ce61f7168038e4077ed6e27a4aa9f2c3c3500099",
+        "rev": "7d46a1fc77c52bf3be4a25a991bb695abee4deed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                      |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`7d46a1fc`](https://github.com/nix-community/srvos/commit/7d46a1fc77c52bf3be4a25a991bb695abee4deed) | `` dev/update-private-narhash: add nix-experimental flags `` |
| [`a470cd94`](https://github.com/nix-community/srvos/commit/a470cd94d8e295fb7cb6b22a12d60359ec491aea) | `` chore: move update-private-narhash to script ``           |
| [`250ecf41`](https://github.com/nix-community/srvos/commit/250ecf411583f9a099862979e9a2ce584e1c0ddd) | `` server/networking: unset tcp BBR and fq (#576) ``         |
| [`d7bc5fa4`](https://github.com/nix-community/srvos/commit/d7bc5fa465c3864fe163815be4247522e29d021a) | `` remove fstrim option ``                                   |
| [`48a1a130`](https://github.com/nix-community/srvos/commit/48a1a1304c558f7443d3944cfba2fed2c30ba2c3) | `` update to 24.11 ``                                        |
| [`7d99c137`](https://github.com/nix-community/srvos/commit/7d99c13781e70beec8e14a0e5bf8c1ecd788c8f2) | `` treefmt ``                                                |
| [`a2249e7d`](https://github.com/nix-community/srvos/commit/a2249e7dc181bceaf9bc3f209ff26d4eeb1c8931) | `` dev/private/flake.lock: Update ``                         |
| [`cdc08175`](https://github.com/nix-community/srvos/commit/cdc08175994c918e98177aa88019b8d8bb3d267a) | `` flake.lock: Update ``                                     |
| [`00053054`](https://github.com/nix-community/srvos/commit/000530540c7c35dd87b80c6d2cc6d60410e51828) | `` chore: remove redundant system.switch.enableNg ``         |