### PR TITLE
chore(flake/home-manager): `b7a7cd5d` -> `10e99c43`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -315,11 +315,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735343815,
-        "narHash": "sha256-p7IJP/97zJda/wwCn1T2LJBz4olF5LjNf4uwhuyvARo=",
+        "lastModified": 1735381016,
+        "narHash": "sha256-CyCZFhMUkuYbSD6bxB/r43EdmDE7hYeZZPTCv0GudO4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b7a7cd5dd1a74a9fe86ed4e016f91c78483b527a",
+        "rev": "10e99c43cdf4a0713b4e81d90691d22c6a58bdf2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                     |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`10e99c43`](https://github.com/nix-community/home-manager/commit/10e99c43cdf4a0713b4e81d90691d22c6a58bdf2) | `` copyq: add option to disable XWayland `` |