### PR TITLE
chore(flake/emacs-overlay): `85d4073e` -> `fbd938f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1735178677,
-        "narHash": "sha256-m6PYpZ2YMoQvHtUuxwKwdRY0kLHG+y3cRyWYjiF1cEI=",
+        "lastModified": 1735204314,
+        "narHash": "sha256-yp5J7/aowCug492TLnsaxm7Oaf/lz57YP+mmWra+0sI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "85d4073e0b45f7a6444dabe02fd30cd0676954be",
+        "rev": "fbd938f1f77da260f283b736e1b46b43efcb9961",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`fbd938f1`](https://github.com/nix-community/emacs-overlay/commit/fbd938f1f77da260f283b736e1b46b43efcb9961) | `` Updated emacs `` |
| [`4170b763`](https://github.com/nix-community/emacs-overlay/commit/4170b763345d7c5658b1be2d80ddcbce87d4d88f) | `` Updated melpa `` |