### PR TITLE
chore(flake/sops-nix): `bcb8b65a` -> `24d89184`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1044,11 +1044,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735468296,
-        "narHash": "sha256-ZjUjbvS06jf4fElOF4ve8EHjbpbRVHHypStoY8HGzk8=",
+        "lastModified": 1735844895,
+        "narHash": "sha256-CIRlqX9tBK2awJkmVu2cKuap/0QziDXStQZ/u/+e8Z4=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "bcb8b65aa596866eb7e5c3e1a6cccbf5d1560b27",
+        "rev": "24d89184adf76d7ccc99e659dc5f3838efb5ee32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                       |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`24d89184`](https://github.com/Mic92/sops-nix/commit/24d89184adf76d7ccc99e659dc5f3838efb5ee32) | `` nix-darwin: fix launchd decrypt scripts `` |