### PR TITLE
chore(flake/nixos-cosmic): `f6036448` -> `86e08fbc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -478,11 +478,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1734620407,
-        "narHash": "sha256-JarUp0GVny6BwGZaUfIXsSQQcz1w7SGMxgCsJZBdv7U=",
+        "lastModified": 1734831407,
+        "narHash": "sha256-4bYFrfh9H+8otS6RtliLoThMxqOFmwEa8ZuPgDodu/8=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "f6036448ff647e02dcd83f673036ccacbd2922b7",
+        "rev": "86e08fbc79f33f98c00097d6dcabe0e17c20faae",
         "type": "github"
       },
       "original": {
@@ -613,11 +613,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1734323986,
-        "narHash": "sha256-m/lh6hYMIWDYHCAsn81CDAiXoT3gmxXI9J987W5tZrE=",
+        "lastModified": 1734737257,
+        "narHash": "sha256-GIMyMt1pkkoXdCq9un859bX6YQZ/iYtukb9R5luazLM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "394571358ce82dff7411395829aa6a3aad45b907",
+        "rev": "1c6e20d41d6a9c1d737945962160e8571df55daa",
         "type": "github"
       },
       "original": {
@@ -827,11 +827,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734489114,
-        "narHash": "sha256-dKBBZr2pw7KDI/7GeiN5qPccqqtvnK2jqAMcMo4rVvU=",
+        "lastModified": 1734747996,
+        "narHash": "sha256-0DUuObdcPITVOMMymq2y6YlM++QEWXZO3cTm6RGYgL8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b2e385f8e5c1d7c0d9ce738d650955c2e94555ae",
+        "rev": "f9086701f5f3d36b8e5f4a3b9c93579ebc2581e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                                                          |
| ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`86e08fbc`](https://github.com/lilyinstarlight/nixos-cosmic/commit/86e08fbc79f33f98c00097d6dcabe0e17c20faae) | `` flake: update inputs (#540) ``                                                                |
| [`0076af5c`](https://github.com/lilyinstarlight/nixos-cosmic/commit/0076af5cbedbb2004dc2c28ecb4cec1046e7f774) | `` cosmic-edit: 1.0.0-alpha.4-unstable-2024-12-18 -> 1.0.0-alpha.4-unstable-2024-12-21 (#539) `` |
| [`1c922245`](https://github.com/lilyinstarlight/nixos-cosmic/commit/1c922245aec471610533c7a225bf9c20e7002ff2) | `` flake: update inputs (#538) ``                                                                |
| [`f7c0d0a5`](https://github.com/lilyinstarlight/nixos-cosmic/commit/f7c0d0a567dd80cd87fdb72c6cbe4865c1038237) | `` quick-webapps: 0.5.4-unstable-2024-12-17 -> 0.5.4-unstable-2024-12-20 (#537) ``               |
| [`b5f8f498`](https://github.com/lilyinstarlight/nixos-cosmic/commit/b5f8f498a70d4ca6fd33772cab9d0cc8f8cf611d) | `` ci: fix architecture usage ``                                                                 |
| [`be889680`](https://github.com/lilyinstarlight/nixos-cosmic/commit/be889680c0d5801c83e0f032ca61a89bf7d0b21e) | `` ci: add cachix pinning to main branch ``                                                      |
| [`eda9e993`](https://github.com/lilyinstarlight/nixos-cosmic/commit/eda9e9936e762dd4e7abdaecd3adeca105451c92) | `` nixos/cosmic: add xkb env vars based on services.xserver.xkb settings ``                      |
| [`7db3019c`](https://github.com/lilyinstarlight/nixos-cosmic/commit/7db3019c79b6a8edfa0300a6d3b8257d321b66a4) | `` ci: attempt to improve performance ``                                                         |
| [`37adb055`](https://github.com/lilyinstarlight/nixos-cosmic/commit/37adb05597d2568837d0b686a46e45787107bdde) | `` ci: add merge_group trigger ``                                                                |
| [`64b255be`](https://github.com/lilyinstarlight/nixos-cosmic/commit/64b255bedca3b6602960bfc63a732493eaacf531) | `` pkgs: update cosmic (#524) ``                                                                 |
| [`36a45682`](https://github.com/lilyinstarlight/nixos-cosmic/commit/36a456823df36fcf2c554436eed0479ad158fa15) | `` flake: update inputs (#534) ``                                                                |
| [`0370a4df`](https://github.com/lilyinstarlight/nixos-cosmic/commit/0370a4df2f768ce8a028c7ba01b4704a5f9b065f) | `` ci: use all cores on runners (#533) ``                                                        |
| [`824b69e5`](https://github.com/lilyinstarlight/nixos-cosmic/commit/824b69e5b482d7e06f90ca754d2718fe1517d050) | `` ci: hack temporarily to use faster x86 VMs (#531) ``                                          |
| [`eb20ad0f`](https://github.com/lilyinstarlight/nixos-cosmic/commit/eb20ad0f4fc1e2f95fd69f08b7b4cd1b9b8bbd2c) | `` pkgs: cargoLock -> useFetchCargoVendor (#526) ``                                              |