### PR TITLE
chore(flake/nur): `be4ede4b` -> `9a91552c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -910,11 +910,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1735543962,
-        "narHash": "sha256-+2yRRwemiUXtC7Xrv9lJY5ScCXF7GjYHi4Fz5ADHEts=",
+        "lastModified": 1735572752,
+        "narHash": "sha256-q+52brvSWw+cuKiBoNMikLFbg3UXX5Q6RPA8HjWCksY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "be4ede4b588b7b879d393caf6eba9e040586ecb3",
+        "rev": "9a91552c1fedac097ad9f67a26df4b0bc78a2773",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9a91552c`](https://github.com/nix-community/NUR/commit/9a91552c1fedac097ad9f67a26df4b0bc78a2773) | `` automatic update `` |
| [`72e992f2`](https://github.com/nix-community/NUR/commit/72e992f26b7c6b2bafce47b3be9625e772a7a6a3) | `` automatic update `` |
| [`489da5bd`](https://github.com/nix-community/NUR/commit/489da5bda008e004588c57b31eb25cabf817552b) | `` automatic update `` |
| [`6a62817a`](https://github.com/nix-community/NUR/commit/6a62817aec9ab0c8bf7e8ca566f6a8b6895110fd) | `` automatic update `` |
| [`7f9e986e`](https://github.com/nix-community/NUR/commit/7f9e986ea8f469e1a8fbc3720f04225450e970b8) | `` automatic update `` |
| [`429cbb95`](https://github.com/nix-community/NUR/commit/429cbb95aeaf9ba25690b34a184a7aa7df306427) | `` automatic update `` |