### PR TITLE
chore(flake/catppuccin): `6239449c` -> `1e4c3803`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1734671418,
-        "narHash": "sha256-K2Su5hM1nEIgKJ55TB5W+UfN9zBHUxC0SjWAtjXLEnI=",
+        "lastModified": 1734734291,
+        "narHash": "sha256-CFX4diEQHKvZYjnhf7TLg20m3ge1O4vqgplsk/Kuaek=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "6239449c96569547af621899f44a5ea333cb2576",
+        "rev": "1e4c3803b8da874ff75224ec8512cb173036bbd8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                     |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`1e4c3803`](https://github.com/catppuccin/nix/commit/1e4c3803b8da874ff75224ec8512cb173036bbd8) | `` chore: release v1.2.1 (#418) ``                          |
| [`f98522b9`](https://github.com/catppuccin/nix/commit/f98522b909d76d5523fb0765519fed23cc0c08d6) | `` fix(home-manager/zed): use correct names (#417) ``       |
| [`e573d16d`](https://github.com/catppuccin/nix/commit/e573d16de4adb9fa9348c03c3d8d4922cd884f62) | `` chore: add v1.2 to options search (#416) ``              |
| [`23ee86db`](https://github.com/catppuccin/nix/commit/23ee86dbf4ed347878115a78971d43025362fab1) | `` chore: v1.2.0 (#414) ``                                  |
| [`dede06da`](https://github.com/catppuccin/nix/commit/dede06da4c944232ba3f95710a26f298729532b9) | `` feat(home-manager): add support for zed-editor (#359) `` |
| [`5501cb50`](https://github.com/catppuccin/nix/commit/5501cb508c2d4224d932a0b924d75454b68680bf) | `` docs: fully document nix library (#413) ``               |