### PR TITLE
chore(flake/treefmt): `50862ba6` -> `357cda84`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1022,11 +1022,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733440889,
-        "narHash": "sha256-qKL3vjO+IXFQ0nTinFDqNq/sbbnnS5bMI1y0xX215fU=",
+        "lastModified": 1733662930,
+        "narHash": "sha256-9qOp6jNdezzLMxwwXaXZWPXosHbNqno+f7Ii/xftqZ8=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "50862ba6a8a0255b87377b9d2d4565e96f29b410",
+        "rev": "357cda84af1d74626afb7fb3bc12d6957167cda9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                               |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`629be24f`](https://github.com/numtide/treefmt-nix/commit/629be24f6330f013b013a61abe2d866e43c87aba) | `` escape names in formatter names `` |