### PR TITLE
chore(flake/emacs-overlay): `644713bf` -> `4b0e7b77`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1735233083,
-        "narHash": "sha256-3AqQQcBXc2iAvpGqZ4UinsJ7RF8lQ41ml3H4plBqqNI=",
+        "lastModified": 1735265093,
+        "narHash": "sha256-vTaiIj5g5AkKf2Z9mAMEeNc0y1OClaSmFNeIbQtP/0s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "644713bfd86acb4198fc416f9452eb6d25775a03",
+        "rev": "4b0e7b77b538ee7a012404c62dad556c1fdf26a2",
         "type": "github"
       },
       "original": {
@@ -581,11 +581,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1734991663,
-        "narHash": "sha256-8T660guvdaOD+2/Cj970bWlQwAyZLKrrbkhYOFcY1YE=",
+        "lastModified": 1735141468,
+        "narHash": "sha256-VIAjBr1qGcEbmhLwQJD6TABppPMggzOvqFsqkDoMsAY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6c90912761c43e22b6fb000025ab96dd31c971ff",
+        "rev": "4005c3ff7505313cbc21081776ad0ce5dfd7a3ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`4b0e7b77`](https://github.com/nix-community/emacs-overlay/commit/4b0e7b77b538ee7a012404c62dad556c1fdf26a2) | `` Updated emacs ``        |
| [`da154a26`](https://github.com/nix-community/emacs-overlay/commit/da154a268947f8dc003c2c896310afb5531a33df) | `` Updated melpa ``        |
| [`5f215d06`](https://github.com/nix-community/emacs-overlay/commit/5f215d06c8a5f0c6043fa851f05701e31961cfa1) | `` Updated elpa ``         |
| [`3b800785`](https://github.com/nix-community/emacs-overlay/commit/3b800785083b9cf6002560e85135ec195b962c06) | `` Updated nongnu ``       |
| [`e1688860`](https://github.com/nix-community/emacs-overlay/commit/e16888608049ca2c4508ec8567a9be40c09f5d8f) | `` Updated flake inputs `` |