### PR TITLE
chore(flake/sops-nix): `a80af892` -> `ed091321`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -863,11 +863,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733785344,
-        "narHash": "sha256-pm4cfEcPXripE36PYCl0A2Tu5ruwHEvTee+HzNk+SQE=",
+        "lastModified": 1734546875,
+        "narHash": "sha256-6OvJbqQ6qPpNw3CA+W8Myo5aaLhIJY/nNFDk3zMXLfM=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "a80af8929781b5fe92ddb8ae52e9027fae780d2a",
+        "rev": "ed091321f4dd88afc28b5b4456e0a15bd8374b4d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                           |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`ed091321`](https://github.com/Mic92/sops-nix/commit/ed091321f4dd88afc28b5b4456e0a15bd8374b4d) | `` update vendorHash ``                                           |
| [`9eb29d2b`](https://github.com/Mic92/sops-nix/commit/9eb29d2bd42681d71e7abd4bfd9bc6a84dd11356) | `` build(deps): bump filippo.io/age from 1.1.1 to 1.2.1 ``        |
| [`2d73fc6a`](https://github.com/Mic92/sops-nix/commit/2d73fc6ac4eba4b9a83d3cb8275096fbb7ab4004) | `` update vendorHash ``                                           |
| [`5803825c`](https://github.com/Mic92/sops-nix/commit/5803825c93add84c93540c616ff35c286e0e6d4c) | `` build(deps): bump golang.org/x/crypto from 0.30.0 to 0.31.0 `` |