### PR TITLE
chore(flake/emacs-overlay): `a4dc7719` -> `b563467d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1735751588,
-        "narHash": "sha256-fvaO6F5PUGGeTwEjAs95REaAEvh4SExhZr0fM5vJQfQ=",
+        "lastModified": 1735783618,
+        "narHash": "sha256-7hnr3Dw5ijhm88U1Wqf1zEVz8lQdejPHdlnjRssvpFU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a4dc77197ec7249cceeaa43cca56a1c217fd440d",
+        "rev": "b563467d6856629839995ff6d8699fb59d960ca9",
         "type": "github"
       },
       "original": {
@@ -724,11 +724,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1735531152,
-        "narHash": "sha256-As8I+ebItDKtboWgDXYZSIjGlKeqiLBvjxsQHUmAf1Q=",
+        "lastModified": 1735669367,
+        "narHash": "sha256-tfYRbFhMOnYaM4ippqqid3BaLOXoFNdImrfBfCp4zn0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3ffbbdbac0566a0977da3d2657b89cbcfe9a173b",
+        "rev": "edf04b75c13c2ac0e54df5ec5c543e300f76f1c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`b563467d`](https://github.com/nix-community/emacs-overlay/commit/b563467d6856629839995ff6d8699fb59d960ca9) | `` Updated emacs ``        |
| [`2bbdfe5a`](https://github.com/nix-community/emacs-overlay/commit/2bbdfe5a0b234c29453fe62aed8e15a3a51b3e0f) | `` Updated melpa ``        |
| [`8feb373d`](https://github.com/nix-community/emacs-overlay/commit/8feb373dfedff3868730877af282afd864a68a16) | `` Updated elpa ``         |
| [`a420c116`](https://github.com/nix-community/emacs-overlay/commit/a420c116d74abc72a5418ceb92151aca14954d75) | `` Updated nongnu ``       |
| [`999df25f`](https://github.com/nix-community/emacs-overlay/commit/999df25f371933effadb7627c892e82472df7a37) | `` Updated flake inputs `` |