### PR TITLE
chore(flake/sops-nix): `c9c88f08` -> `553c7cb2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1043,11 +1043,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736203741,
-        "narHash": "sha256-eSjkBwBdQk+TZWFlLbclF2rAh4JxbGg8az4w/Lfe7f4=",
+        "lastModified": 1736808430,
+        "narHash": "sha256-wlgdf/n7bJMLBheqt1jmPoxJFrUP6FByKQFXuM9YvIk=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c9c88f08e3ee495e888b8d7c8624a0b2519cb773",
+        "rev": "553c7cb22fed19fd60eb310423fdc93045c51ba8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                     |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`553c7cb2`](https://github.com/Mic92/sops-nix/commit/553c7cb22fed19fd60eb310423fdc93045c51ba8) | `` update vendorHash ``                                                     |
| [`de557bfd`](https://github.com/Mic92/sops-nix/commit/de557bfdac74d0501d70b5a312aa97dbd01c3e2c) | `` build(deps): bump golang.org/x/crypto from 0.31.0 to 0.32.0 ``           |
| [`26632980`](https://github.com/Mic92/sops-nix/commit/26632980bf559cc68039de2753acc5ed76acea9c) | `` update vendorHash ``                                                     |
| [`830847a4`](https://github.com/Mic92/sops-nix/commit/830847a4ad0f088cb5589121f696241d0dc6f5a5) | `` build(deps): bump golang.org/x/net from 0.26.0 to 0.33.0 ``              |
| [`644dc90f`](https://github.com/Mic92/sops-nix/commit/644dc90f82e1bb58694c626743e5f2e30f3bdf09) | `` update vendorHash ``                                                     |
| [`7ac4c301`](https://github.com/Mic92/sops-nix/commit/7ac4c301afdf38e51edb8fea329629d927bd1628) | `` build(deps): bump github.com/ProtonMail/go-crypto from 1.1.3 to 1.1.4 `` |
| [`0f4744b5`](https://github.com/Mic92/sops-nix/commit/0f4744b5a95151a85c4f35010dd2d748228f7f53) | `` Fix fast path in atomicSymlink ``                                        |
| [`f214c1b7`](https://github.com/Mic92/sops-nix/commit/f214c1b76c347a4e9c8fb68c73d4293a6820d125) | `` handle /run/secrets more gracefully if its a directory ``                |
| [`74b9fe5d`](https://github.com/Mic92/sops-nix/commit/74b9fe5d7ff2d7301ad1550ab9a1a792745a9713) | `` test 24.11 ``                                                            |