### PR TITLE
chore(flake/emacs-overlay): `d376d6c0` -> `244a2ab1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1736673161,
-        "narHash": "sha256-vlN7PcPnDpnIo2hvuHTqFk7CbCcHCQmTQUSijgBCa24=",
+        "lastModified": 1736759802,
+        "narHash": "sha256-XCaIRTC+YlL5nRi9WJHeftyfw2Z0YXwwzEmHThGuR3Q=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d376d6c0d09b7c5f4c5c026ae1a0ab53fb09fc77",
+        "rev": "244a2ab1459c72bac32a2db088549f8bc6d7a836",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`244a2ab1`](https://github.com/nix-community/emacs-overlay/commit/244a2ab1459c72bac32a2db088549f8bc6d7a836) | `` Updated emacs ``        |
| [`dbc158b2`](https://github.com/nix-community/emacs-overlay/commit/dbc158b2f694240cccd610441e9773f49ca317e2) | `` Updated melpa ``        |
| [`d16ad9dd`](https://github.com/nix-community/emacs-overlay/commit/d16ad9dd4e4a5c591d818d2f2eb73189fb362d82) | `` Updated emacs ``        |
| [`28f2a6ef`](https://github.com/nix-community/emacs-overlay/commit/28f2a6efe28d4dadf0409ab122511f4e228f0cbb) | `` Updated melpa ``        |
| [`4225cc71`](https://github.com/nix-community/emacs-overlay/commit/4225cc71329095bf78e801fd08b996af366a3c98) | `` Updated elpa ``         |
| [`fc17611c`](https://github.com/nix-community/emacs-overlay/commit/fc17611c29123274cfd5b3db9c5c16bd2f66ca05) | `` Updated nongnu ``       |
| [`2790653e`](https://github.com/nix-community/emacs-overlay/commit/2790653e250744d46d9fe501b6152d9f18e4d80d) | `` Updated emacs ``        |
| [`991921ad`](https://github.com/nix-community/emacs-overlay/commit/991921add940cb233df4105cec652cfeb1bd5151) | `` Updated melpa ``        |
| [`cd60643e`](https://github.com/nix-community/emacs-overlay/commit/cd60643e2e3d99ab124aa139cef97f5dedc0dca1) | `` Updated elpa ``         |
| [`44e18529`](https://github.com/nix-community/emacs-overlay/commit/44e185298bbaec0900fd82b2e4c850b70acd5006) | `` Updated nongnu ``       |
| [`01e159d8`](https://github.com/nix-community/emacs-overlay/commit/01e159d8218d6c83a71f69fe8270be0fb392afcb) | `` Updated flake inputs `` |