### PR TITLE
chore(flake/nur): `5a1c6c84` -> `79faae7a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -782,11 +782,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1733231429,
-        "narHash": "sha256-2ekVchNHMyTg/YRXLRj3OO3CU5t0HiEQnr27GMUs1uA=",
+        "lastModified": 1733269642,
+        "narHash": "sha256-j97XbqqCBOWBLQrSqITP1VCriqdW2mpHUcIsprJtwzo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5a1c6c849704bbbdfc60289e7107bba4b9995b91",
+        "rev": "79faae7ad0faee64b643d675b78ea94e7a4fa70e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`79faae7a`](https://github.com/nix-community/NUR/commit/79faae7ad0faee64b643d675b78ea94e7a4fa70e) | `` automatic update `` |
| [`9d1d6d45`](https://github.com/nix-community/NUR/commit/9d1d6d459bf1fcea7bde892cc8e83bd60eaea03d) | `` automatic update `` |
| [`7076531a`](https://github.com/nix-community/NUR/commit/7076531a564eccf001832c2c2f230d7ab0cfd33b) | `` automatic update `` |
| [`0c7ae4a6`](https://github.com/nix-community/NUR/commit/0c7ae4a63afbc6c305e401a06191380027f5ec73) | `` automatic update `` |
| [`05bf4179`](https://github.com/nix-community/NUR/commit/05bf41798961fbbc2b9c0a722548912c59838205) | `` automatic update `` |
| [`6afe0c0f`](https://github.com/nix-community/NUR/commit/6afe0c0fbcc73b2014b9389ac60257c61fdb6c19) | `` automatic update `` |
| [`f2a6ddad`](https://github.com/nix-community/NUR/commit/f2a6ddadaf2743b6a09af9a0da86072b78f2bc81) | `` automatic update `` |
| [`1a776f27`](https://github.com/nix-community/NUR/commit/1a776f27abb96c4563f290bc7cffdc8cd7755fdd) | `` automatic update `` |