### PR TITLE
chore(flake/sops-nix): `5dc08f9c` -> `c9c88f08`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1030,11 +1030,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736064798,
-        "narHash": "sha256-xJRN0FmX9QJ6+w8eIIIxzBU1AyQcLKJ1M/Gp6lnSD20=",
+        "lastModified": 1736203741,
+        "narHash": "sha256-eSjkBwBdQk+TZWFlLbclF2rAh4JxbGg8az4w/Lfe7f4=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "5dc08f9cc77f03b43aacffdfbc8316807773c930",
+        "rev": "c9c88f08e3ee495e888b8d7c8624a0b2519cb773",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                        |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`c9c88f08`](https://github.com/Mic92/sops-nix/commit/c9c88f08e3ee495e888b8d7c8624a0b2519cb773) | `` update vendorHash ``                                        |
| [`e8bab8a3`](https://github.com/Mic92/sops-nix/commit/e8bab8a3bcc720024fda280d08fedcbad7609a4b) | `` build(deps): bump golang.org/x/sys from 0.28.0 to 0.29.0 `` |