### PR TITLE
chore(flake/catppuccin): `63290ea1` -> `b326f48f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -40,11 +40,11 @@
         "nuscht-search": "nuscht-search"
       },
       "locked": {
-        "lastModified": 1735634086,
-        "narHash": "sha256-DTcB/kBZULyJztXXnH3OVF5LHLl+O670DuLZZNUMnNo=",
+        "lastModified": 1735895235,
+        "narHash": "sha256-MtsfkMikkPjnZUMqsqXQ29cHzlRD2lMe27jXua28cHU=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "63290ea1d2a28e65195017ed78a81cfc242ef0df",
+        "rev": "b326f48f17023fc0060590ba299d55f7da8350a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                          |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`b326f48f`](https://github.com/catppuccin/nix/commit/b326f48f17023fc0060590ba299d55f7da8350a5) | `` refactor(home-manager/alacritty): remove importTOML (#443) `` |
| [`8580fa26`](https://github.com/catppuccin/nix/commit/8580fa2696e1557af0a73b15fdba136c8b653a0b) | `` feat(home-manager/zed): accent support (#435) ``              |