### PR TITLE
chore(flake/sops-nix): `ed091321` -> `bcb8b65a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1044,11 +1044,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734546875,
-        "narHash": "sha256-6OvJbqQ6qPpNw3CA+W8Myo5aaLhIJY/nNFDk3zMXLfM=",
+        "lastModified": 1735468296,
+        "narHash": "sha256-ZjUjbvS06jf4fElOF4ve8EHjbpbRVHHypStoY8HGzk8=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "ed091321f4dd88afc28b5b4456e0a15bd8374b4d",
+        "rev": "bcb8b65aa596866eb7e5c3e1a6cccbf5d1560b27",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                             |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`bcb8b65a`](https://github.com/Mic92/sops-nix/commit/bcb8b65aa596866eb7e5c3e1a6cccbf5d1560b27) | `` Fix link to "more complex .sops.yaml example" `` |