### PR TITLE
chore(flake/home-manager): `65912bc6` -> `d00c6f6d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -327,11 +327,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733389730,
-        "narHash": "sha256-KZMu4ddMll5khS0rYkJsVD0hVqjMNHlhTM3PCQar0Ag=",
+        "lastModified": 1733484277,
+        "narHash": "sha256-i5ay20XsvpW91N4URET/nOc0VQWOAd4c4vbqYtcH8Rc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "65912bc6841cf420eb8c0a20e03df7cbbff5963f",
+        "rev": "d00c6f6d0ad16d598bf7e2956f52c1d9d5de3c3a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                     |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`d00c6f6d`](https://github.com/nix-community/home-manager/commit/d00c6f6d0ad16d598bf7e2956f52c1d9d5de3c3a) | `` nix: simplify tests ``                   |
| [`63eb786e`](https://github.com/nix-community/home-manager/commit/63eb786e047fbb101041103f86162cd72d105d79) | `` xresources: simplify tests ``            |
| [`0b42cc1b`](https://github.com/nix-community/home-manager/commit/0b42cc1b1c7a38f32334f217eadbc7b83b3ef44c) | `` cmus: reduce test closure ``             |
| [`953521f7`](https://github.com/nix-community/home-manager/commit/953521f759fd746190ae2d2d052183296425b27b) | `` fcitx5: fix package reference in test `` |