### PR TITLE
chore(flake/nixos-hardware): `c6c90887` -> `cceee0a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -559,11 +559,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1733139194,
-        "narHash": "sha256-PVQW9ovo0CJbhuhCsrhFJGGdD1euwUornspKpBIgdok=",
+        "lastModified": 1733217105,
+        "narHash": "sha256-fc6jTzIwCIVWTX50FtW6AZpuukuQWSEbPiyg6ZRGWFY=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "c6c90887f84c02ce9ebf33b95ca79ef45007bf88",
+        "rev": "cceee0a31d2f01bcc98b2fbd591327c06a4ea4f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message        |
| ----------------------------------------------------------------------------------------------------- | -------------- |
| [`c6cddc7b`](https://github.com/NixOS/nixos-hardware/commit/c6cddc7bb2bb8339bf9c19ab40ec9e2b48299e3c) | `` fix eval `` |