### PR TITLE
chore(flake/nur): `d619a894` -> `ca29a108`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -928,11 +928,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1736840645,
-        "narHash": "sha256-9fIKexybS8kBQlX1sUM1y5IMgGIeEXElyGOQ/F6AFhg=",
+        "lastModified": 1736850407,
+        "narHash": "sha256-RdIfmUNRNiFXig+cti8EKLeNvNSER35nXm+9Ouc/AL8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d619a894bcebc84c4d4020644ac276ae8334a4c5",
+        "rev": "ca29a1085011ca10f8be796c37bad0fadac102c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ca29a108`](https://github.com/nix-community/NUR/commit/ca29a1085011ca10f8be796c37bad0fadac102c1) | `` automatic update `` |
| [`39d63525`](https://github.com/nix-community/NUR/commit/39d635256b94b1afe11789e8a479e70d3ac14c14) | `` automatic update `` |
| [`f2586ad5`](https://github.com/nix-community/NUR/commit/f2586ad58fcd18f59a949a404b6985e6befd8dd2) | `` automatic update `` |