### PR TITLE
chore(flake/emacs-overlay): `0dddcfd8` -> `07a18388`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1733905386,
-        "narHash": "sha256-VJDG7N8w0VGnQWmT5THMOOijEtj9jQIWbXu6s4QqwBw=",
+        "lastModified": 1733966495,
+        "narHash": "sha256-XVAFR00ChfywHJG3v47AOVaCOM8Xcst0zxI/6qyBrxo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0dddcfd81e140abb46d5b11cffe9007fb2ed120a",
+        "rev": "07a183880b1f5bc1c18bbf3583fab17b94b2a110",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`07a18388`](https://github.com/nix-community/emacs-overlay/commit/07a183880b1f5bc1c18bbf3583fab17b94b2a110) | `` Updated elpa ``   |
| [`efe61b09`](https://github.com/nix-community/emacs-overlay/commit/efe61b09c9e49fefcb2694f651711b7d29ef6734) | `` Updated nongnu `` |
| [`f8f3d406`](https://github.com/nix-community/emacs-overlay/commit/f8f3d40658939bffde17781dbfbc97757780d26f) | `` Updated elpa ``   |
| [`752aba94`](https://github.com/nix-community/emacs-overlay/commit/752aba94340a2bd08547fdbd35828b4deb65a916) | `` Updated nongnu `` |