### PR TITLE
chore(flake/nixos-facter-modules): `86264858` -> `53647275`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -493,11 +493,11 @@
     },
     "nixos-facter-modules": {
       "locked": {
-        "lastModified": 1732288619,
-        "narHash": "sha256-zSQ2cR+NRJfHUVfkv+O6Wi53wXfzX8KHiO8fRfnvc0M=",
+        "lastModified": 1734596637,
+        "narHash": "sha256-MRqwVAe3gsb88u4ME1UidmZFVCx+FEnoob0zkpO9DMY=",
         "owner": "numtide",
         "repo": "nixos-facter-modules",
-        "rev": "862648589993a96480c2255197a28feea712f68f",
+        "rev": "536472754982bf03079b4b4e0261838a760587c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                              |
| ------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`391bb3f4`](https://github.com/numtide/nixos-facter-modules/commit/391bb3f408845d75211c8b8f95592a467a42ad07) | `` networking/initrd: init module `` |