### PR TITLE
chore(flake/catppuccin): `20b6328d` -> `21310cde`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1734057772,
-        "narHash": "sha256-waF/2Y39JXJ4kG3zawmw1J1GxPHopyoOkJKJhfJ7RBs=",
+        "lastModified": 1734397929,
+        "narHash": "sha256-VCTVpU/RlrI9StxzDnqc1R3ZTQloLVALSkiN/Fgiad4=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "20b6328df20ae45752c81311d225fd47cba32483",
+        "rev": "21310cde33d3ee8023679dec01a9724a346c63ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                    |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`21310cde`](https://github.com/catppuccin/nix/commit/21310cde33d3ee8023679dec01a9724a346c63ff) | `` refactor(modules): cleanup module importing and lib injection (#385) `` |