### PR TITLE
chore(flake/nur): `166ad545` -> `abde9aca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -912,11 +912,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1736625648,
-        "narHash": "sha256-RIJ5CLxIIuwa0kMko6Kx54BVl0HeZPDu9JqfpBfAkpI=",
+        "lastModified": 1736654372,
+        "narHash": "sha256-HKyodTbfQS+Qg822WVbXg+JGpcr/KX9gjRrHVzii2jo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "166ad545d6a62556a9a7cbd22b94e0bf716af614",
+        "rev": "abde9aca4c9e4ccf658fbf939e874bf5053f0b39",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`abde9aca`](https://github.com/nix-community/NUR/commit/abde9aca4c9e4ccf658fbf939e874bf5053f0b39) | `` automatic update `` |
| [`b174bc43`](https://github.com/nix-community/NUR/commit/b174bc4358a4c2c2862ad9cc2ac3eefbf72038b1) | `` automatic update `` |
| [`c7c51adb`](https://github.com/nix-community/NUR/commit/c7c51adbb69a43a2202950622aaa30b7972eb278) | `` automatic update `` |
| [`b34975e4`](https://github.com/nix-community/NUR/commit/b34975e4b5e2d6fb9cfe3b9647d27e5eeaa53827) | `` automatic update `` |
| [`e142842f`](https://github.com/nix-community/NUR/commit/e142842f0f596b02c5d680adc3abc1114a860f90) | `` automatic update `` |
| [`e834ccb9`](https://github.com/nix-community/NUR/commit/e834ccb9859322f8c2aaf509a0128f73c654dcea) | `` automatic update `` |
| [`5784d880`](https://github.com/nix-community/NUR/commit/5784d880e077a7e5f1514bfdcce0e838810e6323) | `` automatic update `` |
| [`4a549e25`](https://github.com/nix-community/NUR/commit/4a549e25da64655d47ed880a65896b2fd0797987) | `` automatic update `` |
| [`acc4a993`](https://github.com/nix-community/NUR/commit/acc4a993dc11d71b954f7ed0c625ecefcee81fe7) | `` automatic update `` |
| [`44894011`](https://github.com/nix-community/NUR/commit/44894011f7d83e55c50255b784adbb71552fc2e0) | `` automatic update `` |
| [`78727b20`](https://github.com/nix-community/NUR/commit/78727b2031c7e449bbf75132c863b1e6ae880cd4) | `` automatic update `` |