### PR TITLE
chore(flake/treefmt-nix): `1788ca5a` -> `13c913f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1142,11 +1142,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736115332,
-        "narHash": "sha256-FBG9d7e0BTFfxVdw4b5EmNll2Mv7hfRc54hbB4LrKko=",
+        "lastModified": 1736154270,
+        "narHash": "sha256-p2r8xhQZ3TYIEKBoiEhllKWQqWNJNoT9v64Vmg4q8Zw=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "1788ca5acd4b542b923d4757d4cfe4183cc6a92d",
+        "rev": "13c913f5deb3a5c08bb810efd89dc8cb24dd968b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                    |
| ---------------------------------------------------------------------------------------------------- | -------------------------- |
| [`13c913f5`](https://github.com/numtide/treefmt-nix/commit/13c913f5deb3a5c08bb810efd89dc8cb24dd968b) | `` odinfmt: init (#296) `` |