### PR TITLE
chore(flake/nur): `7fcecf72` -> `ad1d02cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -752,11 +752,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1734733981,
-        "narHash": "sha256-hVF82L5TkfM6j9JlGZAWcajY9/NCPE+dWSfHmLXZpOo=",
+        "lastModified": 1734766536,
+        "narHash": "sha256-7bqr4xj6psb04sIG40H8byR2TiX9331nHf090kgMP9w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7fcecf724bae5ec4b70d94722563238dac97ec74",
+        "rev": "ad1d02cb7e74408f3e5e4e4375d92036dd9fbdb2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ad1d02cb`](https://github.com/nix-community/NUR/commit/ad1d02cb7e74408f3e5e4e4375d92036dd9fbdb2) | `` automatic update `` |
| [`54616be4`](https://github.com/nix-community/NUR/commit/54616be4d34b411534d8246f8506eb625e42f948) | `` automatic update `` |
| [`2e982188`](https://github.com/nix-community/NUR/commit/2e9821884a836c910e45bcf9ae4e2f02df033313) | `` automatic update `` |
| [`74ae5912`](https://github.com/nix-community/NUR/commit/74ae5912365c3f7d0a91fac47641fb8394b9452b) | `` automatic update `` |
| [`78447583`](https://github.com/nix-community/NUR/commit/784475830a9fc4773b92fdb195bd6bf5da29eec2) | `` automatic update `` |
| [`05d1f81d`](https://github.com/nix-community/NUR/commit/05d1f81d1d9ac48e1a24ee96955c9d6fcbc81cdf) | `` automatic update `` |
| [`6c4c7937`](https://github.com/nix-community/NUR/commit/6c4c79379b34a4d9611a4f600ee1c5ce1f56b063) | `` automatic update `` |
| [`28dd6625`](https://github.com/nix-community/NUR/commit/28dd6625f95f616dd0e122846252ffffe162696e) | `` automatic update `` |