### PR TITLE
chore(flake/nur): `1338b69a` -> `0f2e73b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -752,11 +752,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1734608823,
-        "narHash": "sha256-ABxTpsvEs7am64tpwgpp4MweGiGaTbWPAWJRmj2OgSE=",
+        "lastModified": 1734637646,
+        "narHash": "sha256-jsbvM9qASOT0Y98+jGgG7EMo5gFowJkIOAWFeegVMME=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1338b69a922c99d6b40d4840d50013f0057f501c",
+        "rev": "0f2e73b1ae46aa46e44ef689148c0baf9c3ebaa5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0f2e73b1`](https://github.com/nix-community/NUR/commit/0f2e73b1ae46aa46e44ef689148c0baf9c3ebaa5) | `` automatic update `` |
| [`a46526ef`](https://github.com/nix-community/NUR/commit/a46526ef26e5973746dba364a3fa8bb114f43cd0) | `` automatic update `` |
| [`7bdb9e6a`](https://github.com/nix-community/NUR/commit/7bdb9e6abd154dde4004c499aa1c7707a6dbcb16) | `` automatic update `` |
| [`674fcf13`](https://github.com/nix-community/NUR/commit/674fcf13eb4420fccf128b85c9213d8ab91f0533) | `` automatic update `` |
| [`89621e43`](https://github.com/nix-community/NUR/commit/89621e43228d2941138a4d54a24924cd70d12bfe) | `` automatic update `` |
| [`30799ac9`](https://github.com/nix-community/NUR/commit/30799ac92a92696c027db9680a8ff22b86d1d6c8) | `` automatic update `` |
| [`b4eb7b18`](https://github.com/nix-community/NUR/commit/b4eb7b182ee1fa9f063bf5cdfcabb3e766ac111a) | `` automatic update `` |