### PR TITLE
chore(flake/emacs-overlay): `7932d8e1` -> `c52319c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1734456142,
-        "narHash": "sha256-mSGDni1iJzHgNS04eiFM8u3d8IB8ziyNuf1A/YU+eWE=",
+        "lastModified": 1734488063,
+        "narHash": "sha256-tyWwlPhPw5TQgU44hOflykBjzizbpDMlU0UX7Aba6mU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7932d8e1fa38eb94ab264469e915c5f04393f7a1",
+        "rev": "c52319c9046fdc812035dae70ce0a238eaab71dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`c52319c9`](https://github.com/nix-community/emacs-overlay/commit/c52319c9046fdc812035dae70ce0a238eaab71dd) | `` Updated emacs ``  |
| [`150225c0`](https://github.com/nix-community/emacs-overlay/commit/150225c0e793dc783835bff826b8375344241154) | `` Updated melpa ``  |
| [`6b727713`](https://github.com/nix-community/emacs-overlay/commit/6b72771305f2fdd691844ca7c29d93d6511afcde) | `` Updated elpa ``   |
| [`1f75789b`](https://github.com/nix-community/emacs-overlay/commit/1f75789b2f199e398e1c6e7c64a8e50c48a27677) | `` Updated nongnu `` |