### PR TITLE
chore(flake/home-manager): `59a4c43e` -> `5f6aa268`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735735907,
-        "narHash": "sha256-/AOGn9qJMjrZQyWYbObHTKmWDUP0q9+0TAXOJnq6ik0=",
+        "lastModified": 1735774425,
+        "narHash": "sha256-C73gLFnEh8ZI0uDijUgCDWCd21T6I6tsaWgIBHcfAXg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "59a4c43e9ba6db24698c112720a58a334117de83",
+        "rev": "5f6aa268e419d053c3d5025da740e390b12ac936",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`5f6aa268`](https://github.com/nix-community/home-manager/commit/5f6aa268e419d053c3d5025da740e390b12ac936) | `` ghostty: add module ``                            |
| [`9a9fef31`](https://github.com/nix-community/home-manager/commit/9a9fef316ad191b3086edda465e850af282de4e0) | `` systemd: use sd-switch by default ``              |
| [`5518f9d4`](https://github.com/nix-community/home-manager/commit/5518f9d43919c255653b235150010da32faa60c0) | `` home-manager: make show news a bit more robust `` |