### PR TITLE
chore(flake/home-manager): `0daaded6` -> `65912bc6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -327,11 +327,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733354384,
-        "narHash": "sha256-foZG2PLwumxYZkpXq7ajHDhuQlXaUeKfOpFfQpMviLM=",
+        "lastModified": 1733389730,
+        "narHash": "sha256-KZMu4ddMll5khS0rYkJsVD0hVqjMNHlhTM3PCQar0Ag=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0daaded612b0e6eaed0a63fc9d0778d8f05940fe",
+        "rev": "65912bc6841cf420eb8c0a20e03df7cbbff5963f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`65912bc6`](https://github.com/nix-community/home-manager/commit/65912bc6841cf420eb8c0a20e03df7cbbff5963f) | `` imapnotify: provide an option for setting PATH `` |