### PR TITLE
chore(flake/emacs-overlay): `e978e83b` -> `96dab5ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1735838071,
-        "narHash": "sha256-ObWvNpjD6aDP63U9bIesbDh+XRn5srygXIQBce8PPbE=",
+        "lastModified": 1735956384,
+        "narHash": "sha256-Umjlgon94K5lBjI28IdIDxg6pdmp0nYg+jomyM6wVAk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e978e83b07462ed833dab3de4544d27da2c03167",
+        "rev": "96dab5ac0c8d83fd5e53760efbc1632ea40d07a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`96dab5ac`](https://github.com/nix-community/emacs-overlay/commit/96dab5ac0c8d83fd5e53760efbc1632ea40d07a5) | `` Updated emacs ``        |
| [`f2a57f15`](https://github.com/nix-community/emacs-overlay/commit/f2a57f15aad9299d93c3eac02228b5c3d3eb2ba4) | `` Updated melpa ``        |
| [`2def670c`](https://github.com/nix-community/emacs-overlay/commit/2def670c4baedab0b94906a319824c160d0ddc74) | `` Updated elpa ``         |
| [`9ebb4a84`](https://github.com/nix-community/emacs-overlay/commit/9ebb4a8413496a056c1caa76e82d9fdd4a973c54) | `` Updated nongnu ``       |
| [`99dd69ce`](https://github.com/nix-community/emacs-overlay/commit/99dd69ceab2be2310bc580094e5327252b40ec84) | `` Updated flake inputs `` |
| [`4181b289`](https://github.com/nix-community/emacs-overlay/commit/4181b289bec9d2121ec741f675383d6c781c353b) | `` Updated melpa ``        |
| [`3df7c4ba`](https://github.com/nix-community/emacs-overlay/commit/3df7c4ba924734ffc24b2175f84e36b6fe8e3334) | `` Updated elpa ``         |
| [`0ed1de47`](https://github.com/nix-community/emacs-overlay/commit/0ed1de4793a553ed0f6c71f329d23e95a972e318) | `` Updated nongnu ``       |
| [`f056a3b8`](https://github.com/nix-community/emacs-overlay/commit/f056a3b82aa523aa3b3a033fe8ffe77d29461079) | `` Updated emacs ``        |
| [`e6bad48f`](https://github.com/nix-community/emacs-overlay/commit/e6bad48f56fc003e96e6332f98397d5c7c5d3b84) | `` Updated melpa ``        |
| [`57ad4a6c`](https://github.com/nix-community/emacs-overlay/commit/57ad4a6cfaf4666c9ce71b81bd7243e4ed2d8b01) | `` Updated emacs ``        |
| [`2b2c0dd0`](https://github.com/nix-community/emacs-overlay/commit/2b2c0dd03b9fcf46a83fb62e99248fd3f56f942f) | `` Updated melpa ``        |
| [`d3db6e75`](https://github.com/nix-community/emacs-overlay/commit/d3db6e753d0b8f93326888e894fed2dd318e2fc0) | `` Updated elpa ``         |
| [`796d9fe5`](https://github.com/nix-community/emacs-overlay/commit/796d9fe5e39152db8ebbd26a8e9b0c043635322d) | `` Updated nongnu ``       |