### PR TITLE
chore(flake/emacs-overlay): `25858d10` -> `fce2b622`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1734282840,
-        "narHash": "sha256-+WVCZU0j9cpxm5brqwZPsmUrVCtym920RAKvSuhrlT0=",
+        "lastModified": 1734315266,
+        "narHash": "sha256-k6ekQwIK/TASoPwTyeY2JiBHzwmPZSLGrYNXF+fLhC8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "25858d10419fdc307aa562695fd5bf3c8c2ec80d",
+        "rev": "fce2b6224adae5f9b6d43d74ecb996a3133a63f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`fce2b622`](https://github.com/nix-community/emacs-overlay/commit/fce2b6224adae5f9b6d43d74ecb996a3133a63f4) | `` Updated emacs ``  |
| [`c4a9ede6`](https://github.com/nix-community/emacs-overlay/commit/c4a9ede6cd03cbb2e3530f9b0aea5d2ec001c13d) | `` Updated melpa ``  |
| [`41d1f2ae`](https://github.com/nix-community/emacs-overlay/commit/41d1f2ae395516cd6024d573716a40168fd2377e) | `` Updated elpa ``   |
| [`1836c396`](https://github.com/nix-community/emacs-overlay/commit/1836c396d3b2b051e1cef8fad3d23bdc7cd939f0) | `` Updated nongnu `` |