### PR TITLE
chore(flake/nixos-hardware): `e563803a` -> `cf737e2e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -580,11 +580,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1733481457,
-        "narHash": "sha256-IS3bxa4N1VMSh3/P6vhEAHQZecQ3oAlKCDvzCQSO5Is=",
+        "lastModified": 1733861262,
+        "narHash": "sha256-+jjPup/ByS0LEVIrBbt7FnGugJgLeG9oc+ivFASYn2U=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "e563803af3526852b6b1d77107a81908c66a9fcf",
+        "rev": "cf737e2eba82b603f54f71b10cb8fd09d22ce3f5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                 |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`cf737e2e`](https://github.com/NixOS/nixos-hardware/commit/cf737e2eba82b603f54f71b10cb8fd09d22ce3f5) | `` apple/t2: kernel 6.12.2 -> 6.12.4 `` |