### PR TITLE
chore(flake/emacs-overlay): `08c065bf` -> `7932d8e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1734427318,
-        "narHash": "sha256-NQ1bI/iV5N7zGcfFd0+SYdh4O5EYBzJ7mTR9j6K1QWQ=",
+        "lastModified": 1734456142,
+        "narHash": "sha256-mSGDni1iJzHgNS04eiFM8u3d8IB8ziyNuf1A/YU+eWE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "08c065bf80654e214e8ded2d27b0dea39c66f452",
+        "rev": "7932d8e1fa38eb94ab264469e915c5f04393f7a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`7932d8e1`](https://github.com/nix-community/emacs-overlay/commit/7932d8e1fa38eb94ab264469e915c5f04393f7a1) | `` Updated emacs ``  |
| [`9254eba9`](https://github.com/nix-community/emacs-overlay/commit/9254eba974b1e099d97fe91eed0075c785da588e) | `` Updated melpa ``  |
| [`8714a74f`](https://github.com/nix-community/emacs-overlay/commit/8714a74fbec707661f7fadf573e68e79722a3476) | `` Updated elpa ``   |
| [`1c9b6dc2`](https://github.com/nix-community/emacs-overlay/commit/1c9b6dc2d30a073658e7dafc69a3c26ce3d2de02) | `` Updated nongnu `` |