### PR TITLE
chore(flake/srvos): `1a2cc9fe` -> `61cc2047`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1063,11 +1063,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736804877,
-        "narHash": "sha256-ITOnRTmMRWxzB/LjOWWYNlyREFpHsTZ0oJFyAKf9/H8=",
+        "lastModified": 1736810122,
+        "narHash": "sha256-29Mp0xa3jXF33Qu92hd/uPz1HZWBestpEKmgG4RyzCo=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "1a2cc9fee346055442b0ad852ddecef4385b11ba",
+        "rev": "61cc2047ad1a4c52ef18d117ac8e6ccfc0e38ea5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                       |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`61cc2047`](https://github.com/nix-community/srvos/commit/61cc2047ad1a4c52ef18d117ac8e6ccfc0e38ea5) | `` nixos/update-diff: activationScripts -> preSwitchChecks `` |
| [`36d049ba`](https://github.com/nix-community/srvos/commit/36d049bad5e77ae2bd5b0a81ffe60ab7ab366d9e) | `` update-diff: refactor ``                                   |
| [`2ff3bf84`](https://github.com/nix-community/srvos/commit/2ff3bf84eed8fe0480c4d2b99dbc60e8d4356f1b) | `` darwin/server: add @admin to trusted-users ``              |
| [`762ba450`](https://github.com/nix-community/srvos/commit/762ba4502de7b2fc6bd044e62fd326b3d220c510) | `` nixos/server: remove root from trusted users ``            |