### PR TITLE
chore(flake/treefmt): `49717b5a` -> `50862ba6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -980,11 +980,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733222881,
-        "narHash": "sha256-JIPcz1PrpXUCbaccEnrcUS8jjEb/1vJbZz5KkobyFdM=",
+        "lastModified": 1733440889,
+        "narHash": "sha256-qKL3vjO+IXFQ0nTinFDqNq/sbbnnS5bMI1y0xX215fU=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "49717b5af6f80172275d47a418c9719a31a78b53",
+        "rev": "50862ba6a8a0255b87377b9d2d4565e96f29b410",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                          |
| ---------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`7e54a93a`](https://github.com/numtide/treefmt-nix/commit/7e54a93a3ba74f971779b73ef62d787aa54c9099) | `` feat: update nixpkgs input `` |