### PR TITLE
chore(flake/emacs-overlay): `c4b02b4b` -> `20239fd0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1736215843,
-        "narHash": "sha256-xFcqxrwIBTI+V1XG5BBW3Eg2IAESLq2abFnE+rWc8Vk=",
+        "lastModified": 1736302279,
+        "narHash": "sha256-TpZGBVmgIvjX4Yfq/ZgIyxDVhhCXnWyx0fLLna86YrE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c4b02b4be54b35b6bf0cd6b33ef01e33b5a041af",
+        "rev": "20239fd0674b2895adcc8dfeacaffe3337dac94b",
         "type": "github"
       },
       "original": {
@@ -726,11 +726,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1736061677,
-        "narHash": "sha256-DjkQPnkAfd7eB522PwnkGhOMuT9QVCZspDpJJYyOj60=",
+        "lastModified": 1736200483,
+        "narHash": "sha256-JO+lFN2HsCwSLMUWXHeOad6QUxOuwe9UOAF/iSl1J4I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cbd8ec4de4469333c82ff40d057350c30e9f7d36",
+        "rev": "3f0a8ac25fb674611b98089ca3a5dd6480175751",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`20239fd0`](https://github.com/nix-community/emacs-overlay/commit/20239fd0674b2895adcc8dfeacaffe3337dac94b) | `` Updated emacs ``        |
| [`487029bb`](https://github.com/nix-community/emacs-overlay/commit/487029bb8f8aa828f26f19b8d399cce79bf0248a) | `` Updated melpa ``        |
| [`e42614ed`](https://github.com/nix-community/emacs-overlay/commit/e42614ed1bf6c342f351b32c3edbe2772df03133) | `` Updated elpa ``         |
| [`aa9035cb`](https://github.com/nix-community/emacs-overlay/commit/aa9035cb983c70fe87e1f7323fad23537b83a59a) | `` Updated nongnu ``       |
| [`d51ac7f3`](https://github.com/nix-community/emacs-overlay/commit/d51ac7f37e4f338fb4f7c5e769af8d0d41de0a99) | `` Updated flake inputs `` |
| [`ad6b500e`](https://github.com/nix-community/emacs-overlay/commit/ad6b500e038fcfea7ea26ce5f667e98bcad17c63) | `` Updated emacs ``        |
| [`34df90b2`](https://github.com/nix-community/emacs-overlay/commit/34df90b253c0b01f25ea6930f968a92eb0b9ddff) | `` Updated melpa ``        |
| [`b4b2a4db`](https://github.com/nix-community/emacs-overlay/commit/b4b2a4db69e021d5c528a9515071f545b6438c1d) | `` Updated elpa ``         |
| [`fd556776`](https://github.com/nix-community/emacs-overlay/commit/fd5567768f46b85f08b54e22576971b9bce185a4) | `` Updated nongnu ``       |