### PR TITLE
chore(flake/emacs-overlay): `8521536b` -> `1d3ff271`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1734772216,
-        "narHash": "sha256-9Hp6GMsXe46MA7zvZM9McO1TMjTzb1AdBNVsC+pkOs8=",
+        "lastModified": 1734801033,
+        "narHash": "sha256-CUA7hFEseT4lUdxHf1n9b2fNgPYCLvpuZ8x02UrC63o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8521536b77195b89b7c6ed51fc8643ae65fff26f",
+        "rev": "1d3ff271d875b7bfacafbc1f4a5dff7ce54ef95d",
         "type": "github"
       },
       "original": {
@@ -581,11 +581,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1734600368,
-        "narHash": "sha256-nbG9TijTMcfr+au7ZVbKpAhMJzzE2nQBYmRvSdXUD8g=",
+        "lastModified": 1734737257,
+        "narHash": "sha256-GIMyMt1pkkoXdCq9un859bX6YQZ/iYtukb9R5luazLM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b47fd6fa00c6afca88b8ee46cfdb00e104f50bca",
+        "rev": "1c6e20d41d6a9c1d737945962160e8571df55daa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`1d3ff271`](https://github.com/nix-community/emacs-overlay/commit/1d3ff271d875b7bfacafbc1f4a5dff7ce54ef95d) | `` Updated emacs ``        |
| [`bc958ac4`](https://github.com/nix-community/emacs-overlay/commit/bc958ac44c7f595c25bf9e32e9f0debc920a6663) | `` Updated melpa ``        |
| [`786143cc`](https://github.com/nix-community/emacs-overlay/commit/786143cc220afd5336c5db8fdf264b38f50fb2de) | `` Updated elpa ``         |
| [`47cc51eb`](https://github.com/nix-community/emacs-overlay/commit/47cc51eb2affa7468c3941ce9057c3fac1fa040c) | `` Updated nongnu ``       |
| [`431b888f`](https://github.com/nix-community/emacs-overlay/commit/431b888f1cf0d23a52137884761ded259f5660bb) | `` Updated flake inputs `` |