### PR TITLE
chore(flake/emacs-overlay): `694acaa1` -> `472f671a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1736129495,
-        "narHash": "sha256-bkFoaJcmNXjAjHPAYB5b+fK99qeZrFfj161A2bQi9pM=",
+        "lastModified": 1736154972,
+        "narHash": "sha256-1yp7DsjzB+4z3uq+z703pRTFtBvVULHWgn3mR6IEto0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "694acaa144f0e88f6a5e7d406e26d5b8a7e51198",
+        "rev": "472f671ae934fc94384ebea0ad9419ef35240afe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`472f671a`](https://github.com/nix-community/emacs-overlay/commit/472f671ae934fc94384ebea0ad9419ef35240afe) | `` Updated emacs ``        |
| [`9cadda73`](https://github.com/nix-community/emacs-overlay/commit/9cadda7363575ba2df862b2ddccca08a2d3a9267) | `` Updated melpa ``        |
| [`a757dd11`](https://github.com/nix-community/emacs-overlay/commit/a757dd117b066d5ee1527ce77c5e3d3ff6014b44) | `` Updated flake inputs `` |