### PR TITLE
chore(flake/nur): `53cda286` -> `633f5a8d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -824,11 +824,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1733803852,
-        "narHash": "sha256-LR0Ty42EoWAdj2TYTwudVR6GiBALhxH3hDwk3f8dt6Y=",
+        "lastModified": 1733816803,
+        "narHash": "sha256-zca4MzlBvdztDtE/9YlMSdIaDn0e3geVhuioA/u/2l0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "53cda286de8fd2b1b32124d80a6ae1637d626aa7",
+        "rev": "633f5a8d50fe0e930319ed17a60b41f27c779a06",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`633f5a8d`](https://github.com/nix-community/NUR/commit/633f5a8d50fe0e930319ed17a60b41f27c779a06) | `` automatic update `` |
| [`90b609d1`](https://github.com/nix-community/NUR/commit/90b609d176bc8f0f97211d9843854a06b240e710) | `` automatic update `` |
| [`c8471f93`](https://github.com/nix-community/NUR/commit/c8471f9325f2520461d6a5a9b628add719950732) | `` automatic update `` |
| [`2eb5bf0b`](https://github.com/nix-community/NUR/commit/2eb5bf0b68d47b0c7fee73bc056f3410e81a0ce6) | `` automatic update `` |
| [`f631a904`](https://github.com/nix-community/NUR/commit/f631a904a3fd53fa01f114a3ad5b97e45389e1a1) | `` automatic update `` |
| [`9fa1c283`](https://github.com/nix-community/NUR/commit/9fa1c28369b8cc5fe1e21cb86d81b6a844bbb609) | `` automatic update `` |
| [`b54fa3d8`](https://github.com/nix-community/NUR/commit/b54fa3d8c020e077d88be036a12a711b84fe2031) | `` automatic update `` |