### PR TITLE
chore(flake/sops-nix): `c6134b6f` -> `a80af892`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -937,11 +937,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733128155,
-        "narHash": "sha256-m6/qwJAJYcidGMEdLqjKzRIjapK4nUfMq7rDCTmZajc=",
+        "lastModified": 1733785344,
+        "narHash": "sha256-pm4cfEcPXripE36PYCl0A2Tu5ruwHEvTee+HzNk+SQE=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c6134b6fff6bda95a1ac872a2a9d5f32e3c37856",
+        "rev": "a80af8929781b5fe92ddb8ae52e9027fae780d2a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                           |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`a80af892`](https://github.com/Mic92/sops-nix/commit/a80af8929781b5fe92ddb8ae52e9027fae780d2a) | `` update vendorHash ``                                           |
| [`1bb029c8`](https://github.com/Mic92/sops-nix/commit/1bb029c84f2f81bd1d509c4d6493d859fe3cdb4d) | `` build(deps): bump golang.org/x/crypto from 0.29.0 to 0.30.0 `` |
| [`1d0c71cb`](https://github.com/Mic92/sops-nix/commit/1d0c71cbf50be07b6add12d9111cba261ae1e10e) | `` update vendorHash ``                                           |
| [`84d8bf5b`](https://github.com/Mic92/sops-nix/commit/84d8bf5ba8806b069d716cd6336987edb2e5701f) | `` build(deps): bump golang.org/x/sys from 0.27.0 to 0.28.0 ``    |