### PR TITLE
chore(flake/home-manager): `10e99c43` -> `59a4c43e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735381016,
-        "narHash": "sha256-CyCZFhMUkuYbSD6bxB/r43EdmDE7hYeZZPTCv0GudO4=",
+        "lastModified": 1735735907,
+        "narHash": "sha256-/AOGn9qJMjrZQyWYbObHTKmWDUP0q9+0TAXOJnq6ik0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "10e99c43cdf4a0713b4e81d90691d22c6a58bdf2",
+        "rev": "59a4c43e9ba6db24698c112720a58a334117de83",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`59a4c43e`](https://github.com/nix-community/home-manager/commit/59a4c43e9ba6db24698c112720a58a334117de83) | `` bacon: fix configuration file location on Darwin `` |
| [`2ac770c0`](https://github.com/nix-community/home-manager/commit/2ac770c007cc5dc26e6fe472956e6a23134dd124) | `` flake.lock: Update ``                               |