### PR TITLE
chore(flake/emacs-overlay): `df40078d` -> `05ed54de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1734599675,
-        "narHash": "sha256-jTfIoLxbVK3r6rFHKs0JS8WEYrmp0AGomzGaPTDZvrE=",
+        "lastModified": 1734628307,
+        "narHash": "sha256-rQtZSvYSgzdsrTSbrpl1RpDAwnD6tAeUxm6nAXdtrds=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "df40078d8d4f3f0439e52a3f3e44af0005e6072e",
+        "rev": "05ed54de2ec7875b97a2a33d810997e00e6ea699",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`05ed54de`](https://github.com/nix-community/emacs-overlay/commit/05ed54de2ec7875b97a2a33d810997e00e6ea699) | `` Updated emacs ``  |
| [`1ac689f2`](https://github.com/nix-community/emacs-overlay/commit/1ac689f2dde2b5e6f1b82a82bf82e48377269830) | `` Updated melpa ``  |
| [`580f3763`](https://github.com/nix-community/emacs-overlay/commit/580f376388cd7050fe08db49066501d494a0cbc9) | `` Updated elpa ``   |
| [`39a1541d`](https://github.com/nix-community/emacs-overlay/commit/39a1541dcde50dec42e11c127a35fd3251f74bb6) | `` Updated nongnu `` |