### PR TITLE
chore(flake/nur): `3df1fbe5` -> `8e0eb693`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -910,11 +910,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1735659976,
-        "narHash": "sha256-YVzKA/McWbpRifCdwKVLHkOXc48ySifdWoM7zwI8NVg=",
+        "lastModified": 1735669623,
+        "narHash": "sha256-bvyCWlpgeWWRQl+KitFnJ4pXbrd6/QI6jGZ2wCalDC4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3df1fbe5e47395d010ebf2648470f1a9961cfe4a",
+        "rev": "8e0eb69371b028cee70121d9d35b8005661510c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8e0eb693`](https://github.com/nix-community/NUR/commit/8e0eb69371b028cee70121d9d35b8005661510c7) | `` automatic update `` |
| [`26a30fdc`](https://github.com/nix-community/NUR/commit/26a30fdcd48c0ff43e23f806b1ba1262006eff47) | `` automatic update `` |
| [`594f61c4`](https://github.com/nix-community/NUR/commit/594f61c4166ad6d0e57a47028f69018334e6221b) | `` automatic update `` |