### PR TITLE
chore(flake/emacs-overlay): `c52319c9` -> `d7697bf2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1734488063,
-        "narHash": "sha256-tyWwlPhPw5TQgU44hOflykBjzizbpDMlU0UX7Aba6mU=",
+        "lastModified": 1734515037,
+        "narHash": "sha256-+DiZ5e6iZEawmqgpwLjP709pkXyuvSApmXkjYnY4yqE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c52319c9046fdc812035dae70ce0a238eaab71dd",
+        "rev": "d7697bf2004fcb6508d3bf146e94fff59ecb2db9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`d7697bf2`](https://github.com/nix-community/emacs-overlay/commit/d7697bf2004fcb6508d3bf146e94fff59ecb2db9) | `` Updated emacs `` |
| [`d01d3ee3`](https://github.com/nix-community/emacs-overlay/commit/d01d3ee3253454934b08ca4cc801baa81ade8e8a) | `` Updated melpa `` |