### PR TITLE
chore(flake/flake-parts): `e37654df` -> `205b12d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -194,11 +194,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1733269028,
-        "narHash": "sha256-kVq/jAKKtbvWwbL9wf0SKDxtxsC5Gb+nlIYEFnyXhGA=",
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "e37654df08605b510ad84eceaafcc7248495e843",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`85954c90`](https://github.com/hercules-ci/flake-parts/commit/85954c907b405159f275949ff49632b5808a02d7) | `` Update get-flake to its upstream, flake-compat `` |