### PR TITLE
chore(flake/nur): `de0a49b0` -> `5b2e0112`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -752,11 +752,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1734126962,
-        "narHash": "sha256-bb0c5eR95pJnpIb99/DYO5kAFuAPSNM2zbl59F+m3o4=",
+        "lastModified": 1734148847,
+        "narHash": "sha256-R6b8wAsem6xtriGbjkR8sevqJDZW/PgUO3RoM1YYjCo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "de0a49b0139bb55f049eba2a8db26006846f322d",
+        "rev": "5b2e0112c60183ecab8b2d25b3006e1bbc3079c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5b2e0112`](https://github.com/nix-community/NUR/commit/5b2e0112c60183ecab8b2d25b3006e1bbc3079c6) | `` automatic update `` |
| [`d6b5477e`](https://github.com/nix-community/NUR/commit/d6b5477eea757f5cae03c47da3fbe2f7be0b9f17) | `` automatic update `` |
| [`0a769f94`](https://github.com/nix-community/NUR/commit/0a769f94417536b76c57010cb5d7b55af820d479) | `` automatic update `` |
| [`445d1d51`](https://github.com/nix-community/NUR/commit/445d1d51aaab73744e633af963951f7a34cd955c) | `` automatic update `` |
| [`790ba51f`](https://github.com/nix-community/NUR/commit/790ba51f04ffd55a391903408afde3790b472334) | `` automatic update `` |