### PR TITLE
chore(flake/emacs-overlay): `80b84fa7` -> `85d4073e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1735059577,
-        "narHash": "sha256-E/pjX9CBXuByVIYn7lQZJhheGlCCgPgXUN50YIna1VY=",
+        "lastModified": 1735178677,
+        "narHash": "sha256-m6PYpZ2YMoQvHtUuxwKwdRY0kLHG+y3cRyWYjiF1cEI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "80b84fa77a5c34245c30242f4c5f6320d877a9f6",
+        "rev": "85d4073e0b45f7a6444dabe02fd30cd0676954be",
         "type": "github"
       },
       "original": {
@@ -581,11 +581,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1734875076,
-        "narHash": "sha256-Pzyb+YNG5u3zP79zoi8HXYMs15Q5dfjDgwCdUI5B0nY=",
+        "lastModified": 1734991663,
+        "narHash": "sha256-8T660guvdaOD+2/Cj970bWlQwAyZLKrrbkhYOFcY1YE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1807c2b91223227ad5599d7067a61665c52d1295",
+        "rev": "6c90912761c43e22b6fb000025ab96dd31c971ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`85d4073e`](https://github.com/nix-community/emacs-overlay/commit/85d4073e0b45f7a6444dabe02fd30cd0676954be) | `` Updated emacs ``        |
| [`33dc2582`](https://github.com/nix-community/emacs-overlay/commit/33dc25822d9ca3e5339ed437208c36e9771c2ac0) | `` Updated melpa ``        |
| [`407cd9bf`](https://github.com/nix-community/emacs-overlay/commit/407cd9bfb013941f0e2578a373e3895d2bf023ee) | `` Updated elpa ``         |
| [`a7bf96d8`](https://github.com/nix-community/emacs-overlay/commit/a7bf96d88990c00f169ec0f766a4a5c04fbd11a6) | `` Updated nongnu ``       |
| [`91de3363`](https://github.com/nix-community/emacs-overlay/commit/91de336375fff7c672d4d0b816a03c8fdfbc92de) | `` Updated melpa ``        |
| [`2d3f780c`](https://github.com/nix-community/emacs-overlay/commit/2d3f780ce2b3be68bc58af55013c004e672a0841) | `` Updated elpa ``         |
| [`94f45001`](https://github.com/nix-community/emacs-overlay/commit/94f450015b545452363a3dce9bfd5edb6b99bd2c) | `` Updated nongnu ``       |
| [`c8e9f6ae`](https://github.com/nix-community/emacs-overlay/commit/c8e9f6ae15da11936055e7aadde9c62a533d6329) | `` Updated flake inputs `` |
| [`0a583fe7`](https://github.com/nix-community/emacs-overlay/commit/0a583fe7317026fbc456209e28718b3a85abbca9) | `` Updated emacs ``        |
| [`6aa87f47`](https://github.com/nix-community/emacs-overlay/commit/6aa87f47a18a1e38f30e8d2c98c269df6e155113) | `` Updated melpa ``        |
| [`52eb809a`](https://github.com/nix-community/emacs-overlay/commit/52eb809a3a5ab12954afa3b85b9e52de570237f0) | `` Updated emacs ``        |
| [`1b886826`](https://github.com/nix-community/emacs-overlay/commit/1b886826db1b9f3ed1b4c056ad5fe614350dfd2d) | `` Updated melpa ``        |
| [`970c8bf0`](https://github.com/nix-community/emacs-overlay/commit/970c8bf0e3a129b8b8000d71b7c6154a7a3c808c) | `` Updated elpa ``         |
| [`d8157b24`](https://github.com/nix-community/emacs-overlay/commit/d8157b244fc20164c39d2844294105ecb55bdc4c) | `` Updated nongnu ``       |