### PR TITLE
chore(flake/srvos): `b1535121` -> `1a2cc9fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1063,11 +1063,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736730062,
-        "narHash": "sha256-tj/j3I9it8kdp8Hh40KNnFZef/PJZQsz8mtUQvF+YF0=",
+        "lastModified": 1736804877,
+        "narHash": "sha256-ITOnRTmMRWxzB/LjOWWYNlyREFpHsTZ0oJFyAKf9/H8=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "b1535121b2c222176da52bbb3513fc87bdc83e5b",
+        "rev": "1a2cc9fee346055442b0ad852ddecef4385b11ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                               |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`1a2cc9fe`](https://github.com/nix-community/srvos/commit/1a2cc9fee346055442b0ad852ddecef4385b11ba) | `` flake: update git-hooks follows `` |