### PR TITLE
chore(flake/emacs-overlay): `0ee304f9` -> `8532ee52`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1735492275,
-        "narHash": "sha256-4Vb5khmaPXR87SbtKvk32g/kSxh1N9TlWJ3ELXwnNnY=",
+        "lastModified": 1735524543,
+        "narHash": "sha256-lh8mdWE/ZHHXj6L3xwZmvlhzZf8CP4HiOkn3mpSF8hQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0ee304f9c74150022a618ecc42bfe565ee5e254c",
+        "rev": "8532ee52b538571d93e8fc7b83d76039e25e1fbf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`8532ee52`](https://github.com/nix-community/emacs-overlay/commit/8532ee52b538571d93e8fc7b83d76039e25e1fbf) | `` Updated emacs ``  |
| [`d39ef672`](https://github.com/nix-community/emacs-overlay/commit/d39ef67248e265591b8ce2080653582c735a3ea0) | `` Updated melpa ``  |
| [`7a8e98ca`](https://github.com/nix-community/emacs-overlay/commit/7a8e98caa27bf77212b3986aa92a05184f67a070) | `` Updated elpa ``   |
| [`71426c53`](https://github.com/nix-community/emacs-overlay/commit/71426c53c0a829c425d73dfd4a51b22b8d90a4ba) | `` Updated nongnu `` |