### PR TITLE
chore(flake/emacs-overlay): `141bcbc8` -> `4ad82df6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1734887366,
-        "narHash": "sha256-xBJkWgLhn7Fot0KOLFKi1CmBD95We4U5ag9xE3UHu+0=",
+        "lastModified": 1735005943,
+        "narHash": "sha256-DkNn2xaTckw0hWFgVpqjPfUX/aSKDUUQMlQ2G65jjbk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "141bcbc88cc068b7715db45b0d10aab43c236ca0",
+        "rev": "4ad82df68a6a5cf1aaee49fae0a1047e0422face",
         "type": "github"
       },
       "original": {
@@ -581,11 +581,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1734737257,
-        "narHash": "sha256-GIMyMt1pkkoXdCq9un859bX6YQZ/iYtukb9R5luazLM=",
+        "lastModified": 1734875076,
+        "narHash": "sha256-Pzyb+YNG5u3zP79zoi8HXYMs15Q5dfjDgwCdUI5B0nY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1c6e20d41d6a9c1d737945962160e8571df55daa",
+        "rev": "1807c2b91223227ad5599d7067a61665c52d1295",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`4ad82df6`](https://github.com/nix-community/emacs-overlay/commit/4ad82df68a6a5cf1aaee49fae0a1047e0422face) | `` Updated emacs ``        |
| [`2c3d5a13`](https://github.com/nix-community/emacs-overlay/commit/2c3d5a1304e2775c4496f29f942c326140427bfb) | `` Updated melpa ``        |
| [`e7662cf1`](https://github.com/nix-community/emacs-overlay/commit/e7662cf1911f9a09488a52aed79eac70deb25f5d) | `` Updated elpa ``         |
| [`aa0db286`](https://github.com/nix-community/emacs-overlay/commit/aa0db28624312e885f91a78146c6e368e007f20b) | `` Updated nongnu ``       |
| [`f4952c0e`](https://github.com/nix-community/emacs-overlay/commit/f4952c0ec0e9ce358188cc81a17008ee99be3c99) | `` Updated emacs ``        |
| [`b16d3eb7`](https://github.com/nix-community/emacs-overlay/commit/b16d3eb7e7df1b8d859d2983746fde844c17db7b) | `` Updated melpa ``        |
| [`27c4e58c`](https://github.com/nix-community/emacs-overlay/commit/27c4e58c0397dead26fdadcec7cb654c3bda4103) | `` Updated elpa ``         |
| [`8deaf5b4`](https://github.com/nix-community/emacs-overlay/commit/8deaf5b42fcbc1ef3d9dc54c4f2bcbee5e4c41ca) | `` Updated nongnu ``       |
| [`f4d610ef`](https://github.com/nix-community/emacs-overlay/commit/f4d610ef67e8a50051075d7030803b94351f8b76) | `` Updated flake inputs `` |
| [`49bd3fd7`](https://github.com/nix-community/emacs-overlay/commit/49bd3fd75db9c063076c4b572778be5c96899570) | `` Updated melpa ``        |
| [`fd87d27a`](https://github.com/nix-community/emacs-overlay/commit/fd87d27a2bd726ef4ea161ee43fc9b1738a6fdb3) | `` Updated emacs ``        |
| [`1f724402`](https://github.com/nix-community/emacs-overlay/commit/1f7244023359387ef58be70452fed030b4364efc) | `` Updated melpa ``        |
| [`adbb7320`](https://github.com/nix-community/emacs-overlay/commit/adbb7320b9996af5757c35e7c405a6b27e372159) | `` Updated elpa ``         |
| [`b2fa7512`](https://github.com/nix-community/emacs-overlay/commit/b2fa75129123c0bf657a9a05109fc77204dfa085) | `` Updated nongnu ``       |