### PR TITLE
chore(flake/nur): `82d9e1f8` -> `53cda286`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -824,11 +824,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1733780835,
-        "narHash": "sha256-wl1MFn822rfgNb/smnJL4KVZkxxe94x8eh/0bQ7sAjw=",
+        "lastModified": 1733803852,
+        "narHash": "sha256-LR0Ty42EoWAdj2TYTwudVR6GiBALhxH3hDwk3f8dt6Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "82d9e1f8ceb6575856a86ac887ef165509ac531c",
+        "rev": "53cda286de8fd2b1b32124d80a6ae1637d626aa7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`53cda286`](https://github.com/nix-community/NUR/commit/53cda286de8fd2b1b32124d80a6ae1637d626aa7) | `` automatic update `` |
| [`bc8799ce`](https://github.com/nix-community/NUR/commit/bc8799cebc9781815321dafbc39ef093d88654bd) | `` automatic update `` |
| [`b4e1ae05`](https://github.com/nix-community/NUR/commit/b4e1ae053d8ed51aa7c4aec714a588e33da6ca95) | `` automatic update `` |
| [`55344b49`](https://github.com/nix-community/NUR/commit/55344b49dccb58cc6ff4c2c60a00578c5799e276) | `` automatic update `` |