### PR TITLE
chore(flake/srvos): `528f3ec7` -> `758e36d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -883,11 +883,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734311023,
-        "narHash": "sha256-NpiSmBZ4usbCuucwLWKX8TypbP+KfKZB5GOJevdp2rM=",
+        "lastModified": 1734587909,
+        "narHash": "sha256-8JzxqQEYm3wKoA1TmCfnfN1uZD/YNn9OZL8xI/OSbes=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "528f3ec754231bd6dc0113cd3010f66513e957f4",
+        "rev": "758e36d85d0dd2fbb01550554e7de68514558a0b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                              |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`05004d51`](https://github.com/nix-community/srvos/commit/05004d5180cbd821b1fa43aff276b5752f34312f) | `` hetzner-online: use DHCP in non-systemd initrd `` |
| [`eb0689cf`](https://github.com/nix-community/srvos/commit/eb0689cf404a1267a10a618eba0ae943e5a3754d) | `` dev/private/flake.lock: Update ``                 |
| [`f886ad77`](https://github.com/nix-community/srvos/commit/f886ad7765919f87b7036f150abac2d13ce562fd) | `` flake.lock: Update ``                             |