### PR TITLE
chore(flake/emacs-overlay): `be04ea9c` -> `f51080de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1734078131,
-        "narHash": "sha256-ReoTgf7fEvXdDUL9137GMPhF4NptvwMwmaCfBM0Vt7M=",
+        "lastModified": 1734106980,
+        "narHash": "sha256-pVHr6CR1hgaG1oIfiBqvqNVs3MR77XUjer3r7kBFvhg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "be04ea9ce6b2bfdddcfb1871dc4a983abc73e690",
+        "rev": "f51080decb05dfc8cda1138ad9bfe87c6d0310ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`f51080de`](https://github.com/nix-community/emacs-overlay/commit/f51080decb05dfc8cda1138ad9bfe87c6d0310ff) | `` Updated elpa ``   |
| [`29923fea`](https://github.com/nix-community/emacs-overlay/commit/29923fea47e5a6067ba52d02607c3806fb1c28c8) | `` Updated nongnu `` |