### PR TITLE
chore(flake/nur): `ec475c3d` -> `1338b69a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -752,11 +752,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1734582852,
-        "narHash": "sha256-noclzoGo/tdXK3ae1B+uzAe3tt8/hkAM+BSBbodeuU4=",
+        "lastModified": 1734608823,
+        "narHash": "sha256-ABxTpsvEs7am64tpwgpp4MweGiGaTbWPAWJRmj2OgSE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ec475c3d51d2eb5a4af54f603fe08edafd1d5380",
+        "rev": "1338b69a922c99d6b40d4840d50013f0057f501c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1338b69a`](https://github.com/nix-community/NUR/commit/1338b69a922c99d6b40d4840d50013f0057f501c) | `` automatic update `` |
| [`ec0e2bfb`](https://github.com/nix-community/NUR/commit/ec0e2bfb466be0a11551110028afc52f0c0236d9) | `` automatic update `` |
| [`a1f08d0a`](https://github.com/nix-community/NUR/commit/a1f08d0a326e1cb3d747a80053a45a95d833032a) | `` automatic update `` |