### PR TITLE
chore(flake/emacs-overlay): `92abfe9a` -> `82784e1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1733242997,
-        "narHash": "sha256-A3MspmYDwUU7fwVTs8UYc/Fox7XTfd4b8G6B1H4kSdQ=",
+        "lastModified": 1733275336,
+        "narHash": "sha256-wm/WIzgw7zgMwOMxAnb1158qyBAs3slI/pVrXHAcgLQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "92abfe9a334c215d4e14cabe1593a0189610ce90",
+        "rev": "82784e1b39d7bdfc247823e01d93efda67cb2a94",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`82784e1b`](https://github.com/nix-community/emacs-overlay/commit/82784e1b39d7bdfc247823e01d93efda67cb2a94) | `` Updated elpa ``         |
| [`6e20ff5e`](https://github.com/nix-community/emacs-overlay/commit/6e20ff5e256610574701bc290b8fbae0762a1bdd) | `` Updated nongnu ``       |
| [`2719cb2f`](https://github.com/nix-community/emacs-overlay/commit/2719cb2f8b84ea33a5acf5c81e2fd2dd377b0753) | `` Updated flake inputs `` |