### PR TITLE
chore(flake/gptel): `f1f65def` -> `3fefce47`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -367,11 +367,11 @@
     "gptel": {
       "flake": false,
       "locked": {
-        "lastModified": 1736210928,
-        "narHash": "sha256-7ITffw/XdqeMSVuE6al2wplDmkxE60rbBoH70hSskG8=",
+        "lastModified": 1736566264,
+        "narHash": "sha256-IzYU0V+z3PFY3yT2IKYiPv9x0DGmAu7Ha5PlTfS4sMs=",
         "owner": "karthink",
         "repo": "gptel",
-        "rev": "f1f65def27dd12f53e2523f4edf2994112356653",
+        "rev": "3fefce47be1d14a7966bb175148cec6938d60f80",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                             |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`3fefce47`](https://github.com/karthink/gptel/commit/3fefce47be1d14a7966bb175148cec6938d60f80) | `` gptel: Handle pending calls/call results in chat buffers ``      |
| [`59ac4382`](https://github.com/karthink/gptel/commit/59ac4382bafcf19043ded88ea8985240731b7714) | `` gptel: Run callback with pending tool calls ``                   |
| [`ab60b3a5`](https://github.com/karthink/gptel/commit/ab60b3a59eb0644aff69e99dc7365cbbc4560c3f) | `` gptel: Add controls to confirm/include tool calls ``             |
| [`fa7aa756`](https://github.com/karthink/gptel/commit/fa7aa756409eaf406743a33ab464192b70f5b5a9) | `` gptel: Indicate tools in gptel-mode header-line ``               |
| [`0db85e5e`](https://github.com/karthink/gptel/commit/0db85e5ec81b800d7016b28d7b9e1b293603a884) | `` gptel-transient: Add tool selection UI ``                        |
| [`3ba7581b`](https://github.com/karthink/gptel/commit/3ba7581b37cb118fb20776e9dba40f0a9084c48d) | `` gptel: Bump transient required version to 0.7.4 ``               |
| [`b7919789`](https://github.com/karthink/gptel/commit/b7919789c2199c86a06b6427794eec95029a199d) | `` gptel: Add a registry for tools ``                               |
| [`78cedc6b`](https://github.com/karthink/gptel/commit/78cedc6bd99b64201df778a68e4f3d323a2a900b) | `` gptel: Add a diagnostic display for latest request ``            |
| [`89e2b224`](https://github.com/karthink/gptel/commit/89e2b224b8daba8158437aca49181018464e56bc) | `` gptel: Activate tool use ``                                      |
| [`55be4e31`](https://github.com/karthink/gptel/commit/55be4e3151046bad1655a71005629705ba6f2420) | `` gptel: Add tool calling to gptel's state machine ``              |
| [`2c396fa6`](https://github.com/karthink/gptel/commit/2c396fa697c63fdf058420f185268da44a6978ad) | `` gptel: Add tool definition and result parsers ``                 |
| [`d070ad4d`](https://github.com/karthink/gptel/commit/d070ad4de84da7d2ae119ca094e27565d6f0c45c) | `` gptel: Add tool call parsing (only) to most backends ``          |
| [`3852da01`](https://github.com/karthink/gptel/commit/3852da01ae30185f35739fe4ef73bdfb1e12b7a1) | `` gptel: Change JSON parsing semantics ``                          |
| [`406f708e`](https://github.com/karthink/gptel/commit/406f708edc28210cc88cbac94ed62ccf258da0ef) | `` gptel: Simplify gptel--request-data ``                           |
| [`5c5938af`](https://github.com/karthink/gptel/commit/5c5938aff11155c15f8df7e3f9503a413a5e9086) | `` gptel: Update inspect-query functions for FSM ``                 |
| [`5bb2c234`](https://github.com/karthink/gptel/commit/5bb2c23407e80ef757b2b8a6c1d097a49d6f5fa3) | `` gptel: Use FSM to drive gptel requests ``                        |
| [`6253d436`](https://github.com/karthink/gptel/commit/6253d4367b489d83dcd34eac1776488e961262a6) | `` gptel: default state transition handlers, predicates ``          |
| [`14bd1668`](https://github.com/karthink/gptel/commit/14bd1668fc1158d29605c74ad340a315543a0dcd) | `` gptel: Add finite state machine ``                               |
| [`5115d441`](https://github.com/karthink/gptel/commit/5115d441e7426287836d0e9bd39b02f69e63eb11) | `` gptel-org: Handle LLMs mixing up Markdown/Org src blocks ``      |
| [`99d7bb38`](https://github.com/karthink/gptel/commit/99d7bb3861164740ab9228dbaaf097984f7d7fe7) | `` gptel-openai: Add support for o1, deprecate o1-preview (#559) `` |
| [`ea041a49`](https://github.com/karthink/gptel/commit/ea041a499b26f677689d8df8588a65bd4938ebe0) | `` gptel: Fix gptel-beginning-of-response ``                        |