### PR TITLE
chore(flake/srvos): `9f50af3c` -> `6047d415`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -915,11 +915,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733217096,
-        "narHash": "sha256-cERPAk4SapOveXNNjKZYuiazXHw2bp3L87eOw6BlrP8=",
+        "lastModified": 1733365027,
+        "narHash": "sha256-Vl0pOGckECuFoMbiotwj65jjoFE8Mc2yUXNIllttxkI=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "9f50af3cd4d8b180c5048ccb80da3c36720c0910",
+        "rev": "6047d415ca8dc7eae73dd17c832f7dc08ad544f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                             |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`6047d415`](https://github.com/nix-community/srvos/commit/6047d415ca8dc7eae73dd17c832f7dc08ad544f4) | `` dev/private/flake.lock: Update ``                |
| [`0ca47133`](https://github.com/nix-community/srvos/commit/0ca47133bd0440e1ffe3087b63eb20b776617fed) | `` flake.lock: Update ``                            |
| [`a6ac04bf`](https://github.com/nix-community/srvos/commit/a6ac04bf8ac513d8e4a506d7d69c0f161e4b528c) | `` dev/update-private-narhash: flags -> features `` |