### PR TITLE
chore(flake/catppuccin): `5dfc780a` -> `20b6328d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1733908662,
-        "narHash": "sha256-vuyqYX91/kEs+oYAw0az5A/JHeIX8hrv06WtLmhfZ5A=",
+        "lastModified": 1734057772,
+        "narHash": "sha256-waF/2Y39JXJ4kG3zawmw1J1GxPHopyoOkJKJhfJ7RBs=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "5dfc780ad24353d01161c3c5784200ef042019af",
+        "rev": "20b6328df20ae45752c81311d225fd47cba32483",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                     |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`20b6328d`](https://github.com/catppuccin/nix/commit/20b6328df20ae45752c81311d225fd47cba32483) | `` style: format 24421fc ``                                 |
| [`24421fce`](https://github.com/catppuccin/nix/commit/24421fceb3edebf366576711f0c9fee5a46a60cc) | `` chore: bump minimum supported release to 24.11 (#386) `` |
| [`7e17c694`](https://github.com/catppuccin/nix/commit/7e17c6946516d6599b9ccd4b04447e6567506a1e) | `` chore: bump dev flake to v1.1.1 (#404) ``                |
| [`7221d6ca`](https://github.com/catppuccin/nix/commit/7221d6ca17ac36ed20588e1c3a80177ac5843fa7) | `` chore: v1.1.1 (#402) ``                                  |