### PR TITLE
chore(flake/srvos): `aa9ae0b6` -> `04f4200a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -957,11 +957,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733706349,
-        "narHash": "sha256-+V546s1ivi6epTinVhKhdx8h0r9Oiq2Lx4q+KDDqTTw=",
+        "lastModified": 1733965925,
+        "narHash": "sha256-hPXtCGEna+jerXrednMwjVuBV/AqrSAVida0yTTRMqE=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "aa9ae0b6b140410704e064b88d1f23a285bfd03e",
+        "rev": "04f4200ac3a4eee62f9065b1f35010a382adfc6a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`04f4200a`](https://github.com/nix-community/srvos/commit/04f4200ac3a4eee62f9065b1f35010a382adfc6a) | `` dev/private/flake.lock: Update `` |
| [`67902566`](https://github.com/nix-community/srvos/commit/6790256601a5a15ffa8e9bb8511c7c92fc15224e) | `` flake.lock: Update ``             |