### PR TITLE
chore(flake/emacs-overlay): `8532ee52` -> `bc19dc80`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1735524543,
-        "narHash": "sha256-lh8mdWE/ZHHXj6L3xwZmvlhzZf8CP4HiOkn3mpSF8hQ=",
+        "lastModified": 1735550039,
+        "narHash": "sha256-hIyQM5hqBpOfvb6lMHl+707pg7iwBJKfbsANEZFhV+0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8532ee52b538571d93e8fc7b83d76039e25e1fbf",
+        "rev": "bc19dc80cd2987406a19b5c644e0400c4cf67e33",
         "type": "github"
       },
       "original": {
@@ -724,11 +724,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1735264675,
-        "narHash": "sha256-MgdXpeX2GuJbtlBrH9EdsUeWl/yXEubyvxM1G+yO4Ak=",
+        "lastModified": 1735412871,
+        "narHash": "sha256-Qoz0ow6jDGUIBHxduc7Y1cjYFS71tvEGJV5Src/mj98=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d49da4c08359e3c39c4e27c74ac7ac9b70085966",
+        "rev": "9f94733f93e4fe6e82f516efae007096e4ab5a21",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`bc19dc80`](https://github.com/nix-community/emacs-overlay/commit/bc19dc80cd2987406a19b5c644e0400c4cf67e33) | `` Updated emacs ``        |
| [`19bd95e4`](https://github.com/nix-community/emacs-overlay/commit/19bd95e4f5cc0677fac4e501ba68f3ec7d1da2c3) | `` Updated melpa ``        |
| [`467b69d2`](https://github.com/nix-community/emacs-overlay/commit/467b69d2d152d1b8df3e216cf0aaccd5aa59bfae) | `` Updated flake inputs `` |