### PR TITLE
chore(flake/treefmt): `56c0ecd7` -> `29806aba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1112,11 +1112,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735653038,
-        "narHash": "sha256-Q6xAmciTXDtZfUxf6c15QqtRR8BvX4edYPstF/uoqMk=",
+        "lastModified": 1735905407,
+        "narHash": "sha256-1hKMRIT+QZNWX46e4gIovoQ7H8QRb7803ZH4qSKI45o=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "56c0ecd79f7ba01a0ec027da015df751d6ca3ae7",
+        "rev": "29806abab803e498df96d82dd6f34b32eb8dd2c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                    |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`fb017439`](https://github.com/numtide/treefmt-nix/commit/fb017439ed72c5e4d00cb4fa0998ad9acebd3ca4) | `` refactor: DRY defaultSpecialArgs ``                                     |
| [`301b1599`](https://github.com/numtide/treefmt-nix/commit/301b1599e5a56df5fed34404c737e3b961f586d8) | `` doc: Improve genemichaels ``                                            |
| [`401cea42`](https://github.com/numtide/treefmt-nix/commit/401cea427e85d7aa16def05702e22d43703b90f5) | `` refactor/fix: Extract submoduleWith entrypoint from flake-module.nix `` |
| [`8030839d`](https://github.com/numtide/treefmt-nix/commit/8030839df7f82182b71bb25054f10b30111be250) | `` convert programs to mkFormatterModule ``                                |
| [`48961f31`](https://github.com/numtide/treefmt-nix/commit/48961f31e992e43203afb2ea9cb1402ad392d94b) | `` genemichaels: init (#277) ``                                            |
| [`a9a7fecd`](https://github.com/numtide/treefmt-nix/commit/a9a7fecd68fdfeef047b4033e3db043b1e64176d) | `` standardize program options with mkFormatterModule ``                   |
| [`246639a1`](https://github.com/numtide/treefmt-nix/commit/246639a1ec081bb40941a25e9eb8481a66d71b49) | `` feat: update nixpkgs input (#289) ``                                    |
| [`8cfde27e`](https://github.com/numtide/treefmt-nix/commit/8cfde27e47460d80e92f759caadddfb31f391d0f) | `` Fix typo: Biome -> elm-format (#290) ``                                 |