### PR TITLE
chore(flake/nur): `8e0eb693` -> `a0b5edb4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -910,11 +910,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1735669623,
-        "narHash": "sha256-bvyCWlpgeWWRQl+KitFnJ4pXbrd6/QI6jGZ2wCalDC4=",
+        "lastModified": 1735674316,
+        "narHash": "sha256-qpXgrWWdI4vns/pcrSkDg8knXxzIePfNE+mv92Tdv/Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8e0eb69371b028cee70121d9d35b8005661510c7",
+        "rev": "a0b5edb463997aae23c82a72cee1ce09a2a7de71",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a0b5edb4`](https://github.com/nix-community/NUR/commit/a0b5edb463997aae23c82a72cee1ce09a2a7de71) | `` automatic update `` |