### PR TITLE
chore(flake/nur): `9a91552c` -> `3293565e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -910,11 +910,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1735572752,
-        "narHash": "sha256-q+52brvSWw+cuKiBoNMikLFbg3UXX5Q6RPA8HjWCksY=",
+        "lastModified": 1735588031,
+        "narHash": "sha256-dAAYQhP9YbUyREfORbiDa7bJvvbmnYlG/1r8k3EL0TM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9a91552c1fedac097ad9f67a26df4b0bc78a2773",
+        "rev": "3293565e1e6d8099aa564bfd9c3b0fc36c92a720",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3293565e`](https://github.com/nix-community/NUR/commit/3293565e1e6d8099aa564bfd9c3b0fc36c92a720) | `` automatic update `` |
| [`9b8e4b87`](https://github.com/nix-community/NUR/commit/9b8e4b87ff11dee31e28a32b70fba6280a49b515) | `` automatic update `` |
| [`5a1f5491`](https://github.com/nix-community/NUR/commit/5a1f5491f1e5bd655079e4ad79fb13ab07bb7eda) | `` automatic update `` |