### PR TITLE
chore(flake/nixos-cosmic): `0830abee` -> `ffa6eea2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1736214624,
-        "narHash": "sha256-Pi70vbASZ1O9cR8RO5d2hBiNjIJBKKLoABl4sxWyOgg=",
+        "lastModified": 1736391924,
+        "narHash": "sha256-0iils2qitbyYQswdgiSOeateOVsKRjhJqGaSNFWKRHE=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "0830abeebf3b2d1bae44652ffb2c89cf0d56ddaa",
+        "rev": "ffa6eea20301d21932fd9870570418a4fb96204c",
         "type": "github"
       },
       "original": {
@@ -759,11 +759,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1736061677,
-        "narHash": "sha256-DjkQPnkAfd7eB522PwnkGhOMuT9QVCZspDpJJYyOj60=",
+        "lastModified": 1736200483,
+        "narHash": "sha256-JO+lFN2HsCwSLMUWXHeOad6QUxOuwe9UOAF/iSl1J4I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cbd8ec4de4469333c82ff40d057350c30e9f7d36",
+        "rev": "3f0a8ac25fb674611b98089ca3a5dd6480175751",
         "type": "github"
       },
       "original": {
@@ -1012,11 +1012,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736130662,
-        "narHash": "sha256-z+WGez9oTR2OsiUWE5ZhIpETqM1ogrv6Xcd24WFi6KQ=",
+        "lastModified": 1736390353,
+        "narHash": "sha256-e2SP1zV9CISHlYZwEhwT53N9CW7yPh0tKTR0vuQqiWc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2f5d4d9cd31cc02c36e51cb2e21c4b25c4f78c52",
+        "rev": "1033caad3e26a56050de55ba0384df5ff0fa5ebd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                        |
| ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`ffa6eea2`](https://github.com/lilyinstarlight/nixos-cosmic/commit/ffa6eea20301d21932fd9870570418a4fb96204c) | `` flake: update inputs (#579) ``                              |
| [`729f46d0`](https://github.com/lilyinstarlight/nixos-cosmic/commit/729f46d00b05817115374fab31576a009102c664) | `` pkgs: update cosmic (#578) ``                               |
| [`257cd359`](https://github.com/lilyinstarlight/nixos-cosmic/commit/257cd359b4d8a831f95fa639c8b0cf114b75bd06) | `` pkgs: update cosmic (#575) ``                               |
| [`a17b5f10`](https://github.com/lilyinstarlight/nixos-cosmic/commit/a17b5f107b49c5e9f70dd503eeba667561fb5eda) | `` flake: update inputs (#577) ``                              |
| [`960b817b`](https://github.com/lilyinstarlight/nixos-cosmic/commit/960b817bab24c5aa5df9fc258b14109faef3ae2c) | `` cosmic-comp: add libdisplay-info ``                         |
| [`f1f4f58a`](https://github.com/lilyinstarlight/nixos-cosmic/commit/f1f4f58aaffff1d519e38021ee5b9ac82e9c9652) | `` vm: remove cosmic-player from extra testing package list `` |