### PR TITLE
chore(flake/nur): `5b2e0112` -> `3a6a25e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -752,11 +752,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1734148847,
-        "narHash": "sha256-R6b8wAsem6xtriGbjkR8sevqJDZW/PgUO3RoM1YYjCo=",
+        "lastModified": 1734161914,
+        "narHash": "sha256-ExfXU3QblJezWnfHSxKSe5k4zC08jfuNvwZxDOtKSOY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5b2e0112c60183ecab8b2d25b3006e1bbc3079c6",
+        "rev": "3a6a25e030e226a50877d6b9bd64f6743c4ebb0a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3a6a25e0`](https://github.com/nix-community/NUR/commit/3a6a25e030e226a50877d6b9bd64f6743c4ebb0a) | `` automatic update `` |
| [`0bdd9b77`](https://github.com/nix-community/NUR/commit/0bdd9b77cfbec795c65d2144d248509dd10feab9) | `` automatic update `` |
| [`c250676a`](https://github.com/nix-community/NUR/commit/c250676a75f38030d840e82929ae68eb00f63d59) | `` automatic update `` |
| [`3cf0182e`](https://github.com/nix-community/NUR/commit/3cf0182e397010be9aca4f88a77bea8092a6c4e3) | `` automatic update `` |
| [`c6e35fa5`](https://github.com/nix-community/NUR/commit/c6e35fa57553f303e38482ed766573589ffb2462) | `` automatic update `` |
| [`5f1f8146`](https://github.com/nix-community/NUR/commit/5f1f8146e2cc3c9202d7dfcc4b5ce8131537408c) | `` automatic update `` |