### PR TITLE
chore(flake/nixos-cosmic): `6f74fba1` -> `9e7f30f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -604,11 +604,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1735522648,
-        "narHash": "sha256-A73vDMGBEq9KwUMmtMkg3zvReMsdRrb1ruXjNjzJh+I=",
+        "lastModified": 1735574565,
+        "narHash": "sha256-KWRnHS228oIbWCaGskaAEAGO7Eix/vmAQEA2J76wW/s=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "6f74fba14f206b6e74ed5d2320facf9c43c3771a",
+        "rev": "9e7f30f1f5b4ef4116567c64ea016af0b688a054",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                             |
| ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`9e7f30f1`](https://github.com/lilyinstarlight/nixos-cosmic/commit/9e7f30f1f5b4ef4116567c64ea016af0b688a054) | `` cosmic-ext-ctl: switch to useFetchCargoVendor `` |
| [`e1437e4e`](https://github.com/lilyinstarlight/nixos-cosmic/commit/e1437e4e8d0ebc7b646aa36733cb53d5b5d5d852) | `` nixos/cosmic: enable avahi by default ``         |
| [`79c99fb2`](https://github.com/lilyinstarlight/nixos-cosmic/commit/79c99fb2aeba5592bb6c28f2682c843e2d821845) | `` nixos/cosmic: enable geoclue2 system service ``  |