### PR TITLE
chore(flake/nur): `6ac8fe2a` -> `d77ff069`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -913,11 +913,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1736412376,
-        "narHash": "sha256-iuLJ46T8RXLt4aMo//1PvhRJuwcBtvV67stg7XpsbvQ=",
+        "lastModified": 1736422909,
+        "narHash": "sha256-wYAV1dYQCBCxYPr8Rd5ZIecyS8AStAYj1097VtsMHFQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6ac8fe2ae1bff7d46688f78f791d49a8e08b014b",
+        "rev": "d77ff06974bccfc66df7fe5dc61f2c55b696ca8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d77ff069`](https://github.com/nix-community/NUR/commit/d77ff06974bccfc66df7fe5dc61f2c55b696ca8b) | `` automatic update `` |