### PR TITLE
chore(flake/nur): `3293565e` -> `9b1c14d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -910,11 +910,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1735588031,
-        "narHash": "sha256-dAAYQhP9YbUyREfORbiDa7bJvvbmnYlG/1r8k3EL0TM=",
+        "lastModified": 1735627902,
+        "narHash": "sha256-J/HCnlthc1JnuaUVsrVlgJWsvoB9prSC8TLq/UJa7bM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3293565e1e6d8099aa564bfd9c3b0fc36c92a720",
+        "rev": "9b1c14d6292d8f8e34415deb7d267e2512e41a6b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9b1c14d6`](https://github.com/nix-community/NUR/commit/9b1c14d6292d8f8e34415deb7d267e2512e41a6b) | `` automatic update `` |
| [`69511c5b`](https://github.com/nix-community/NUR/commit/69511c5b411995a238d2ecb0409d7f018d4a05e4) | `` automatic update `` |
| [`4143c7ba`](https://github.com/nix-community/NUR/commit/4143c7ba31bda9df45dbf14f4e26f33162a746eb) | `` automatic update `` |
| [`ea637262`](https://github.com/nix-community/NUR/commit/ea63726219ec277290f3b88c475a4c9cb011ee1d) | `` automatic update `` |
| [`cabea587`](https://github.com/nix-community/NUR/commit/cabea587b3610207e3e659ba24b5270c37d38c94) | `` automatic update `` |
| [`b3e35a24`](https://github.com/nix-community/NUR/commit/b3e35a248e9406cf4d10ede74acd0a7334297918) | `` automatic update `` |
| [`f010b652`](https://github.com/nix-community/NUR/commit/f010b6522aab87ead507d6a4c085b8ed8aa12586) | `` automatic update `` |