### PR TITLE
chore(flake/home-manager): `cb27edb5` -> `edb8b00e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -315,11 +315,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734862405,
-        "narHash": "sha256-bXZJvUMJ2A6sIpYcCUAGjYCD5UDzmpmQCdmJSkPhleU=",
+        "lastModified": 1734893686,
+        "narHash": "sha256-JUEZn9MmpLGsW4J3luSX+R4BhcThccYpYg5AuKW7zG0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cb27edb5221d2f2920a03155f8becc502cf60e35",
+        "rev": "edb8b00e4d17b2116b60eca50f38ac68f12b9ab4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                       |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`edb8b00e`](https://github.com/nix-community/home-manager/commit/edb8b00e4d17b2116b60eca50f38ac68f12b9ab4) | `` Translate using Weblate (Czech) ``         |
| [`1f74238a`](https://github.com/nix-community/home-manager/commit/1f74238a4c8e534a1b6be72cb5153043071ffd17) | `` xresources: allow floating point values `` |