### PR TITLE
chore(flake/emacs-overlay): `a10b59f7` -> `f583e369`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1733534443,
-        "narHash": "sha256-nWqAToFnyYuzkRZc7FAWsjaTEULVJTn3Zdwgs1Tq47g=",
+        "lastModified": 1733591475,
+        "narHash": "sha256-xdGGGZ8ZsTr6XbPb1N8pnK73hugkdlPwM5Iz8umcXTY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a10b59f755abef2a8b2c9f077f109764bb4b208b",
+        "rev": "f583e3691e30db811c8a5b9d45cdf433dba1bccd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`f583e369`](https://github.com/nix-community/emacs-overlay/commit/f583e3691e30db811c8a5b9d45cdf433dba1bccd) | `` Updated emacs ``  |
| [`f75bb35a`](https://github.com/nix-community/emacs-overlay/commit/f75bb35a27b207eed7c1430d21995fabf68ea190) | `` Updated melpa ``  |
| [`8668b468`](https://github.com/nix-community/emacs-overlay/commit/8668b46808a0117cda69acf9d61d17ac2ab374b5) | `` Updated elpa ``   |
| [`81fe8f6c`](https://github.com/nix-community/emacs-overlay/commit/81fe8f6c2ac036290e7c37f6a96a9e4a3b730ce9) | `` Updated nongnu `` |