### PR TITLE
chore(flake/nixos-cosmic): `e1b76524` -> `368e94ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -529,11 +529,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1733265593,
-        "narHash": "sha256-sMd0QBqmH68O2N7DAfz7WtCTPzgY2MWjAIw18dUgNcg=",
+        "lastModified": 1733339972,
+        "narHash": "sha256-6Ocb/x/7Y8mEjZU/xuxDZNX7EIQ5O0hKpzcYvH7+XdM=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "e1b76524988d600dcf415ec5355a727ca2c5debe",
+        "rev": "368e94ef348c45ec800f5f4a6939a397c024f984",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                                |
| ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`368e94ef`](https://github.com/lilyinstarlight/nixos-cosmic/commit/368e94ef348c45ec800f5f4a6939a397c024f984) | `` ci: set `min-free` to prevent temp runner disk filling up (#506) `` |
| [`2e87e0f9`](https://github.com/lilyinstarlight/nixos-cosmic/commit/2e87e0f9f40a31396ed94b4a42595662c2eeaf31) | `` ci: temporarily increase build time limit (#505) ``                 |