### PR TITLE
chore(flake/emacs-overlay): `f51080de` -> `25858d10`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1734106980,
-        "narHash": "sha256-pVHr6CR1hgaG1oIfiBqvqNVs3MR77XUjer3r7kBFvhg=",
+        "lastModified": 1734282840,
+        "narHash": "sha256-+WVCZU0j9cpxm5brqwZPsmUrVCtym920RAKvSuhrlT0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f51080decb05dfc8cda1138ad9bfe87c6d0310ff",
+        "rev": "25858d10419fdc307aa562695fd5bf3c8c2ec80d",
         "type": "github"
       },
       "original": {
@@ -581,11 +581,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1733808091,
-        "narHash": "sha256-KWwINTQelKOoQgrXftxoqxmKFZb9pLVfnRvK270nkVk=",
+        "lastModified": 1734083684,
+        "narHash": "sha256-5fNndbndxSx5d+C/D0p/VF32xDiJCJzyOqorOYW4JEo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a0f3e10d94359665dba45b71b4227b0aeb851f8e",
+        "rev": "314e12ba369ccdb9b352a4db26ff419f7c49fa84",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                          |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`25858d10`](https://github.com/nix-community/emacs-overlay/commit/25858d10419fdc307aa562695fd5bf3c8c2ec80d) | `` Updated emacs ``                              |
| [`f44e9866`](https://github.com/nix-community/emacs-overlay/commit/f44e986695256fa0fde8ef7198c5633e8adfba5f) | `` Updated melpa ``                              |
| [`2ce90473`](https://github.com/nix-community/emacs-overlay/commit/2ce904731649301654f34f2f638daf6a4473857a) | `` Updated elpa ``                               |
| [`fd8a73c6`](https://github.com/nix-community/emacs-overlay/commit/fd8a73c6082986dcbe32f91a9e8bb16fb4639a9c) | `` Updated nongnu ``                             |
| [`5822823c`](https://github.com/nix-community/emacs-overlay/commit/5822823cf2fbead676f26629d8f3ad0f907f574d) | `` Updated flake inputs ``                       |
| [`d6353ce8`](https://github.com/nix-community/emacs-overlay/commit/d6353ce807b7845ffec114d234c90ece44c39122) | `` Updated melpa ``                              |
| [`76e6bf04`](https://github.com/nix-community/emacs-overlay/commit/76e6bf04179ade0b79079f395d642a41348eb78e) | `` Updated emacs ``                              |
| [`3409e86b`](https://github.com/nix-community/emacs-overlay/commit/3409e86b5731cfa81321b30de003aab27e20c6c2) | `` Updated melpa ``                              |
| [`5b94691f`](https://github.com/nix-community/emacs-overlay/commit/5b94691f623a763ffd48f9784e00293656586d0f) | `` Updated elpa ``                               |
| [`b44c20e8`](https://github.com/nix-community/emacs-overlay/commit/b44c20e8fe4d20222d26d4b54e17b955052b363a) | `` Updated nongnu ``                             |
| [`917e9c73`](https://github.com/nix-community/emacs-overlay/commit/917e9c735316551eaac9bc47d1cf0de18540da87) | `` Updated flake inputs ``                       |
| [`e621b262`](https://github.com/nix-community/emacs-overlay/commit/e621b2624bed4ada7b997845de10537152ba522b) | `` Updated emacs ``                              |
| [`399d8b3e`](https://github.com/nix-community/emacs-overlay/commit/399d8b3e2121615993b09636d421733b30dcc0ba) | `` Updated melpa ``                              |
| [`e465cb34`](https://github.com/nix-community/emacs-overlay/commit/e465cb34d54fc7c637af703f6adb50ec2ade3245) | `` Updated elpa ``                               |
| [`a960c044`](https://github.com/nix-community/emacs-overlay/commit/a960c04475a6eebdec1f6057e27224aa4c0c7842) | `` Updated nongnu ``                             |
| [`6c65dad3`](https://github.com/nix-community/emacs-overlay/commit/6c65dad3a545b08c9d5cc4632f6ce6442aa3d33f) | `` Updated emacs ``                              |
| [`c335c009`](https://github.com/nix-community/emacs-overlay/commit/c335c0094b99e8fd6ab1dcd29efe3bcc88b7da6b) | `` Updated melpa ``                              |
| [`7b68c5b0`](https://github.com/nix-community/emacs-overlay/commit/7b68c5b041f0dc12d45470e66418a706464bf79d) | `` README: clarify `emacsExtraPackages` usage `` |
| [`4310724e`](https://github.com/nix-community/emacs-overlay/commit/4310724e208e868521b0f34795d42668bd8f9cdb) | `` Updated emacs ``                              |
| [`91394111`](https://github.com/nix-community/emacs-overlay/commit/91394111f9fad62bd7c909dcdb149d4cf4594487) | `` Updated melpa ``                              |
| [`91734080`](https://github.com/nix-community/emacs-overlay/commit/91734080b60643d2c9cca288d0dcec77a1e0fce7) | `` Updated elpa ``                               |
| [`9404f94f`](https://github.com/nix-community/emacs-overlay/commit/9404f94f50ab55f0ce075ad06719cfff90e93c16) | `` Updated nongnu ``                             |