### PR TITLE
chore(flake/catppuccin): `23191822` -> `f47bf8bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1733869110,
-        "narHash": "sha256-MJ/EYyrqTUMTSIhPdGQkbAiBk6QP58GpPEzsAIfNugg=",
+        "lastModified": 1733900652,
+        "narHash": "sha256-g2A9sNPPaumDzb2jNd2h8eiKzlwmlFzO1qymaq2GovU=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "231918224d0ba4101a3f369cb911e838d1511692",
+        "rev": "f47bf8bbec54f721b0b5282e6bcfa85888b822dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                       |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`f47bf8bb`](https://github.com/catppuccin/nix/commit/f47bf8bbec54f721b0b5282e6bcfa85888b822dd) | `` docs: link to new options search (#401) `` |