### PR TITLE
chore(flake/home-manager): `e952e949` -> `f26aa4b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -348,11 +348,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733769654,
-        "narHash": "sha256-aVvYDt8eitZVF6fdOrSoIzYRkQ5Gh6kfRvqkiaDRLL0=",
+        "lastModified": 1733873195,
+        "narHash": "sha256-dTosiZ3sZ/NKoLKQ++v8nZdEHya0eTNEsaizNp+MUPM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e952e94955dcc6fa2120c1430789fc41363f5237",
+        "rev": "f26aa4b76fb7606127032d33ac73d7d507d82758",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`f26aa4b7`](https://github.com/nix-community/home-manager/commit/f26aa4b76fb7606127032d33ac73d7d507d82758) | `` gpg-agent: fix GCR DBus package note ``          |
| [`c6a5fbfd`](https://github.com/nix-community/home-manager/commit/c6a5fbfd99bccfafbe99a6bb87b351c8fb7de70a) | `` qt: install kio when qt.platformTheme = "kde" `` |
| [`8772bae5`](https://github.com/nix-community/home-manager/commit/8772bae58c0a1390727aaf13802debfa29757d67) | `` nushell: allow installing plugins ``             |