### PR TITLE
chore(flake/nixos-cosmic): `62b64213` -> `faebaec6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -621,11 +621,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1736712287,
-        "narHash": "sha256-0T/2niVZlaNYoc5RhDaIVDp5jOZxQofVc/Uv03E5vGA=",
+        "lastModified": 1736736712,
+        "narHash": "sha256-MBAedX0OvuqWy0/cDfSC72865R3jvd2TU2qZj3gQvhM=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "62b6421304f00c37b5b794c917214c0212d6352d",
+        "rev": "faebaec667724c7d4df9fcf2fec26683ee08bb50",
         "type": "github"
       },
       "original": {
@@ -789,11 +789,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1736344531,
-        "narHash": "sha256-8YVQ9ZbSfuUk2bUf2KRj60NRraLPKPS0Q4QFTbc+c2c=",
+        "lastModified": 1736523798,
+        "narHash": "sha256-Xb8mke6UCYjge9kPR9o4P1nVrhk7QBbKv3xQ9cj7h2s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bffc22eb12172e6db3c5dde9e3e5628f8e3e7912",
+        "rev": "130595eba61081acde9001f43de3248d8888ac4a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                          |
| ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`faebaec6`](https://github.com/lilyinstarlight/nixos-cosmic/commit/faebaec667724c7d4df9fcf2fec26683ee08bb50) | `` treewide: adjust with usage in meta (#586) `` |
| [`00b06c8f`](https://github.com/lilyinstarlight/nixos-cosmic/commit/00b06c8fba21782c1ac3d13a849c3c2ffa9255ea) | `` flake: update inputs (#587) ``                |