### PR TITLE
chore(flake/emacs-overlay): `e3ac055c` -> `b5d8ba00`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1733473330,
-        "narHash": "sha256-u+omEO2O4TaUIxOCkCBbgYC9piLN4NEiq/nYwB8hCRY=",
+        "lastModified": 1733502201,
+        "narHash": "sha256-hqNroABR/MHZwnSsNPFTsK0KtGHyIMPiGWsnAXjgaC0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e3ac055c27f9268a294c911578c7cb04c087c7ab",
+        "rev": "b5d8ba006311a92e22d93e59086f888b24a17508",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`b5d8ba00`](https://github.com/nix-community/emacs-overlay/commit/b5d8ba006311a92e22d93e59086f888b24a17508) | `` Updated elpa ``   |
| [`fe3384fe`](https://github.com/nix-community/emacs-overlay/commit/fe3384fe7e2047fa055005a99c43dca830bc7508) | `` Updated nongnu `` |