### PR TITLE
chore(flake/emacs-overlay): `472f671a` -> `c4b02b4b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1736154972,
-        "narHash": "sha256-1yp7DsjzB+4z3uq+z703pRTFtBvVULHWgn3mR6IEto0=",
+        "lastModified": 1736215843,
+        "narHash": "sha256-xFcqxrwIBTI+V1XG5BBW3Eg2IAESLq2abFnE+rWc8Vk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "472f671ae934fc94384ebea0ad9419ef35240afe",
+        "rev": "c4b02b4be54b35b6bf0cd6b33ef01e33b5a041af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`c4b02b4b`](https://github.com/nix-community/emacs-overlay/commit/c4b02b4be54b35b6bf0cd6b33ef01e33b5a041af) | `` Updated emacs ``  |
| [`4fc88777`](https://github.com/nix-community/emacs-overlay/commit/4fc887777894174eb09978c65a7c6889607d6f3c) | `` Updated melpa ``  |
| [`8ad5c671`](https://github.com/nix-community/emacs-overlay/commit/8ad5c6717131c70aa7f61ffaf23b7bd59a2a2859) | `` Updated elpa ``   |
| [`9e158991`](https://github.com/nix-community/emacs-overlay/commit/9e158991cad34a9536a93f90f7c33e61e8b50c18) | `` Updated nongnu `` |
| [`6fbd3dab`](https://github.com/nix-community/emacs-overlay/commit/6fbd3dabc666841af3240c1f3f3aa52c037eb80d) | `` Updated emacs ``  |
| [`6cc2cb46`](https://github.com/nix-community/emacs-overlay/commit/6cc2cb466c04376fd6d323b911d3c9c208ed7cfb) | `` Updated melpa ``  |
| [`5cde00c7`](https://github.com/nix-community/emacs-overlay/commit/5cde00c74d2b8ba4ed1ab1d4efabc3f3caca8f72) | `` Updated elpa ``   |
| [`94f9472c`](https://github.com/nix-community/emacs-overlay/commit/94f9472c4efc9678cc12c06400d1220d9b083bea) | `` Updated nongnu `` |