### PR TITLE
chore(flake/emacs-overlay): `3c24690a` -> `f1941db6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1734833431,
-        "narHash": "sha256-X142+eukhjxdkJkeyN8IUGxUVZ2pO9lX3N9pMYNqOJQ=",
+        "lastModified": 1734858647,
+        "narHash": "sha256-aNjb0mYepYrGQaXxOvZbV2O7pDJr6Vh9Ct7qmWtmufg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3c24690ab6fe48f82675b13cd6addb9a8dadfb92",
+        "rev": "f1941db6f24f6a1ca138b373dd7c25ffd48530c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`f1941db6`](https://github.com/nix-community/emacs-overlay/commit/f1941db6f24f6a1ca138b373dd7c25ffd48530c3) | `` Updated emacs ``        |
| [`89be1569`](https://github.com/nix-community/emacs-overlay/commit/89be1569ffe3dbe9022a50e973b6c9e7285a4654) | `` Updated melpa ``        |
| [`6e615f22`](https://github.com/nix-community/emacs-overlay/commit/6e615f2298f3738547ccfc9bd6cacee3b9a323e6) | `` Updated flake inputs `` |