### PR TITLE
chore(flake/nur): `a0b5edb4` -> `7218066e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -910,11 +910,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1735674316,
-        "narHash": "sha256-qpXgrWWdI4vns/pcrSkDg8knXxzIePfNE+mv92Tdv/Q=",
+        "lastModified": 1735676854,
+        "narHash": "sha256-46dHgs25vi/q4K6gVe98uSV1XkoweqSMnKheA0J94T4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a0b5edb463997aae23c82a72cee1ce09a2a7de71",
+        "rev": "7218066e541efddf848d2248e63824f1ae0bfb47",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7218066e`](https://github.com/nix-community/NUR/commit/7218066e541efddf848d2248e63824f1ae0bfb47) | `` automatic update `` |