### PR TITLE
chore(flake/srvos): `7d46a1fc` -> `de795aa5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -915,11 +915,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733137728,
-        "narHash": "sha256-ichY2vLnuNfUJGgr8QmPEaU0CwFDhMbt9F9KNKN9VVs=",
+        "lastModified": 1733179518,
+        "narHash": "sha256-BHhsh/JF89YCrOP66b1YKOGVOyXG99Jv8JTreJ4+J1c=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "7d46a1fc77c52bf3be4a25a991bb695abee4deed",
+        "rev": "de795aa589a38f40bb63d033bd39fc0aea5bb815",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                               |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`de795aa5`](https://github.com/nix-community/srvos/commit/de795aa589a38f40bb63d033bd39fc0aea5bb815) | `` Revert "ci: set install_url to pin nix version" `` |