### PR TITLE
chore(flake/emacs-overlay): `d3f55c97` -> `af0d3635`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1733621237,
-        "narHash": "sha256-VssGAIF33aFHe+U7DaT9jSHjETD25rVWaW/Y+IWMrSI=",
+        "lastModified": 1733674853,
+        "narHash": "sha256-V1DSHrN8cRMZ0N5pB1gTEw41nWkX9Qtmze1Tp9zYgcM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d3f55c978e1faef8940ab52b580bb8a2c3f68cef",
+        "rev": "af0d36350388a62326d8dd78952bd99767a32fb3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`af0d3635`](https://github.com/nix-community/emacs-overlay/commit/af0d36350388a62326d8dd78952bd99767a32fb3) | `` Updated elpa ``         |
| [`b2882beb`](https://github.com/nix-community/emacs-overlay/commit/b2882bebd48a348f17873aaddf9b0a8ecf573bbf) | `` Updated nongnu ``       |
| [`c5cad68c`](https://github.com/nix-community/emacs-overlay/commit/c5cad68c66a0e4eb2f98c91f5aa356acd8ef3200) | `` Updated flake inputs `` |