### PR TITLE
chore(flake/emacs-overlay): `42b7368d` -> `b8a53ec5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1736327656,
-        "narHash": "sha256-vDli473KKyf13uexB4Ja9Jt7KmeUSbHbeuwIDP0M2yM=",
+        "lastModified": 1736385356,
+        "narHash": "sha256-ddNEYJylKbApbxboWk57oq/wkIs3QRYnhDuSgUwG4wE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "42b7368d193ad1939c32e87b48e970423f22f242",
+        "rev": "b8a53ec5e21526aff929faa711dd22b3d9c5d49b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`b8a53ec5`](https://github.com/nix-community/emacs-overlay/commit/b8a53ec5e21526aff929faa711dd22b3d9c5d49b) | `` Updated elpa ``   |
| [`c0c5f2d3`](https://github.com/nix-community/emacs-overlay/commit/c0c5f2d3b04f251d3036432e6473af08eb394beb) | `` Updated nongnu `` |
| [`7beb5f1e`](https://github.com/nix-community/emacs-overlay/commit/7beb5f1e34fb652bb68aa5d33247f92a1718f781) | `` Updated emacs ``  |
| [`b9bce28f`](https://github.com/nix-community/emacs-overlay/commit/b9bce28f228f3a73da311ddf3d44b2a6a7bc56d9) | `` Updated melpa ``  |
| [`6007ea80`](https://github.com/nix-community/emacs-overlay/commit/6007ea80bdb1b4321dd09427709e1d80fae5efbe) | `` Updated elpa ``   |