### PR TITLE
chore(flake/home-manager): `ad48eb25` -> `0daaded6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -327,11 +327,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733317578,
-        "narHash": "sha256-anN/LcP5IuqEARvhPETg1vnbyG3IQ0wdvSAYEJfIQzA=",
+        "lastModified": 1733354384,
+        "narHash": "sha256-foZG2PLwumxYZkpXq7ajHDhuQlXaUeKfOpFfQpMviLM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ad48eb25cd0b00ce730da00fa1f8e6e6c27b397d",
+        "rev": "0daaded612b0e6eaed0a63fc9d0778d8f05940fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`0daaded6`](https://github.com/nix-community/home-manager/commit/0daaded612b0e6eaed0a63fc9d0778d8f05940fe) | `` starship: replace `eval` with `source` for fish ``    |
| [`86ee1290`](https://github.com/nix-community/home-manager/commit/86ee1290d76bcd5f7ee6c80f181288a28ab0dca0) | `` starship: add `enableInteractive` option for fish ``  |
| [`1cd17a2f`](https://github.com/nix-community/home-manager/commit/1cd17a2f76f7711b06d5d59f1746cef602974498) | `` mangohud: fix a non-working example ``                |
| [`3a7fc9cd`](https://github.com/nix-community/home-manager/commit/3a7fc9cd71a844aae9c6b6bb44700cea9539bc13) | `` zsh: make autosuggest strategy accept more options `` |