### PR TITLE
chore(flake/sops-nix): `3433ea14` -> `c6134b6f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -895,11 +895,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732575825,
-        "narHash": "sha256-xtt95+c7OUMoqZf4OvA/7AemiH3aVuWHQbErYQoPwFk=",
+        "lastModified": 1733128155,
+        "narHash": "sha256-m6/qwJAJYcidGMEdLqjKzRIjapK4nUfMq7rDCTmZajc=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "3433ea14fbd9e6671d0ff0dd45ed15ee4c156ffa",
+        "rev": "c6134b6fff6bda95a1ac872a2a9d5f32e3c37856",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                           |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`c6134b6f`](https://github.com/Mic92/sops-nix/commit/c6134b6fff6bda95a1ac872a2a9d5f32e3c37856) | `` fix queuing conditions ``                      |
| [`fb055f30`](https://github.com/Mic92/sops-nix/commit/fb055f309d1c67307ace07af69a01f362ada561a) | `` {darwin,home-manager}: add example template `` |
| [`8d136263`](https://github.com/Mic92/sops-nix/commit/8d1362635116b5ff2f364e18b1f67a32e3726c9a) | `` try fixing templates on home-manager ``        |