### PR TITLE
chore(flake/home-manager): `1395379a` -> `cb27edb5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -315,11 +315,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734622215,
-        "narHash": "sha256-OOfI0XhSJGHblfdNDhfnn8QnZxng63rWk9eeJ2tCbiI=",
+        "lastModified": 1734862405,
+        "narHash": "sha256-bXZJvUMJ2A6sIpYcCUAGjYCD5UDzmpmQCdmJSkPhleU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1395379a7a36e40f2a76e7b9936cc52950baa1be",
+        "rev": "cb27edb5221d2f2920a03155f8becc502cf60e35",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`cb27edb5`](https://github.com/nix-community/home-manager/commit/cb27edb5221d2f2920a03155f8becc502cf60e35) | `` waybar: add systemd restart triggers ``             |
| [`f47b6c15`](https://github.com/nix-community/home-manager/commit/f47b6c153ad31187a519bd569ccbcb20acb16ce0) | `` cavalier: add module ``                             |
| [`c903b1f6`](https://github.com/nix-community/home-manager/commit/c903b1f6fbfc2039963806df896f698331b77aa8) | `` flake.lock: Update ``                               |
| [`51160a09`](https://github.com/nix-community/home-manager/commit/51160a097a850839b7eae7ef08d0d3e7e353dfc3) | `` thunderbird: implement `extensions` for profiles `` |
| [`f342df3a`](https://github.com/nix-community/home-manager/commit/f342df3ad938f205a913973b832f52c12546aac6) | `` flake.lock: Update ``                               |
| [`db9a98e1`](https://github.com/nix-community/home-manager/commit/db9a98e178b57a8aff46b3482dfccb3f4d8d4ce3) | `` pay-respects: add module ``                         |
| [`99f54cdf`](https://github.com/nix-community/home-manager/commit/99f54cdfef395bb3de1c7b8dd422412de65b038d) | `` yazi: fix example option for settings ``            |