### PR TITLE
chore(flake/srvos): `758e36d8` -> `31c75c0d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -883,11 +883,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734587909,
-        "narHash": "sha256-8JzxqQEYm3wKoA1TmCfnfN1uZD/YNn9OZL8xI/OSbes=",
+        "lastModified": 1734915306,
+        "narHash": "sha256-cXoiU+doyRAZ/tcCCGcJjwK2bEZbRcuC0E+ZrnmgFOI=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "758e36d85d0dd2fbb01550554e7de68514558a0b",
+        "rev": "31c75c0d702f940aeb89eacc9c5dbde5d43df338",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`31c75c0d`](https://github.com/nix-community/srvos/commit/31c75c0d702f940aeb89eacc9c5dbde5d43df338) | `` dev/private/flake.lock: Update `` |
| [`d79c6dc6`](https://github.com/nix-community/srvos/commit/d79c6dc6e3262c22eba03eb54d0706cb4b6d1efa) | `` flake.lock: Update ``             |