### PR TITLE
chore(flake/nur): `df2f5820` -> `77494914`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -896,11 +896,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1736307711,
-        "narHash": "sha256-3qPbTf2ki+U+vjlMl/T3OVTejfH1D0i4aNVagl7b4Y8=",
+        "lastModified": 1736331332,
+        "narHash": "sha256-UIm+oVXPfVfv1L/t+e07kzl1635rjBGy17RjSsrBRvU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "df2f5820e79ddc867118933b2290f32b1473474b",
+        "rev": "77494914e552d313383c7a2d9b0a50dfb7c482d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`77494914`](https://github.com/nix-community/NUR/commit/77494914e552d313383c7a2d9b0a50dfb7c482d5) | `` automatic update `` |
| [`6792ac93`](https://github.com/nix-community/NUR/commit/6792ac93b3783602f3787079636b56b9b5586510) | `` automatic update `` |
| [`ef4deb54`](https://github.com/nix-community/NUR/commit/ef4deb5461e2eb3e5ebe881799854d571a9219b2) | `` automatic update `` |
| [`4cbf26a2`](https://github.com/nix-community/NUR/commit/4cbf26a208dab2142f5c4be0806415c6ab669b83) | `` automatic update `` |
| [`dc668949`](https://github.com/nix-community/NUR/commit/dc668949931b281d4d203695bcea5dae1430e4d9) | `` automatic update `` |
| [`f6585660`](https://github.com/nix-community/NUR/commit/f65856601ec560e839c957a71bdd589ea517ded7) | `` automatic update `` |
| [`6bdff7bb`](https://github.com/nix-community/NUR/commit/6bdff7bbfde23a23437da6c7ba8d9c002e9dbd60) | `` automatic update `` |
| [`1c622663`](https://github.com/nix-community/NUR/commit/1c6226632cea9063d529d253b5601965847092b3) | `` automatic update `` |
| [`6fa75850`](https://github.com/nix-community/NUR/commit/6fa75850da39b931630dbdd290998c15c1f1bb2c) | `` automatic update `` |
| [`9b1d124a`](https://github.com/nix-community/NUR/commit/9b1d124a644d88233f2e16b1fbd590cefcffe1f8) | `` automatic update `` |
| [`28568773`](https://github.com/nix-community/NUR/commit/2856877385d0fce64ac7d5cd08740de3c00b8927) | `` automatic update `` |