### PR TITLE
chore(flake/home-manager): `11ab0854` -> `172b91bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -414,11 +414,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735979091,
-        "narHash": "sha256-WpFjt6+8UD81EP386c269ZTqpEmlGJgcPw+OB4b7EBs=",
+        "lastModified": 1736089250,
+        "narHash": "sha256-/LPWMiiJGPHGd7ZYEgmbE2da4zvBW0acmshUjYC3WG4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "11ab08541e61ac3bbf2ab27229f68622629401df",
+        "rev": "172b91bfb2b7f5c4a8c6ceac29fd53a01ef07196",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`172b91bf`](https://github.com/nix-community/home-manager/commit/172b91bfb2b7f5c4a8c6ceac29fd53a01ef07196) | `` Translate using Weblate (German) ``                |
| [`4795ebe6`](https://github.com/nix-community/home-manager/commit/4795ebe6cc6e5f60a3e66e3627b4f182ac4771b5) | `` Translate using Weblate (French) ``                |
| [`5ad12b6e`](https://github.com/nix-community/home-manager/commit/5ad12b6ea06b84e48f6b677957c74f32d47bdee0) | `` flake.lock: Update ``                              |
| [`0d7908bd`](https://github.com/nix-community/home-manager/commit/0d7908bd09165db6699908b7e3970f137327cbf0) | `` neomutt: Document how to bind Ctrl keys (#6254) `` |