### PR TITLE
chore(flake/home-manager): `5c430231` -> `7e008565`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -414,11 +414,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736277415,
-        "narHash": "sha256-kPDXF6cIPsVqSK08XF5EC6KM7BdMnM9vtJDzsnf+lLU=",
+        "lastModified": 1736366465,
+        "narHash": "sha256-Fo68EF6p/N9GJyHiAUbXtiE7IJlb3IMjK86LuxFMsRU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5c4302313d9207f7ec0886d68f8ff4a3c71209a1",
+        "rev": "7e00856596891850ba5ad4c5ecd2ed74468c08c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                  |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`7e008565`](https://github.com/nix-community/home-manager/commit/7e00856596891850ba5ad4c5ecd2ed74468c08c5) | `` flake.lock: Update ``                                                 |
| [`54b330ac`](https://github.com/nix-community/home-manager/commit/54b330ac067e74314f8ca6b38af6fcfbd17f3e9e) | `` go: add telemetry options ``                                          |
| [`fcc4259c`](https://github.com/nix-community/home-manager/commit/fcc4259cdbcb76138b48ed36b4f41c521910db0d) | `` treewide: stub tests (#6275) ``                                       |
| [`456e599f`](https://github.com/nix-community/home-manager/commit/456e599f9101ed153dde268b4401c5d294ba6c8c) | `` wayfire: add module (#6066) ``                                        |
| [`45bcdbc9`](https://github.com/nix-community/home-manager/commit/45bcdbc910dc5131943bb6f7edb156617898fd1a) | `` gpg-agent: fix compatibility with sh when enableSshSupport (#6287) `` |