### PR TITLE
chore(flake/treefmt): `76159fc7` -> `65712f5a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -933,11 +933,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734543842,
-        "narHash": "sha256-/QceWozrNg915Db9x/Ie5k67n9wKgGdTFng+Z1Qw0kE=",
+        "lastModified": 1734704479,
+        "narHash": "sha256-MMi74+WckoyEWBRcg/oaGRvXC9BVVxDZNRMpL+72wBI=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "76159fc74eeac0599c3618e3601ac2b980a29263",
+        "rev": "65712f5af67234dad91a5a4baee986a8b62dbf8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                     |
| ---------------------------------------------------------------------------------------------------- | --------------------------- |
| [`65712f5a`](https://github.com/numtide/treefmt-nix/commit/65712f5af67234dad91a5a4baee986a8b62dbf8f) | `` perltidy: init (#281) `` |