### PR TITLE
chore(flake/nur): `b6835984` -> `1b5c56b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -910,11 +910,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1735496794,
-        "narHash": "sha256-3i7+Me0gPSBmMN9d2/vW18hXYeyAYXNLOrVCT7S0mW4=",
+        "lastModified": 1735502314,
+        "narHash": "sha256-K2RohlIblHXrZO99j3v2VeYXCx9kuII9/NgbjldD4ws=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b6835984668a42dc960cd4d60735e94d9f3c90e8",
+        "rev": "1b5c56b885b50f1dc8709d20882a58d89466e423",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1b5c56b8`](https://github.com/nix-community/NUR/commit/1b5c56b885b50f1dc8709d20882a58d89466e423) | `` automatic update `` |