### PR TITLE
chore(flake/emacs-overlay): `b501185a` -> `df40078d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1734543168,
-        "narHash": "sha256-v7tqM+hxYGgjO4g+C20LF9SnsE4exSRuzXwSQMA50xk=",
+        "lastModified": 1734599675,
+        "narHash": "sha256-jTfIoLxbVK3r6rFHKs0JS8WEYrmp0AGomzGaPTDZvrE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b501185a01bca853da21a1d35c058bb48a9a84eb",
+        "rev": "df40078d8d4f3f0439e52a3f3e44af0005e6072e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`df40078d`](https://github.com/nix-community/emacs-overlay/commit/df40078d8d4f3f0439e52a3f3e44af0005e6072e) | `` Updated emacs ``  |
| [`b132f0d1`](https://github.com/nix-community/emacs-overlay/commit/b132f0d1c8d2f8fdbc842cd5057fab7b39462c74) | `` Updated melpa ``  |
| [`7fe6fa39`](https://github.com/nix-community/emacs-overlay/commit/7fe6fa395b9faa227071788bf01297a95d502fb6) | `` Updated emacs ``  |
| [`b2ee9e08`](https://github.com/nix-community/emacs-overlay/commit/b2ee9e086fc9c22a19c0e2c1843d626d8e1d4e27) | `` Updated melpa ``  |
| [`4915a556`](https://github.com/nix-community/emacs-overlay/commit/4915a55645571f8edfaaf598e05e94f3d287de0c) | `` Updated elpa ``   |
| [`003885cb`](https://github.com/nix-community/emacs-overlay/commit/003885cb5fa02bd2f4bc66a6406a7dbf6f36e361) | `` Updated nongnu `` |