### PR TITLE
chore(flake/home-manager): `6e5b2d9e` -> `3066cc58`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -348,11 +348,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733951607,
-        "narHash": "sha256-CN6q6iCzxI1gkNyk4xLdwaMKi10r7n+aJkRzWj8PXwQ=",
+        "lastModified": 1734043726,
+        "narHash": "sha256-e9YAMReFV1fDPcZLFC2pa4k/8TloSXeX0z2VysNMAoA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6e5b2d9e8014b5572e3367937a329e7053458d34",
+        "rev": "3066cc58f552421a2c5414e78407fa5603405b1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                            |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`3066cc58`](https://github.com/nix-community/home-manager/commit/3066cc58f552421a2c5414e78407fa5603405b1e) | `` kanshi: dont write config in absence of nix settings (#6198) `` |
| [`e526fd2b`](https://github.com/nix-community/home-manager/commit/e526fd2b1a40e4ca0b5e07e87b8c960281c67412) | `` gnome-shell: fix extensions' default (#6199) ``                 |
| [`15151bb5`](https://github.com/nix-community/home-manager/commit/15151bb5e7d6e352247ecaeeeefc34d0f306b287) | `` gpg: fix hash of test (#6200) ``                                |