### PR TITLE
chore(flake/srvos): `eea4ff20` -> `b1535121`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1046,11 +1046,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735858634,
-        "narHash": "sha256-qp83fDr3W5b6QoWSp+vfcH1vFNEhreW98qe9tlhSaXE=",
+        "lastModified": 1736730062,
+        "narHash": "sha256-tj/j3I9it8kdp8Hh40KNnFZef/PJZQsz8mtUQvF+YF0=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "eea4ff2050968da5134788c73d63a2461f9daf27",
+        "rev": "b1535121b2c222176da52bbb3513fc87bdc83e5b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`b1535121`](https://github.com/nix-community/srvos/commit/b1535121b2c222176da52bbb3513fc87bdc83e5b) | `` dev/private/flake.lock: Update `` |
| [`9435fbd4`](https://github.com/nix-community/srvos/commit/9435fbd4bc7f8c5d482f92bbe518ebe62fece18e) | `` flake.lock: Update ``             |