### PR TITLE
chore(flake/emacs-overlay): `bc19dc80` -> `d7aadd31`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1735550039,
-        "narHash": "sha256-hIyQM5hqBpOfvb6lMHl+707pg7iwBJKfbsANEZFhV+0=",
+        "lastModified": 1735578774,
+        "narHash": "sha256-h3rnJtvyccfe/OITy9t4Guenu/UYL2TloC0lLMUaW6Q=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bc19dc80cd2987406a19b5c644e0400c4cf67e33",
+        "rev": "d7aadd31e28779d86de9134ff7d356f948f0933b",
         "type": "github"
       },
       "original": {
@@ -724,11 +724,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1735412871,
-        "narHash": "sha256-Qoz0ow6jDGUIBHxduc7Y1cjYFS71tvEGJV5Src/mj98=",
+        "lastModified": 1735531152,
+        "narHash": "sha256-As8I+ebItDKtboWgDXYZSIjGlKeqiLBvjxsQHUmAf1Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9f94733f93e4fe6e82f516efae007096e4ab5a21",
+        "rev": "3ffbbdbac0566a0977da3d2657b89cbcfe9a173b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`d7aadd31`](https://github.com/nix-community/emacs-overlay/commit/d7aadd31e28779d86de9134ff7d356f948f0933b) | `` Updated emacs ``        |
| [`dc669001`](https://github.com/nix-community/emacs-overlay/commit/dc66900102152af56b9594875aae3525f43991e3) | `` Updated melpa ``        |
| [`eab2ed35`](https://github.com/nix-community/emacs-overlay/commit/eab2ed354a88a6870ffca4980abb470bba0e4452) | `` Updated elpa ``         |
| [`d2080e24`](https://github.com/nix-community/emacs-overlay/commit/d2080e24be22a0df2d9faeeb193f60e92ae08a08) | `` Updated nongnu ``       |
| [`3c8333b6`](https://github.com/nix-community/emacs-overlay/commit/3c8333b60023af1d1a83e528df09aec0e0acf1a9) | `` Updated flake inputs `` |