### PR TITLE
chore(flake/emacs-overlay): `519b67fa` -> `08c065bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1734369337,
-        "narHash": "sha256-hUX63V5zo5uqlnV+QSZsiSrvbuRG3Nh49gzJ9DegEXU=",
+        "lastModified": 1734427318,
+        "narHash": "sha256-NQ1bI/iV5N7zGcfFd0+SYdh4O5EYBzJ7mTR9j6K1QWQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "519b67faa4da472a390c579a7310d296994b62f1",
+        "rev": "08c065bf80654e214e8ded2d27b0dea39c66f452",
         "type": "github"
       },
       "original": {
@@ -581,11 +581,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1734083684,
-        "narHash": "sha256-5fNndbndxSx5d+C/D0p/VF32xDiJCJzyOqorOYW4JEo=",
+        "lastModified": 1734323986,
+        "narHash": "sha256-m/lh6hYMIWDYHCAsn81CDAiXoT3gmxXI9J987W5tZrE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "314e12ba369ccdb9b352a4db26ff419f7c49fa84",
+        "rev": "394571358ce82dff7411395829aa6a3aad45b907",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`08c065bf`](https://github.com/nix-community/emacs-overlay/commit/08c065bf80654e214e8ded2d27b0dea39c66f452) | `` Updated emacs ``        |
| [`3b18975e`](https://github.com/nix-community/emacs-overlay/commit/3b18975e9d8bcef2e44bddd063f6edc829f7db86) | `` Updated melpa ``        |
| [`840a2fa3`](https://github.com/nix-community/emacs-overlay/commit/840a2fa3e9d546ecbcc080ee13bf6aa0e8697b10) | `` Updated flake inputs `` |
| [`c098c637`](https://github.com/nix-community/emacs-overlay/commit/c098c63704be5ebcaba15d0f1273395c44482417) | `` Updated emacs ``        |
| [`291e2700`](https://github.com/nix-community/emacs-overlay/commit/291e270067fe4bd4f375ac253c90ecc33df7fab1) | `` Updated melpa ``        |
| [`36387a83`](https://github.com/nix-community/emacs-overlay/commit/36387a83305573dcb2c9e63272247f0124742e8a) | `` Updated elpa ``         |
| [`28e282ca`](https://github.com/nix-community/emacs-overlay/commit/28e282ca970d1ee9f946a032af5feb1ad88c9267) | `` Updated nongnu ``       |