### PR TITLE
chore(flake/nix-index-database): `a2200b49` -> `271e5bd7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -576,11 +576,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736440205,
-        "narHash": "sha256-QJgTI//KEGuEJC6FDxuI9Dq8PewIpnxD2NVx2/OHbfc=",
+        "lastModified": 1736652904,
+        "narHash": "sha256-8uolHABgroXqzs03QdulHp8H9e5kWQZnnhcda1MKbBM=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "a2200b499efa01ca8646173e94cdfcc93188f2b8",
+        "rev": "271e5bd7c57e1f001693799518b10a02d1123b12",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`271e5bd7`](https://github.com/nix-community/nix-index-database/commit/271e5bd7c57e1f001693799518b10a02d1123b12) | `` update generated.nix to release 2025-01-12-031855 `` |
| [`eb593fb1`](https://github.com/nix-community/nix-index-database/commit/eb593fb1ddcbafe3d4280f0c301222f2223d18a8) | `` flake.lock: Update ``                                |