### PR TITLE
chore(flake/git-hooks): `aa9f40c9` -> `0bb4be58`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -274,11 +274,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1734279981,
-        "narHash": "sha256-NdaCraHPp8iYMWzdXAt5Nv6sA3MUzlCiGiR586TCwo0=",
+        "lastModified": 1734379367,
+        "narHash": "sha256-Keu8z5VgT5gnCF4pmB+g7XZFftHpfl4qOn7nqBcywdE=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "aa9f40c906904ebd83da78e7f328cd8aeaeae785",
+        "rev": "0bb4be58f21ff38fc3cdbd6c778eb67db97f0b99",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`96209c15`](https://github.com/cachix/git-hooks.nix/commit/96209c15446f3fa6985306fbb9034635cf69c1fc) | `` Throw a pretty error if the hooks cannot be sorted `` |
| [`4d562428`](https://github.com/cachix/git-hooks.nix/commit/4d562428f8bfebae5504f6189acef68833a6450d) | `` Simplify internal `before`/`after` code ``            |