### PR TITLE
chore(flake/nix-index-database): `6e0b7f81` -> `f1e477a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -483,11 +483,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733024876,
-        "narHash": "sha256-vy9Q41hBE7Zg0yakF79neVgb3i3PQMSMR7uHPpPywFE=",
+        "lastModified": 1733629314,
+        "narHash": "sha256-U0vivjQFAwjNDYt49Krevs1murX9hKBFe2Ye0cHpgbU=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "6e0b7f81367069589a480b91603a10bcf71f3103",
+        "rev": "f1e477a7dd11e27e7f98b646349cd66bbabf2fb8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`f1e477a7`](https://github.com/nix-community/nix-index-database/commit/f1e477a7dd11e27e7f98b646349cd66bbabf2fb8) | `` update generated.nix to release 2024-12-08-032901 `` |
| [`871d3049`](https://github.com/nix-community/nix-index-database/commit/871d304912084543002cd90a32d5ccc3f88b30f5) | `` flake.lock: Update ``                                |