### PR TITLE
chore(flake/catppuccin): `8b6baed3` -> `7413a65b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -40,11 +40,11 @@
         "nuscht-search": "nuscht-search"
       },
       "locked": {
-        "lastModified": 1735399522,
-        "narHash": "sha256-1lIjMEBvtxJH3V7c66D8pN/pPp4xsFGz6PjcOYX/Niw=",
+        "lastModified": 1735569271,
+        "narHash": "sha256-4CIClg4LMcmcCRIXSTcHDe6ujPzlxMtbCjMH7ntV784=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "8b6baed3d010416da6295805012b12cfa05c09f7",
+        "rev": "7413a65b3ed37964c16e2fbe20145b55bcda8281",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                   |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`7413a65b`](https://github.com/catppuccin/nix/commit/7413a65b3ed37964c16e2fbe20145b55bcda8281) | `` fix(home-manager/fcitx5): ajust source (#436) ``                       |
| [`457c23a6`](https://github.com/catppuccin/nix/commit/457c23a697c99da92db7523d45b1d905feae5858) | `` fix(home-manager/gtk): ajust config.gtk.name for new package (#439) `` |
| [`c56711a2`](https://github.com/catppuccin/nix/commit/c56711a2636881ffcf70d2c23198eb98523d8016) | `` style: format a5570a6 ``                                               |
| [`a5570a6f`](https://github.com/catppuccin/nix/commit/a5570a6f83ac1eb4802352c8e1c4328b57be7429) | `` fix(pkgs/nvim): copy overrides from nixpkgs (#432) ``                  |