### PR TITLE
chore(flake/catppuccin): `7413a65b` -> `63290ea1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -40,11 +40,11 @@
         "nuscht-search": "nuscht-search"
       },
       "locked": {
-        "lastModified": 1735569271,
-        "narHash": "sha256-4CIClg4LMcmcCRIXSTcHDe6ujPzlxMtbCjMH7ntV784=",
+        "lastModified": 1735634086,
+        "narHash": "sha256-DTcB/kBZULyJztXXnH3OVF5LHLl+O670DuLZZNUMnNo=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "7413a65b3ed37964c16e2fbe20145b55bcda8281",
+        "rev": "63290ea1d2a28e65195017ed78a81cfc242ef0df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                              |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`63290ea1`](https://github.com/catppuccin/nix/commit/63290ea1d2a28e65195017ed78a81cfc242ef0df) | `` feat(home-manager): init wlogout module (#398) `` |
| [`edc3c33c`](https://github.com/catppuccin/nix/commit/edc3c33cc5a311ce4a61d03e76df448936c3d8f6) | `` docs(README): sync FAQ with site (#441) ``        |