### PR TITLE
chore(flake/nur): `5fef0822` -> `12bcdb7c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -752,11 +752,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1734176737,
-        "narHash": "sha256-YMRsoc3813iClOkeWDR9BdVRB8Cvv/jRhLBSE//1tZw=",
+        "lastModified": 1734221225,
+        "narHash": "sha256-PQtNGbg3B93+MINMe4/mwYWZkVDNzaf+O2Hw7xDznNk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5fef0822ac7b4537cd89bc8aafaec7925cf18797",
+        "rev": "12bcdb7c86a2598761a7e2ada1b1e6cd7542197c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`12bcdb7c`](https://github.com/nix-community/NUR/commit/12bcdb7c86a2598761a7e2ada1b1e6cd7542197c) | `` automatic update `` |
| [`314305cd`](https://github.com/nix-community/NUR/commit/314305cdada0cc1ed581eebc3c52c10212bb9d86) | `` automatic update `` |
| [`f2d6c9fd`](https://github.com/nix-community/NUR/commit/f2d6c9fd0abce648bf52cfb0348bf6afbf7fe733) | `` automatic update `` |
| [`88a9fa0d`](https://github.com/nix-community/NUR/commit/88a9fa0d28f97fde9e3fd2d0c222d2adb977fe37) | `` automatic update `` |
| [`e47e15ee`](https://github.com/nix-community/NUR/commit/e47e15ee1015c505fd0a0eb38811cb1f7880445d) | `` automatic update `` |
| [`5879d7d5`](https://github.com/nix-community/NUR/commit/5879d7d512ecc6d4fc25cdce2f288c0cf3b818d0) | `` automatic update `` |
| [`ce95daef`](https://github.com/nix-community/NUR/commit/ce95daefbf418c90c8c9dd77d295937debb83e2d) | `` automatic update `` |
| [`cc04e1f2`](https://github.com/nix-community/NUR/commit/cc04e1f2ef06dcff746205d460c2374466a2c463) | `` automatic update `` |
| [`23c2979c`](https://github.com/nix-community/NUR/commit/23c2979ced3b4a5124f618180a69c6ad5bd3d182) | `` automatic update `` |
| [`e6a189b2`](https://github.com/nix-community/NUR/commit/e6a189b201c880d258a1a1613c294da1450bb17a) | `` automatic update `` |
| [`ea0d3874`](https://github.com/nix-community/NUR/commit/ea0d387462d43cfd6496d1241d69df2476db5ef3) | `` automatic update `` |