### PR TITLE
chore(flake/emacs-overlay): `c4908cd5` -> `519b67fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1734355561,
-        "narHash": "sha256-ZdWqrGn+4f2kZT19ZiRvDNFpoBsGZp9cLytAqunZUyU=",
+        "lastModified": 1734369337,
+        "narHash": "sha256-hUX63V5zo5uqlnV+QSZsiSrvbuRG3Nh49gzJ9DegEXU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c4908cd54234341a1faa15e55f673fc60a34b9d6",
+        "rev": "519b67faa4da472a390c579a7310d296994b62f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                        |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------- |
| [`519b67fa`](https://github.com/nix-community/emacs-overlay/commit/519b67faa4da472a390c579a7310d296994b62f1) | `` Reapply "Disable webkit2gtk integration" `` |
| [`2ecfec26`](https://github.com/nix-community/emacs-overlay/commit/2ecfec265881bf624527e5e25e7bd6fdd5be86ca) | `` Updated elpa ``                             |
| [`fe83961a`](https://github.com/nix-community/emacs-overlay/commit/fe83961a65b4ed4cd76ddd22653a8fe5a0039041) | `` Updated nongnu ``                           |