### PR TITLE
chore(flake/srvos): `6047d415` -> `aa9ae0b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -957,11 +957,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733365027,
-        "narHash": "sha256-Vl0pOGckECuFoMbiotwj65jjoFE8Mc2yUXNIllttxkI=",
+        "lastModified": 1733706349,
+        "narHash": "sha256-+V546s1ivi6epTinVhKhdx8h0r9Oiq2Lx4q+KDDqTTw=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "6047d415ca8dc7eae73dd17c832f7dc08ad544f4",
+        "rev": "aa9ae0b6b140410704e064b88d1f23a285bfd03e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`aa9ae0b6`](https://github.com/nix-community/srvos/commit/aa9ae0b6b140410704e064b88d1f23a285bfd03e) | `` format tree ``                    |
| [`8f4235b1`](https://github.com/nix-community/srvos/commit/8f4235b1be5eb6f283b553326b24e68adeaeffb7) | `` dev/private/flake.lock: Update `` |
| [`f970b2d7`](https://github.com/nix-community/srvos/commit/f970b2d707e15c371314f0872e5b5823eb5fd213) | `` flake.lock: Update ``             |