### PR TITLE
chore(flake/srvos): `31c75c0d` -> `e3b40489`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1064,11 +1064,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734915306,
-        "narHash": "sha256-cXoiU+doyRAZ/tcCCGcJjwK2bEZbRcuC0E+ZrnmgFOI=",
+        "lastModified": 1735379278,
+        "narHash": "sha256-DpihJuI9SaWOUc1lRrw+e5014Qj+WHn9Xla89jxA6jk=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "31c75c0d702f940aeb89eacc9c5dbde5d43df338",
+        "rev": "e3b404890cfb44caec3edc8b84facb8934299428",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`a48f731c`](https://github.com/nix-community/srvos/commit/a48f731c4da642a465e169fcae1a00bb5e4d3e19) | `` no longer set nixpkgs.flake.source ``                               |
| [`02c52bc1`](https://github.com/nix-community/srvos/commit/02c52bc1c42827418f4179f4a3cf72f6a20574f3) | `` mdns: don't explicilty unset multicast dns if useDHCP is not set `` |
| [`6bbe4d81`](https://github.com/nix-community/srvos/commit/6bbe4d8190993f838f42b6410241a17ee3350849) | `` darwin/nix-experimental: disable uid-range ``                       |
| [`2a30339b`](https://github.com/nix-community/srvos/commit/2a30339b3f4336092557655d57448cdcb3a2ee77) | `` depend on gitMinimal instead of git (#587) ``                       |
| [`c32a1fab`](https://github.com/nix-community/srvos/commit/c32a1fabfe3d7bc12c0378343ac536ba7d25f1c0) | `` Add Hetzner time servers for NTP resolution (#589) ``               |