### PR TITLE
chore(flake/nur): `ca9c757f` -> `df2f5820`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -896,11 +896,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1736263064,
-        "narHash": "sha256-UGc/ikH9GUWfErzTXcyttdqC18ih/NCtL+vO6pOkiFk=",
+        "lastModified": 1736307711,
+        "narHash": "sha256-3qPbTf2ki+U+vjlMl/T3OVTejfH1D0i4aNVagl7b4Y8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ca9c757ffce0193240967cf5d485758bea1b4f05",
+        "rev": "df2f5820e79ddc867118933b2290f32b1473474b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`df2f5820`](https://github.com/nix-community/NUR/commit/df2f5820e79ddc867118933b2290f32b1473474b) | `` automatic update `` |
| [`25aaa8a4`](https://github.com/nix-community/NUR/commit/25aaa8a41d69f47c5e03a2a4876d1c850e2159a9) | `` automatic update `` |
| [`f59808e8`](https://github.com/nix-community/NUR/commit/f59808e8bfd40c1bfb2536d106ba125cc7474eae) | `` automatic update `` |
| [`dd2cd3bc`](https://github.com/nix-community/NUR/commit/dd2cd3bc1a67d0f926b9a4ff98e12ec3750ceb71) | `` automatic update `` |
| [`587c37a7`](https://github.com/nix-community/NUR/commit/587c37a7830efa636cae937252d0e6fe594f173d) | `` automatic update `` |
| [`116254f0`](https://github.com/nix-community/NUR/commit/116254f0b768fc28678c844a69c011c07d04c1d1) | `` automatic update `` |
| [`449b0d70`](https://github.com/nix-community/NUR/commit/449b0d706462c61b45c6a5328034fc442b39cd67) | `` automatic update `` |
| [`92ab1ff1`](https://github.com/nix-community/NUR/commit/92ab1ff1403739a434b7b4c29f3d9f3651f6e2e5) | `` automatic update `` |
| [`c0ec3b49`](https://github.com/nix-community/NUR/commit/c0ec3b496b909b5b18d09a01e2434063e1feb919) | `` automatic update `` |
| [`8b3679f1`](https://github.com/nix-community/NUR/commit/8b3679f146ce461dfedf73d6fb7aaf578616845c) | `` automatic update `` |
| [`e6907655`](https://github.com/nix-community/NUR/commit/e6907655df2228ce6a8a61e43d6701519551895d) | `` automatic update `` |
| [`706045eb`](https://github.com/nix-community/NUR/commit/706045eb80f347d5418e81c5aa80d6c410394991) | `` automatic update `` |