### PR TITLE
chore(flake/home-manager): `2532b500` -> `fc52a210`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -447,11 +447,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736508663,
-        "narHash": "sha256-ZOaGwa+WnB7Zn3YXimqjmIugAnHePdXCmNu+AHkq808=",
+        "lastModified": 1736785676,
+        "narHash": "sha256-TY0jUwR3EW0fnS0X5wXMAVy6h4Z7Y6a3m+Yq++C9AyE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2532b500c3ed2b8940e831039dcec5a5ea093afc",
+        "rev": "fc52a210b60f2f52c74eac41a8647c1573d2071d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                             |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`fc52a210`](https://github.com/nix-community/home-manager/commit/fc52a210b60f2f52c74eac41a8647c1573d2071d) | `` network-manager-applet: changed nm-applet description (#6311) `` |
| [`0da8b6ba`](https://github.com/nix-community/home-manager/commit/0da8b6bae9b3179af68c72827541ef88cad413fc) | `` sway: allow sway specific hideEdgeBorders options (#6304) ``     |
| [`9616d81f`](https://github.com/nix-community/home-manager/commit/9616d81f98032d1ee9bec68ab4b6a8c833add88c) | `` mangohud: make `false` values actually disable (#6299) ``        |