### PR TITLE
chore(flake/catppuccin): `07f97a49` -> `8eada392`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -40,11 +40,11 @@
         "nuscht-search": "nuscht-search"
       },
       "locked": {
-        "lastModified": 1735937475,
-        "narHash": "sha256-TYs1HHBRfCBb3aAak1bJ9087gX9DeYLGy69Dkiz9WdE=",
+        "lastModified": 1736069220,
+        "narHash": "sha256-76MaB3COao55nlhWmSmq9PKgu2iGIs54C1cAE0E5J6Y=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "07f97a4990c138032a594b830bb02fd5dcf91ec2",
+        "rev": "8eada392fd6571a747e1c5fc358dd61c14c8704e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                                 |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`8eada392`](https://github.com/catppuccin/nix/commit/8eada392fd6571a747e1c5fc358dd61c14c8704e) | `` home-manager: remove IFD from helix and yazi (#449) ``                               |
| [`f05d79d4`](https://github.com/catppuccin/nix/commit/f05d79d46faea2b153b5b69ea8858e5ec64cba68) | `` fix(home-manager/zed): correctly enable & select accent (#448) ``                    |
| [`c2818cb8`](https://github.com/catppuccin/nix/commit/c2818cb875dce80af45599f0c94a4d2646d0114e) | `` feat(home-manager): add support for chromium and chromium-based browsers (#447) ``   |
| [`2dafc413`](https://github.com/catppuccin/nix/commit/2dafc413dd280c2616524cd2d286bbb7c3e79cd5) | `` revert: "fix(home-manager/alacritty): remove the `general` setting option" (#452) `` |
| [`89bbaf19`](https://github.com/catppuccin/nix/commit/89bbaf1987e8e0e2c891463ebb5be3a6cbd781a1) | `` fix(home-manager/alacritty): remove the `general` setting option (#450) ``           |