### PR TITLE
chore(flake/nur): `77494914` -> `91d6536a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -896,11 +896,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1736331332,
-        "narHash": "sha256-UIm+oVXPfVfv1L/t+e07kzl1635rjBGy17RjSsrBRvU=",
+        "lastModified": 1736365537,
+        "narHash": "sha256-NpAmI8zq3DliRGWjJDvdCzFIu5+SlVwjRAjEQHpBQWk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "77494914e552d313383c7a2d9b0a50dfb7c482d5",
+        "rev": "91d6536ae047898683265c25112cbf458fe72759",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`91d6536a`](https://github.com/nix-community/NUR/commit/91d6536ae047898683265c25112cbf458fe72759) | `` automatic update `` |
| [`5c58f97c`](https://github.com/nix-community/NUR/commit/5c58f97c11627ff1715de0a9e1c0a2b6b469d01e) | `` automatic update `` |
| [`d6ef5551`](https://github.com/nix-community/NUR/commit/d6ef55516534cbdff8b3be925820bf897e058ba0) | `` automatic update `` |
| [`90b5dabc`](https://github.com/nix-community/NUR/commit/90b5dabc87a61800504cd2e899d4ca704a0d070d) | `` automatic update `` |
| [`2d96d233`](https://github.com/nix-community/NUR/commit/2d96d2338c185780a93e290be7d9fe13814cd95a) | `` automatic update `` |
| [`3cd3e6c2`](https://github.com/nix-community/NUR/commit/3cd3e6c29d1343ab573eae77b881e20cfaf63342) | `` automatic update `` |
| [`037dd18f`](https://github.com/nix-community/NUR/commit/037dd18fb478fd231775704263386a29a6595074) | `` automatic update `` |
| [`c50588f0`](https://github.com/nix-community/NUR/commit/c50588f0dadadc380235b10d2dd93edbee8f453e) | `` automatic update `` |
| [`10179cfa`](https://github.com/nix-community/NUR/commit/10179cfaae2ad7ec5ae881fc2e49f94bd8a9f9b3) | `` automatic update `` |
| [`ffd92de0`](https://github.com/nix-community/NUR/commit/ffd92de0a9e5c1812b00d4e21c8d3b9461409b98) | `` automatic update `` |
| [`05de57e2`](https://github.com/nix-community/NUR/commit/05de57e2d0f4dcaa2c16365fb2d83637eb20aebe) | `` automatic update `` |