### PR TITLE
chore(flake/nur): `9cb83cb0` -> `80b24eed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -912,11 +912,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1736506669,
-        "narHash": "sha256-hX5bemt5lmgIXKsRxtm4p8IrvNTNeus/eEz7EcJ4JX8=",
+        "lastModified": 1736538354,
+        "narHash": "sha256-qPgUE5K/qcgzpQRHzruAgwT/7SCSAOUOyK1qyofe0TY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9cb83cb0f7871b02d6defa60354dbaede0be72c1",
+        "rev": "80b24eed6e716dc5a31a360f8465636a7a2a990f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`80b24eed`](https://github.com/nix-community/NUR/commit/80b24eed6e716dc5a31a360f8465636a7a2a990f) | `` automatic update `` |
| [`9eb03375`](https://github.com/nix-community/NUR/commit/9eb03375fb3f077d055ae730d39bae589814ca6e) | `` automatic update `` |
| [`84b1303f`](https://github.com/nix-community/NUR/commit/84b1303f7a2e21dddcb55a0a112a68803f88ff27) | `` automatic update `` |
| [`c20f15ff`](https://github.com/nix-community/NUR/commit/c20f15ff992ae4ae34377f0f1ade9d7d7cb918b9) | `` automatic update `` |
| [`950ec127`](https://github.com/nix-community/NUR/commit/950ec1270558b41a6dd2ee662daa052deee01086) | `` automatic update `` |
| [`36c37030`](https://github.com/nix-community/NUR/commit/36c370306435fc155e1aafb3cfede6d6f7436203) | `` automatic update `` |