### PR TITLE
chore(flake/emacs-overlay): `d7697bf2` -> `b501185a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1734515037,
-        "narHash": "sha256-+DiZ5e6iZEawmqgpwLjP709pkXyuvSApmXkjYnY4yqE=",
+        "lastModified": 1734543168,
+        "narHash": "sha256-v7tqM+hxYGgjO4g+C20LF9SnsE4exSRuzXwSQMA50xk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d7697bf2004fcb6508d3bf146e94fff59ecb2db9",
+        "rev": "b501185a01bca853da21a1d35c058bb48a9a84eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`b501185a`](https://github.com/nix-community/emacs-overlay/commit/b501185a01bca853da21a1d35c058bb48a9a84eb) | `` Updated emacs ``        |
| [`52c1aa91`](https://github.com/nix-community/emacs-overlay/commit/52c1aa9113ab656c8cf0dc59259ae3c31d2f701c) | `` Updated melpa ``        |
| [`695c3f28`](https://github.com/nix-community/emacs-overlay/commit/695c3f283df1fac966f8c7a2e53476d75d72be14) | `` Updated elpa ``         |
| [`9534c782`](https://github.com/nix-community/emacs-overlay/commit/9534c782c0ca964660f8bdb05a6363e687a804e8) | `` Updated nongnu ``       |
| [`324c3785`](https://github.com/nix-community/emacs-overlay/commit/324c3785c467ceeafc8bf7b14ad4149534120ba0) | `` Updated flake inputs `` |