### PR TITLE
chore(flake/nur): `dda476d2` -> `8e6e9b8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -782,11 +782,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1733294525,
-        "narHash": "sha256-3EUU3tm+T3vUHmZdsLWisxHjWzn6RT2U2KMOaGho9Oo=",
+        "lastModified": 1733467284,
+        "narHash": "sha256-pzSHveN18sSTTrjE5KU2si3h7XEOawOMLcasgGPjRK8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dda476d2da1f38f7a5391a60b563d520eb1ea4f9",
+        "rev": "8e6e9b8e2d04f0eea11dfa701f790bee797295b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                  |
| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`8e6e9b8e`](https://github.com/nix-community/NUR/commit/8e6e9b8e2d04f0eea11dfa701f790bee797295b1) | `` automatic update ``                                   |
| [`1a5cae13`](https://github.com/nix-community/NUR/commit/1a5cae1376b341235de0d1a995cf8a8e731fd3c7) | `` made it possible to use NUR with without overrides `` |
| [`b046e0f1`](https://github.com/nix-community/NUR/commit/b046e0f172bf5bfd8f331650953360bd08f860d0) | `` automatic update ``                                   |
| [`159462cf`](https://github.com/nix-community/NUR/commit/159462cffc247f0aa1fdf12bd86b7c36a9a4841b) | `` automatic update ``                                   |
| [`558e8fd2`](https://github.com/nix-community/NUR/commit/558e8fd25244ae4116cac22383397cccc9b7a8b0) | `` automatic update ``                                   |
| [`51d22b2c`](https://github.com/nix-community/NUR/commit/51d22b2ccb3d8277f669fa1378aa54cd2a19aff2) | `` automatic update ``                                   |
| [`0f6df2ef`](https://github.com/nix-community/NUR/commit/0f6df2ef2b93c29f48698636181ce04dc0589846) | `` automatic update ``                                   |
| [`bee75884`](https://github.com/nix-community/NUR/commit/bee75884252842cf9dffd396ffa72af990e39090) | `` automatic update ``                                   |
| [`c19dc6c4`](https://github.com/nix-community/NUR/commit/c19dc6c45669b25482d3f8f56be3b1c90bd2cfe6) | `` automatic update ``                                   |
| [`be37ee25`](https://github.com/nix-community/NUR/commit/be37ee259fb4ff58855a6df3054d3c62e3094340) | `` automatic update ``                                   |
| [`da89e823`](https://github.com/nix-community/NUR/commit/da89e823a81b9bbd3d76e770f55bee1fd61c3d6d) | `` automatic update ``                                   |
| [`438ad1df`](https://github.com/nix-community/NUR/commit/438ad1df4b17e4a0b4e3abf0ea6d6c8cbecd2edd) | `` automatic update ``                                   |
| [`8cfc6270`](https://github.com/nix-community/NUR/commit/8cfc6270eef30201c59255b388092930a9a273ed) | `` automatic update ``                                   |
| [`5833f160`](https://github.com/nix-community/NUR/commit/5833f1608b9d6fddabc94206065f51d58f8707ee) | `` automatic update ``                                   |
| [`0a8f2e63`](https://github.com/nix-community/NUR/commit/0a8f2e63e4674490b1e4b302480b5392eb60768f) | `` automatic update ``                                   |
| [`9ca9a332`](https://github.com/nix-community/NUR/commit/9ca9a3321667195ddf41c0d5d994f4b0a955329f) | `` add picokeys-nix repository ``                        |
| [`6e671d63`](https://github.com/nix-community/NUR/commit/6e671d63e6b1e29f31781b8dfef69b147b69ab77) | `` automatic update ``                                   |
| [`15d28036`](https://github.com/nix-community/NUR/commit/15d28036c49a29dcaef9a060227320cd9f8fd14e) | `` automatic update ``                                   |
| [`0e430de4`](https://github.com/nix-community/NUR/commit/0e430de4463ee78b6f10e5b7c80375fb6a3c3a8d) | `` automatic update ``                                   |
| [`e6098b03`](https://github.com/nix-community/NUR/commit/e6098b0360b6436634f3604c134e99b608a8c252) | `` automatic update ``                                   |
| [`e2dc915c`](https://github.com/nix-community/NUR/commit/e2dc915c6f06a3ef6b4d43c65459bb247a7a8e30) | `` automatic update ``                                   |
| [`c87700bf`](https://github.com/nix-community/NUR/commit/c87700bf8dfc620ab70e9996e2979a033190d677) | `` automatic update ``                                   |
| [`1ce49311`](https://github.com/nix-community/NUR/commit/1ce493118a8d2344177629c1e51bc44912202154) | `` automatic update ``                                   |
| [`d9f371d6`](https://github.com/nix-community/NUR/commit/d9f371d6e85d87298a88a7405be4ee2ef9cabe8c) | `` automatic update ``                                   |
| [`456d0b89`](https://github.com/nix-community/NUR/commit/456d0b899066713bec01dd0922bc4ccdf11cac2a) | `` automatic update ``                                   |
| [`bf1bfc00`](https://github.com/nix-community/NUR/commit/bf1bfc00a69d119a81df27bc45c7f5ae10527908) | `` automatic update ``                                   |
| [`4e9b7ce4`](https://github.com/nix-community/NUR/commit/4e9b7ce4f1d50215da7bad43f52bc883a04ea2ef) | `` automatic update ``                                   |
| [`9223fb58`](https://github.com/nix-community/NUR/commit/9223fb5839acf2342955c532f561e912d34accdb) | `` automatic update ``                                   |
| [`00a08a0d`](https://github.com/nix-community/NUR/commit/00a08a0d51c928d4fb299c7177969c0f791cdf3d) | `` automatic update ``                                   |
| [`f88b83cf`](https://github.com/nix-community/NUR/commit/f88b83cffc6018fed64748672692298407c879f1) | `` automatic update ``                                   |
| [`5ad82412`](https://github.com/nix-community/NUR/commit/5ad82412b61d822951f74d23606a3b71f82b86cd) | `` automatic update ``                                   |
| [`6bd4edaf`](https://github.com/nix-community/NUR/commit/6bd4edaf2e576f16a08d606e869941f56d282c34) | `` automatic update ``                                   |
| [`af7d71a8`](https://github.com/nix-community/NUR/commit/af7d71a8ec1b439c5f7ff8441fbf5af7abed9544) | `` automatic update ``                                   |
| [`c27c4ed1`](https://github.com/nix-community/NUR/commit/c27c4ed1029b396a1986db133ce7cf55079ea472) | `` automatic update ``                                   |
| [`fc513359`](https://github.com/nix-community/NUR/commit/fc513359b70bd8b57854e5bb60d6bcd318d9350a) | `` automatic update ``                                   |
| [`dbe7754d`](https://github.com/nix-community/NUR/commit/dbe7754d6c287a67f3b9934157914c29c65cb741) | `` automatic update ``                                   |
| [`34bb1d97`](https://github.com/nix-community/NUR/commit/34bb1d972e5fd17d38832ca805cf251ec4b12e91) | `` add nishimara repository ``                           |
| [`81acc5a2`](https://github.com/nix-community/NUR/commit/81acc5a20ba2d84d206f61d2784147900965cd9f) | `` automatic update ``                                   |
| [`a75e4511`](https://github.com/nix-community/NUR/commit/a75e451161b22ce0e94b397937085e93c9666be7) | `` automatic update ``                                   |
| [`5f19ae3e`](https://github.com/nix-community/NUR/commit/5f19ae3e3e679a583c4303f68435dfda885c0c78) | `` automatic update ``                                   |
| [`8bf1e06e`](https://github.com/nix-community/NUR/commit/8bf1e06e0b7a939df6282c569e1c1def8720df85) | `` automatic update ``                                   |
| [`848c612b`](https://github.com/nix-community/NUR/commit/848c612b8b41ed91fdc9bc49594bb58fce1998e9) | `` automatic update ``                                   |
| [`594e7cb6`](https://github.com/nix-community/NUR/commit/594e7cb6fb8e23a6dfd06d64ebf9e9e91cb3fff7) | `` automatic update ``                                   |
| [`c661197f`](https://github.com/nix-community/NUR/commit/c661197fd019ffa31b6ca180cb7728f4bef2ef00) | `` automatic update ``                                   |
| [`d07fbb0b`](https://github.com/nix-community/NUR/commit/d07fbb0bcbdc0a0969373a8679d24aa565805a35) | `` automatic update ``                                   |
| [`b1174f03`](https://github.com/nix-community/NUR/commit/b1174f03870dbe8fe1d487d21a4acad6b5a44082) | `` automatic update ``                                   |
| [`0e00c4ba`](https://github.com/nix-community/NUR/commit/0e00c4bab72a69d3b3deebb7bbbec0d30f5993e7) | `` automatic update ``                                   |