### PR TITLE
chore(flake/emacs-overlay): `f1941db6` -> `141bcbc8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1734858647,
-        "narHash": "sha256-aNjb0mYepYrGQaXxOvZbV2O7pDJr6Vh9Ct7qmWtmufg=",
+        "lastModified": 1734887366,
+        "narHash": "sha256-xBJkWgLhn7Fot0KOLFKi1CmBD95We4U5ag9xE3UHu+0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f1941db6f24f6a1ca138b373dd7c25ffd48530c3",
+        "rev": "141bcbc88cc068b7715db45b0d10aab43c236ca0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`141bcbc8`](https://github.com/nix-community/emacs-overlay/commit/141bcbc88cc068b7715db45b0d10aab43c236ca0) | `` Updated emacs ``  |
| [`6166691a`](https://github.com/nix-community/emacs-overlay/commit/6166691a52ee0d63f548483c24331d8210186111) | `` Updated melpa ``  |
| [`2129f15e`](https://github.com/nix-community/emacs-overlay/commit/2129f15e6c9fd12ce0ccd4a2d6fbe173cc59370d) | `` Updated elpa ``   |
| [`4542eb16`](https://github.com/nix-community/emacs-overlay/commit/4542eb16105ebbd8b771af4304796ef3ed8c2c98) | `` Updated nongnu `` |