### PR TITLE
chore(flake/nixpkgs): `88195a94` -> `6df24922`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -786,11 +786,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1735471104,
-        "narHash": "sha256-0q9NGQySwDQc7RhAV2ukfnu7Gxa5/ybJ2ANT8DQrQrs=",
+        "lastModified": 1735834308,
+        "narHash": "sha256-dklw3AXr3OGO4/XT1Tu3Xz9n/we8GctZZ75ZWVqAVhk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "88195a94f390381c6afcdaa933c2f6ff93959cb4",
+        "rev": "6df24922a1400241dae323af55f30e4318a6ca65",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`a35271af`](https://github.com/NixOS/nixpkgs/commit/a35271af53ba19f95e82335db1ac8a5dc5aa1aed) | `` mailmap: add jopejoe1 ``                                                          |
| [`1227084c`](https://github.com/NixOS/nixpkgs/commit/1227084c58918525780997af4e814395885d7cd6) | `` maintainers: update jopejoe1 ``                                                   |
| [`0725951b`](https://github.com/NixOS/nixpkgs/commit/0725951bfc4bbc2efff3a537837ca13159b4aec9) | `` nixos/libvirtd: link Microsoft-templated OVMF files to shared folder (#346904) `` |
| [`04c5813b`](https://github.com/NixOS/nixpkgs/commit/04c5813ba200257d968d719982d899de22f531af) | `` tinymist: 0.12.14 -> 0.12.16 ``                                                   |
| [`d798810f`](https://github.com/NixOS/nixpkgs/commit/d798810f57742f2dfafaa3966cc7abfb9d6036b9) | `` linux_6_1: 6.1.122 -> 6.1.123 ``                                                  |
| [`71435ccf`](https://github.com/NixOS/nixpkgs/commit/71435ccf3eeeeb2e1a4dd0f8149df574d28d18c5) | `` linux_6_6: 6.6.68 -> 6.6.69 ``                                                    |
| [`1ba73a81`](https://github.com/NixOS/nixpkgs/commit/1ba73a81a6c20bf998ae685561e4534f03b85743) | `` linux_6_12: 6.12.7 -> 6.12.8 ``                                                   |
| [`6ff39470`](https://github.com/NixOS/nixpkgs/commit/6ff39470d983d4861165dc3734c13f6aa9243fbe) | `` linux_testing: 6.13-rc4 -> 6.13-rc5 ``                                            |
| [`10a75ab5`](https://github.com/NixOS/nixpkgs/commit/10a75ab5b2c237e3c30556d65de3ee49ff4b6830) | `` doc: titanium tombstone ``                                                        |
| [`9516e693`](https://github.com/NixOS/nixpkgs/commit/9516e693c6bb03a922992d037ef9dd35aaa03567) | `` doc/rl-2505: mention removal of titaniumenv, titanium, and titanium-alloy ``      |
| [`91a004b9`](https://github.com/NixOS/nixpkgs/commit/91a004b943e9b88a8f24adb4b8917d05734827e7) | `` titanium: remove ``                                                               |
| [`d2f4842d`](https://github.com/NixOS/nixpkgs/commit/d2f4842daa9556df09d908423058817a8154254e) | `` titanium-alloy: remove ``                                                         |
| [`b754b036`](https://github.com/NixOS/nixpkgs/commit/b754b036e3f77973bbc2a482c7085692194c2962) | `` titaniumenv: remove ``                                                            |
| [`87ba234f`](https://github.com/NixOS/nixpkgs/commit/87ba234f1bcb9fb80e87754dac9828196103aeba) | `` beets: fix building in 2025 ``                                                    |
| [`eadbe6c7`](https://github.com/NixOS/nixpkgs/commit/eadbe6c73c7e18e4f52ad3f50b0939371045bd22) | `` iay: 0.4.2 -> 0.4.3 ``                                                            |
| [`1514589a`](https://github.com/NixOS/nixpkgs/commit/1514589aa6f001b1214afee2df9283fc06cdcd91) | `` numbat: refactor meta ``                                                          |
| [`6d17306e`](https://github.com/NixOS/nixpkgs/commit/6d17306e6761abb7175f7a090559a0453787a53e) | `` numbat: use version check hook, nix update script ``                              |
| [`d19c3249`](https://github.com/NixOS/nixpkgs/commit/d19c3249afd168fdc5d5787c615447b0bed590f5) | `` go-callvis: 0.7.0 -> 0.7.1 ``                                                     |
| [`403f488b`](https://github.com/NixOS/nixpkgs/commit/403f488b80fd97cf60e8e5924fdcedb82f09a082) | `` numbat: 1.14.0 -> 1.15.0 ``                                                       |
| [`d37ad3d2`](https://github.com/NixOS/nixpkgs/commit/d37ad3d28fae19036467ae3ded7792478f8b2c1f) | `` nerd-fonts: add releaseVersion to passthru ``                                     |
| [`06d52b09`](https://github.com/NixOS/nixpkgs/commit/06d52b09a2e425de9be8dae109d66524b559d34d) | `` nerd-fonts: fix attr name and version handling ``                                 |
| [`e18aa0b1`](https://github.com/NixOS/nixpkgs/commit/e18aa0b180a55d09032382d4e76ba3b582cd7e59) | `` nerd-fonts: change pname, version and license schema ``                           |
| [`dcbd5609`](https://github.com/NixOS/nixpkgs/commit/dcbd560920fad8463ccadfdb656dc28f69ba12d3) | `` prism: minor refactoring ``                                                       |
| [`6a22aaca`](https://github.com/NixOS/nixpkgs/commit/6a22aaca7219ede672ab5361b30a3b472223d5fd) | `` python312Packages.pyseries: init at 1.0.26 ``                                     |
| [`41ea9f46`](https://github.com/NixOS/nixpkgs/commit/41ea9f469098acee3c247bf3860610ee74adefa7) | `` python312Packages.pyedflib: init at 0.1.38 ``                                     |
| [`01ff4040`](https://github.com/NixOS/nixpkgs/commit/01ff4040a971787e1c2395418cc8e00137f7e717) | `` ruff: 0.8.4 -> 0.8.5 ``                                                           |
| [`6e95ad3b`](https://github.com/NixOS/nixpkgs/commit/6e95ad3b2b49d5da92feb3c310286a650c349dd6) | `` lcalc: workaround for vendored <complex> ``                                       |
| [`8c30dd41`](https://github.com/NixOS/nixpkgs/commit/8c30dd41a7f580b2eac5fecfc872daed3c233dd3) | `` python312Packages.blockdiag: fix missing runtime dependency ``                    |
| [`5651648b`](https://github.com/NixOS/nixpkgs/commit/5651648b38a4b112049e0cbf8d2deaddc0140982) | `` sgt-puzzles: 20241223.5eea14c -> 20241230.79be403 ``                              |
| [`501e5ba9`](https://github.com/NixOS/nixpkgs/commit/501e5ba9ceb02d3209c2dc12df3df26ff00884a2) | `` python312Packages.mmcv: clean derivation ``                                       |
| [`5f7fc7be`](https://github.com/NixOS/nixpkgs/commit/5f7fc7beb0ea15bf33927735576a175b1edc253f) | `` python312Packages.plotnine: 0.14.4 -> 0.14.5 ``                                   |
| [`1833a29a`](https://github.com/NixOS/nixpkgs/commit/1833a29ada0ef0a34af80de337a22bbeab570af0) | `` bacon: 3.6.0 -> 3.7.0 ``                                                          |
| [`3b11e0c5`](https://github.com/NixOS/nixpkgs/commit/3b11e0c595be016251ebc641ca523bc95aa01e17) | `` vectorscan: reformat ``                                                           |
| [`fac85fd1`](https://github.com/NixOS/nixpkgs/commit/fac85fd1fccae52b528c0ed8cc04b6c404ae6e38) | `` vectorscan: fix pkg-config ``                                                     |
| [`8474f557`](https://github.com/NixOS/nixpkgs/commit/8474f557efabe0741d87ace6571ee1614d8d53e8) | `` rspamd: build with vectorscan ``                                                  |
| [`2eecf15a`](https://github.com/NixOS/nixpkgs/commit/2eecf15ad7776f924f8fc01e329d9bd17fbd6bf5) | `` python312Packages.deepdish: fix build ``                                          |
| [`41f7b3d6`](https://github.com/NixOS/nixpkgs/commit/41f7b3d67bf62aaf4b7494c06c35b66d1d473358) | `` factoriolab: 3.8.9 -> 3.8.10 ``                                                   |
| [`b287c667`](https://github.com/NixOS/nixpkgs/commit/b287c667e03207351291e8c84bd5a5384470ecd9) | `` gfan: fix clang-19 build ``                                                       |
| [`4d3b1bca`](https://github.com/NixOS/nixpkgs/commit/4d3b1bcad8797b28a4cf744fdad043b4f438ba32) | `` singular: fix clang-19 build ``                                                   |
| [`0f3c1d31`](https://github.com/NixOS/nixpkgs/commit/0f3c1d31bfb512edfca8a28ce19a8a5bc69f8eb7) | `` renode-dts2repl: 0-unstable-2024-12-20 -> 0-unstable-2024-12-28 ``                |
| [`7f338aad`](https://github.com/NixOS/nixpkgs/commit/7f338aad226d63423d512a3e79035f0837c7a07f) | `` vectorscan: fix cross-compile ``                                                  |
| [`297e7125`](https://github.com/NixOS/nixpkgs/commit/297e71258a7bc903f28ef5be37d14fc9e8175a50) | `` python312Packages.marimo: 0.10.5 -> 0.10.9 ``                                     |
| [`041cda87`](https://github.com/NixOS/nixpkgs/commit/041cda876a039c2e254c740b431224584c1c8f48) | `` iosevka: 32.2.1 -> 32.3.1 ``                                                      |
| [`a5ca2074`](https://github.com/NixOS/nixpkgs/commit/a5ca2074895abb48e0745412df495df9cdb345c1) | `` dprint-plugins: init (#369415) ``                                                 |
| [`57cb0844`](https://github.com/NixOS/nixpkgs/commit/57cb0844450ac2fd8ebc72899e987a53b55ae806) | `` jj: 0.24.0 -> 0.25.0 ``                                                           |
| [`f8371729`](https://github.com/NixOS/nixpkgs/commit/f837172930e0132e9cf8266bb63ba4e3ebaab8bb) | `` restate: init at 1.1.6 ``                                                         |
| [`28f43d46`](https://github.com/NixOS/nixpkgs/commit/28f43d4628fc7f1d039efde754fce409a7788994) | `` nixos/zfs-replication: add --verbose to command line arguments ``                 |
| [`83af87a2`](https://github.com/NixOS/nixpkgs/commit/83af87a20653e11be4cc0d39c9c3fce38c36c039) | `` nixos/zfs-replication: use expanded arguments for clarity ``                      |
| [`737defd4`](https://github.com/NixOS/nixpkgs/commit/737defd4cd97ada9a268bde05603eee367425f1c) | `` ncps: init at 0.1.1 ``                                                            |
| [`559ebf51`](https://github.com/NixOS/nixpkgs/commit/559ebf51a9ba65aa751e7ec58c8405b7671f0ab7) | `` dosbox-x: 2024.12.04 -> 2025.01.01 ``                                             |
| [`ba58e46c`](https://github.com/NixOS/nixpkgs/commit/ba58e46cc70cdaf6b046df1f2d20fc47f6698b49) | `` ckan: Install desktop file and icons ``                                           |
| [`8a5e208a`](https://github.com/NixOS/nixpkgs/commit/8a5e208a0f15f555f37e0b471a90feba5d33ed1a) | `` spacevim: 2.3.0 -> 2.4.0 ``                                                       |
| [`8b9f8cac`](https://github.com/NixOS/nixpkgs/commit/8b9f8cac1c1108d0d5340bbe0845c3049c1d2c0c) | `` eza: 0.20.14 -> 0.20.15 ``                                                        |
| [`e48d27cb`](https://github.com/NixOS/nixpkgs/commit/e48d27cb8f382d5e7c190095a5f2cc22e9a18f7d) | `` formatjson5: fix missing_docs error ``                                            |
| [`0d1111fb`](https://github.com/NixOS/nixpkgs/commit/0d1111fb417de5be3347dd51f16058759b1c75ec) | `` rip2: 0.9.0 -> 0.9.2 ``                                                           |
| [`755e20ec`](https://github.com/NixOS/nixpkgs/commit/755e20ecdba7a27ad80e9f9ce17b97c2c86157c4) | `` vimPlugins.linediff-vim: init at 2024-04-22 ``                                    |
| [`aa6e01db`](https://github.com/NixOS/nixpkgs/commit/aa6e01dbf7105956b15f96cad60d922529a3be03) | `` vimPlugins.nvim-numbertoggle: init at 2024-03-29 ``                               |
| [`137419b4`](https://github.com/NixOS/nixpkgs/commit/137419b48bbcaa12d7876d81caa9842927733662) | `` python313Packages.google-auth: fix build ``                                       |
| [`93e7e39c`](https://github.com/NixOS/nixpkgs/commit/93e7e39c71b13a406ea70b3da1808f56be207b24) | `` mieru: 3.9.0 -> 3.10.0 ``                                                         |
| [`709930aa`](https://github.com/NixOS/nixpkgs/commit/709930aaf6d5b55c8635b2bac7eb92191e6f214f) | `` beam27Packages.elixir-ls: 0.25.0 -> 0.26.1 ``                                     |
| [`9e9fe337`](https://github.com/NixOS/nixpkgs/commit/9e9fe337e29512eab45ee9e8e8325d423f1527c1) | `` release-haskell.nix: add kmonad nixos test ``                                     |
| [`93ccd7bb`](https://github.com/NixOS/nixpkgs/commit/93ccd7bb6f387df8b53b34cc53a4c57b3ba20940) | `` sound-of-sorting: fix darwin build ``                                             |
| [`161f45d4`](https://github.com/NixOS/nixpkgs/commit/161f45d4be41a7b93c41d874f5fc8fd858dfeffb) | `` nixosTest.lvm2: don't run one test on old 5.15 kernel without support ``          |
| [`0c160da0`](https://github.com/NixOS/nixpkgs/commit/0c160da06c202aa7a1a4614c52f6582f30dd50ff) | `` nixosTest.lvm2: remove 4.19 kernel, test on 6.6 ``                                |
| [`b74d4091`](https://github.com/NixOS/nixpkgs/commit/b74d40912714f72e87b65a556f0ade8c9f2c3cf7) | `` nixos/tor: fix eval take three ``                                                 |
| [`fac4c997`](https://github.com/NixOS/nixpkgs/commit/fac4c997a615d68e6606f7ab9ce2206b46e31cbc) | `` python312Packages.strawberry-graphql: fix build ``                                |
| [`cbd736c3`](https://github.com/NixOS/nixpkgs/commit/cbd736c3e130d696af740b48765e08c3db51b561) | `` spotube: unify linux and darwin builder ``                                        |
| [`fd8921d8`](https://github.com/NixOS/nixpkgs/commit/fd8921d8c80e60bbfcfba91a40495f2c3bee5c46) | `` python312Packages.jax: reenable cuda support and clean up ``                      |
| [`29f2c03f`](https://github.com/NixOS/nixpkgs/commit/29f2c03f1610d0f35ce8901db3ef6798d7982118) | `` maintainers: add myypo ``                                                         |
| [`05176adf`](https://github.com/NixOS/nixpkgs/commit/05176adfbd5983430b4790c071e7aa3dc3480d32) | `` roddhjav-apparmor-rules: 0-unstable-2024-12-13 -> 0-unstable-2024-12-25 ``        |
| [`0b22020d`](https://github.com/NixOS/nixpkgs/commit/0b22020d8841d3b2e342567bdabfb6c5575edfa1) | `` vscode-extensions.visualjj.visualjj: switch to VSCode marketplace ``              |
| [`23908099`](https://github.com/NixOS/nixpkgs/commit/2390809980a276226c53e3e07d169fdc45de7c13) | `` tlsclient: 1.6.5 -> 1.6.6 ``                                                      |
| [`031e8ea9`](https://github.com/NixOS/nixpkgs/commit/031e8ea9ef4c3135588e1272f4f2b3456cacb337) | `` antora-lunr-extension: conventionally sort fetch attributes ``                    |
| [`5ab7ac68`](https://github.com/NixOS/nixpkgs/commit/5ab7ac6886342f59496a221bb17d370c1432580c) | `` antora-ui-default: conventionally sort fetch attributes ``                        |
| [`94ae419b`](https://github.com/NixOS/nixpkgs/commit/94ae419b96b80b486180920899df9cfa65714c9c) | `` python312Packages.diagrams: 0.23.4 -> 0.24.2 ``                                   |
| [`7faac508`](https://github.com/NixOS/nixpkgs/commit/7faac508af7d39701a856bf8013e33f5674a600d) | `` home-assistant-custom-components.calendar_export: init at 0.1.0 ``                |
| [`5b816767`](https://github.com/NixOS/nixpkgs/commit/5b816767fd23694290a622d42d38b2a4fcd7fde6) | `` tinymist: generate shell completion ``                                            |
| [`f11148a3`](https://github.com/NixOS/nixpkgs/commit/f11148a34ccbdf909e07bd25d738d103dabf0fcf) | `` albert: 0.26.10 -> 0.26.11 ``                                                     |
| [`676d9199`](https://github.com/NixOS/nixpkgs/commit/676d91998d2e43a2dcf74a655ef1481fd1e38c92) | `` ovn: fix missing scripts and wrong paths ``                                       |
| [`a97234e2`](https://github.com/NixOS/nixpkgs/commit/a97234e2fdc84169e49ad675e66aec37f0500389) | `` heroic: fix packaging ``                                                          |
| [`c0f2a3cc`](https://github.com/NixOS/nixpkgs/commit/c0f2a3cc206838ccf27a98ddf3bd845cdc1509f9) | `` nixos/endlessh-go: fix eval ``                                                    |
| [`7bb552f1`](https://github.com/NixOS/nixpkgs/commit/7bb552f178ab6def1248a49619137f1a13a49a4c) | `` nixos/magnetico: fix eval ``                                                      |
| [`18765d04`](https://github.com/NixOS/nixpkgs/commit/18765d044a50ad46192212355ee492bb0b014152) | `` nixos/tor: fix eval ``                                                            |