### PR TITLE
chore(flake/catppuccin): `1e4c3803` -> `bfd20bcf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1734734291,
-        "narHash": "sha256-CFX4diEQHKvZYjnhf7TLg20m3ge1O4vqgplsk/Kuaek=",
+        "lastModified": 1735028008,
+        "narHash": "sha256-crbQNRVQgPH0hX5vZk8xL9JStXo74Es7zDBjRcc4i+A=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "1e4c3803b8da874ff75224ec8512cb173036bbd8",
+        "rev": "bfd20bcf45f1de0e97b551be51495abf8a727f1a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                     |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`bfd20bcf`](https://github.com/catppuccin/nix/commit/bfd20bcf45f1de0e97b551be51495abf8a727f1a) | `` style: format b65f24d ``                                 |
| [`b65f24d3`](https://github.com/catppuccin/nix/commit/b65f24d3491b721314c9b490a69b3d831bdd1927) | `` fix(home-manager/zed): correctly apply italics (#422) `` |