### PR TITLE
chore(flake/nur): `ca29a108` -> `b48f4234`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -928,11 +928,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1736850407,
-        "narHash": "sha256-RdIfmUNRNiFXig+cti8EKLeNvNSER35nXm+9Ouc/AL8=",
+        "lastModified": 1736869623,
+        "narHash": "sha256-Z/0UvFI/ht2/QYrPK+d+ffZ+O64D5nT95O+L43/ftV0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ca29a1085011ca10f8be796c37bad0fadac102c1",
+        "rev": "b48f4234ff5426b253119a4fc9d5a7b90e011187",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b48f4234`](https://github.com/nix-community/NUR/commit/b48f4234ff5426b253119a4fc9d5a7b90e011187) | `` automatic update `` |
| [`d878cd79`](https://github.com/nix-community/NUR/commit/d878cd7962383dc47f56f18e052a8ad7fbbfdef8) | `` automatic update `` |