### PR TITLE
chore(flake/nixos-cosmic): `ffa6eea2` -> `f8ffb77e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -618,15 +618,14 @@
       "inputs": {
         "flake-compat": "flake-compat_2",
         "nixpkgs": "nixpkgs_3",
-        "nixpkgs-stable": "nixpkgs-stable_3",
-        "rust-overlay": "rust-overlay_2"
+        "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1736391924,
-        "narHash": "sha256-0iils2qitbyYQswdgiSOeateOVsKRjhJqGaSNFWKRHE=",
+        "lastModified": 1736439092,
+        "narHash": "sha256-vkweBSXUhoOiFAlM7ghuBfrGAJdbkBcHbxl8TvgP0wc=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "ffa6eea20301d21932fd9870570418a4fb96204c",
+        "rev": "f8ffb77eacca855881794d83fd4752b53d00833c",
         "type": "github"
       },
       "original": {
@@ -996,27 +995,6 @@
         "owner": "oxalica",
         "repo": "rust-overlay",
         "rev": "0be641045af6d8666c11c2c40e45ffc9667839b5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "rust-overlay_2": {
-      "inputs": {
-        "nixpkgs": [
-          "nixos-cosmic",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1736390353,
-        "narHash": "sha256-e2SP1zV9CISHlYZwEhwT53N9CW7yPh0tKTR0vuQqiWc=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "1033caad3e26a56050de55ba0384df5ff0fa5ebd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                                                   |
| ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`f8ffb77e`](https://github.com/lilyinstarlight/nixos-cosmic/commit/f8ffb77eacca855881794d83fd4752b53d00833c) | `` cosmic-files: reformat ``                                                              |
| [`b1e98c92`](https://github.com/lilyinstarlight/nixos-cosmic/commit/b1e98c92eecb25b672c1cbb0870c19fc84e342fb) | `` cosmic-files: remove kludge to deal with prior mutually exclusive feature selection `` |
| [`885fae41`](https://github.com/lilyinstarlight/nixos-cosmic/commit/885fae411cac372c4571af33a712650da378c6dd) | `` xdg-desktop-portal-cosmic: fix typo ``                                                 |
| [`e360b9b4`](https://github.com/lilyinstarlight/nixos-cosmic/commit/e360b9b41aaf7607f2fc6f66a80decc3da84cc92) | `` nixos: remove 24.11 workarounds ``                                                     |
| [`929561eb`](https://github.com/lilyinstarlight/nixos-cosmic/commit/929561eb679cbbb9354895ae219f31c392ff07c7) | `` xdg-desktop-portal-cosmic: remove absolute path in dbus service file ``                |
| [`c91f1104`](https://github.com/lilyinstarlight/nixos-cosmic/commit/c91f1104f886f9b3211fca2570931c50f69443f4) | `` flake: remove now-unnecessary rust-overlay ``                                          |