### PR TITLE
chore(flake/srvos): `de795aa5` -> `9f50af3c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -915,11 +915,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733179518,
-        "narHash": "sha256-BHhsh/JF89YCrOP66b1YKOGVOyXG99Jv8JTreJ4+J1c=",
+        "lastModified": 1733217096,
+        "narHash": "sha256-cERPAk4SapOveXNNjKZYuiazXHw2bp3L87eOw6BlrP8=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "de795aa589a38f40bb63d033bd39fc0aea5bb815",
+        "rev": "9f50af3cd4d8b180c5048ccb80da3c36720c0910",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                         |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`9f50af3c`](https://github.com/nix-community/srvos/commit/9f50af3cd4d8b180c5048ccb80da3c36720c0910) | `` common/flake: include cfg.flake in telegraf inputs (#578) `` |