### PR TITLE
chore(flake/nixpkgs): `130595eb` -> `ed4a395e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -805,11 +805,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1736523798,
-        "narHash": "sha256-Xb8mke6UCYjge9kPR9o4P1nVrhk7QBbKv3xQ9cj7h2s=",
+        "lastModified": 1736701207,
+        "narHash": "sha256-jG/+MvjVY7SlTakzZ2fJ5dC3V1PrKKrUEOEE30jrOKA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+        "rev": "ed4a395ea001367c1f13d34b1e01aa10290f67d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`dd252f51`](https://github.com/NixOS/nixpkgs/commit/dd252f51784f8a5c586126e3fd23491aba361c9b) | `` lziprecover: 1.24 -> 1.25 ``                                             |
| [`e1af25de`](https://github.com/NixOS/nixpkgs/commit/e1af25de8294bf775466bbdef3f55ea961c970b8) | `` home-assistant-custom-lovelace-modules.weather-card: 1.5.0 -> 2.0.0b0 `` |
| [`9c6b6bf1`](https://github.com/NixOS/nixpkgs/commit/9c6b6bf1979bb5deacdb423626aa2cefcb29c4bc) | `` tty-share: 2.4.0 -> 2.4.1 ``                                             |
| [`2e3990c5`](https://github.com/NixOS/nixpkgs/commit/2e3990c5f89b10a88adbe7e61a59937dd3b05425) | `` stu: 0.6.5 -> 0.6.6 ``                                                   |
| [`e57a2f29`](https://github.com/NixOS/nixpkgs/commit/e57a2f292130b67a815019112d38018731df3b5c) | `` svg2tikz: 3.2.0 -> 3.3.0 ``                                              |
| [`063dab6a`](https://github.com/NixOS/nixpkgs/commit/063dab6a70318d470a2a1f55a741e83bef84a18b) | `` chiaki-ng: 1.9.3 -> 1.9.4 ``                                             |
| [`3c4f91e9`](https://github.com/NixOS/nixpkgs/commit/3c4f91e93e50ac3f012a9953bfb8f8183ce98e38) | `` qtox: 1.17.6 -> 1.18.0, switch to TokTok fork ``                         |
| [`e321d2d8`](https://github.com/NixOS/nixpkgs/commit/e321d2d82a22a002e14a62ab374b6e19069da778) | `` magic-wormhole-rs: 0.7.4 -> 0.7.5 ``                                     |
| [`d6532a31`](https://github.com/NixOS/nixpkgs/commit/d6532a31c1e9e4442f9b881dd4b2a5be46fd34c3) | `` mympd: 19.0.2 -> 19.0.3 ``                                               |
| [`ef04fe83`](https://github.com/NixOS/nixpkgs/commit/ef04fe83d706a55d92bc35d2824a83248e9b9971) | `` licensure: 0.5.1 -> 0.6.0 ``                                             |
| [`41580f05`](https://github.com/NixOS/nixpkgs/commit/41580f054095658fc7428454e7e51ebd80318e92) | `` python312Packages.llama-cloud: 0.1.7 -> 0.1.8 ``                         |
| [`f64a0cd8`](https://github.com/NixOS/nixpkgs/commit/f64a0cd82aa3a0b211a24233c4fea06df5f4b120) | `` python312Packages.groq: 0.13.0 -> 0.15.0 ``                              |
| [`c283597e`](https://github.com/NixOS/nixpkgs/commit/c283597e8626b6820130a50874b7a1809baedf58) | `` gh-markdown-preview: 1.8.0 -> 1.9.0 ``                                   |
| [`d5504660`](https://github.com/NixOS/nixpkgs/commit/d55046609d9b2789318d94ccc097eb0639a0fc58) | `` yq-go: 4.44.6 -> 4.45.1 ``                                               |
| [`f4b07cc9`](https://github.com/NixOS/nixpkgs/commit/f4b07cc99d5c47f37bbf8bf6b8976c9778dd612e) | `` cargo-chef: 0.1.68 -> 0.1.69 ``                                          |
| [`d725592c`](https://github.com/NixOS/nixpkgs/commit/d725592cd1d6afa5d8f261d9ab24a1f46218fb84) | `` workflows/periodic-merge: move fork condition to calling workflow ``     |
| [`ba963db7`](https://github.com/NixOS/nixpkgs/commit/ba963db727fd6186bf6ad42f9805e8ecdfdd9e14) | `` pinentry-rofi: fix strictDeps build ``                                   |
| [`405b01e2`](https://github.com/NixOS/nixpkgs/commit/405b01e23ece1f13db7b6767ca3ab2e2deff8f76) | `` squeezelite: 2.0.0.1517 -> 2.0.0.1518 ``                                 |
| [`8a080ce7`](https://github.com/NixOS/nixpkgs/commit/8a080ce71d09293f154acad261c4e76d488cff49) | `` python313Packages.finitude: add changelog to meta ``                     |
| [`974d40a9`](https://github.com/NixOS/nixpkgs/commit/974d40a9001d5f97ac6b47c0b98595db5542a543) | `` python312Packages.boschshcpy: 0.2.101 -> 0.2.104 ``                      |
| [`3f7e5e23`](https://github.com/NixOS/nixpkgs/commit/3f7e5e23c547429910e202f6f93a9f4da87f8e1f) | `` python312Packages.aiohomeconnect: 0.7.5 -> 0.9.0 ``                      |
| [`483cf49b`](https://github.com/NixOS/nixpkgs/commit/483cf49b039c9e64fff565ce424087439e30ccef) | `` resolve-march-native: 5.1.0 -> 6.0.1 ``                                  |
| [`a57f6499`](https://github.com/NixOS/nixpkgs/commit/a57f6499d644819a5d13ca97d6459823a57638ba) | `` python312Packages.airthings-ble: 0.9.2 -> 1.0.0 ``                       |
| [`45cd69c9`](https://github.com/NixOS/nixpkgs/commit/45cd69c9c30839e7e8fc3c72a41455bfc21ea570) | `` pass: fix strictDeps build ``                                            |
| [`bc0bb922`](https://github.com/NixOS/nixpkgs/commit/bc0bb9222568434e1c2407a80d2d215a90974ba6) | `` i3: fix tests with strictDeps ``                                         |
| [`afffa89e`](https://github.com/NixOS/nixpkgs/commit/afffa89ec53b44f017bfb6a315e8b08a2ed85bac) | `` ssh: Fix environment variable parsing (#177503) ``                       |
| [`6e7de8c2`](https://github.com/NixOS/nixpkgs/commit/6e7de8c242e82e5f6149833b354c65975bbdf4b9) | `` vivaldi: 7.0.3495.27 -> 7.0.3495.29 ``                                   |
| [`841b7851`](https://github.com/NixOS/nixpkgs/commit/841b7851dc2193453c989d7b1f4a1e16740e3744) | `` python313Packages.finitude: fix build ``                                 |
| [`816ec374`](https://github.com/NixOS/nixpkgs/commit/816ec374f1c6e5e8af6c072f5bc2d8a3bc7cce65) | `` onnxruntime: fix build on darwin ``                                      |
| [`80d08100`](https://github.com/NixOS/nixpkgs/commit/80d08100fa04fdb0187f3a7a8667e12aa3614b5e) | `` bat-extras: disable broken tests ``                                      |
| [`8213eace`](https://github.com/NixOS/nixpkgs/commit/8213eace781866dc2fcbe7c9fd473737565de349) | `` arpack: use final attribute pattern ``                                   |
| [`74da643a`](https://github.com/NixOS/nixpkgs/commit/74da643a43f86e0c03d88616aa23f8f561e97e32) | `` n2048: fix build ``                                                      |
| [`d5493eb7`](https://github.com/NixOS/nixpkgs/commit/d5493eb70174b5e342553ad973206c5ce35497cf) | `` nixos/klipper: restart when config changes ``                            |
| [`809f9788`](https://github.com/NixOS/nixpkgs/commit/809f97881d4e0d827ca5e872bd2e435fef363855) | `` nixos/klipper: preserve SAVE_CONFIG for nixos-managed config ``          |
| [`e79173d7`](https://github.com/NixOS/nixpkgs/commit/e79173d7b48c3401a74067dc09aefb8f037704bb) | `` python312Packages.moderngl-window: 3.0.3 -> 3.1.0 ``                     |
| [`f4fafc4b`](https://github.com/NixOS/nixpkgs/commit/f4fafc4bc25095fd27dc3ec4a5a2c7049dafe471) | `` exo: 0.0.4-alpha -> 0.0.5-alpha ``                                       |
| [`b284586d`](https://github.com/NixOS/nixpkgs/commit/b284586d5c722cad8030d9a2f7474cb7ac292544) | `` impl: 1.3.0 -> 1.4.0 ``                                                  |
| [`fa1c337f`](https://github.com/NixOS/nixpkgs/commit/fa1c337fd00a5e19866843843eda9f14a7e4838f) | `` home-assistant-custom-components.homematicip_local: 1.77.0 -> 1.78.0 ``  |
| [`d2c35a1d`](https://github.com/NixOS/nixpkgs/commit/d2c35a1d9042c45a45d0ee8874dd704afeeba17c) | `` python313Packages.hahomematic: 2025.1.0 -> 2025.1.5 ``                   |
| [`a2b71edd`](https://github.com/NixOS/nixpkgs/commit/a2b71edd54586f87cc714c8771cf73b29dca26fe) | `` mvnd: fix eval ``                                                        |
| [`a4781430`](https://github.com/NixOS/nixpkgs/commit/a478143064c0fe370f27f88e464bad2f6aaa5932) | `` niri: avoid flaky tests ``                                               |
| [`2b306c83`](https://github.com/NixOS/nixpkgs/commit/2b306c831769a6bb29b202d008487e48694bfea4) | `` python312Packages.pwlf: fix src tag ``                                   |
| [`a7699ed2`](https://github.com/NixOS/nixpkgs/commit/a7699ed2d53573b9bdfa043de3cf129eedb7745d) | `` vcmi: 1.6.2 -> 1.6.3 ``                                                  |
| [`b0995f8d`](https://github.com/NixOS/nixpkgs/commit/b0995f8d3b85275b194e536a3e701278eb0cd775) | `` ikos: remove unused argument fetchpatch ``                               |
| [`fb4526fa`](https://github.com/NixOS/nixpkgs/commit/fb4526fa56cc300b18de6e5df5e670481ea94225) | `` pyproj: remove unused argument fetchpatch ``                             |
| [`bfac9a0a`](https://github.com/NixOS/nixpkgs/commit/bfac9a0a439077c0963ee4ee89d11f5176a397bd) | `` juce: remove unused argument fetchpatch ``                               |
| [`48baa48a`](https://github.com/NixOS/nixpkgs/commit/48baa48a52d6e90f77fcfde3aae4c87d68f2c5a0) | `` meshcentral: remove unused argument fetchpatch ``                        |
| [`7e36e984`](https://github.com/NixOS/nixpkgs/commit/7e36e984f573ac24d2b63e3cc401881136db9aee) | `` linuxPackages_latest.prl-tools: 20.1.3-55743 -> 20.2.0-55872 ``          |
| [`edd1f64e`](https://github.com/NixOS/nixpkgs/commit/edd1f64e4fbb21660f3c16fac28f90de5886af52) | `` rqlite: 8.36.3 -> 8.36.5 ``                                              |
| [`b4e5418d`](https://github.com/NixOS/nixpkgs/commit/b4e5418dc1ea5531f86b82f66f4a736ca1e2b606) | `` python312Packages.flask-versioned: refactor ``                           |
| [`b019a951`](https://github.com/NixOS/nixpkgs/commit/b019a951eb66ca0a98a60a0b7b6ef1475b51dd83) | `` python312Packages.flask-versioned: fix version ``                        |
| [`62b4c800`](https://github.com/NixOS/nixpkgs/commit/62b4c800b379407b9c7c87d299fed6cc4ae0e6c4) | `` python312Packages.flask-sslify: refactor ``                              |
| [`62444656`](https://github.com/NixOS/nixpkgs/commit/624446569ad1088f5f34ce4262e7adde7a943674) | `` python312Packages.flask-silk: refactor ``                                |
| [`e17ea5e2`](https://github.com/NixOS/nixpkgs/commit/e17ea5e209848b846303114fbeeeb6718f1b59eb) | `` python312Packages.flask-silk: fix version ``                             |
| [`32799c1f`](https://github.com/NixOS/nixpkgs/commit/32799c1f42fcaed95eeb5ddef0177c5c12fa17ad) | `` python312Packages.flask-common: remove ``                                |
| [`d87aec31`](https://github.com/NixOS/nixpkgs/commit/d87aec31fa73c2971ef14b4017624adae9775fe7) | `` linuxPackages_latest.prl-tools: skip git commit in update.sh ``          |
| [`9de1be4b`](https://github.com/NixOS/nixpkgs/commit/9de1be4b2c8418fc569b04cb6390d7463ce19f25) | `` television: 0.9.1 -> 0.9.2 ``                                            |
| [`69553485`](https://github.com/NixOS/nixpkgs/commit/69553485558239456146cddb9e44211fcbe1435b) | `` python312Packages.edk2-pytool-library: 0.22.4 -> 0.22.5 ``               |
| [`2f651cfa`](https://github.com/NixOS/nixpkgs/commit/2f651cfab69f90e50b0d238f8fce0b13da37514f) | `` unpoller: 2.11.2 -> 2.14.0 ``                                            |
| [`807dd189`](https://github.com/NixOS/nixpkgs/commit/807dd189263c3d2adc0087c7a0e0f2822a639352) | `` macskk: init at 1.4.1 ``                                                 |
| [`0dfd1237`](https://github.com/NixOS/nixpkgs/commit/0dfd1237cb9a4c7c74a300fbabce87c44c3a5877) | `` git-mit: 5.14.2 -> 5.14.3 ``                                             |
| [`ce618668`](https://github.com/NixOS/nixpkgs/commit/ce618668cb14205aa440edad1fbf991ca602e8ab) | `` Add rust-project to the buck2 package ``                                 |
| [`338271a0`](https://github.com/NixOS/nixpkgs/commit/338271a02083de5719df32b831d21cfbc7cdeedb) | `` interactsh: 1.2.2 -> 1.2.3 ``                                            |
| [`cc3de1ef`](https://github.com/NixOS/nixpkgs/commit/cc3de1ef3857e12a7e28eee50c607bc43d4a50e0) | `` cargo-tauri: update hash for hook test ``                                |
| [`4e7ab8d7`](https://github.com/NixOS/nixpkgs/commit/4e7ab8d7de98e6613419a32555a3d377803e288c) | `` nfpm: 2.41.1 -> 2.41.2 ``                                                |
| [`a0289d3e`](https://github.com/NixOS/nixpkgs/commit/a0289d3eedc4f13a62230f85ee497ad190ce0e9c) | `` helm-ls: 0.1.0 -> 0.1.1 ``                                               |
| [`528ea9b8`](https://github.com/NixOS/nixpkgs/commit/528ea9b8c3aa3aed90b2aa9406321ddf23ebf6bc) | `` maintainers: remove johnramsden (#373017) ``                             |
| [`7c848a76`](https://github.com/NixOS/nixpkgs/commit/7c848a760575fdbe5c08acf10eba2a36fa9200e3) | `` tiled: 1.11.0 -> 1.11.1 ``                                               |
| [`d16dad9b`](https://github.com/NixOS/nixpkgs/commit/d16dad9b71273013f1c2c22b8c337e056afdd736) | `` lldpd: 1.0.18 -> 1.0.19 ``                                               |
| [`567f3cb4`](https://github.com/NixOS/nixpkgs/commit/567f3cb4bfe12146593231671c5ac247d43cb3c6) | `` famistudio: 4.3.0 -> 4.3.1 ``                                            |
| [`e5b47e16`](https://github.com/NixOS/nixpkgs/commit/e5b47e167ad5663297ad6c139476ad58259bfa64) | `` nixos/tmux: add package option (#372994) ``                              |
| [`a5b92a6b`](https://github.com/NixOS/nixpkgs/commit/a5b92a6b78570d7814bfbf8bfd9962286fff4221) | `` nph: Fix nph -v ``                                                       |
| [`9735b683`](https://github.com/NixOS/nixpkgs/commit/9735b6834e0f171ab144eb5537a9ef5358dca34f) | `` remnote: 1.18.26 -> 1.18.28 ``                                           |
| [`f38ed82a`](https://github.com/NixOS/nixpkgs/commit/f38ed82a0b987e14faae185b66187a5fa8cfeb88) | `` barman: disable failing test ``                                          |
| [`51335e4a`](https://github.com/NixOS/nixpkgs/commit/51335e4ae5ad73e7cc0df98ad97e8ef00aeea0e8) | `` python313Packages.pyfma: add patch for numpy > 2 ``                      |
| [`ffa34211`](https://github.com/NixOS/nixpkgs/commit/ffa34211e16f385da4c0e934fe159b9682065182) | `` python312Packages.pyfma: refactor ``                                     |
| [`890e8cb5`](https://github.com/NixOS/nixpkgs/commit/890e8cb5f6e4f9910c1e8bd739da898603ffb54e) | `` python312Packages.pylibjpeg-libjpeg: 2.2.0 -> 2.3.0 ``                   |
| [`d480cffe`](https://github.com/NixOS/nixpkgs/commit/d480cffe72436df65b406351e439f36168814734) | `` python312Packages.getjump: 2.6.1 -> 2.7.1 ``                             |
| [`fa48427b`](https://github.com/NixOS/nixpkgs/commit/fa48427b834d8a3f99abe2a937a5c3b0da25fc28) | `` onnxruntime: mark as broken on darwin ``                                 |
| [`28d6c720`](https://github.com/NixOS/nixpkgs/commit/28d6c72005507fe201dae588d051e3b0c2e998c6) | `` python312Packages.azure-mgmt-compute: 33.0.0 -> 33.1.0 ``                |
| [`12a64733`](https://github.com/NixOS/nixpkgs/commit/12a647333d67da8fc818b1ebcfe120d9e068b0bb) | `` tsukimi: 0.18.2 -> 0.18.3 ``                                             |
| [`d820ff34`](https://github.com/NixOS/nixpkgs/commit/d820ff34d88259a2a519419472554b90d3e1f5b9) | `` python312Packages.aubio: disable failing tests ``                        |
| [`e6ec408b`](https://github.com/NixOS/nixpkgs/commit/e6ec408b5b6da446c4bc0a1e5a5070b7b1be1f2c) | `` python312Packages.aubio:: remove buildInputs ``                          |
| [`f4bb0042`](https://github.com/NixOS/nixpkgs/commit/f4bb0042d915fa0c2b61a1855d06f90c2e74a33f) | `` python312Packages.aubio: update meta ``                                  |
| [`51829915`](https://github.com/NixOS/nixpkgs/commit/518299159339220c5b51b28a7c45a738755b52e5) | `` python312Packages.flax: disable failing tests on darwin ``               |
| [`1172244c`](https://github.com/NixOS/nixpkgs/commit/1172244c58f5ac1a09bc9285698a74c087e51d08) | `` python312Packages.energyflow: 1.3.3 -> 1.4.0 ``                          |