### PR TITLE
chore(flake/emacs-overlay): `2f6e00e6` -> `315894ec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1733415888,
-        "narHash": "sha256-3SsUtfxKL7q63dDFH9XdsRnZ0yQRletQu23sVyLqouE=",
+        "lastModified": 1733448064,
+        "narHash": "sha256-b2Yoxsn6Ja+GqDWJB5uUnoXF4GlX/GlSLrIWIPaelhY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2f6e00e690fd83b9c24eef9a026a5d6d8c34c5a0",
+        "rev": "315894eca1fcb961f21ace3f32e022768f2e6405",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`315894ec`](https://github.com/nix-community/emacs-overlay/commit/315894eca1fcb961f21ace3f32e022768f2e6405) | `` Updated elpa ``   |
| [`7b2066e3`](https://github.com/nix-community/emacs-overlay/commit/7b2066e3d3714fda877edcc6713ae81c5cc320a0) | `` Updated nongnu `` |