### PR TITLE
chore(flake/nixos-hardware): `cf737e2e` -> `b12e3147`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -508,11 +508,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1733861262,
-        "narHash": "sha256-+jjPup/ByS0LEVIrBbt7FnGugJgLeG9oc+ivFASYn2U=",
+        "lastModified": 1734352517,
+        "narHash": "sha256-mfv+J/vO4nqmIOlq8Y1rRW8hVsGH3M+I2ESMjhuebDs=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "cf737e2eba82b603f54f71b10cb8fd09d22ce3f5",
+        "rev": "b12e314726a4226298fe82776b4baeaa7bcf3dcd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                          |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`b12e3147`](https://github.com/NixOS/nixos-hardware/commit/b12e314726a4226298fe82776b4baeaa7bcf3dcd) | `` microsoft/surface: Update to kernel 6.12.4 `` |