### PR TITLE
chore(flake/emacs-overlay): `964a44f6` -> `665b9fb1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1735664350,
-        "narHash": "sha256-ang/5tqyt3JealgO/v9sD1RsFzrlsP2IJfrRqCbEvFI=",
+        "lastModified": 1735722864,
+        "narHash": "sha256-fMOZzocD+7nl0346oyFmln+C3yq1OUU2n/kCSfp5j60=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "964a44f6585f8cae26c228409676d92822f78de0",
+        "rev": "665b9fb1235c5cca2125623bd2078d19c8093d2e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`665b9fb1`](https://github.com/nix-community/emacs-overlay/commit/665b9fb1235c5cca2125623bd2078d19c8093d2e) | `` Updated emacs `` |
| [`a93c1ab3`](https://github.com/nix-community/emacs-overlay/commit/a93c1ab37851e8dc49e087b3f440e1ccd34f19fd) | `` Updated melpa `` |
| [`f018d916`](https://github.com/nix-community/emacs-overlay/commit/f018d91651195552f17c5b922644b353179ba7a6) | `` Updated emacs `` |
| [`adb0c271`](https://github.com/nix-community/emacs-overlay/commit/adb0c271770161a17c66414a9828ed1ae01a2acb) | `` Updated melpa `` |
| [`d79f6fe2`](https://github.com/nix-community/emacs-overlay/commit/d79f6fe2b6f6d4bcffdebf4aa0515873d557e2b8) | `` Updated elpa ``  |