### PR TITLE
chore(flake/emacs-overlay): `5801bf52` -> `c4de2fd2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1733736037,
-        "narHash": "sha256-J+l1D+/hcp4LkEvOdYn17dcDvRN1JEcfF54pNgXUoag=",
+        "lastModified": 1733793776,
+        "narHash": "sha256-IKVxMIwXNzaij8oZVoVmcR2QX5nCnh7SnVFJ5pujtXs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5801bf5202cd0fea8637d3891040669f46813a95",
+        "rev": "c4de2fd2fe16d3cfff15d2db0e2b684972a82012",
         "type": "github"
       },
       "original": {
@@ -653,11 +653,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1733412085,
-        "narHash": "sha256-FillH0qdWDt/nlO6ED7h4cmN+G9uXwGjwmCnHs0QVYM=",
+        "lastModified": 1733550349,
+        "narHash": "sha256-NcGumB4Lr6KSDq+nIqXtNA8QwAQKDSZT7N9OTGWbTrs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4dc2fc4e62dbf62b84132fe526356fbac7b03541",
+        "rev": "e2605d0744c2417b09f8bf850dfca42fcf537d34",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`c4de2fd2`](https://github.com/nix-community/emacs-overlay/commit/c4de2fd2fe16d3cfff15d2db0e2b684972a82012) | `` Updated elpa ``         |
| [`10234b60`](https://github.com/nix-community/emacs-overlay/commit/10234b60c7ea22a618f936b0545675982163f1dd) | `` Updated nongnu ``       |
| [`4f8045e9`](https://github.com/nix-community/emacs-overlay/commit/4f8045e953c68f261e2b870507f2a9e6c35a5629) | `` Updated emacs ``        |
| [`ca3a1267`](https://github.com/nix-community/emacs-overlay/commit/ca3a12671632965263c18e19a84ff2cb094ebffb) | `` Updated melpa ``        |
| [`68fddf69`](https://github.com/nix-community/emacs-overlay/commit/68fddf69137e3d5354765401d86e071ee1b97849) | `` Updated elpa ``         |
| [`e76d3a74`](https://github.com/nix-community/emacs-overlay/commit/e76d3a7447ebc92942769a9ec5d2cdfa34190af4) | `` Updated nongnu ``       |
| [`c4ff56a2`](https://github.com/nix-community/emacs-overlay/commit/c4ff56a2fe6f0e36fe84dcdf137c4a67fcaaf9ca) | `` Updated flake inputs `` |