### PR TITLE
chore(flake/catppuccin): `5cdefd69` -> `63b711e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1734546365,
-        "narHash": "sha256-g8GoZj1+r78/+gl2uWqausP+5oUap+GQsUKHnj+yB38=",
+        "lastModified": 1734606175,
+        "narHash": "sha256-1j7XrbwvwH7/tJ+m+LJiSjAdxBgT+hDLPnS716NfXcg=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "5cdefd69fc9238a6fe512e76ed9d22169c661616",
+        "rev": "63b711e67687bb206b4e051a14f1c67e66b1a105",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                           |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`63b711e6`](https://github.com/catppuccin/nix/commit/63b711e67687bb206b4e051a14f1c67e66b1a105) | `` feat(home-manager): add transparent option for micro (#406) `` |
| [`a1ae41ad`](https://github.com/catppuccin/nix/commit/a1ae41ad8cf4f874ebb4b9819e6e952b1bd627b5) | `` chore: bump rolling input in dev flake (#407) ``               |
| [`dcc1cbe9`](https://github.com/catppuccin/nix/commit/dcc1cbe936d053efca73483cfca81a35d2318c6b) | `` style: format 20c0cb2 ``                                       |
| [`20c0cb2f`](https://github.com/catppuccin/nix/commit/20c0cb2f68e6b44f75957dd2beff97d6857a667e) | `` feat(modules): move to catppuccin namespace (#371) ``          |