### PR TITLE
chore(flake/nur): `20f2b24b` -> `b6835984`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -910,11 +910,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1735443611,
-        "narHash": "sha256-KmmQZyOuqRX9jcF9TifBG3KW97t3qWa8pvehC59Xrz0=",
+        "lastModified": 1735496794,
+        "narHash": "sha256-3i7+Me0gPSBmMN9d2/vW18hXYeyAYXNLOrVCT7S0mW4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "20f2b24b14f8aa0ded993332e1321ec4d13b8efe",
+        "rev": "b6835984668a42dc960cd4d60735e94d9f3c90e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b6835984`](https://github.com/nix-community/NUR/commit/b6835984668a42dc960cd4d60735e94d9f3c90e8) | `` automatic update `` |
| [`ef47699f`](https://github.com/nix-community/NUR/commit/ef47699fdcde7b96b8b3f3ea6e1a3e82728598af) | `` automatic update `` |
| [`49e3cfba`](https://github.com/nix-community/NUR/commit/49e3cfba8ccccc14ec57587fdf787f5b15161b51) | `` automatic update `` |
| [`69f33b21`](https://github.com/nix-community/NUR/commit/69f33b21fab40d98058247256fb8f964eb2c24e9) | `` automatic update `` |
| [`285c7ac1`](https://github.com/nix-community/NUR/commit/285c7ac130eba7e34c73284fabecc6ce141e9528) | `` automatic update `` |
| [`39785da2`](https://github.com/nix-community/NUR/commit/39785da29f41800edfe08c954ecf7a9fa94ff32a) | `` automatic update `` |
| [`493dbcd9`](https://github.com/nix-community/NUR/commit/493dbcd9df5aa49af2695721fc10978009b64dad) | `` automatic update `` |
| [`ac8eaafe`](https://github.com/nix-community/NUR/commit/ac8eaafe08708a97921cdcec53ede1abe5f08d37) | `` automatic update `` |
| [`24aadcfa`](https://github.com/nix-community/NUR/commit/24aadcfa5e2a6f767d225109324e1ee4492e7e04) | `` automatic update `` |
| [`e70956e3`](https://github.com/nix-community/NUR/commit/e70956e3498c04d5340cb34c17c2d35eb76e6dc8) | `` automatic update `` |
| [`96978136`](https://github.com/nix-community/NUR/commit/96978136bd754cbbcb16d0584abefdd95a569427) | `` automatic update `` |