### PR TITLE
chore(flake/treefmt): `357cda84` -> `0ce9d149`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1022,11 +1022,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733662930,
-        "narHash": "sha256-9qOp6jNdezzLMxwwXaXZWPXosHbNqno+f7Ii/xftqZ8=",
+        "lastModified": 1733761991,
+        "narHash": "sha256-s4DalCDepD22jtKL5Nw6f4LP5UwoMcPzPZgHWjAfqbQ=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "357cda84af1d74626afb7fb3bc12d6957167cda9",
+        "rev": "0ce9d149d99bc383d1f2d85f31f6ebd146e46085",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                             |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`0ce9d149`](https://github.com/numtide/treefmt-nix/commit/0ce9d149d99bc383d1f2d85f31f6ebd146e46085) | `` 🆙 Include all opentofu-compatible files for Terraform (#275) `` |