### PR TITLE
chore(flake/nur): `d77ff069` -> `c8894fa5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -913,11 +913,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1736422909,
-        "narHash": "sha256-wYAV1dYQCBCxYPr8Rd5ZIecyS8AStAYj1097VtsMHFQ=",
+        "lastModified": 1736435153,
+        "narHash": "sha256-R9SsuL6WERMyj2J2HRldUn/BoZiVf8jPeOt1pw5pllg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d77ff06974bccfc66df7fe5dc61f2c55b696ca8b",
+        "rev": "c8894fa58d5e1a9d498cfe7d062f7b188a51be16",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c8894fa5`](https://github.com/nix-community/NUR/commit/c8894fa58d5e1a9d498cfe7d062f7b188a51be16) | `` automatic update `` |
| [`588b4454`](https://github.com/nix-community/NUR/commit/588b44547461ffced7d6ce8dfd4b74e18e9c9998) | `` automatic update `` |
| [`5690d0b3`](https://github.com/nix-community/NUR/commit/5690d0b38724c789f2aecc1e1c0b62fb13afb740) | `` automatic update `` |