### PR TITLE
chore(flake/nixpkgs): `d3c42f18` -> `d70bd19e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -645,11 +645,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1734424634,
-        "narHash": "sha256-cHar1vqHOOyC7f1+tVycPoWTfKIaqkoe1Q6TnKzuti4=",
+        "lastModified": 1734649271,
+        "narHash": "sha256-4EVBRhOjMDuGtMaofAIqzJbg4Ql7Ai0PSeuVZTHjyKQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d3c42f187194c26d9f0309a8ecc469d6c878ce33",
+        "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                            |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`d70bd19e`](https://github.com/NixOS/nixpkgs/commit/d70bd19e0a38ad4790d3913bf08fcbfc9eeca507) | `` Revert "netpbm: 11.8.1 -> 11.8.2" (#366656) ``                                  |
| [`78bfef8d`](https://github.com/NixOS/nixpkgs/commit/78bfef8ddaa9befda2253153d18219a5e1b1fad5) | `` go_1_24: init at 1.24rc1 ``                                                     |
| [`a4e52be6`](https://github.com/NixOS/nixpkgs/commit/a4e52be6d970d4f31a25140f9fa51c21fb3c6aa6) | `` tippecanoe: 2.72.0 -> 2.73.0 ``                                                 |
| [`7dae87b2`](https://github.com/NixOS/nixpkgs/commit/7dae87b2384dced7212f349bd475b90c9552c094) | `` plexRaw: 1.41.2.9200-c6bbc1b53 -> 1.41.3.9292-bc7397402 ``                      |
| [`a0722258`](https://github.com/NixOS/nixpkgs/commit/a07222588d06932e5a6d6f276c00b4fe59366c3c) | `` myEnvFun: fix build ``                                                          |
| [`2cfb049f`](https://github.com/NixOS/nixpkgs/commit/2cfb049f6800ba8f715c65073c52bab9ba9173d3) | `` tana: 1.0.18 -> 1.0.20 ``                                                       |
| [`159385c1`](https://github.com/NixOS/nixpkgs/commit/159385c1aec83734ea490c762925647846f749b6) | `` opencascade-occt: fix compilation on darwin (#365409) ``                        |
| [`cc46eef8`](https://github.com/NixOS/nixpkgs/commit/cc46eef84e17b5bc6b189a9c61a7d3e45993f025) | `` blender: 4.3.1 -> 4.3.2 (#366295) ``                                            |
| [`cd47d562`](https://github.com/NixOS/nixpkgs/commit/cd47d5624e0ec4ceedc9fcef4dec8722da633652) | `` aws-signing-helper: 1.3.0 -> 1.4.0 ``                                           |
| [`6aac2ea1`](https://github.com/NixOS/nixpkgs/commit/6aac2ea11faa45086e65379bcb50c05bd7b65590) | `` aws-signing-helper: init at 1.3.0 ``                                            |
| [`a20685f5`](https://github.com/NixOS/nixpkgs/commit/a20685f5a12ddce55d9a7f9b0f41f92a774b69df) | `` maintainers: add pandanz ``                                                     |
| [`602677cb`](https://github.com/NixOS/nixpkgs/commit/602677cb48ff444cbd799cf6dd9b687fe3670620) | `` cubical-mini: init at nightly-20241214 ``                                       |
| [`45c4bca8`](https://github.com/NixOS/nixpkgs/commit/45c4bca8e43c10975b816660321cea533da74f01) | `` osu-lazer-bin: 2024.1208.0 -> 2024.1219.2 ``                                    |
| [`d133ab9d`](https://github.com/NixOS/nixpkgs/commit/d133ab9d3262a6038b783c2f9e8db9bf9aee26cd) | `` osu-lazer: 2024.1208.0 -> 2024.1219.2 ``                                        |
| [`ffcf6b78`](https://github.com/NixOS/nixpkgs/commit/ffcf6b781e9bb18ceb86e0f836a8adb53c2d7c30) | `` addNugetDeps.fetch-deps: remove `set -u` ``                                     |
| [`956c4042`](https://github.com/NixOS/nixpkgs/commit/956c40423c170c73a1181644e7eb74c193eb76ae) | `` barman: add distutils to dependencies ``                                        |
| [`af008b3f`](https://github.com/NixOS/nixpkgs/commit/af008b3fa5d95eb0065672a9225c42451de36f61) | `` taskwarrior3: 3.2.0-unstable-2024-12-18 -> 3.3.0 ``                             |
| [`98dd0ae0`](https://github.com/NixOS/nixpkgs/commit/98dd0ae04cf3052b93074ebff8e1f564f9518405) | `` cloud-hypervisor: 42.0 -> 43.0 ``                                               |
| [`438969f9`](https://github.com/NixOS/nixpkgs/commit/438969f9eed4e5d82ec227f6fd481dc3a9f2956d) | `` nixos/nvidia: add nvidia_dc_565 drivers ``                                      |
| [`51fabd13`](https://github.com/NixOS/nixpkgs/commit/51fabd133e56b98da321cef8ea843b495b89243a) | `` nixos/nvidia: run nixfmt on nvidia related files ``                             |
| [`170a250e`](https://github.com/NixOS/nixpkgs/commit/170a250e10d47c77eb32ba3f5f8afb79977a272a) | `` nixpkgs-review: 2.12.0 -> 3.0.0 ``                                              |
| [`7a25e387`](https://github.com/NixOS/nixpkgs/commit/7a25e3878f8ea6bffdea1ebd35eb0efff77ba94c) | `` chromium,chromedriver: 131.0.6778.139 -> 131.0.6778.204 ``                      |
| [`6a711c3e`](https://github.com/NixOS/nixpkgs/commit/6a711c3e8f0c69a3abb7100ba8a52760ea7751cb) | `` chromium: fix cross-"building" of recompressed FODs ``                          |
| [`055e87ad`](https://github.com/NixOS/nixpkgs/commit/055e87add1baeaf5e6cb4ee0e60301498c3d36ed) | `` python312Packages.craft-application: 4.5.0 -> 4.6.0 ``                          |
| [`7d43d693`](https://github.com/NixOS/nixpkgs/commit/7d43d69341688440e89e4d1a4997518b1a7828fb) | `` dunst: 1.12.0 -> 1.12.1 ``                                                      |
| [`aa8d8dfc`](https://github.com/NixOS/nixpkgs/commit/aa8d8dfc551569cf67b6258e48be4ccb2ad0f44b) | `` sile: 0.15.7 → 0.15.8 ``                                                        |
| [`2f56118b`](https://github.com/NixOS/nixpkgs/commit/2f56118be07cffef1b25f17ef13a26af5eef989e) | `` tidb: 8.4.0 -> 8.5.0 ``                                                         |
| [`313f7061`](https://github.com/NixOS/nixpkgs/commit/313f7061052d1f21f3b5e45ce958a062bb5ce687) | `` nuget-to-json: fix tools not being added to the lockfile ``                     |
| [`0e4e4c0b`](https://github.com/NixOS/nixpkgs/commit/0e4e4c0b73c7fc5872baabd47656238a0dbdccba) | `` minio-client: 2024-11-17T19-35-25Z -> 2024-11-21T17-21-54Z ``                   |
| [`fad76b10`](https://github.com/NixOS/nixpkgs/commit/fad76b102a8c842b57c5b7e5bc927b99abb7ce06) | `` basedpyright: 1.22.1 -> 1.23.1 ``                                               |
| [`cd5d16e2`](https://github.com/NixOS/nixpkgs/commit/cd5d16e2e9d0f1f28f3afe54ec40340650c633c0) | `` phrase-cli: 2.34.1 -> 2.35.2 ``                                                 |
| [`cfd3cc19`](https://github.com/NixOS/nixpkgs/commit/cfd3cc19fb47c4a257774a027c65d2ab48727413) | `` python312Packages.tencentcloud-sdk-python: 3.0.1283 -> 3.0.1284 ``              |
| [`b5b161c2`](https://github.com/NixOS/nixpkgs/commit/b5b161c24be603c00f3b32ddfe575ca8e9e48e09) | `` oras: 1.2.1 -> 1.2.2 ``                                                         |
| [`8d85a3c3`](https://github.com/NixOS/nixpkgs/commit/8d85a3c35837f176fd4c859119528798e480b83e) | `` evcc: 0.131.11 -> 0.131.12 ``                                                   |
| [`e33db7b3`](https://github.com/NixOS/nixpkgs/commit/e33db7b3574653bb899c49b067481422124515ce) | `` esphome: 2024.12.0 -> 2024.12.1 ``                                              |
| [`ba774098`](https://github.com/NixOS/nixpkgs/commit/ba774098453aa20bc368a27d1a826d27187cc8ed) | `` fabric-ai: 1.4.119 -> 1.4.122 ``                                                |
| [`f6f1febc`](https://github.com/NixOS/nixpkgs/commit/f6f1febc43645b48659111015e0fb322ddfb0ed5) | `` nixos/prometheux-exporters/rasdaemon: init ``                                   |
| [`92c9cba6`](https://github.com/NixOS/nixpkgs/commit/92c9cba6897fe96876d24f09cb5f5d2a238ac215) | `` aegisub: feature_12 -> 3.4.0 ``                                                 |
| [`4d696c4b`](https://github.com/NixOS/nixpkgs/commit/4d696c4b5cbe693deea96ab6836dfaa32cc19aca) | `` aegisub: switch to arch1t3cht’s fork ``                                         |
| [`92f30b65`](https://github.com/NixOS/nixpkgs/commit/92f30b653481d2c183840de9f9ccb0defecbfa86) | `` vapoursynth-bestsource: broaden `meta.platforms` ``                             |
| [`c6cf2896`](https://github.com/NixOS/nixpkgs/commit/c6cf289696567b30047a74aaadb9b31b8faed10a) | `` okms-cli: 0.1.2 -> 0.1.4 ``                                                     |
| [`10ddebe5`](https://github.com/NixOS/nixpkgs/commit/10ddebe5cee5121b5be0dd92ca629a698ce5912a) | `` msbuild-structured-log-viewer: 2.2.383 -> 2.2.392 ``                            |
| [`487c9bd4`](https://github.com/NixOS/nixpkgs/commit/487c9bd4457101f49f53a0fce296005c1a6481ef) | `` aws-codeartifact-proxy: 0.5.1 -> 0.6.0 ``                                       |
| [`3505d148`](https://github.com/NixOS/nixpkgs/commit/3505d1484aaba6ae01e86c814e54b5167e5a4830) | `` upbound: 0.34.0 -> 0.36.1, upbound-main: init at 0.37.0-0.rc.0.38.g797e121 ``   |
| [`211aac5e`](https://github.com/NixOS/nixpkgs/commit/211aac5eb9dd846fd8f6d7fb1bca0ce164da1632) | `` automatic-timezoned: 2.0.40 -> 2.0.42 ``                                        |
| [`d8bd5d3e`](https://github.com/NixOS/nixpkgs/commit/d8bd5d3e0d2e0a739b9c0ea8afe7c7b0b8394137) | `` ansible-navigator: 24.10.0 -> 24.12.0 ``                                        |
| [`81ab5847`](https://github.com/NixOS/nixpkgs/commit/81ab58479676079cae07ae2a8bb58961acfabee2) | `` mediamtx: fix build on non-linux platforms ``                                   |
| [`9228e03b`](https://github.com/NixOS/nixpkgs/commit/9228e03b1fc1ebae9b6a8868382156bd209e5dbe) | `` mediamtx: 1.9.3 -> 1.10.0 ``                                                    |
| [`63106e17`](https://github.com/NixOS/nixpkgs/commit/63106e17f67581b2b4284c9ba370432b8e80a6da) | `` testkube: 2.1.72 -> 2.1.79 ``                                                   |
| [`c0125794`](https://github.com/NixOS/nixpkgs/commit/c0125794c47fa7a76f52f11a7edf51bd8dbb4d49) | `` prowler: 5.0.1 -> 5.0.2 ``                                                      |
| [`a5e1bbfc`](https://github.com/NixOS/nixpkgs/commit/a5e1bbfc203caace6a58a4d6a0c39b54b8007e2e) | `` anydesk: remove myself from maintainers ``                                      |
| [`7c746b4a`](https://github.com/NixOS/nixpkgs/commit/7c746b4ab0e3b87eb509f868b71a5c0a310c41f6) | `` cloudflare-dynamic-dns: 4.3.11 -> 4.3.12 ``                                     |
| [`12cb9a84`](https://github.com/NixOS/nixpkgs/commit/12cb9a84b69d57630267a3b394af007566653105) | `` hyprland: fix cross compilation ``                                              |
| [`142f211c`](https://github.com/NixOS/nixpkgs/commit/142f211cc7987570b1c099f35838ca6369e18881) | `` tui-journal: 0.13.0 -> 0.13.1 ``                                                |
| [`0f87d1cd`](https://github.com/NixOS/nixpkgs/commit/0f87d1cdd34aed0d46aa1786cec56ddf3720dd13) | `` home-assistant-custom-lovelace-modules.universal-remote-card: 4.2.1 -> 4.3.1 `` |
| [`51feeeaf`](https://github.com/NixOS/nixpkgs/commit/51feeeaf41472737623c8832338d7d658ac41a0b) | `` evolution-data-server: enable cross compilation ``                              |
| [`53953bbd`](https://github.com/NixOS/nixpkgs/commit/53953bbde55d5b8c4a495cf3a6d2de8332024768) | `` softmaker-office: 2021.1032 -> 2024.1222 ``                                     |
| [`a165f0aa`](https://github.com/NixOS/nixpkgs/commit/a165f0aa38e04afa786ce2856626a0224ed7013b) | `` freeoffice: 2021.1054 -> 2024.1220 ``                                           |
| [`654b19ac`](https://github.com/NixOS/nixpkgs/commit/654b19ace381f998167399c4a684f07e098a5cdf) | `` softmaker: format ``                                                            |
| [`8cb4f5b7`](https://github.com/NixOS/nixpkgs/commit/8cb4f5b7020d69b07729f74bcf97a2875e777d98) | `` wrapQemuBinfmtP: don't use pkgsStatic ``                                        |
| [`02b6bf87`](https://github.com/NixOS/nixpkgs/commit/02b6bf874d29600437c003a61a54ad64a5d41f9b) | `` linux/common-config: remove duplicate conditional for ChromeOS support ``       |
| [`667e57cf`](https://github.com/NixOS/nixpkgs/commit/667e57cfcf2a2947ebf124a01e529c4bea345ff0) | `` storj-uplink: 1.118.8 -> 1.119.3 ``                                             |
| [`4410ed3e`](https://github.com/NixOS/nixpkgs/commit/4410ed3e80d45666d7028e3293959b8a17a0e7cd) | `` python312Packages.msgraph-sdk: 1.14.0 -> 1.15.0 ``                              |
| [`97389b02`](https://github.com/NixOS/nixpkgs/commit/97389b02b05cc66d526ae731fa7de6756b8cc74f) | `` vuls: 0.28.0 -> 0.28.1 ``                                                       |
| [`c64af83e`](https://github.com/NixOS/nixpkgs/commit/c64af83ee048027740fc89cda8000a804287dfe2) | `` parmmg: init at 1.4.0-unstable-2024-04-22 ``                                    |
| [`752e74fd`](https://github.com/NixOS/nixpkgs/commit/752e74fd935f2bdf7498ead960816c208b5f5adb) | `` python312Packages.weblate-language-data: 2024.14 -> 2024.15 ``                  |
| [`244d9ebf`](https://github.com/NixOS/nixpkgs/commit/244d9ebfef5b2dbb6ad151dacd2aaf7dbd643c94) | `` c3c: 0.6.4 -> 0.6.5 ``                                                          |
| [`0fda7ce3`](https://github.com/NixOS/nixpkgs/commit/0fda7ce38dca0cd865283e2ec9dfb775076f8e27) | `` railway: 3.19.1 -> 3.20.0 ``                                                    |
| [`92fbd14c`](https://github.com/NixOS/nixpkgs/commit/92fbd14ccb17497395c7df674b0980b02c9ed534) | `` credhub-cli: 2.9.39 -> 2.9.40 ``                                                |
| [`3bd4110e`](https://github.com/NixOS/nixpkgs/commit/3bd4110ea2e3f32fa9627005adecf1bc60625675) | `` cargo-leptos: 0.2.22 -> 0.2.24 ``                                               |
| [`ed1fdb4c`](https://github.com/NixOS/nixpkgs/commit/ed1fdb4c90a3010543507cfb23e0bd194d2cfb82) | `` zizmor: 0.9.1 -> 0.9.2 ``                                                       |
| [`1ebb5dec`](https://github.com/NixOS/nixpkgs/commit/1ebb5dece3e40a822cbb3a600a86507ce880c1ce) | `` go-blueprint: 0.10.1 -> 0.10.3 ``                                               |