### PR TITLE
chore(flake/emacs-overlay): `fc45166e` -> `8521536b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1734685919,
-        "narHash": "sha256-tSZ304sUldpArqNNg8ldCI6sHdcMQFsVx6ftH29ZR1U=",
+        "lastModified": 1734772216,
+        "narHash": "sha256-9Hp6GMsXe46MA7zvZM9McO1TMjTzb1AdBNVsC+pkOs8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fc45166e48995bc14d800c4ddcdf97d52799cce1",
+        "rev": "8521536b77195b89b7c6ed51fc8643ae65fff26f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`8521536b`](https://github.com/nix-community/emacs-overlay/commit/8521536b77195b89b7c6ed51fc8643ae65fff26f) | `` Updated emacs ``  |
| [`d714e233`](https://github.com/nix-community/emacs-overlay/commit/d714e233bc77b18e3b5af4b5bcff2407303338ef) | `` Updated melpa ``  |
| [`87d2f5f8`](https://github.com/nix-community/emacs-overlay/commit/87d2f5f8d77f119be56ed7a52243378f25c1f946) | `` Updated emacs ``  |
| [`c55bcda9`](https://github.com/nix-community/emacs-overlay/commit/c55bcda95d90ef94d781ce9c3d711aa998083df3) | `` Updated melpa ``  |
| [`63781cfc`](https://github.com/nix-community/emacs-overlay/commit/63781cfcc11e9998a407651ce73c63de385b5a7c) | `` Updated elpa ``   |
| [`e42e8b8f`](https://github.com/nix-community/emacs-overlay/commit/e42e8b8f2338e989a15e25ed6b9215460b9e3233) | `` Updated nongnu `` |
| [`c712f393`](https://github.com/nix-community/emacs-overlay/commit/c712f393aa716377f358ca34ac66f9b8efbcc7ff) | `` Updated emacs ``  |
| [`ba5ce567`](https://github.com/nix-community/emacs-overlay/commit/ba5ce5679a3e5167ed119fece4437d2a5314c9d8) | `` Updated melpa ``  |
| [`f529e106`](https://github.com/nix-community/emacs-overlay/commit/f529e106317e87227f005fb39e470be358754081) | `` Updated elpa ``   |
| [`86857229`](https://github.com/nix-community/emacs-overlay/commit/868572293f0a3276d074b62ddb09b2b84abce0e6) | `` Updated nongnu `` |