### PR TITLE
chore(flake/nixos-facter-modules): `53647275` -> `fa11d87b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -652,11 +652,11 @@
     },
     "nixos-facter-modules": {
       "locked": {
-        "lastModified": 1734596637,
-        "narHash": "sha256-MRqwVAe3gsb88u4ME1UidmZFVCx+FEnoob0zkpO9DMY=",
+        "lastModified": 1736931726,
+        "narHash": "sha256-aY55yiifyo1XPPpbpH0kWlV1g2dNGBlx6622b7OK8ks=",
         "owner": "numtide",
         "repo": "nixos-facter-modules",
-        "rev": "536472754982bf03079b4b4e0261838a760587c0",
+        "rev": "fa11d87b61b2163efbb9aed7b7a5ae0299e5ab9c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                              | Message                        |
| ------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`39233dd9`](https://github.com/nix-community/nixos-facter-modules/commit/39233dd9e34a6bf2c3f714f15d86c0884f3ce4c8) | `` README: update docs link `` |
| [`4b3efa59`](https://github.com/nix-community/nixos-facter-modules/commit/4b3efa59abbc4546fee6b0657c29dea1bb0cc9db) | `` drop beta status ``         |