### PR TITLE
chore(flake/emacs-overlay): `b8a53ec5` -> `0924fcda`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1736385356,
-        "narHash": "sha256-ddNEYJylKbApbxboWk57oq/wkIs3QRYnhDuSgUwG4wE=",
+        "lastModified": 1736414269,
+        "narHash": "sha256-HrRQ54D2JfevmU3u7Rw2auCdJPaT7PlIg3IUf8iamBo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b8a53ec5e21526aff929faa711dd22b3d9c5d49b",
+        "rev": "0924fcda6ea2ff09c857663d965a6d01e5d13ea6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`0924fcda`](https://github.com/nix-community/emacs-overlay/commit/0924fcda6ea2ff09c857663d965a6d01e5d13ea6) | `` Updated emacs `` |
| [`f15d1123`](https://github.com/nix-community/emacs-overlay/commit/f15d1123688272b19b761a16e42b20218e6ae3a8) | `` Updated melpa `` |