### PR TITLE
chore(flake/emacs-overlay): `3f0d0e1e` -> `0ee304f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1735462818,
-        "narHash": "sha256-GekGodAVddpJW6rx3Jd13nX3vactk2GMgCxi1atyRQU=",
+        "lastModified": 1735492275,
+        "narHash": "sha256-4Vb5khmaPXR87SbtKvk32g/kSxh1N9TlWJ3ELXwnNnY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3f0d0e1e5905cd4359aa2e4ed039c710cf047c99",
+        "rev": "0ee304f9c74150022a618ecc42bfe565ee5e254c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`0ee304f9`](https://github.com/nix-community/emacs-overlay/commit/0ee304f9c74150022a618ecc42bfe565ee5e254c) | `` Updated emacs ``  |
| [`01498098`](https://github.com/nix-community/emacs-overlay/commit/01498098ee08512e6fd22c4fdab37f1c18006b52) | `` Updated melpa ``  |
| [`4335244d`](https://github.com/nix-community/emacs-overlay/commit/4335244def5e78c6d0d4b67861e398337e40b422) | `` Updated elpa ``   |
| [`8a291cec`](https://github.com/nix-community/emacs-overlay/commit/8a291cec04f546542bf4d594d0c192ef93157624) | `` Updated nongnu `` |