### PR TITLE
chore(flake/emacs-overlay): `af0d3635` -> `9df047f0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1733674853,
-        "narHash": "sha256-V1DSHrN8cRMZ0N5pB1gTEw41nWkX9Qtmze1Tp9zYgcM=",
+        "lastModified": 1733710411,
+        "narHash": "sha256-IGJ+rHxK0m0tSr5mVOczDJXH9D13T+48taKr2bFD764=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "af0d36350388a62326d8dd78952bd99767a32fb3",
+        "rev": "9df047f0cd70ac7a2c0fa4750394f07677ca3860",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`9df047f0`](https://github.com/nix-community/emacs-overlay/commit/9df047f0cd70ac7a2c0fa4750394f07677ca3860) | `` Updated emacs ``  |
| [`37481613`](https://github.com/nix-community/emacs-overlay/commit/37481613849f600a38307e29ea25184ec889ea4f) | `` Updated melpa ``  |
| [`004d589f`](https://github.com/nix-community/emacs-overlay/commit/004d589f0433676c2e044729435486ac8ba5fe06) | `` Updated elpa ``   |
| [`fadb2265`](https://github.com/nix-community/emacs-overlay/commit/fadb2265e02959662db0cb34872846f1e6f998ae) | `` Updated nongnu `` |