### PR TITLE
chore(flake/home-manager): `7e008565` -> `d4aebb94`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -431,11 +431,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736366465,
-        "narHash": "sha256-Fo68EF6p/N9GJyHiAUbXtiE7IJlb3IMjK86LuxFMsRU=",
+        "lastModified": 1736421950,
+        "narHash": "sha256-RyrX0WFXxFrYvzHNLTIyuk3NcNl3UBykuYru/P0zW5E=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7e00856596891850ba5ad4c5ecd2ed74468c08c5",
+        "rev": "d4aebb947a301b8da8654a804979a738c5c5da50",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`d4aebb94`](https://github.com/nix-community/home-manager/commit/d4aebb947a301b8da8654a804979a738c5c5da50) | `` todoman: add todoman module (#5252) ``      |
| [`01f40d52`](https://github.com/nix-community/home-manager/commit/01f40d52d65318463d71aa485fe9ad6f26357b45) | `` zsh/prezto: add `package` option (#5938) `` |