### PR TITLE
chore(flake/nur): `cf4022fa` -> `e9208f1c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -752,11 +752,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1734850149,
-        "narHash": "sha256-OkcMRs+3YysXxQKl5WWiG1QN7M3wDKHNU3OVZA7qNQM=",
+        "lastModified": 1734881373,
+        "narHash": "sha256-khROZz9OKNY44ic6QlREBUVBq/eRdsk86nzDSdIKj+Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cf4022fae9d7a59798e681f3e3c07c0146f2ec66",
+        "rev": "e9208f1c4665772f6844fae5ea7593d857ff29c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e9208f1c`](https://github.com/nix-community/NUR/commit/e9208f1c4665772f6844fae5ea7593d857ff29c5) | `` automatic update `` |
| [`d12f6411`](https://github.com/nix-community/NUR/commit/d12f641133504251687ff3a0b71da9522049dc9c) | `` automatic update `` |
| [`761623be`](https://github.com/nix-community/NUR/commit/761623be1ab828c4e0d411194fada04fead471ea) | `` automatic update `` |
| [`45ac6a78`](https://github.com/nix-community/NUR/commit/45ac6a78988950c729623b6b97d9c680858d114f) | `` automatic update `` |
| [`0555467e`](https://github.com/nix-community/NUR/commit/0555467ea73103bcafe36ae9dcb12da17e6a8ce6) | `` automatic update `` |
| [`88312f1d`](https://github.com/nix-community/NUR/commit/88312f1dd8e82aad14bbfd4795021df6a300f946) | `` automatic update `` |