### PR TITLE
chore(flake/lanzaboote): `26a59c1b` -> `93e6f0d7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -361,11 +361,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1734820165,
-        "narHash": "sha256-qkPmnVYb6w2KdipyigI9ipNR7A8dsFStBRH5sZ+rmqA=",
+        "lastModified": 1734994463,
+        "narHash": "sha256-S9MgfQjNt4J3I7obdLOVY23h+Yl/hnyibwGfOl+1uOE=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "26a59c1b037e43f82b0fada2a218aeb128bc5d21",
+        "rev": "93e6f0d77548be8757c11ebda5c4235ef4f3bc67",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                               |
| --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`9f2c57f2`](https://github.com/nix-community/lanzaboote/commit/9f2c57f2b3e9010ce54e259100ca37ec9de3b6f0) | `` docs: Use new pkiBundle default location ``        |
| [`7cec007d`](https://github.com/nix-community/lanzaboote/commit/7cec007ddc45d8887f79f151c0de1a900e22c4a3) | `` docs: Add Framework Core Ultra Series 1 warning `` |