### PR TITLE
chore(flake/emacs-overlay): `d7aadd31` -> `54484c89`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1735578774,
-        "narHash": "sha256-h3rnJtvyccfe/OITy9t4Guenu/UYL2TloC0lLMUaW6Q=",
+        "lastModified": 1735611027,
+        "narHash": "sha256-cXObV60S6GksW+FDbxZgPRDQxrPdDN5Jg7xxiPUKGUA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d7aadd31e28779d86de9134ff7d356f948f0933b",
+        "rev": "54484c89441501961a1e1e7449389b81fffa1c68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`54484c89`](https://github.com/nix-community/emacs-overlay/commit/54484c89441501961a1e1e7449389b81fffa1c68) | `` Updated emacs ``  |
| [`a2ba4f7c`](https://github.com/nix-community/emacs-overlay/commit/a2ba4f7cd6196263a7af10b4d2c9a46c479b9522) | `` Updated melpa ``  |
| [`91fc19de`](https://github.com/nix-community/emacs-overlay/commit/91fc19dee8e4c85047381f51bd8ce8116e56e217) | `` Updated elpa ``   |
| [`9eaf2014`](https://github.com/nix-community/emacs-overlay/commit/9eaf2014c36b1081ef2c5d597d9203830687a399) | `` Updated nongnu `` |