### PR TITLE
chore(flake/home-manager): `1c8d4c8d` -> `11ab0854`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -412,11 +412,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735900408,
-        "narHash": "sha256-U+oZBQ3f5fF2hHsupKQH4ihgTKLHgcJh6jEmKDg+W10=",
+        "lastModified": 1735979091,
+        "narHash": "sha256-WpFjt6+8UD81EP386c269ZTqpEmlGJgcPw+OB4b7EBs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1c8d4c8d592e8fab4cff4397db5529ec6f078cf9",
+        "rev": "11ab08541e61ac3bbf2ab27229f68622629401df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                            |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`11ab0854`](https://github.com/nix-community/home-manager/commit/11ab08541e61ac3bbf2ab27229f68622629401df) | `` ghostty: validate configuration on change ``    |
| [`a9987622`](https://github.com/nix-community/home-manager/commit/a9987622b7b93c82e147f198574e8e6ffbf5e327) | `` maintainers: updated username to midirhee12 ``  |
| [`14cb0c8c`](https://github.com/nix-community/home-manager/commit/14cb0c8cfaa28d62a0e0cb4829e921635cd2b296) | `` fnott: use config.wayland.systemd.target ``     |
| [`656ae5ab`](https://github.com/nix-community/home-manager/commit/656ae5aba2d48adfe5bb3aa8d433b9a50cfb2a11) | `` clipman: use config.wayland.systemd.target ``   |
| [`a6db8c8f`](https://github.com/nix-community/home-manager/commit/a6db8c8f6c201df0cfb5482241368ac02a5b17f3) | `` hypridle: use config.wayland.systemd.target ``  |
| [`da12f0b1`](https://github.com/nix-community/home-manager/commit/da12f0b143558490efc52b7f550e19d9fcf27909) | `` hyprpaper: use config.wayland.systemd.target `` |
| [`8f48fea0`](https://github.com/nix-community/home-manager/commit/8f48fea0f8a8392f4b81da07333342824fdb35c9) | `` avizo: use config.wayland.systemd.target ``     |
| [`adcf0b62`](https://github.com/nix-community/home-manager/commit/adcf0b6281f4d8c00ea263c49f52a71130ee875f) | `` wob: use config.wayland.systemd.target ``       |
| [`51ba4aac`](https://github.com/nix-community/home-manager/commit/51ba4aacec867a1ecc2b92bf5ecdc66dbf9eb6c2) | `` swayosd: use config.wayland.systemd.target ``   |
| [`4cbc8a58`](https://github.com/nix-community/home-manager/commit/4cbc8a58ab94e5eea5fe3185837d6489579a7f68) | `` swaync: use config.wayland.systemd.target ``    |
| [`d3c500a8`](https://github.com/nix-community/home-manager/commit/d3c500a8f8f88587c0867ba13ae6dba6e3c58cec) | `` kanshi: use config.wayland.systemd.target ``    |
| [`8587c2ff`](https://github.com/nix-community/home-manager/commit/8587c2ff0ea82a93a265dbcbad7df88c80de1b9c) | `` waybar: use config.wayland.systemd.target ``    |
| [`89fe48b1`](https://github.com/nix-community/home-manager/commit/89fe48b1c1c51d5616343b71822a45f894b16dcf) | `` swayidle: use config.wayland.systemd.target ``  |
| [`0734cfab`](https://github.com/nix-community/home-manager/commit/0734cfab07a90a34bb91428e24646e5fe78d9e24) | `` wayland: add module ``                          |