### PR TITLE
chore(flake/home-manager): `5f6aa268` -> `1c8d4c8d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -412,11 +412,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735774425,
-        "narHash": "sha256-C73gLFnEh8ZI0uDijUgCDWCd21T6I6tsaWgIBHcfAXg=",
+        "lastModified": 1735900408,
+        "narHash": "sha256-U+oZBQ3f5fF2hHsupKQH4ihgTKLHgcJh6jEmKDg+W10=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5f6aa268e419d053c3d5025da740e390b12ac936",
+        "rev": "1c8d4c8d592e8fab4cff4397db5529ec6f078cf9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`1c8d4c8d`](https://github.com/nix-community/home-manager/commit/1c8d4c8d592e8fab4cff4397db5529ec6f078cf9) | `` mako: add center-left & center-right ``      |
| [`7254063d`](https://github.com/nix-community/home-manager/commit/7254063d529d666f10d73ce3fe5756d6c325ddc3) | `` Update translation files ``                  |
| [`12327fc3`](https://github.com/nix-community/home-manager/commit/12327fc3d83ee6c3f39b1b8852d9139fa4d2a176) | `` Add translation using Weblate (Tamil) ``     |
| [`7f16e9c3`](https://github.com/nix-community/home-manager/commit/7f16e9c3cb00ca6df680917ab37ebf00177a19e9) | `` Translate using Weblate (Tamil) ``           |
| [`a6f37e57`](https://github.com/nix-community/home-manager/commit/a6f37e5785a5057ab43b4f5a64c590dcc709f043) | `` ghostty: fix configuration for bat syntax `` |
| [`1e68dc75`](https://github.com/nix-community/home-manager/commit/1e68dc759b3b3e0dc56589ecd3e58c3699ff9b27) | `` home-manager: move profile management ``     |
| [`1e2a9d2d`](https://github.com/nix-community/home-manager/commit/1e2a9d2d29216f3512e6a02905b4f88f11bf5d0e) | `` format: ignore system and user git config `` |
| [`f4f8d09f`](https://github.com/nix-community/home-manager/commit/f4f8d09f909b4ef34afd9bad2284042d307bc95f) | `` home-manager: update copyright year ``       |