### PR TITLE
chore(flake/nur): `fa60ccb1` -> `b239382e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -752,11 +752,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1734494689,
-        "narHash": "sha256-OKFgj5KRK3RQegBBwaD62voS/MT9brOOMxv4OAHQaYM=",
+        "lastModified": 1734522319,
+        "narHash": "sha256-1soPdbp9R1t2Vwp96Pr0FqJJEFD4/w3oYyEuwheHlMM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fa60ccb1d491d97bbd45649fede43a4d81926bc0",
+        "rev": "b239382e0673b333d1d2ac8ac8c3369ab85d3e8e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b239382e`](https://github.com/nix-community/NUR/commit/b239382e0673b333d1d2ac8ac8c3369ab85d3e8e) | `` automatic update `` |
| [`f084b98a`](https://github.com/nix-community/NUR/commit/f084b98a5ea7bf830197f41119441d30e7ef1c66) | `` automatic update `` |
| [`d4b924a6`](https://github.com/nix-community/NUR/commit/d4b924a6b5e809d6ad3ea6bb3332f3cc1e530954) | `` automatic update `` |
| [`8fdeedcd`](https://github.com/nix-community/NUR/commit/8fdeedcd24d5b73758ccf5993b36acce85e484af) | `` automatic update `` |
| [`b8b3fcbd`](https://github.com/nix-community/NUR/commit/b8b3fcbd00fbd6857acc41928c8246bad83dc7bd) | `` automatic update `` |
| [`5ad08842`](https://github.com/nix-community/NUR/commit/5ad0884223ed949cd5b0800666320b982d082143) | `` automatic update `` |