### PR TITLE
chore(flake/emacs-overlay): `49e8a084` -> `43393ea4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1736474984,
-        "narHash": "sha256-omdT+afSBbA8kcNj2QLUKgyZJJz4VEtJSuoNx7BrRjI=",
+        "lastModified": 1736529231,
+        "narHash": "sha256-r06UiczR3jaRR7HcjVssb529gP4ubZsfZyDnO2UcQnY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "49e8a08498d157af476dfacf3ddec0f14dc4e512",
+        "rev": "43393ea424f1d8ad6ed2a1053cbf67f5bab1a524",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`43393ea4`](https://github.com/nix-community/emacs-overlay/commit/43393ea424f1d8ad6ed2a1053cbf67f5bab1a524) | `` Updated emacs ``  |
| [`6bd5f512`](https://github.com/nix-community/emacs-overlay/commit/6bd5f512b30ec3f1b1539757a6f18c1d73b9a799) | `` Updated melpa ``  |
| [`edab7e49`](https://github.com/nix-community/emacs-overlay/commit/edab7e49e85690e361700cf1613fb5afc22e1e50) | `` Updated elpa ``   |
| [`ed1abfef`](https://github.com/nix-community/emacs-overlay/commit/ed1abfef0a4e87c0731f91d8d1b160e3e261a3a8) | `` Updated nongnu `` |
| [`a543218e`](https://github.com/nix-community/emacs-overlay/commit/a543218ec15d1c97f3735c2698bf91003f470cd2) | `` Updated emacs ``  |
| [`2830c0d7`](https://github.com/nix-community/emacs-overlay/commit/2830c0d7b99849d2a163f25d14d2004ebb86bfd3) | `` Updated melpa ``  |