### PR TITLE
chore(flake/nur): `12bcdb7c` -> `836d7ff8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -752,11 +752,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1734221225,
-        "narHash": "sha256-PQtNGbg3B93+MINMe4/mwYWZkVDNzaf+O2Hw7xDznNk=",
+        "lastModified": 1734235518,
+        "narHash": "sha256-/2yY+YoIIqO5LQbINUshkrskM/hdgZn/nXNlav2G1Ek=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "12bcdb7c86a2598761a7e2ada1b1e6cd7542197c",
+        "rev": "836d7ff8617a64b228fb4ace8ab7c12c4ba83ba0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`836d7ff8`](https://github.com/nix-community/NUR/commit/836d7ff8617a64b228fb4ace8ab7c12c4ba83ba0) | `` automatic update `` |
| [`e89cfd48`](https://github.com/nix-community/NUR/commit/e89cfd48ac18c70b78a92e9b400885cbf27d8290) | `` automatic update `` |
| [`6ceca7c9`](https://github.com/nix-community/NUR/commit/6ceca7c98b9df63423b8f381aaa6f6c062fb61c6) | `` automatic update `` |