### PR TITLE
chore(flake/emacs-overlay): `0924fcda` -> `49e8a084`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1736414269,
-        "narHash": "sha256-HrRQ54D2JfevmU3u7Rw2auCdJPaT7PlIg3IUf8iamBo=",
+        "lastModified": 1736474984,
+        "narHash": "sha256-omdT+afSBbA8kcNj2QLUKgyZJJz4VEtJSuoNx7BrRjI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0924fcda6ea2ff09c857663d965a6d01e5d13ea6",
+        "rev": "49e8a08498d157af476dfacf3ddec0f14dc4e512",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`49e8a084`](https://github.com/nix-community/emacs-overlay/commit/49e8a08498d157af476dfacf3ddec0f14dc4e512) | `` Updated emacs ``        |
| [`4c2faae7`](https://github.com/nix-community/emacs-overlay/commit/4c2faae7ac7d7400ea73e1ac327211b31f51fad0) | `` Updated melpa ``        |
| [`5ef946d9`](https://github.com/nix-community/emacs-overlay/commit/5ef946d9eba9892b8400ec6717289a14ca3838b1) | `` Updated elpa ``         |
| [`7d2087d8`](https://github.com/nix-community/emacs-overlay/commit/7d2087d88404112cb79a202ad004e078fd2ff35d) | `` Updated nongnu ``       |
| [`f919d765`](https://github.com/nix-community/emacs-overlay/commit/f919d7650380b43fd27d271e1e096ac1b8fdd7ba) | `` Updated emacs ``        |
| [`69ecdf68`](https://github.com/nix-community/emacs-overlay/commit/69ecdf68894d67c91724838d3ef2d35db1a9ea78) | `` Updated melpa ``        |
| [`aaf6d144`](https://github.com/nix-community/emacs-overlay/commit/aaf6d1443de5e2bf18231f4c1e435c5ff0cb667c) | `` Updated nongnu ``       |
| [`50a7bc59`](https://github.com/nix-community/emacs-overlay/commit/50a7bc59d4cf844dc07e3c54b025b73f8319daed) | `` Updated flake inputs `` |