### PR TITLE
chore(flake/impermanence): `c6323585` -> `0ab2f858`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -330,11 +330,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1734200366,
-        "narHash": "sha256-0NursoP4BUdnc+wy+Mq3icHkXu/RgP1Sjo0MJxV2+Dw=",
+        "lastModified": 1734772301,
+        "narHash": "sha256-mQEQQzCTUlDiEw/EbblB510P/GQOmIPtKoJrqDqeGVc=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "c6323585fa0035d780e3d8906eb1b24b65d19a48",
+        "rev": "0ab2f858dfefe73402eb53fbe6a3bad4f6702d5f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                               |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`62aa3abc`](https://github.com/nix-community/impermanence/commit/62aa3abc281b58781908efebb7c42a029294a737) | `` nixos: Fix the machine-id workaround to also work on first boot `` |
| [`ad544a2b`](https://github.com/nix-community/impermanence/commit/ad544a2b324f3960a9fb3c24635f7aeb7ae8e88d) | `` mount-file, create-directories: Remove some unnecessary quoting `` |
| [`0e9480d6`](https://github.com/nix-community/impermanence/commit/0e9480d62a9def6f1264f5a2faabed8caef13f57) | `` nixos: depend on mount unit for bind mounts ``                     |