### PR TITLE
chore(flake/nur): `13f5f3da` -> `ca9c757f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -896,11 +896,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1736192728,
-        "narHash": "sha256-7nMxUw6GaKTcPYWabVfWEwGc+UmGemPZkh2yh0/tBIY=",
+        "lastModified": 1736263064,
+        "narHash": "sha256-UGc/ikH9GUWfErzTXcyttdqC18ih/NCtL+vO6pOkiFk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "13f5f3da150fd007f3dc9a56e9c124cb5a50aa73",
+        "rev": "ca9c757ffce0193240967cf5d485758bea1b4f05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ca9c757f`](https://github.com/nix-community/NUR/commit/ca9c757ffce0193240967cf5d485758bea1b4f05) | `` automatic update `` |
| [`3039f520`](https://github.com/nix-community/NUR/commit/3039f5207715711c24df9867ec3bbf507edb648d) | `` automatic update `` |
| [`85d6414d`](https://github.com/nix-community/NUR/commit/85d6414d94613464b15a8a09d228e569721cf500) | `` automatic update `` |
| [`142e7467`](https://github.com/nix-community/NUR/commit/142e746732bec1552c682bdf7c81721620293e6b) | `` automatic update `` |
| [`9abe8b2b`](https://github.com/nix-community/NUR/commit/9abe8b2bfa504576aae00ba74a74c9eddd8b8892) | `` automatic update `` |
| [`5dbd66a5`](https://github.com/nix-community/NUR/commit/5dbd66a5894c61e680de459ff553cb94bbb96a53) | `` automatic update `` |
| [`9f1243de`](https://github.com/nix-community/NUR/commit/9f1243de41b455b433a303dba4b08ad25551f13d) | `` automatic update `` |
| [`be5ac597`](https://github.com/nix-community/NUR/commit/be5ac597b3002bd8fd1c3e495df0e5fba1645a26) | `` automatic update `` |
| [`5476a3ef`](https://github.com/nix-community/NUR/commit/5476a3ef040e48e613e2913c3d142bbd9c65baa5) | `` automatic update `` |
| [`6088aeba`](https://github.com/nix-community/NUR/commit/6088aeba48bb7f8d31be74aa1fb3b375d635dca2) | `` automatic update `` |
| [`414093f0`](https://github.com/nix-community/NUR/commit/414093f011536a0ed6276be4e8655e8ec1f5feb9) | `` automatic update `` |
| [`3f2ad5a3`](https://github.com/nix-community/NUR/commit/3f2ad5a33e1f34831c6ec932515de62134a3bad8) | `` automatic update `` |
| [`fced9488`](https://github.com/nix-community/NUR/commit/fced9488686a97d75c7577a12b78aec19d256cb6) | `` automatic update `` |
| [`08581dba`](https://github.com/nix-community/NUR/commit/08581dba8a3e843c3616e109ba6f6d396688add8) | `` automatic update `` |
| [`d02fcbe4`](https://github.com/nix-community/NUR/commit/d02fcbe48721759fb9d015be20dd183224a38c56) | `` automatic update `` |
| [`8a35d411`](https://github.com/nix-community/NUR/commit/8a35d4116290d04fcdb0649d56b289a5e3dd867c) | `` automatic update `` |
| [`43f04698`](https://github.com/nix-community/NUR/commit/43f0469860550182ee0f830e57024397dfb19354) | `` automatic update `` |
| [`fb3d46a9`](https://github.com/nix-community/NUR/commit/fb3d46a9e224c76b30d43b4116f93160edf7702c) | `` automatic update `` |
| [`ee2a092b`](https://github.com/nix-community/NUR/commit/ee2a092b4b4a2dd676d28c7228474e530622a79e) | `` automatic update `` |