### PR TITLE
chore(flake/nur): `3a6a25e0` -> `5fef0822`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -752,11 +752,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1734161914,
-        "narHash": "sha256-ExfXU3QblJezWnfHSxKSe5k4zC08jfuNvwZxDOtKSOY=",
+        "lastModified": 1734176737,
+        "narHash": "sha256-YMRsoc3813iClOkeWDR9BdVRB8Cvv/jRhLBSE//1tZw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3a6a25e030e226a50877d6b9bd64f6743c4ebb0a",
+        "rev": "5fef0822ac7b4537cd89bc8aafaec7925cf18797",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5fef0822`](https://github.com/nix-community/NUR/commit/5fef0822ac7b4537cd89bc8aafaec7925cf18797) | `` automatic update `` |
| [`e06a083e`](https://github.com/nix-community/NUR/commit/e06a083e1258845c7c8bcd5f4dcc2aab9964318c) | `` automatic update `` |
| [`b2d3b4b5`](https://github.com/nix-community/NUR/commit/b2d3b4b5ffefcae64f54e811e204421689b3235c) | `` automatic update `` |
| [`a1dbdc64`](https://github.com/nix-community/NUR/commit/a1dbdc64e1debaa57f6df003a4f8c0a9089f0f9f) | `` automatic update `` |