### PR TITLE
chore(flake/emacs-overlay): `d4670235` -> `e978e83b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1735809468,
-        "narHash": "sha256-ahutc7YYOSqOPPkzyWLYjPJ//TsPHm3u/u82VDfzPKg=",
+        "lastModified": 1735838071,
+        "narHash": "sha256-ObWvNpjD6aDP63U9bIesbDh+XRn5srygXIQBce8PPbE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d467023596c548b43277215365020906697c00a2",
+        "rev": "e978e83b07462ed833dab3de4544d27da2c03167",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`e978e83b`](https://github.com/nix-community/emacs-overlay/commit/e978e83b07462ed833dab3de4544d27da2c03167) | `` Updated emacs ``  |
| [`74ed3538`](https://github.com/nix-community/emacs-overlay/commit/74ed3538299fef83c01c2efd7cb89360d3a764bb) | `` Updated melpa ``  |
| [`b9644e3a`](https://github.com/nix-community/emacs-overlay/commit/b9644e3a7d83e77aac2bb579bb79e25b02f3a63c) | `` Updated elpa ``   |
| [`21536dec`](https://github.com/nix-community/emacs-overlay/commit/21536dec00ea82d855bb6a725583518ae362f8ae) | `` Updated nongnu `` |