### PR TITLE
chore(flake/git-hooks): `6f4e2a21` -> `d8c02f0f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -307,11 +307,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1733318908,
-        "narHash": "sha256-SVQVsbafSM1dJ4fpgyBqLZ+Lft+jcQuMtEL3lQWx2Sk=",
+        "lastModified": 1733665616,
+        "narHash": "sha256-+XTFXYlFJBxohhMGLDpYdEnhUNdxN8dyTA8WAd+lh2A=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "6f4e2a2112050951a314d2733a994fbab94864c6",
+        "rev": "d8c02f0ffef0ef39f6063731fc539d8c71eb463a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                        |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`b6d9d72d`](https://github.com/cachix/git-hooks.nix/commit/b6d9d72d3dcedbe564a0c5ad47d311a0bc6a6563) | `` feat: support cargo/runtime dependencies `` |