### PR TITLE
chore(flake/emacs-overlay): `4ad82df6` -> `0657c6e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1735005943,
-        "narHash": "sha256-DkNn2xaTckw0hWFgVpqjPfUX/aSKDUUQMlQ2G65jjbk=",
+        "lastModified": 1735031605,
+        "narHash": "sha256-daG88lfmfD+jSL7+zOcMbocAcHKrokGHXx7edZnMmnE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4ad82df68a6a5cf1aaee49fae0a1047e0422face",
+        "rev": "0657c6e51b025e4b569c413d28ad4a5f4e64e93c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`0657c6e5`](https://github.com/nix-community/emacs-overlay/commit/0657c6e51b025e4b569c413d28ad4a5f4e64e93c) | `` Updated emacs `` |
| [`18921dbe`](https://github.com/nix-community/emacs-overlay/commit/18921dbeab3d835a42c5bd081a0629f86897b2e4) | `` Updated melpa `` |