### PR TITLE
chore(flake/srvos): `e3b40489` -> `eea4ff20`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1047,11 +1047,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735379278,
-        "narHash": "sha256-DpihJuI9SaWOUc1lRrw+e5014Qj+WHn9Xla89jxA6jk=",
+        "lastModified": 1735858634,
+        "narHash": "sha256-qp83fDr3W5b6QoWSp+vfcH1vFNEhreW98qe9tlhSaXE=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "e3b404890cfb44caec3edc8b84facb8934299428",
+        "rev": "eea4ff2050968da5134788c73d63a2461f9daf27",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                        |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`eea4ff20`](https://github.com/nix-community/srvos/commit/eea4ff2050968da5134788c73d63a2461f9daf27) | `` detect-hostname-change: fix $EXPECTED_HOSTNAME ``           |
| [`a36b4676`](https://github.com/nix-community/srvos/commit/a36b46760aea1ee6c8fef489786060c0b858eeff) | `` detect-hostname-change: add $EXPECTED_HOSTNAME ``           |
| [`670c11e0`](https://github.com/nix-community/srvos/commit/670c11e0b915804e90d50d08c08a00f5adbd2e07) | `` server: add option to re-enable documentation ``            |
| [`f918d307`](https://github.com/nix-community/srvos/commit/f918d30734be207ac84a6287b5222c30fb71ac73) | `` nixos/common: remove `documentation.info.enable = false` `` |
| [`bb08ae16`](https://github.com/nix-community/srvos/commit/bb08ae161a8b6bbbaa44df2b480acfb9442cf43c) | `` feat: add hostname change detection ``                      |