### PR TITLE
chore(flake/emacs-overlay): `54d10269` -> `2118e282`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1733156634,
-        "narHash": "sha256-YKPkdjUDUQxyQvBVlAV/e8z90RJT7PJHciSpzPyelHU=",
+        "lastModified": 1733188911,
+        "narHash": "sha256-aagoXv9MaL5zQKA5tF3NYoPdR3t5GywwUocFvYR/A8o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "54d102696b787b0baf144fd71a377172b561af62",
+        "rev": "2118e2829ef4b6dd969684cf9a4e0e771c943761",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`2118e282`](https://github.com/nix-community/emacs-overlay/commit/2118e2829ef4b6dd969684cf9a4e0e771c943761) | `` Updated elpa ``   |
| [`fe0cac73`](https://github.com/nix-community/emacs-overlay/commit/fe0cac736304960d31d88e364f59582246f5cc17) | `` Updated nongnu `` |