### PR TITLE
chore(flake/emacs-overlay): `af7f5d0e` -> `f8ae6558`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1733847939,
-        "narHash": "sha256-VGMfFL0N+d8JoeDpPThVScVl+e+oqJmCIQuYO2cjVfU=",
+        "lastModified": 1733880107,
+        "narHash": "sha256-FfeY6r0pcHHiMOhuyH8W64U5dpOI6o+DIg7+DVzEnTI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "af7f5d0e6d69bc40777e56c86f568ae997aee9e2",
+        "rev": "f8ae6558b7d7fb3493937cab280b6869a9195621",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`f8ae6558`](https://github.com/nix-community/emacs-overlay/commit/f8ae6558b7d7fb3493937cab280b6869a9195621) | `` Updated elpa ``   |
| [`5177ee9d`](https://github.com/nix-community/emacs-overlay/commit/5177ee9d0c33b0f91b97ece0cdfd855c06f8734c) | `` Updated nongnu `` |