### PR TITLE
chore(flake/emacs-overlay): `f583e369` -> `d3f55c97`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1733591475,
-        "narHash": "sha256-xdGGGZ8ZsTr6XbPb1N8pnK73hugkdlPwM5Iz8umcXTY=",
+        "lastModified": 1733621237,
+        "narHash": "sha256-VssGAIF33aFHe+U7DaT9jSHjETD25rVWaW/Y+IWMrSI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f583e3691e30db811c8a5b9d45cdf433dba1bccd",
+        "rev": "d3f55c978e1faef8940ab52b580bb8a2c3f68cef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`d3f55c97`](https://github.com/nix-community/emacs-overlay/commit/d3f55c978e1faef8940ab52b580bb8a2c3f68cef) | `` Updated elpa ``   |
| [`7d21d337`](https://github.com/nix-community/emacs-overlay/commit/7d21d337e27c51435bb1d55f7b14aa6358303f66) | `` Updated nongnu `` |