### PR TITLE
chore(flake/emacs-overlay): `05ed54de` -> `fc45166e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1734628307,
-        "narHash": "sha256-rQtZSvYSgzdsrTSbrpl1RpDAwnD6tAeUxm6nAXdtrds=",
+        "lastModified": 1734685919,
+        "narHash": "sha256-tSZ304sUldpArqNNg8ldCI6sHdcMQFsVx6ftH29ZR1U=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "05ed54de2ec7875b97a2a33d810997e00e6ea699",
+        "rev": "fc45166e48995bc14d800c4ddcdf97d52799cce1",
         "type": "github"
       },
       "original": {
@@ -581,11 +581,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1734323986,
-        "narHash": "sha256-m/lh6hYMIWDYHCAsn81CDAiXoT3gmxXI9J987W5tZrE=",
+        "lastModified": 1734600368,
+        "narHash": "sha256-nbG9TijTMcfr+au7ZVbKpAhMJzzE2nQBYmRvSdXUD8g=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "394571358ce82dff7411395829aa6a3aad45b907",
+        "rev": "b47fd6fa00c6afca88b8ee46cfdb00e104f50bca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`fc45166e`](https://github.com/nix-community/emacs-overlay/commit/fc45166e48995bc14d800c4ddcdf97d52799cce1) | `` Updated emacs ``        |
| [`d04fdd1b`](https://github.com/nix-community/emacs-overlay/commit/d04fdd1bd2cb85a4005d7203fbc68325e39ca799) | `` Updated melpa ``        |
| [`0164b013`](https://github.com/nix-community/emacs-overlay/commit/0164b013076cc9549e4a694cf3fdecf411427e2d) | `` Updated flake inputs `` |
| [`03bdf32e`](https://github.com/nix-community/emacs-overlay/commit/03bdf32edf7ef2a8f5fa4c6cd2fac32fbf43bb4c) | `` Updated emacs ``        |
| [`701b5841`](https://github.com/nix-community/emacs-overlay/commit/701b5841ea2667e19b2a49640db174969c3ea573) | `` Updated melpa ``        |
| [`c264b783`](https://github.com/nix-community/emacs-overlay/commit/c264b783a2d1ffbf9bea7ae4c0ed2639ff811224) | `` Updated elpa ``         |
| [`bb6dce92`](https://github.com/nix-community/emacs-overlay/commit/bb6dce92b187d44e11e74a8e8f70e925024a8b42) | `` Updated nongnu ``       |