### PR TITLE
chore(flake/nixpkgs): `55d15ad1` -> `22c3f2cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -717,11 +717,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1733212471,
-        "narHash": "sha256-M1+uCoV5igihRfcUKrr1riygbe73/dzNnzPsmaLCmpo=",
+        "lastModified": 1733581040,
+        "narHash": "sha256-Qn3nPMSopRQJgmvHzVqPcE3I03zJyl8cSbgnnltfFDY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "55d15ad12a74eb7d4646254e13638ad0c4128776",
+        "rev": "22c3f2cf41a0e70184334a958e6b124fb0ce3e01",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                  |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`882ff1b9`](https://github.com/NixOS/nixpkgs/commit/882ff1b923f74821589dd571d6a9e9b955f42fc6) | `` satellite: 0.5.0 -> 0.9.0 ``                                                          |
| [`6ad564a3`](https://github.com/NixOS/nixpkgs/commit/6ad564a324d33163e41fcc8d5aeff42b9c14b260) | `` satellite: refactor ``                                                                |
| [`3b299a3c`](https://github.com/NixOS/nixpkgs/commit/3b299a3c9ba649bac23402d4051b1f371102d788) | `` minio: 2024-09-22T00-33-43Z -> 2024-11-07T00-52-20Z ``                                |
| [`b56a00b2`](https://github.com/NixOS/nixpkgs/commit/b56a00b23c3fb2c1463e4448063be77af725a711) | `` pilipalax: init at 1.0.22-beta.12+174 ``                                              |
| [`a6efb32b`](https://github.com/NixOS/nixpkgs/commit/a6efb32b0e9c86f8fb7b6f50061c302217c7a736) | `` rtkit: fix reduce logging patch URL (#360182) ``                                      |
| [`b89b83eb`](https://github.com/NixOS/nixpkgs/commit/b89b83eb3116265bacb253ccf2129db0c93f0428) | `` topgrade: 16.0.1 -> 16.0.2 ``                                                         |
| [`e2e988d9`](https://github.com/NixOS/nixpkgs/commit/e2e988d9172b8a87b01ecd8a0d863f5bf367a6c7) | `` gnome-extension-manager: fix black screen via upstream patch (#358236) ``             |
| [`f4fdea6a`](https://github.com/NixOS/nixpkgs/commit/f4fdea6accc918e928903c1d56e66061c4ed0374) | `` morewaita-icon-theme: 47.1-> 47.2 (#361807) ``                                        |
| [`8c2f5710`](https://github.com/NixOS/nixpkgs/commit/8c2f571052c58e33e945a2696d3673434e8a7e57) | `` nerd-fonts: improve alias throw to give example migration ``                          |
| [`aa6aa758`](https://github.com/NixOS/nixpkgs/commit/aa6aa758d63ce0e978721692b606bc981d232a3f) | `` typstyle: 0.12.7 -> 0.12.8 ``                                                         |
| [`d4b04132`](https://github.com/NixOS/nixpkgs/commit/d4b04132463963a40567a955976c48c67e0bb66d) | `` bilibili: 1.14.0-2 -> 1.15.2-2 ``                                                     |
| [`7aad7090`](https://github.com/NixOS/nixpkgs/commit/7aad7090b7bd3b5f18e1c5788f1aa35a7b2e57bc) | `` nixos/zfs: order pool sync services before final.target ``                            |
| [`bbd31446`](https://github.com/NixOS/nixpkgs/commit/bbd314463df3253326e0e8dc902eb76cb29b362d) | `` python312Packages.cement: disable tests on Darwin ``                                  |
| [`508a791f`](https://github.com/NixOS/nixpkgs/commit/508a791f9ef7583531ad8145e448047b9f2c52d5) | `` awsebcli: update override for cement ``                                               |
| [`e1eb67dc`](https://github.com/NixOS/nixpkgs/commit/e1eb67dc93120577a80d2bab0fbebe885cb9b140) | `` python312Packages.cement: 3.0.10 -> 3.0.12 ``                                         |
| [`841a952d`](https://github.com/NixOS/nixpkgs/commit/841a952de1397fb15901ab0e1b4bda4d53672d47) | `` python312Packages.tensorflow-metadata: 1.15.0 -> 1.16.1 ``                            |
| [`5a4f44dd`](https://github.com/NixOS/nixpkgs/commit/5a4f44dd31e7fbab2184839df1560a33fe5e5b79) | `` python312Packages.scikit-posthocs: 0.9.1 -> 0.11.0 ``                                 |
| [`6d2395e8`](https://github.com/NixOS/nixpkgs/commit/6d2395e8c6dbc9a9e4c586d774836af5505cd6f4) | `` python312Packages.itemadapter: 0.9.0 -> 0.10.0 ``                                     |
| [`379aeabd`](https://github.com/NixOS/nixpkgs/commit/379aeabd483dfdd093ed2ea9b30726032b102a35) | `` python312Packages.dm-haiku: 0.0.12 -> 0.0.13 ``                                       |
| [`3dcd875c`](https://github.com/NixOS/nixpkgs/commit/3dcd875c9a3623f2cdbc5f546698d5a36bacf97d) | `` cot: fixes for python312 (#362256) ``                                                 |
| [`51da9320`](https://github.com/NixOS/nixpkgs/commit/51da93207ee529c3eff0e719e65edc3b2f705b52) | `` python312Packages.rdflib: use default pytestCheckHook ``                              |
| [`0290856a`](https://github.com/NixOS/nixpkgs/commit/0290856af4e05fc9a7a959f2cdb67fee357cfb0f) | `` python312Packages.total-connect-client: 2024.5 -> 2024.12 ``                          |
| [`3d73d057`](https://github.com/NixOS/nixpkgs/commit/3d73d0579187384901c0bd7c45f9b5281fa0e0a7) | `` time: fix implicit function declaration (#362226) ``                                  |
| [`9ded9ca8`](https://github.com/NixOS/nixpkgs/commit/9ded9ca8eb4d0359fe3c7e47e47495a4db2d7438) | `` python312Packages.rdflib: 7.0.0 -> 7.1.1 ``                                           |
| [`5714c332`](https://github.com/NixOS/nixpkgs/commit/5714c33244540bab6b0941da0b3379dc07f9336b) | `` python312Packages.sphinxcontrib-confluencebuilder: 2.7.1 -> 2.9.0 ``                  |
| [`3d7bcbb8`](https://github.com/NixOS/nixpkgs/commit/3d7bcbb8105ae78f09de20e2fab0f4ea6123e2fe) | `` gatus: 5.13.0 -> 5.13.1 ``                                                            |
| [`7053f294`](https://github.com/NixOS/nixpkgs/commit/7053f294538bee194bfc64a2b2906a3bd03a374f) | `` trueseeing: 2.2.4 -> 2.2.5 ``                                                         |
| [`dc6b8fa2`](https://github.com/NixOS/nixpkgs/commit/dc6b8fa2ed1ae628c7283d4f902a9fcb611dbbff) | `` step-ca: 0.28.0 -> 0.28.1 ``                                                          |
| [`21cf8f98`](https://github.com/NixOS/nixpkgs/commit/21cf8f9842d66d4f2ccc8c7fcb3fd3013fcdfa23) | `` crd2pulumi: 1.5.3 -> 1.5.4 ``                                                         |
| [`d5f81093`](https://github.com/NixOS/nixpkgs/commit/d5f81093065906bb55c497b33687f571158373ca) | `` flarectl: 0.108.0 -> 0.111.0 ``                                                       |
| [`a0430003`](https://github.com/NixOS/nixpkgs/commit/a043000373a5bae01f7ae7a10ca413c1aca3e1c2) | `` vtm: 0.9.99.35 -> 0.9.99.55 ``                                                        |
| [`41331ec5`](https://github.com/NixOS/nixpkgs/commit/41331ec50715bc39b280ee6bcb410f25d7df13db) | `` gqlgenc: 0.25.3 -> 0.27.3 ``                                                          |
| [`8a97d662`](https://github.com/NixOS/nixpkgs/commit/8a97d662ddc24d839f19c5f4f9dba4ecf46d8f94) | `` nixos/hostapd: remove HT40- from default capabilities ``                              |
| [`45fe26aa`](https://github.com/NixOS/nixpkgs/commit/45fe26aaf8847951df2c1c97e845bee0177ac57b) | `` minijinja: 2.4.0 -> 2.5.0 ``                                                          |
| [`af6d0825`](https://github.com/NixOS/nixpkgs/commit/af6d0825caa50ed94722a01bf9ce97137a49a2f5) | `` ttags: 0.4.1 -> 0.4.2 ``                                                              |
| [`d2428f7e`](https://github.com/NixOS/nixpkgs/commit/d2428f7e442e2c1d8b2b83f83a823f07c5558dcd) | `` onedrive: patch missed paths ``                                                       |
| [`3b33901c`](https://github.com/NixOS/nixpkgs/commit/3b33901cff7b9aa5ba14100f09ec36628a4ae25a) | `` terraform-providers.archive: 2.6.0 -> 2.7.0 ``                                        |
| [`5d45a500`](https://github.com/NixOS/nixpkgs/commit/5d45a500ce076535b4d5341f16c6a43b3c6c5a15) | `` qtscrcpy: 2.2.1 -> 3.0.0 ``                                                           |
| [`3e191c86`](https://github.com/NixOS/nixpkgs/commit/3e191c86b4b0c3e28a75dc2e486432f8c5af9790) | `` mint-l-theme: 1.9.8 -> 1.9.9 ``                                                       |
| [`e889fb97`](https://github.com/NixOS/nixpkgs/commit/e889fb97d0642803dcd24e0307e08eeabd4bd61a) | `` python312Packages.sigstore: 3.5.1 -> 3.5.3 ``                                         |
| [`b79e67eb`](https://github.com/NixOS/nixpkgs/commit/b79e67eb6440063ea2672f37de8b5ff58d6ab5c8) | `` python312Packages.sigstore-rekor-types: 0.0.13 -> 0.0.17 ``                           |
| [`f0ca7ba5`](https://github.com/NixOS/nixpkgs/commit/f0ca7ba5581e0ea64d5a967d71114ce064f919bb) | `` python312Packages.securesystemslib: 1.1.0 -> 1.2.0 ``                                 |
| [`30a17658`](https://github.com/NixOS/nixpkgs/commit/30a17658ac99c5825fed38ceb4205678df9c2477) | `` python312Packages.mypy-boto3-s3: 1.35.74 -> 1.35.76 ``                                |
| [`0631a11e`](https://github.com/NixOS/nixpkgs/commit/0631a11eede0340af3f3654c96fc441493f6dbef) | `` python312Packages.pylamarzocco: 1.2.11 -> 1.3.2 ``                                    |
| [`36f4e01a`](https://github.com/NixOS/nixpkgs/commit/36f4e01add1e7e1cf8fdcf7485a0e3aa3b568877) | `` gpxsee: 13.26 -> 13.32 ``                                                             |
| [`ed650782`](https://github.com/NixOS/nixpkgs/commit/ed65078227d933e1632b1748c2a200a2b0a96cbb) | `` python312Packages.llama-cloud: 0.1.5 -> 0.1.6 ``                                      |
| [`190e90e9`](https://github.com/NixOS/nixpkgs/commit/190e90e9fe1500f3f9de89669d498dad7374ca8e) | `` python312Packages.llama-index-question-gen-openai: 0.2.0 -> 0.3.0 ``                  |
| [`f94c5444`](https://github.com/NixOS/nixpkgs/commit/f94c54447acf2f9d692d87ad98628e85dc611416) | `` python312Packages.llama-index-embeddings-ollama: relax ollama ``                      |
| [`e9a51c43`](https://github.com/NixOS/nixpkgs/commit/e9a51c43beeb141ae53e3c75638c4abcd365f687) | `` python312Packages.llama-index-program-openai: 0.2.0 -> 0.3.1 ``                       |
| [`efe65ae5`](https://github.com/NixOS/nixpkgs/commit/efe65ae5063ee65cb28a13dec8b7828484f7ba4b) | `` python312Packages.llama-index-readers-s3: 0.3.0 -> 0.4.0 ``                           |
| [`ada12612`](https://github.com/NixOS/nixpkgs/commit/ada1261254f084f22d8fc86278625e5cd507173b) | `` python312Packages.llama-index-llms-openai-like: 0.2.0 -> 0.3.0 ``                     |
| [`250f38e1`](https://github.com/NixOS/nixpkgs/commit/250f38e1d63a66a3eae485c70d2dbed42b77bd70) | `` python312Packages.llama-index-agent-openai: 0.3.4 -> 0.4.0 ``                         |
| [`e91b0011`](https://github.com/NixOS/nixpkgs/commit/e91b0011816f8dc91df41116aec4727a51a606ba) | `` python312Packages.llama-index-multi-modal-llms-openai: 0.2.3 -> 0.3.0 ``              |
| [`5eef17f8`](https://github.com/NixOS/nixpkgs/commit/5eef17f8999e26b0cfc84fd21d630fb7200764dd) | `` python312Packages.llama-index-llms-openai: 0.3.1 -> 0.3.2 ``                          |
| [`0e0f7788`](https://github.com/NixOS/nixpkgs/commit/0e0f7788233d980a281d384d155f9a971310c543) | `` python312Packages.llama-index-indices-managed-llama-cloud: 0.6.2 -> 0.6.3 ``          |
| [`4e878960`](https://github.com/NixOS/nixpkgs/commit/4e8789601f3b845f04ca88f8119e4ab1f9db3150) | `` python312Packages.llama-index-llms-ollama: 0.4.0 -> 0.4.1 ``                          |
| [`7fed8724`](https://github.com/NixOS/nixpkgs/commit/7fed8724d2f9fe3803352669f749210a54c2c778) | `` python312Packages.llama-index-vector-stores-postgres: 0.3.0 -> 0.3.2 ``               |
| [`501ebee4`](https://github.com/NixOS/nixpkgs/commit/501ebee47f1626519efe4ed6552b8b93b40b6a78) | `` python312Packages.llama-index-cli: 0.3.1 -> 0.4.0 ``                                  |
| [`e95e2179`](https://github.com/NixOS/nixpkgs/commit/e95e2179ee84886a18f18600d6fae56b8d091c4a) | `` python312Packages.llama-index-core: 0.12.1 -> 0.12.2 ``                               |
| [`66e137ca`](https://github.com/NixOS/nixpkgs/commit/66e137cacffc219595db7fe31ae4f3362c4dab83) | `` python312Packages.llama-index-embeddings-gemini: 0.2.2 -> 0.3.0 ``                    |
| [`b9790e52`](https://github.com/NixOS/nixpkgs/commit/b9790e52bd954ab11ff8dafe14993a944aa6c0b5) | `` python312Packages.llama-index-embeddings-google: 0.2.1 -> 0.3.0 ``                    |
| [`10196932`](https://github.com/NixOS/nixpkgs/commit/10196932892f89f05db50aadc3628aa5b1a02307) | `` python312Packages.llama-index-embeddings-huggingface: 0.3.1 -> 0.4.0 ``               |
| [`6fee9b26`](https://github.com/NixOS/nixpkgs/commit/6fee9b2698265f97a6c2c1f1bf2baa4f22ff55a5) | `` python312Packages.llama-index-embeddings-ollama: 0.3.1 -> 0.4.0 ``                    |
| [`de3d7e1b`](https://github.com/NixOS/nixpkgs/commit/de3d7e1b7b60a662c3cc099e08649ca0968c13dc) | `` python312Packages.llama-index-embeddings-openai: 0.2.5 -> 0.3.0 ``                    |
| [`6b69c4f7`](https://github.com/NixOS/nixpkgs/commit/6b69c4f77a59fd89cd59c803d70eb9590b4d1b44) | `` python312Packages.llama-index-graph-stores-nebula: 0.3.0 -> 0.4.0 ``                  |
| [`11f3a49b`](https://github.com/NixOS/nixpkgs/commit/11f3a49b2bf97023538872aca66f6b349a3aaa57) | `` python312Packages.llama-index-graph-stores-neo4j: 0.3.5 -> 0.4.0 ``                   |
| [`770be765`](https://github.com/NixOS/nixpkgs/commit/770be765cf9202be56124829229834b7fc84e74b) | `` python312Packages.llama-index-graph-stores-neptune: 0.2.2 -> 0.3.0 ``                 |
| [`c2b4b6f8`](https://github.com/NixOS/nixpkgs/commit/c2b4b6f877ae673c6cf8030203a3cdd68be085e0) | `` python312Packages.llama-index-indices-managed-llama-cloud: 0.4.0 -> 0.6.2 ``          |
| [`445745b7`](https://github.com/NixOS/nixpkgs/commit/445745b737957a37266afaabb49cb297fc3b5ad2) | `` python312Packages.llama-index-llms-ollama: 0.3.6 -> 0.4.0 ``                          |
| [`931ddfd2`](https://github.com/NixOS/nixpkgs/commit/931ddfd2ae9c40cba9357d908268ad9502d70b04) | `` python312Packages.llama-index-llms-openai: 0.2.16 -> 0.3.1 ``                         |
| [`f0f1aca5`](https://github.com/NixOS/nixpkgs/commit/f0f1aca558b6eeb05d7e170fa96c02242ff4126f) | `` python312Packages.llama-index-readers-database: 0.2.0 -> 0.3.0 ``                     |
| [`32fd961b`](https://github.com/NixOS/nixpkgs/commit/32fd961b84fe1add5845f51793760c5d69821ef0) | `` python312Packages.llama-index-readers-file: 0.3.0 -> 0.4.0 ``                         |
| [`0ca5eccb`](https://github.com/NixOS/nixpkgs/commit/0ca5eccb319787facd951e94960eb359c0c8a732) | `` python312Packages.llama-index-readers-json: 0.2.0 -> 0.3.0 ``                         |
| [`5eccc27f`](https://github.com/NixOS/nixpkgs/commit/5eccc27f85fc5bb8e404a05216dc0d90948cf228) | `` python312Packages.llama-index-readers-llama-parse: 0.3.0 -> 0.4.0 ``                  |
| [`9917a494`](https://github.com/NixOS/nixpkgs/commit/9917a494deec3f0ba24e26b4a1b76e1542bbe324) | `` python312Packages.llama-index-readers-twitter: 0.2.0 -> 0.3.0 ``                      |
| [`25495a31`](https://github.com/NixOS/nixpkgs/commit/25495a31da4475cba467b4ed9cf59154a86de17f) | `` python312Packages.llama-index-readers-txtai: 0.2.0 -> 0.3.0 ``                        |
| [`7ac3e82e`](https://github.com/NixOS/nixpkgs/commit/7ac3e82e7f2933319e256eb59e8ce6eb3bb7ee41) | `` python312Packages.llama-index-readers-weather: 0.2.0 -> 0.3.0 ``                      |
| [`07674991`](https://github.com/NixOS/nixpkgs/commit/07674991342243ebeac557b8693dc5efff148403) | `` python312Packages.llama-index-vector-stores-chroma: 0.3.0 -> 0.4.0 ``                 |
| [`626b683a`](https://github.com/NixOS/nixpkgs/commit/626b683a7123e1fc959fb355da62a3dc31fcd207) | `` python312Packages.chromadb: 0.5.18 -> 0.5.20 ``                                       |
| [`59bcfab9`](https://github.com/NixOS/nixpkgs/commit/59bcfab931ed492ad5281c5bef0d8dc3f83c26d1) | `` python312Packages.llama-index-vector-stores-google: 0.2.0 -> 0.3.0 ``                 |
| [`0fe6cbc6`](https://github.com/NixOS/nixpkgs/commit/0fe6cbc6facf19893035e194dc1a55f0dc9bbf32) | `` python312Packages.llama-index-vector-stores-postgres: 0.2.6 -> 0.3.0 ``               |
| [`bd7864fb`](https://github.com/NixOS/nixpkgs/commit/bd7864fb6cc62b03c705b782b5a30314d576be25) | `` python312Packages.llama-index-vector-stores-qdrant: 0.3.3 -> 0.4.0 ``                 |
| [`6abf3593`](https://github.com/NixOS/nixpkgs/commit/6abf35936b466edc4db48c899fe8144924f53a19) | `` python312Packages.llama-index-core: 0.11.23 -> 0.12.1 ``                              |
| [`301b8fe9`](https://github.com/NixOS/nixpkgs/commit/301b8fe9acddd568dfe4c09569cb263318bf83f4) | `` python312Packages.llama-cloud: 0.1.4 -> 0.1.5 ``                                      |
| [`411d15dc`](https://github.com/NixOS/nixpkgs/commit/411d15dc68efe762249f2f8bf97a7ff6c990652b) | `` python312Packages.weconnect: 0.60.5 -> 0.60.6 ``                                      |
| [`d1caef8c`](https://github.com/NixOS/nixpkgs/commit/d1caef8c5b77511547065c8debcae056f68ad637) | `` python312Packages.id: 1.4.0 -> 1.5.0 ``                                               |
| [`b0fed75a`](https://github.com/NixOS/nixpkgs/commit/b0fed75a832881dbb280306e818685fb94f693b1) | `` python312Packages.pontos: 24.9.0 -> 24.12.0 ``                                        |
| [`de0efdf7`](https://github.com/NixOS/nixpkgs/commit/de0efdf77900f1eb3aaaad840067f10465d0d1ab) | `` python312Packages.openrgb-python: 0.3.2 -> 0.3.3 ``                                   |
| [`cc2454d9`](https://github.com/NixOS/nixpkgs/commit/cc2454d93246a037671e3d744d0de2389335ce25) | `` python312Packages.fastcore: 1.7.22 -> 1.7.23 ``                                       |
| [`612abc0c`](https://github.com/NixOS/nixpkgs/commit/612abc0c6783081fa97050ca3835a80037d434ad) | `` python312Packages.autoslot: refactor ``                                               |
| [`0d023171`](https://github.com/NixOS/nixpkgs/commit/0d02317114092677683463029686bb6e9515d4a0) | `` python312Packages.autoslot: 2022.12.1 -> 2024.12.1 ``                                 |
| [`2d3107bd`](https://github.com/NixOS/nixpkgs/commit/2d3107bd028f9b730f422b0506f57c4a8482a11b) | `` python312Packages.asyncmy: 0.2.9 -> 0.2.10 ``                                         |
| [`29159115`](https://github.com/NixOS/nixpkgs/commit/291591157d1e42092b8eed4bcec0e2b76d7e233e) | `` python312Packages.aiortm: 0.9.38 -> 0.9.42 ``                                         |
| [`cc6febd7`](https://github.com/NixOS/nixpkgs/commit/cc6febd78974a2ffd90c1258b892ac8030bae12f) | `` python312Packages.aioopenexchangerates: 0.6.17 -> 0.6.18 ``                           |
| [`a01ee2f7`](https://github.com/NixOS/nixpkgs/commit/a01ee2f7f3e0f33f6738b6f49d24d3653a415682) | `` terraform-providers.spacelift: 1.16.1 -> 1.19.0 ``                                    |
| [`ab29891a`](https://github.com/NixOS/nixpkgs/commit/ab29891a1995da35290337b51b073cb08f76429b) | `` terraform-providers.incus: 0.1.4 -> 0.2.0 ``                                          |
| [`4c0bbe32`](https://github.com/NixOS/nixpkgs/commit/4c0bbe324e862584eb738f4317bd4f27555f8dde) | `` terraform-providers.hcloud: 1.48.1 -> 1.49.1 ``                                       |
| [`2943e975`](https://github.com/NixOS/nixpkgs/commit/2943e975f3c2971f623e52662f807809e08e07cf) | `` python312Packages.aioesphomeapi: 27.0.1 -> 28.0.0 ``                                  |
| [`f1426205`](https://github.com/NixOS/nixpkgs/commit/f1426205cee60dc3f98da50eac5dbf4411ace3a4) | `` python312Packages.hass-nabucasa: 0.83.0 -> 0.86.0 ``                                  |
| [`ff1502b9`](https://github.com/NixOS/nixpkgs/commit/ff1502b97d8902e4b4f0bd21b8ba024fbcbec9d0) | `` chsrc: init at 0.1.9 ``                                                               |
| [`01532839`](https://github.com/NixOS/nixpkgs/commit/015328399ec733874282b9bc8855bca7db650e73) | `` home-assistant-custom-lovelace-modules.vacuum-card: init at 2.10.1 ``                 |
| [`da61cc23`](https://github.com/NixOS/nixpkgs/commit/da61cc23b502e83459619f540c34466faa4444b6) | `` ad-miner: 1.6.1 -> 1.7.0 ``                                                           |
| [`7e81a7f7`](https://github.com/NixOS/nixpkgs/commit/7e81a7f76dc141fab4dff07d6b750b4ea589c18b) | `` home-assistant-custom-components.homematicip_local: 1.72.0 -> 1.73.0 ``               |
| [`05c78a80`](https://github.com/NixOS/nixpkgs/commit/05c78a8045d67279a3b2a6e2510fb81375b931ed) | `` python312Packages.hahomematic: 2024.11.8 -> 2024.12.0 ``                              |
| [`5d029a72`](https://github.com/NixOS/nixpkgs/commit/5d029a72b3ac5f013580075ce33027224c406516) | `` sile: mark broken on darwin ``                                                        |
| [`5edc28db`](https://github.com/NixOS/nixpkgs/commit/5edc28dbabaae835c1ad7e3c97984c44e8d9828a) | `` sile: drop obsolete workaround for fetchCargoTarball triggering configure ``          |
| [`5017d412`](https://github.com/NixOS/nixpkgs/commit/5017d412385266a90430d3a07853dedb0dd5f664) | `` git-warp-time: drop obsolete workaround for fetchCargoTarball triggering configure `` |
| [`9bde82f5`](https://github.com/NixOS/nixpkgs/commit/9bde82f503b18120f1b04c1b76076ab23abd45c1) | `` decasify: drop obsolete workaround for fetchCargoTarball triggering configure ``      |
| [`dd7d0b79`](https://github.com/NixOS/nixpkgs/commit/dd7d0b79b508f175c0a1be4bd5e984ae8a79fba7) | `` dbeaver-bin: 24.2.3 -> 24.3.0 ``                                                      |
| [`674835a9`](https://github.com/NixOS/nixpkgs/commit/674835a9d98fd037c8f6ce1c954b5e07e56b0832) | `` chromium: remove ofborg maintainer ping workaround, use CODEOWNERS ``                 |