### PR TITLE
chore(flake/emacs-overlay): `8bc91082` -> `5fb1f4fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1735290740,
-        "narHash": "sha256-D9IKkVBswPzjawjuKFZbTALW5nz8HPeS3cqY4rNdVjs=",
+        "lastModified": 1735319479,
+        "narHash": "sha256-0VPcmQys77YTIvazTBJTBqm9uA343+sV/LOjjcYX7gQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8bc910823b5594e669812d55fcd62c50d37759bb",
+        "rev": "5fb1f4fbdd31fd047dc92eb4c06e2a1349d96437",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`5fb1f4fb`](https://github.com/nix-community/emacs-overlay/commit/5fb1f4fbdd31fd047dc92eb4c06e2a1349d96437) | `` Updated emacs ``  |
| [`b8ea105a`](https://github.com/nix-community/emacs-overlay/commit/b8ea105a3920e385287261739a9944b93914ede7) | `` Updated melpa ``  |
| [`58e0e1b7`](https://github.com/nix-community/emacs-overlay/commit/58e0e1b766896cacd34d6183d4f272a21c4605e0) | `` Updated nongnu `` |