### PR TITLE
chore(flake/emacs-overlay): `7dc139df` -> `964a44f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1735635676,
-        "narHash": "sha256-mr3Slf2LDg6YMjQcrNdj/i8tQK4p7NIYVshVPBgtYBM=",
+        "lastModified": 1735664350,
+        "narHash": "sha256-ang/5tqyt3JealgO/v9sD1RsFzrlsP2IJfrRqCbEvFI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7dc139dffc4ad8301c639210a00d993e1c158069",
+        "rev": "964a44f6585f8cae26c228409676d92822f78de0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`964a44f6`](https://github.com/nix-community/emacs-overlay/commit/964a44f6585f8cae26c228409676d92822f78de0) | `` Updated melpa ``  |
| [`24de0683`](https://github.com/nix-community/emacs-overlay/commit/24de06834be49839d0754b7fca56d0ce16e79935) | `` Updated elpa ``   |
| [`b678938b`](https://github.com/nix-community/emacs-overlay/commit/b678938bf435d410fb7056b95fb1fdbd601b03ab) | `` Updated nongnu `` |