### PR TITLE
chore(flake/nur): `1b5c56b8` -> `fecf125e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -910,11 +910,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1735502314,
-        "narHash": "sha256-K2RohlIblHXrZO99j3v2VeYXCx9kuII9/NgbjldD4ws=",
+        "lastModified": 1735512424,
+        "narHash": "sha256-cx8vvo7UMKmM4m4zTnz5rh7Lo1XqjkLntwH72+Ll2l0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1b5c56b885b50f1dc8709d20882a58d89466e423",
+        "rev": "fecf125e4108d53df6d7f69f010ae38f8ea17154",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                     |
| -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`fecf125e`](https://github.com/nix-community/NUR/commit/fecf125e4108d53df6d7f69f010ae38f8ea17154) | `` automatic update ``                                      |
| [`cc8d9724`](https://github.com/nix-community/NUR/commit/cc8d972404b9dd543d7d25d45d9d232a740ead9e) | `` automatic update ``                                      |
| [`632397d1`](https://github.com/nix-community/NUR/commit/632397d1b87a4eaedcddfe0e0532f8005c0fb25e) | `` Removed ona-li-toki-e-jan-Epiphany-tawa-mi repository `` |