### PR TITLE
chore(flake/nur): `79faae7a` -> `dda476d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -782,11 +782,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1733269642,
-        "narHash": "sha256-j97XbqqCBOWBLQrSqITP1VCriqdW2mpHUcIsprJtwzo=",
+        "lastModified": 1733294525,
+        "narHash": "sha256-3EUU3tm+T3vUHmZdsLWisxHjWzn6RT2U2KMOaGho9Oo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "79faae7ad0faee64b643d675b78ea94e7a4fa70e",
+        "rev": "dda476d2da1f38f7a5391a60b563d520eb1ea4f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dda476d2`](https://github.com/nix-community/NUR/commit/dda476d2da1f38f7a5391a60b563d520eb1ea4f9) | `` automatic update `` |
| [`9a266411`](https://github.com/nix-community/NUR/commit/9a26641139d1b8f59059fad2500fbf06ca5918ab) | `` automatic update `` |
| [`e2a910a0`](https://github.com/nix-community/NUR/commit/e2a910a0aa18fe90cfcc72d8d337cf30822fae4f) | `` automatic update `` |
| [`5daca116`](https://github.com/nix-community/NUR/commit/5daca116d08e2677239a57eefe5ea28cd1225ec2) | `` automatic update `` |
| [`388adad5`](https://github.com/nix-community/NUR/commit/388adad566ea6210e7d0b2c94df77b62d9891b26) | `` automatic update `` |
| [`2f07cc04`](https://github.com/nix-community/NUR/commit/2f07cc048a0cb271fef753e97352380e31a47e65) | `` automatic update `` |