### PR TITLE
chore(flake/emacs-overlay): `fce2b622` -> `c4908cd5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1734315266,
-        "narHash": "sha256-k6ekQwIK/TASoPwTyeY2JiBHzwmPZSLGrYNXF+fLhC8=",
+        "lastModified": 1734355561,
+        "narHash": "sha256-ZdWqrGn+4f2kZT19ZiRvDNFpoBsGZp9cLytAqunZUyU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fce2b6224adae5f9b6d43d74ecb996a3133a63f4",
+        "rev": "c4908cd54234341a1faa15e55f673fc60a34b9d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                       |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------- |
| [`8823d476`](https://github.com/nix-community/emacs-overlay/commit/8823d476190cdaebc8d6c8bcf664b0179935e20d) | `` Revert "Disable webkit2gtk integration" `` |
| [`3eb85a97`](https://github.com/nix-community/emacs-overlay/commit/3eb85a97f21d14e125364b022acf7f0d197859a9) | `` Updated emacs ``                           |
| [`cdd908f4`](https://github.com/nix-community/emacs-overlay/commit/cdd908f4c350b85a43a277d6a0916fd26a458d4e) | `` Updated melpa ``                           |