### PR TITLE
chore(flake/home-manager): `873e39d5` -> `bf23fe41`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -327,11 +327,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733133928,
-        "narHash": "sha256-gU40r9AfpIr4eq+0noM8yH1Hxf+EA3dqfIpFtQl8Y1E=",
+        "lastModified": 1733175814,
+        "narHash": "sha256-zFOtOaqjzZfPMsm1mwu98syv3y+jziAq5DfWygaMtLg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "873e39d5f4437d2f3ab06881fea8e63e45e1d011",
+        "rev": "bf23fe41082aa0289c209169302afd3397092f22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                       |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`bf23fe41`](https://github.com/nix-community/home-manager/commit/bf23fe41082aa0289c209169302afd3397092f22) | `` tmux: add 'focusEvents' `` |