### PR TITLE
chore(flake/nur): `7218066e` -> `e16edb4a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -910,11 +910,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1735676854,
-        "narHash": "sha256-46dHgs25vi/q4K6gVe98uSV1XkoweqSMnKheA0J94T4=",
+        "lastModified": 1735760745,
+        "narHash": "sha256-COHm2EEkeC+SlUUMtHBptsI5IznBR2/kLmX18CLmpig=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7218066e541efddf848d2248e63824f1ae0bfb47",
+        "rev": "e16edb4abf01c3fe232f22d0ef8364853dde7cec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e16edb4a`](https://github.com/nix-community/NUR/commit/e16edb4abf01c3fe232f22d0ef8364853dde7cec) | `` automatic update `` |
| [`ad833590`](https://github.com/nix-community/NUR/commit/ad83359075b1c5d774bfc4d1d08cac4970f62750) | `` automatic update `` |
| [`cfad7032`](https://github.com/nix-community/NUR/commit/cfad7032d277074c1b8bb040405095c71b808fba) | `` automatic update `` |
| [`1381479d`](https://github.com/nix-community/NUR/commit/1381479d973294515189878b41450e3780d18012) | `` automatic update `` |
| [`543f0bf7`](https://github.com/nix-community/NUR/commit/543f0bf7b68ea3a3cbfb8d310f85d9e222247cce) | `` automatic update `` |
| [`0dae436c`](https://github.com/nix-community/NUR/commit/0dae436ca5421a4e90bc174bec823792d83354df) | `` automatic update `` |
| [`21096db6`](https://github.com/nix-community/NUR/commit/21096db6c9ba41cd300a22ee42b86851366bd94f) | `` automatic update `` |
| [`8e6a43dd`](https://github.com/nix-community/NUR/commit/8e6a43dd518c82532594b200b980d37428f153ee) | `` automatic update `` |
| [`0bb12f27`](https://github.com/nix-community/NUR/commit/0bb12f274d673b196cc4e680912d3374b98ad23b) | `` automatic update `` |
| [`075bd2ee`](https://github.com/nix-community/NUR/commit/075bd2ee34e40aae8f971e75caadd59cef35a506) | `` automatic update `` |
| [`72064492`](https://github.com/nix-community/NUR/commit/72064492bfa08e1c819e4b5ca1e18cb82d5fa947) | `` automatic update `` |