### PR TITLE
chore(flake/nur): `9b1c14d6` -> `3df1fbe5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -910,11 +910,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1735627902,
-        "narHash": "sha256-J/HCnlthc1JnuaUVsrVlgJWsvoB9prSC8TLq/UJa7bM=",
+        "lastModified": 1735659976,
+        "narHash": "sha256-YVzKA/McWbpRifCdwKVLHkOXc48ySifdWoM7zwI8NVg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9b1c14d6292d8f8e34415deb7d267e2512e41a6b",
+        "rev": "3df1fbe5e47395d010ebf2648470f1a9961cfe4a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3df1fbe5`](https://github.com/nix-community/NUR/commit/3df1fbe5e47395d010ebf2648470f1a9961cfe4a) | `` automatic update `` |
| [`1bb7310d`](https://github.com/nix-community/NUR/commit/1bb7310d7d1eeaa33d1d009ac493bc2b38acef40) | `` automatic update `` |
| [`e9393f73`](https://github.com/nix-community/NUR/commit/e9393f73113b4e34a4ed8b8685e241b71c0811a9) | `` automatic update `` |
| [`c639a075`](https://github.com/nix-community/NUR/commit/c639a0750ca212216bb10f2a9d7e9688e01ee54a) | `` automatic update `` |
| [`6b363a90`](https://github.com/nix-community/NUR/commit/6b363a90fabc6f634708ccda93131e19d3856720) | `` automatic update `` |