### PR TITLE
chore(flake/nur): `bdd8ef25` -> `d4d145ea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -896,11 +896,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1736131073,
-        "narHash": "sha256-WTJ3anpUYOXitwJuao2hhD/ytXl2pvBln1ZK1uLf6K8=",
+        "lastModified": 1736135135,
+        "narHash": "sha256-u5YnOZoZnQYyjhNkxKlU7NS4Nq1g+JidmP++7dvRYcM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bdd8ef2586ba51c55b5c17b48c4c7f082557b8d3",
+        "rev": "d4d145ea46319b6eea53662104a5786394deb328",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d4d145ea`](https://github.com/nix-community/NUR/commit/d4d145ea46319b6eea53662104a5786394deb328) | `` automatic update `` |
| [`25fb573a`](https://github.com/nix-community/NUR/commit/25fb573a5554959fedbbbba6a8c0d22e02093cad) | `` automatic update `` |
| [`bfae6018`](https://github.com/nix-community/NUR/commit/bfae60186c3db92926876e9af7446880140cc998) | `` automatic update `` |