### PR TITLE
chore(flake/nur): `b14ac3ba` -> `5a1c6c84`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -782,11 +782,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1733154268,
-        "narHash": "sha256-9lpHhQ+hCq23lzXjAB2cgAoQM9eeGillgtpDtaykvOI=",
+        "lastModified": 1733231429,
+        "narHash": "sha256-2ekVchNHMyTg/YRXLRj3OO3CU5t0HiEQnr27GMUs1uA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b14ac3ba3d011b8b3b161b5b4912c7fc77a6d6ec",
+        "rev": "5a1c6c849704bbbdfc60289e7107bba4b9995b91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5a1c6c84`](https://github.com/nix-community/NUR/commit/5a1c6c849704bbbdfc60289e7107bba4b9995b91) | `` automatic update `` |
| [`251d756a`](https://github.com/nix-community/NUR/commit/251d756a74e67bda25d89327b01a3da19dddabae) | `` automatic update `` |
| [`73f5fdd3`](https://github.com/nix-community/NUR/commit/73f5fdd3058c9bb2be71d9ca3b21a2d0a0abe9b4) | `` automatic update `` |
| [`0a75324d`](https://github.com/nix-community/NUR/commit/0a75324d01a7dbd84fbcee4e88e0aa8ca0fea051) | `` automatic update `` |
| [`0a7651ea`](https://github.com/nix-community/NUR/commit/0a7651ea6bd139f2e11c58754a6af185344b715b) | `` automatic update `` |
| [`57859914`](https://github.com/nix-community/NUR/commit/5785991401b9031f530d39d2485f897b26441894) | `` automatic update `` |
| [`b5653530`](https://github.com/nix-community/NUR/commit/b565353069ba1750455e147fb2a95bf22a27c20a) | `` automatic update `` |
| [`89771240`](https://github.com/nix-community/NUR/commit/897712404c434e872be872adf582266923c4e5b9) | `` automatic update `` |
| [`353b69b6`](https://github.com/nix-community/NUR/commit/353b69b66425a03d8511e2b4fb234cb20eb5aafd) | `` automatic update `` |
| [`7975d47a`](https://github.com/nix-community/NUR/commit/7975d47a821ef9cd2a9c647d17d62fe330a03a24) | `` automatic update `` |
| [`72dd27a5`](https://github.com/nix-community/NUR/commit/72dd27a5b4d5a0a50c14d9f52e319f635b3b69b5) | `` automatic update `` |
| [`3a3af16d`](https://github.com/nix-community/NUR/commit/3a3af16dbd85439471220aa0c90aea48a0155d53) | `` automatic update `` |
| [`b297fe1a`](https://github.com/nix-community/NUR/commit/b297fe1aa942511477e5bda25d9d749c3985be78) | `` automatic update `` |
| [`c42c4b14`](https://github.com/nix-community/NUR/commit/c42c4b142e3eea2fd21d3cba6f1f41a6ea1d45c6) | `` automatic update `` |
| [`927ae4b2`](https://github.com/nix-community/NUR/commit/927ae4b218c59b6f351d2bb90d4606b271bf19d3) | `` automatic update `` |
| [`bf18a89d`](https://github.com/nix-community/NUR/commit/bf18a89de274a616198311bd6dd09f3db686e242) | `` automatic update `` |
| [`d7be861f`](https://github.com/nix-community/NUR/commit/d7be861f9452d424733e5335754639a849ae0df3) | `` automatic update `` |
| [`d16ebc0f`](https://github.com/nix-community/NUR/commit/d16ebc0f37506eb6a382ed415aa91965ad590358) | `` automatic update `` |