### PR TITLE
chore(flake/treefmt): `65712f5a` -> `9e09d30a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -933,11 +933,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734704479,
-        "narHash": "sha256-MMi74+WckoyEWBRcg/oaGRvXC9BVVxDZNRMpL+72wBI=",
+        "lastModified": 1735135567,
+        "narHash": "sha256-8T3K5amndEavxnludPyfj3Z1IkcFdRpR23q+T0BVeZE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "65712f5af67234dad91a5a4baee986a8b62dbf8f",
+        "rev": "9e09d30a644c57257715902efbb3adc56c79cf28",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                              |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`9e09d30a`](https://github.com/numtide/treefmt-nix/commit/9e09d30a644c57257715902efbb3adc56c79cf28) | `` sqruff: init (#283) ``                                            |
| [`e41e948c`](https://github.com/numtide/treefmt-nix/commit/e41e948cf097cbf96ba4dff47a30ea6891af9f33) | `` README: fix the formatter example to include the system (#284) `` |