### PR TITLE
chore(flake/nur): `80b24eed` -> `e5a302de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -912,11 +912,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1736538354,
-        "narHash": "sha256-qPgUE5K/qcgzpQRHzruAgwT/7SCSAOUOyK1qyofe0TY=",
+        "lastModified": 1736580656,
+        "narHash": "sha256-WFhwR7SU2Q0DzAXLsutW/9c9zwH9rgz6SWIQcOpkFfc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "80b24eed6e716dc5a31a360f8465636a7a2a990f",
+        "rev": "e5a302deaa59a4c8361c61b1a1db96b559946140",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                   |
| -------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`e5a302de`](https://github.com/nix-community/NUR/commit/e5a302deaa59a4c8361c61b1a1db96b559946140) | `` automatic update ``                    |
| [`192b940f`](https://github.com/nix-community/NUR/commit/192b940f8aa3d253435c0dd8a80945a0339675c8) | `` automatic update ``                    |
| [`8897cb28`](https://github.com/nix-community/NUR/commit/8897cb28addb484d322b7a2cc0906c318c8f3c89) | `` Add concurrency rules to update.yml `` |
| [`05b23f8c`](https://github.com/nix-community/NUR/commit/05b23f8c3be2ec37ad2d6286ce1c9027f8e9b94a) | `` automatic update ``                    |
| [`0b08129f`](https://github.com/nix-community/NUR/commit/0b08129f1376927569275016f5e1d5dd60fb3fa4) | `` add nikolaizombie1 repository ``       |
| [`231a0d82`](https://github.com/nix-community/NUR/commit/231a0d82cef0901347ec796b9969910d3f84c8df) | `` fix accidental rycee downgrade ``      |
| [`056959cc`](https://github.com/nix-community/NUR/commit/056959cc9aae8a0157bc067e8083d4697d51b4a0) | `` Manually update kugland entry ``       |
| [`f17b69f8`](https://github.com/nix-community/NUR/commit/f17b69f887d4416b38fb8a9b241c0c59074206de) | `` automatic update ``                    |
| [`9cd677dc`](https://github.com/nix-community/NUR/commit/9cd677dc0180f7ec44419d4e4c60accefc29a828) | `` Remove kugland from repos.json.lock `` |
| [`82ecbe27`](https://github.com/nix-community/NUR/commit/82ecbe2706b9dc7a5f138bed1f7a933611085421) | `` automatic update ``                    |
| [`f1d3f049`](https://github.com/nix-community/NUR/commit/f1d3f049790b064929a4151dbcb68072672c0281) | `` automatic update ``                    |
| [`103df61d`](https://github.com/nix-community/NUR/commit/103df61d375b34182afc2f1e8d42be9bd3130cbe) | `` automatic update ``                    |
| [`ed6fb752`](https://github.com/nix-community/NUR/commit/ed6fb7526216933560a982dbf4db3d63970bdff0) | `` automatic update ``                    |
| [`16233e8f`](https://github.com/nix-community/NUR/commit/16233e8f300759fccdc1920cb30afb7036145a8b) | `` automatic update ``                    |
| [`51f5fcef`](https://github.com/nix-community/NUR/commit/51f5fcef1e6cacea56c32313e5512652b761d19f) | `` automatic update ``                    |