### PR TITLE
chore(flake/emacs-overlay): `5fb1f4fb` -> `4c344936`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1735319479,
-        "narHash": "sha256-0VPcmQys77YTIvazTBJTBqm9uA343+sV/LOjjcYX7gQ=",
+        "lastModified": 1735438498,
+        "narHash": "sha256-zVHyH34jY6naEqsJG06LlKulIyNiQMLEFBS/o+FYqXU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5fb1f4fbdd31fd047dc92eb4c06e2a1349d96437",
+        "rev": "4c344936ab4e21146d4fbe5806005a2e1b5c4844",
         "type": "github"
       },
       "original": {
@@ -724,11 +724,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1735141468,
-        "narHash": "sha256-VIAjBr1qGcEbmhLwQJD6TABppPMggzOvqFsqkDoMsAY=",
+        "lastModified": 1735264675,
+        "narHash": "sha256-MgdXpeX2GuJbtlBrH9EdsUeWl/yXEubyvxM1G+yO4Ak=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4005c3ff7505313cbc21081776ad0ce5dfd7a3ce",
+        "rev": "d49da4c08359e3c39c4e27c74ac7ac9b70085966",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`4c344936`](https://github.com/nix-community/emacs-overlay/commit/4c344936ab4e21146d4fbe5806005a2e1b5c4844) | `` Updated emacs ``        |
| [`6b3d624e`](https://github.com/nix-community/emacs-overlay/commit/6b3d624e57119b658ef8b5b0616825d86353bef3) | `` Updated melpa ``        |
| [`3d382964`](https://github.com/nix-community/emacs-overlay/commit/3d382964be308d4446b445ece8f951e7e5c36496) | `` Updated elpa ``         |
| [`84e0ee59`](https://github.com/nix-community/emacs-overlay/commit/84e0ee5985e6d5c039849b5ef47993aeb1689468) | `` Updated nongnu ``       |
| [`74388037`](https://github.com/nix-community/emacs-overlay/commit/74388037057110eb4b64dc94c75395ddf4d0f940) | `` Updated emacs ``        |
| [`27642084`](https://github.com/nix-community/emacs-overlay/commit/27642084fcad18551771d5cb8a8af457c969436a) | `` Updated melpa ``        |
| [`5ae8c408`](https://github.com/nix-community/emacs-overlay/commit/5ae8c40812e57097cb0d38b89d833d722c3a3589) | `` Updated elpa ``         |
| [`b19c34a7`](https://github.com/nix-community/emacs-overlay/commit/b19c34a7c9e19f02f2e1fd690c04cb4ec232de3d) | `` Updated nongnu ``       |
| [`968f0ff0`](https://github.com/nix-community/emacs-overlay/commit/968f0ff01de11ab6f74101bb27008a70ab726632) | `` Updated flake inputs `` |
| [`97678931`](https://github.com/nix-community/emacs-overlay/commit/97678931872b1bad445ed341e083c09025b4f0e7) | `` Updated melpa ``        |
| [`b25255c4`](https://github.com/nix-community/emacs-overlay/commit/b25255c4ff136938d16c1972f27840094e627b6b) | `` Updated emacs ``        |
| [`fb70a5df`](https://github.com/nix-community/emacs-overlay/commit/fb70a5dfc5ce9e7e6bbc364d593247f2cbfd17d3) | `` Updated melpa ``        |
| [`8c93b259`](https://github.com/nix-community/emacs-overlay/commit/8c93b2599001d56a59fc175d9585932b3de7ac3b) | `` Updated elpa ``         |
| [`0a0b4415`](https://github.com/nix-community/emacs-overlay/commit/0a0b4415e39287c9f398d77180c17a58bdc88d6e) | `` Updated nongnu ``       |
| [`4a63bf83`](https://github.com/nix-community/emacs-overlay/commit/4a63bf83a190feaf033928530b46fb3942529fdc) | `` Updated flake inputs `` |