### PR TITLE
chore(flake/emacs-overlay): `fbd938f1` -> `644713bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1735204314,
-        "narHash": "sha256-yp5J7/aowCug492TLnsaxm7Oaf/lz57YP+mmWra+0sI=",
+        "lastModified": 1735233083,
+        "narHash": "sha256-3AqQQcBXc2iAvpGqZ4UinsJ7RF8lQ41ml3H4plBqqNI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fbd938f1f77da260f283b736e1b46b43efcb9961",
+        "rev": "644713bfd86acb4198fc416f9452eb6d25775a03",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`644713bf`](https://github.com/nix-community/emacs-overlay/commit/644713bfd86acb4198fc416f9452eb6d25775a03) | `` Updated emacs ``  |
| [`07d721df`](https://github.com/nix-community/emacs-overlay/commit/07d721dfecdded7ed8f208554bdbd65f16fe46cb) | `` Updated melpa ``  |
| [`48f87c7b`](https://github.com/nix-community/emacs-overlay/commit/48f87c7b174fd54c0446fc4c2f393475ecbe7525) | `` Updated elpa ``   |
| [`66c82eb7`](https://github.com/nix-community/emacs-overlay/commit/66c82eb7ba0569aafad4f6e349f376a4271f6297) | `` Updated nongnu `` |