### PR TITLE
chore(flake/nur): `fec4a216` -> `0286f6d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -752,11 +752,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1734895664,
-        "narHash": "sha256-URmuo7mt6AtTGVfNFJkHUOn9PlxEfSblrWBcqbTKLp8=",
+        "lastModified": 1734926708,
+        "narHash": "sha256-sR3v5wOoYeFCu/El2hLgDb3y88uIGvmKoifbJmqp1s4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fec4a216aa4f86cc84148773f8687c9b138d5847",
+        "rev": "0286f6d0365738b564d882a7968471db21d4c0de",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0286f6d0`](https://github.com/nix-community/NUR/commit/0286f6d0365738b564d882a7968471db21d4c0de) | `` automatic update `` |
| [`135e406c`](https://github.com/nix-community/NUR/commit/135e406c11146a92883f6313925bf9fe2a3406aa) | `` automatic update `` |
| [`6f85066a`](https://github.com/nix-community/NUR/commit/6f85066a2b5aa95b7dad94b33bcd972cdff5e9f1) | `` automatic update `` |
| [`159f70bb`](https://github.com/nix-community/NUR/commit/159f70bb0b3843e81abaa6963e08983babeebf04) | `` automatic update `` |
| [`e9398ee9`](https://github.com/nix-community/NUR/commit/e9398ee9879025e22af7d6da78350f59b0475175) | `` automatic update `` |
| [`44ccf8a5`](https://github.com/nix-community/NUR/commit/44ccf8a5fa18582d9df463fcdc9f43c2d771d788) | `` automatic update `` |
| [`34b8ff5f`](https://github.com/nix-community/NUR/commit/34b8ff5fe5c4b48b2177d160d545231c69a7f13f) | `` automatic update `` |
| [`f678b46e`](https://github.com/nix-community/NUR/commit/f678b46e5ea4e3aff9ced76928fa67b0283f31d9) | `` automatic update `` |
| [`281019ac`](https://github.com/nix-community/NUR/commit/281019accfe4ca94700052fc9833db3b5017eaad) | `` automatic update `` |