### PR TITLE
chore(flake/emacs-overlay): `1d3ff271` -> `3c24690a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1734801033,
-        "narHash": "sha256-CUA7hFEseT4lUdxHf1n9b2fNgPYCLvpuZ8x02UrC63o=",
+        "lastModified": 1734833431,
+        "narHash": "sha256-X142+eukhjxdkJkeyN8IUGxUVZ2pO9lX3N9pMYNqOJQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1d3ff271d875b7bfacafbc1f4a5dff7ce54ef95d",
+        "rev": "3c24690ab6fe48f82675b13cd6addb9a8dadfb92",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`3c24690a`](https://github.com/nix-community/emacs-overlay/commit/3c24690ab6fe48f82675b13cd6addb9a8dadfb92) | `` Updated emacs `` |
| [`2d9f8378`](https://github.com/nix-community/emacs-overlay/commit/2d9f83781449facf15b488cff5e6297bdd227bd8) | `` Updated melpa `` |
| [`3c66cd81`](https://github.com/nix-community/emacs-overlay/commit/3c66cd813a126cea5fcb9782563ab50797f65b1f) | `` Updated elpa ``  |