### PR TITLE
chore(flake/emacs-overlay): `43393ea4` -> `d376d6c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1736529231,
-        "narHash": "sha256-r06UiczR3jaRR7HcjVssb529gP4ubZsfZyDnO2UcQnY=",
+        "lastModified": 1736673161,
+        "narHash": "sha256-vlN7PcPnDpnIo2hvuHTqFk7CbCcHCQmTQUSijgBCa24=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "43393ea424f1d8ad6ed2a1053cbf67f5bab1a524",
+        "rev": "d376d6c0d09b7c5f4c5c026ae1a0ab53fb09fc77",
         "type": "github"
       },
       "original": {
@@ -742,11 +742,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1736200483,
-        "narHash": "sha256-JO+lFN2HsCwSLMUWXHeOad6QUxOuwe9UOAF/iSl1J4I=",
+        "lastModified": 1736549401,
+        "narHash": "sha256-ibkQrMHxF/7TqAYcQE+tOnIsSEzXmMegzyBWza6uHKM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3f0a8ac25fb674611b98089ca3a5dd6480175751",
+        "rev": "1dab772dd4a68a7bba5d9460685547ff8e17d899",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`d376d6c0`](https://github.com/nix-community/emacs-overlay/commit/d376d6c0d09b7c5f4c5c026ae1a0ab53fb09fc77) | `` Updated emacs ``        |
| [`c8f7c0c1`](https://github.com/nix-community/emacs-overlay/commit/c8f7c0c1e8f31e7ce8915b4f3aa3a1e4381c00b0) | `` Updated melpa ``        |
| [`05465c0b`](https://github.com/nix-community/emacs-overlay/commit/05465c0bbbbfa3db409e477e0a85bd161d27953e) | `` Updated emacs ``        |
| [`9d57f70c`](https://github.com/nix-community/emacs-overlay/commit/9d57f70c9a98c0dc27c32a4c0e7625dfe8d97c42) | `` Updated melpa ``        |
| [`4c1a300f`](https://github.com/nix-community/emacs-overlay/commit/4c1a300fedccf11194c39f26204f77d9e82ff728) | `` Updated elpa ``         |
| [`58c89a99`](https://github.com/nix-community/emacs-overlay/commit/58c89a9912aed6ca10e120589ae67eba50e23d61) | `` Updated nongnu ``       |
| [`cb9f3553`](https://github.com/nix-community/emacs-overlay/commit/cb9f3553b34e1670e4c5b12cfc2757aa830652cd) | `` Updated flake inputs `` |
| [`38789ef3`](https://github.com/nix-community/emacs-overlay/commit/38789ef3dafe7a3a8927ccc874ddc90d0d5ef3b2) | `` Updated emacs ``        |
| [`4954635f`](https://github.com/nix-community/emacs-overlay/commit/4954635f98b8ef2ff9ce469f82beee958ec6d783) | `` Updated melpa ``        |
| [`d25badb8`](https://github.com/nix-community/emacs-overlay/commit/d25badb857fd7e1ef13c31354fb1e5b47ed4591c) | `` Updated elpa ``         |
| [`a431a78d`](https://github.com/nix-community/emacs-overlay/commit/a431a78dd09b2903c9f7f2b0bd78f53d0bb9161b) | `` Updated nongnu ``       |
| [`8e1fd211`](https://github.com/nix-community/emacs-overlay/commit/8e1fd211d50232c3227a6e7a555515e5b3d3e333) | `` Updated emacs ``        |
| [`e150cf4d`](https://github.com/nix-community/emacs-overlay/commit/e150cf4d4d3d2f90322e8c26eb6d72e246c9d634) | `` Updated melpa ``        |
| [`f776f828`](https://github.com/nix-community/emacs-overlay/commit/f776f828fe9de155a4b1139266e5aa557e8d2d22) | `` Updated emacs ``        |
| [`4dc3f1bd`](https://github.com/nix-community/emacs-overlay/commit/4dc3f1bddb275435e5d5ce99fd921d9eb74a9132) | `` Updated melpa ``        |
| [`ccfe4a79`](https://github.com/nix-community/emacs-overlay/commit/ccfe4a79aa99f1f79dbafa3f6009c0438a8d760c) | `` Updated elpa ``         |