### PR TITLE
chore(flake/treefmt-nix): `29806aba` -> `1788ca5a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1142,11 +1142,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735905407,
-        "narHash": "sha256-1hKMRIT+QZNWX46e4gIovoQ7H8QRb7803ZH4qSKI45o=",
+        "lastModified": 1736115332,
+        "narHash": "sha256-FBG9d7e0BTFfxVdw4b5EmNll2Mv7hfRc54hbB4LrKko=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "29806abab803e498df96d82dd6f34b32eb8dd2c8",
+        "rev": "1788ca5acd4b542b923d4757d4cfe4183cc6a92d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                                 |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`1788ca5a`](https://github.com/numtide/treefmt-nix/commit/1788ca5acd4b542b923d4757d4cfe4183cc6a92d) | `` mdformat: maintainer add; add settings: `end-of-line`, `number`, `wrapper` (#294) `` |
| [`b2cef38d`](https://github.com/numtide/treefmt-nix/commit/b2cef38dc3c6d2bcd54481da82b23d481dcd1d61) | `` dos2unix: explicitly set `mainProgram` to `dos2unix`; maintainer add (#295) ``       |
| [`94ae2357`](https://github.com/numtide/treefmt-nix/commit/94ae23570d1c5baf710989fa1736eaea537fec27) | `` Revert "wrapper: add treefmt-nix executable to output (#243)" (#291) ``              |