### PR TITLE
chore(flake/emacs-overlay): `665b9fb1` -> `a4dc7719`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1735722864,
-        "narHash": "sha256-fMOZzocD+7nl0346oyFmln+C3yq1OUU2n/kCSfp5j60=",
+        "lastModified": 1735751588,
+        "narHash": "sha256-fvaO6F5PUGGeTwEjAs95REaAEvh4SExhZr0fM5vJQfQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "665b9fb1235c5cca2125623bd2078d19c8093d2e",
+        "rev": "a4dc77197ec7249cceeaa43cca56a1c217fd440d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`a4dc7719`](https://github.com/nix-community/emacs-overlay/commit/a4dc77197ec7249cceeaa43cca56a1c217fd440d) | `` Updated emacs ``  |
| [`df789667`](https://github.com/nix-community/emacs-overlay/commit/df789667dc9cd738953b63ca29a461ea9157bd15) | `` Updated melpa ``  |
| [`9652bd62`](https://github.com/nix-community/emacs-overlay/commit/9652bd6277e776b009b0c54594365c118cfa76ad) | `` Updated elpa ``   |
| [`f6a19756`](https://github.com/nix-community/emacs-overlay/commit/f6a19756445da13b78e969ca786fa888954bbb54) | `` Updated nongnu `` |