### PR TITLE
chore(flake/nur): `e5a302de` -> `bc3d78ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -912,11 +912,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1736580656,
-        "narHash": "sha256-WFhwR7SU2Q0DzAXLsutW/9c9zwH9rgz6SWIQcOpkFfc=",
+        "lastModified": 1736610420,
+        "narHash": "sha256-MvvjzN4DJSQmRLQSfQWC3a70GWVu6RiwE0D71c8el2U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e5a302deaa59a4c8361c61b1a1db96b559946140",
+        "rev": "bc3d78ce1ae003f42ddd6434256262861247cfe1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bc3d78ce`](https://github.com/nix-community/NUR/commit/bc3d78ce1ae003f42ddd6434256262861247cfe1) | `` automatic update `` |
| [`419956b2`](https://github.com/nix-community/NUR/commit/419956b2765c703735d5aa6fb46474adcad160af) | `` automatic update `` |
| [`1e53e9bc`](https://github.com/nix-community/NUR/commit/1e53e9bc8629392eb07c7903657b3cf3a65964c1) | `` automatic update `` |
| [`a99b075f`](https://github.com/nix-community/NUR/commit/a99b075f3290c31336c839ee328f105280559d74) | `` automatic update `` |
| [`f02e9c39`](https://github.com/nix-community/NUR/commit/f02e9c39ecfd89b87886ff6eb48354a86cb6f836) | `` automatic update `` |
| [`764ca234`](https://github.com/nix-community/NUR/commit/764ca2343bfb3ef4549c05309a3c23f35318b877) | `` automatic update `` |
| [`7caf42d8`](https://github.com/nix-community/NUR/commit/7caf42d8bcb3a673013065094c003c0b8b90ba5b) | `` automatic update `` |