### PR TITLE
chore(flake/nur): `af8d074c` -> `fa60ccb1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -661,11 +661,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1733940404,
-        "narHash": "sha256-Pj39hSoUA86ZePPF/UXiYHHM7hMIkios8TYG29kQT4g=",
+        "lastModified": 1734119587,
+        "narHash": "sha256-AKU6qqskl0yf2+JdRdD0cfxX4b9x3KKV5RqA6wijmPM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
+        "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
         "type": "github"
       },
       "original": {
@@ -752,11 +752,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1734275363,
-        "narHash": "sha256-2HVv7IrDZkJoV0cjviOkIfmM05kyQKdh98DjrUPXGgM=",
+        "lastModified": 1734494689,
+        "narHash": "sha256-OKFgj5KRK3RQegBBwaD62voS/MT9brOOMxv4OAHQaYM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "af8d074caa7e5d7e55a774cff52d21d7161451c1",
+        "rev": "fa60ccb1d491d97bbd45649fede43a4d81926bc0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                      |
| -------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`fa60ccb1`](https://github.com/nix-community/NUR/commit/fa60ccb1d491d97bbd45649fede43a4d81926bc0) | `` automatic update ``                       |
| [`53f2f3b9`](https://github.com/nix-community/NUR/commit/53f2f3b914dc24e28c3cc1bebb8498044e1fda54) | `` automatic update ``                       |
| [`8078133e`](https://github.com/nix-community/NUR/commit/8078133e33b94077a415a858da25551dbd741de0) | `` automatic update ``                       |
| [`24a04cb0`](https://github.com/nix-community/NUR/commit/24a04cb00533ff6bd9098d303a789764afe81193) | `` automatic update ``                       |
| [`3daad120`](https://github.com/nix-community/NUR/commit/3daad120c11819c17c0caafec032c096b5d3f407) | `` automatic update ``                       |
| [`2f963f03`](https://github.com/nix-community/NUR/commit/2f963f0368a9a0928cc0bff1617c4fd007a994f6) | `` add cvtx repository ``                    |
| [`41b5fcf5`](https://github.com/nix-community/NUR/commit/41b5fcf5d5f4fb1286663987b3813f43a160aa4b) | `` automatic update ``                       |
| [`d4aba0b1`](https://github.com/nix-community/NUR/commit/d4aba0b137b5a6b444c3a4f4052f2b3f29097c4b) | `` automatic update ``                       |
| [`b753f48a`](https://github.com/nix-community/NUR/commit/b753f48a95a43b5ddaa37ade6dd7fa032704955b) | `` automatic update ``                       |
| [`1c5f0d8d`](https://github.com/nix-community/NUR/commit/1c5f0d8d6dcb3ccae32a97286e84b7b429bc3ca2) | `` automatic update ``                       |
| [`5f37c665`](https://github.com/nix-community/NUR/commit/5f37c66585d5c978b2f42ac5a23dd74f215a0b30) | `` automatic update ``                       |
| [`4a74c3ac`](https://github.com/nix-community/NUR/commit/4a74c3ace066a6e98f9fe118f5812b2aebe672f3) | `` automatic update ``                       |
| [`6df25dc1`](https://github.com/nix-community/NUR/commit/6df25dc17e9c708bee5866a23d6974be4f90b332) | `` automatic update ``                       |
| [`43fccb72`](https://github.com/nix-community/NUR/commit/43fccb728c9fa1db8b3abe1817ebdb016593c92c) | `` automatic update ``                       |
| [`19276920`](https://github.com/nix-community/NUR/commit/1927692024afaad74ef35096c66b03e7a3c35887) | `` automatic update ``                       |
| [`4cbefda7`](https://github.com/nix-community/NUR/commit/4cbefda7b0adf10110a901115222907910a9e8c4) | `` automatic update ``                       |
| [`1e9c9570`](https://github.com/nix-community/NUR/commit/1e9c957044041ee37162ed409e70d6850f1dfd08) | `` automatic update ``                       |
| [`999ac103`](https://github.com/nix-community/NUR/commit/999ac103e196209d0012dfbcc38c71a1e8610215) | `` automatic update ``                       |
| [`3756c04c`](https://github.com/nix-community/NUR/commit/3756c04cd4829c712a6e8077334cedba5b654be8) | `` automatic update ``                       |
| [`863f8664`](https://github.com/nix-community/NUR/commit/863f86643df36b79f4c439a8076bec5cb7e6d358) | `` automatic update ``                       |
| [`a748295a`](https://github.com/nix-community/NUR/commit/a748295aae47da4905716b0b57c78528392cf6eb) | `` automatic update ``                       |
| [`e769b1f1`](https://github.com/nix-community/NUR/commit/e769b1f18c059468aa6e7b1603d7b2bb776fa350) | `` automatic update ``                       |
| [`00037f20`](https://github.com/nix-community/NUR/commit/00037f20ce8c5501130b2ba90c2c8da1ac6f9e24) | `` automatic update ``                       |
| [`5d0daa5a`](https://github.com/nix-community/NUR/commit/5d0daa5a8d76e1d3f603ee1a45646c820290e8b9) | `` automatic update ``                       |
| [`01a59d82`](https://github.com/nix-community/NUR/commit/01a59d82d0fba7cfa92deab23241a2e6b22c5d82) | `` automatic update ``                       |
| [`081940ad`](https://github.com/nix-community/NUR/commit/081940ad8fa838350b572386584fbe63a0ca6fcb) | `` automatic update ``                       |
| [`4bb63c4c`](https://github.com/nix-community/NUR/commit/4bb63c4c7ee2eb895a9c17c7e3a3252586f3ffa2) | `` automatic update ``                       |
| [`dd0547bb`](https://github.com/nix-community/NUR/commit/dd0547bbb746d13c2a42c749dc577db96a0194d6) | `` automatic update ``                       |
| [`92b7f8e4`](https://github.com/nix-community/NUR/commit/92b7f8e4f3d08bf14a43b319765c08b059a0f131) | `` automatic update ``                       |
| [`981c0b5c`](https://github.com/nix-community/NUR/commit/981c0b5c80449e76733d400d4ec988de85f246d9) | `` automatic update ``                       |
| [`cf9f90b2`](https://github.com/nix-community/NUR/commit/cf9f90b23617c67e6027aa25520c6ffc5266eb2b) | `` automatic update ``                       |
| [`3e5068d3`](https://github.com/nix-community/NUR/commit/3e5068d3b206b5618394785690ecc0efff7942d5) | `` automatic update ``                       |
| [`664aa06e`](https://github.com/nix-community/NUR/commit/664aa06e6c457a343faa82db6d4bac60d7d9f01c) | `` automatic update ``                       |
| [`da1b6cc2`](https://github.com/nix-community/NUR/commit/da1b6cc2a1733db9e6716d38c47df6a08c2ba76c) | `` add tuckershea/nur-packages repository `` |
| [`561671c3`](https://github.com/nix-community/NUR/commit/561671c3ffe3d7380a0a76d07a9c294a3df40d49) | `` automatic update ``                       |
| [`da2a7536`](https://github.com/nix-community/NUR/commit/da2a753678dd619a92280e78784ef1d09de242e3) | `` automatic update ``                       |
| [`547facf8`](https://github.com/nix-community/NUR/commit/547facf8dc54f4d93421851d0c0a6d77d954e324) | `` automatic update ``                       |
| [`897de016`](https://github.com/nix-community/NUR/commit/897de016b3bb85087aabbf92de81611066c14272) | `` automatic update ``                       |
| [`6202335d`](https://github.com/nix-community/NUR/commit/6202335d06a2d6ad046ac749db26198313593a11) | `` automatic update ``                       |
| [`48d6835f`](https://github.com/nix-community/NUR/commit/48d6835f1b7869ccbb18035b697c9263fd02a452) | `` automatic update ``                       |
| [`5df64595`](https://github.com/nix-community/NUR/commit/5df645957a273092020683752611818db6ba131d) | `` automatic update ``                       |
| [`e1479d2a`](https://github.com/nix-community/NUR/commit/e1479d2af2196165607e5a449b2764c31e010e57) | `` automatic update ``                       |
| [`5a7ef65d`](https://github.com/nix-community/NUR/commit/5a7ef65d4502d7e932c25b15e6a7b7dcd7f62380) | `` automatic update ``                       |
| [`63678806`](https://github.com/nix-community/NUR/commit/636788065a20eef93ce0a0d61af740dd295c1c62) | `` automatic update ``                       |
| [`b6a20761`](https://github.com/nix-community/NUR/commit/b6a2076164c1d00cc484db13c4e6c5ee4346da80) | `` automatic update ``                       |
| [`e7c7da3e`](https://github.com/nix-community/NUR/commit/e7c7da3e78ce8653826d5c2880c53c7a4b59a30b) | `` automatic update ``                       |
| [`748a6f77`](https://github.com/nix-community/NUR/commit/748a6f77abb0a1eb070d22b8e4ccf1e036d135a9) | `` automatic update ``                       |
| [`b9d0fea7`](https://github.com/nix-community/NUR/commit/b9d0fea7b68b81f7a40235bae82dd776445ef5ef) | `` automatic update ``                       |
| [`4833b8af`](https://github.com/nix-community/NUR/commit/4833b8af92d7d12bd89379b3ae870d862bcd09b0) | `` automatic update ``                       |
| [`5d4ce816`](https://github.com/nix-community/NUR/commit/5d4ce8162326e2cd6b27ac4f9b19e3e1cfbfbb0a) | `` automatic update ``                       |
| [`b39f0a9b`](https://github.com/nix-community/NUR/commit/b39f0a9b5a3a70a4259a1ba4ea438620b1a40322) | `` automatic update ``                       |
| [`3d3b39db`](https://github.com/nix-community/NUR/commit/3d3b39dbfb201d65fb8c2ee2a0cf6b1ada87a8dc) | `` automatic update ``                       |
| [`0ea46f67`](https://github.com/nix-community/NUR/commit/0ea46f67fcb0f73e625f15df9b7ec68224191d33) | `` automatic update ``                       |
| [`aad4a659`](https://github.com/nix-community/NUR/commit/aad4a65913445ed9cb6496b79bcc75e303523208) | `` automatic update ``                       |
| [`1a9a1b15`](https://github.com/nix-community/NUR/commit/1a9a1b150d04344e86e834af7716dfc7070f7b58) | `` automatic update ``                       |
| [`6c6346ec`](https://github.com/nix-community/NUR/commit/6c6346ecf69b32fc020784314a074b60dd1a2fd6) | `` automatic update ``                       |
| [`83ee9902`](https://github.com/nix-community/NUR/commit/83ee99021147a51a78ee1150c7fe1c3836f8bb06) | `` automatic update ``                       |
| [`48de1acb`](https://github.com/nix-community/NUR/commit/48de1acb50ca9389b057aa6bd4ec5b6014db1652) | `` add hhr2020 repository ``                 |
| [`3ec8fe0c`](https://github.com/nix-community/NUR/commit/3ec8fe0cbd3c544b680e3ded49c29dee4db0bd5c) | `` automatic update ``                       |
| [`fef3c39c`](https://github.com/nix-community/NUR/commit/fef3c39c97c93f61f53f5b1579bcc4d857235245) | `` automatic update ``                       |