### PR TITLE
chore(flake/catppuccin): `63b711e6` -> `6239449c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1734606175,
-        "narHash": "sha256-1j7XrbwvwH7/tJ+m+LJiSjAdxBgT+hDLPnS716NfXcg=",
+        "lastModified": 1734671418,
+        "narHash": "sha256-K2Su5hM1nEIgKJ55TB5W+UfN9zBHUxC0SjWAtjXLEnI=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "63b711e67687bb206b4e051a14f1c67e66b1a105",
+        "rev": "6239449c96569547af621899f44a5ea333cb2576",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                     |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`6239449c`](https://github.com/catppuccin/nix/commit/6239449c96569547af621899f44a5ea333cb2576) | `` chore(modules): update ports (#411) ``                   |
| [`72387df8`](https://github.com/catppuccin/nix/commit/72387df84ad52b0b54b98c3e72a62fa4a510413a) | `` fix(home-manager/hyprland): rename accent (#410) ``      |
| [`562a0ace`](https://github.com/catppuccin/nix/commit/562a0ace199ab59413d5093e31d6745704bd0d11) | `` fix(home-manager/swaylock): use correct option (#408) `` |