### PR TITLE
chore(flake/nix-index-database): `311d6cf3` -> `d583b2d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -432,11 +432,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734234111,
-        "narHash": "sha256-icEMqBt4HtGH52PU5FHidgBrNJvOfXH6VQKNtnD1aw8=",
+        "lastModified": 1734838217,
+        "narHash": "sha256-zvMLS8BGn+kMG7tLLT3PJ67/S9yqZ9B7V8hKBa9cRRY=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "311d6cf3ad3f56cb051ffab1f480b2909b3f754d",
+        "rev": "d583b2d142f0428313df099f4a2dcf2a0496aa78",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`d583b2d1`](https://github.com/nix-community/nix-index-database/commit/d583b2d142f0428313df099f4a2dcf2a0496aa78) | `` update generated.nix to release 2024-12-22-031612 `` |
| [`af62b107`](https://github.com/nix-community/nix-index-database/commit/af62b10745e18133fbc6ed164baf4846c75ef5d5) | `` flake.lock: Update ``                                |