### PR TITLE
chore(flake/darwin): `6a1fdb2a` -> `3feaf376`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -103,11 +103,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735685839,
-        "narHash": "sha256-62xAPSs5VRZoPH7eRanUn5S5vZEd+8vM4bD5I+zxokc=",
+        "lastModified": 1735956190,
+        "narHash": "sha256-svzx3yVXD5tbBJZCn3Lt1RriH8GHo6CyVUPTHejf7sU=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "6a1fdb2a1204c0de038847b601cff5012e162b5e",
+        "rev": "3feaf376d75d3d58ebf7e9a4f584d00628548ad9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                                            |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
| [`492a7200`](https://github.com/LnL7/nix-darwin/commit/492a72007ae2e7bd5895458fcd72ac2c8c9a0dc4) | `` power: echo to print in error messages ``                                                       |
| [`62d8f5f2`](https://github.com/LnL7/nix-darwin/commit/62d8f5f289341497ea0fa21814e734cbea69a0a1) | `` power: move the check for restartPowerfailure support to checks.nix ``                          |
| [`016b1608`](https://github.com/LnL7/nix-darwin/commit/016b1608eec6c54cfaece96b63ec9d1a6cd4672b) | `` power: restartAfterPowerFailure option is carried out in activation script only if supported `` |