### PR TITLE
chore(flake/nur): `ad1d02cb` -> `cf4022fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -661,11 +661,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1734424634,
-        "narHash": "sha256-cHar1vqHOOyC7f1+tVycPoWTfKIaqkoe1Q6TnKzuti4=",
+        "lastModified": 1734649271,
+        "narHash": "sha256-4EVBRhOjMDuGtMaofAIqzJbg4Ql7Ai0PSeuVZTHjyKQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d3c42f187194c26d9f0309a8ecc469d6c878ce33",
+        "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
         "type": "github"
       },
       "original": {
@@ -752,11 +752,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1734766536,
-        "narHash": "sha256-7bqr4xj6psb04sIG40H8byR2TiX9331nHf090kgMP9w=",
+        "lastModified": 1734850149,
+        "narHash": "sha256-OkcMRs+3YysXxQKl5WWiG1QN7M3wDKHNU3OVZA7qNQM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ad1d02cb7e74408f3e5e4e4375d92036dd9fbdb2",
+        "rev": "cf4022fae9d7a59798e681f3e3c07c0146f2ec66",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cf4022fa`](https://github.com/nix-community/NUR/commit/cf4022fae9d7a59798e681f3e3c07c0146f2ec66) | `` automatic update `` |
| [`c7e88f68`](https://github.com/nix-community/NUR/commit/c7e88f6879c8db58e35492aa2200eb95838c1e74) | `` automatic update `` |
| [`feb347e2`](https://github.com/nix-community/NUR/commit/feb347e25940b27026a5c78155a895904c702d29) | `` automatic update `` |
| [`fc46e956`](https://github.com/nix-community/NUR/commit/fc46e9563bb0703b7022209dd524a35f6cf81e69) | `` automatic update `` |
| [`661541aa`](https://github.com/nix-community/NUR/commit/661541aa489fc5a7f62cfb5a8ce1f348b49f9248) | `` automatic update `` |
| [`72cace31`](https://github.com/nix-community/NUR/commit/72cace318293f9d49df3e3c4273874238673c8bc) | `` automatic update `` |
| [`311b6a0e`](https://github.com/nix-community/NUR/commit/311b6a0ed1af52a0a85e462058159fee8d6d9b17) | `` automatic update `` |
| [`9d1f3365`](https://github.com/nix-community/NUR/commit/9d1f3365a54575ce60f55db6d11eeedd23bc4b44) | `` automatic update `` |
| [`6659ff22`](https://github.com/nix-community/NUR/commit/6659ff2273dc9b31a72c15f8ebcf073a48702cdb) | `` automatic update `` |
| [`3025fdb6`](https://github.com/nix-community/NUR/commit/3025fdb6dfd2bde512e4e40ed9886094fc929fcc) | `` automatic update `` |
| [`7741d2b7`](https://github.com/nix-community/NUR/commit/7741d2b708ed78681c944d6f8a4c668df09edef2) | `` automatic update `` |
| [`38dcbcaf`](https://github.com/nix-community/NUR/commit/38dcbcaf256ad46349e35ce52a2f576610a14255) | `` automatic update `` |
| [`c49cb9a3`](https://github.com/nix-community/NUR/commit/c49cb9a301da03f51c3bb32a86d96ec2d619b750) | `` automatic update `` |
| [`efd07bee`](https://github.com/nix-community/NUR/commit/efd07bee1717f9d3f3f369e6967b4f17a09aabf3) | `` automatic update `` |
| [`aba8b45c`](https://github.com/nix-community/NUR/commit/aba8b45c6165d2504c9acb142138a4d4f48e1262) | `` automatic update `` |
| [`e7b7b92a`](https://github.com/nix-community/NUR/commit/e7b7b92a7c97a91f1465ab433bbdf6d00df1db8e) | `` automatic update `` |
| [`594419e5`](https://github.com/nix-community/NUR/commit/594419e5c701651994f798504a0e6194f5707ad3) | `` automatic update `` |
| [`27e991bd`](https://github.com/nix-community/NUR/commit/27e991bd1e44f74da783d19986790c5819ae2356) | `` automatic update `` |
| [`2aa785a8`](https://github.com/nix-community/NUR/commit/2aa785a8b88c88f55b5d545c33f2352911773047) | `` automatic update `` |
| [`8f1c0d7f`](https://github.com/nix-community/NUR/commit/8f1c0d7f14f775f0949e3839d14f022fba43b704) | `` automatic update `` |
| [`2ba94aaf`](https://github.com/nix-community/NUR/commit/2ba94aaf241bd4c92d885d18d38847ce25374928) | `` automatic update `` |
| [`91101081`](https://github.com/nix-community/NUR/commit/911010813761636f28ddda81eb2c49faa8bc4233) | `` automatic update `` |
| [`db4e0d95`](https://github.com/nix-community/NUR/commit/db4e0d95cd1f9f77113cd9c3c9de5974fa721a98) | `` automatic update `` |
| [`3f165648`](https://github.com/nix-community/NUR/commit/3f165648d0d2461e3de2cc567a98de3b75cf61c5) | `` automatic update `` |
| [`7d3976de`](https://github.com/nix-community/NUR/commit/7d3976de23745668765fbf5f697d9fd35d0f5176) | `` automatic update `` |
| [`887090ab`](https://github.com/nix-community/NUR/commit/887090ab19e70bcb02c0091a017f777888b4932f) | `` automatic update `` |