### PR TITLE
chore(flake/darwin): `57733bd1` -> `6ace2f2d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -103,11 +103,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736370755,
-        "narHash": "sha256-iWcjToBpx4PUd74uqvIGAfqqVfyrvRLRauC/SxEKIF0=",
+        "lastModified": 1736631212,
+        "narHash": "sha256-mG9lRZBcPiAGiVJ9B97BJoIGQcSBWIVlBiN30QYCtG0=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "57733bd1dc81900e13438e5b4439239f1b29db0e",
+        "rev": "6ace2f2d12bdf74235d5cbf9fbd34a71c9716685",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                    |
| ------------------------------------------------------------------------------------------------ | -------------------------- |
| [`be4c1b89`](https://github.com/LnL7/nix-darwin/commit/be4c1b897accbdfc3429e99b5bd5234c5663776e) | `` openssh: init module `` |