### PR TITLE
chore(flake/emacs-overlay): `4b0e7b77` -> `8bc91082`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1735265093,
-        "narHash": "sha256-vTaiIj5g5AkKf2Z9mAMEeNc0y1OClaSmFNeIbQtP/0s=",
+        "lastModified": 1735290740,
+        "narHash": "sha256-D9IKkVBswPzjawjuKFZbTALW5nz8HPeS3cqY4rNdVjs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4b0e7b77b538ee7a012404c62dad556c1fdf26a2",
+        "rev": "8bc910823b5594e669812d55fcd62c50d37759bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`8bc91082`](https://github.com/nix-community/emacs-overlay/commit/8bc910823b5594e669812d55fcd62c50d37759bb) | `` Updated emacs `` |
| [`9f501537`](https://github.com/nix-community/emacs-overlay/commit/9f5015375befaa23ee4269babbfb8ff7f60fdbf9) | `` Updated melpa `` |