### PR TITLE
chore(flake/emacs-overlay): `9df047f0` -> `5801bf52`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1733710411,
-        "narHash": "sha256-IGJ+rHxK0m0tSr5mVOczDJXH9D13T+48taKr2bFD764=",
+        "lastModified": 1733736037,
+        "narHash": "sha256-J+l1D+/hcp4LkEvOdYn17dcDvRN1JEcfF54pNgXUoag=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9df047f0cd70ac7a2c0fa4750394f07677ca3860",
+        "rev": "5801bf5202cd0fea8637d3891040669f46813a95",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`5801bf52`](https://github.com/nix-community/emacs-overlay/commit/5801bf5202cd0fea8637d3891040669f46813a95) | `` Updated emacs `` |
| [`59141957`](https://github.com/nix-community/emacs-overlay/commit/591419570c52573c2285ccb083cb916f0ad7d95f) | `` Updated melpa `` |