### PR TITLE
chore(flake/nur): `1844924b` -> `d760e544`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -782,11 +782,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1733125101,
-        "narHash": "sha256-C8f6ekiZ4kP84JWLDrMigvnSK6RXQoxLEDoteXMx1yc=",
+        "lastModified": 1733151007,
+        "narHash": "sha256-GdEEOg+pzL9owtBOvuuYsN3wict5nCKPMvRP38epF4I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1844924bf1e7e5a98198eca17b6c27cc9a363b05",
+        "rev": "d760e5443360d142ebb2276833afb89bc42c62b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d760e544`](https://github.com/nix-community/NUR/commit/d760e5443360d142ebb2276833afb89bc42c62b2) | `` automatic update `` |
| [`e73a3cfe`](https://github.com/nix-community/NUR/commit/e73a3cfea5a1e8a516fc36927a1db4983012decb) | `` automatic update `` |
| [`f3f9f09e`](https://github.com/nix-community/NUR/commit/f3f9f09e78c4a450b7bd22efde628a1a8f52223f) | `` automatic update `` |
| [`aadc32a2`](https://github.com/nix-community/NUR/commit/aadc32a2305cd303d1866be1d500ad6f7b344b82) | `` automatic update `` |
| [`f6b1d111`](https://github.com/nix-community/NUR/commit/f6b1d11161a18420ae699f3202f6cf113f509e8a) | `` automatic update `` |
| [`822c4d97`](https://github.com/nix-community/NUR/commit/822c4d97bd2654a65b90dea6b6694d467a2aad47) | `` automatic update `` |
| [`e23f1ed7`](https://github.com/nix-community/NUR/commit/e23f1ed7ff100d18c284a83514ae98587f6edb37) | `` automatic update `` |