### PR TITLE
chore(flake/emacs-overlay): `d3342b2b` -> `2f6e00e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1733340018,
-        "narHash": "sha256-wLuZpNB2QC7+yG7qoYBazdE6gmKQg/fIkrzCwzxq0XQ=",
+        "lastModified": 1733415888,
+        "narHash": "sha256-3SsUtfxKL7q63dDFH9XdsRnZ0yQRletQu23sVyLqouE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d3342b2b1be90527b9cd54494e1c063613c6454c",
+        "rev": "2f6e00e690fd83b9c24eef9a026a5d6d8c34c5a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`2f6e00e6`](https://github.com/nix-community/emacs-overlay/commit/2f6e00e690fd83b9c24eef9a026a5d6d8c34c5a0) | `` Updated elpa ``   |
| [`e2a6b004`](https://github.com/nix-community/emacs-overlay/commit/e2a6b0046e00fede39cf8c84d7636f20f3f07256) | `` Updated nongnu `` |
| [`2e6e7801`](https://github.com/nix-community/emacs-overlay/commit/2e6e7801a515f8dbece2d888244a6a2604e36e86) | `` Updated elpa ``   |
| [`f4ffb367`](https://github.com/nix-community/emacs-overlay/commit/f4ffb3671dac9e298f329f97664c90a76259b569) | `` Updated nongnu `` |