### PR TITLE
chore(flake/gptel): `7cac2195` -> `87e181ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -383,11 +383,11 @@
     "gptel": {
       "flake": false,
       "locked": {
-        "lastModified": 1736823739,
-        "narHash": "sha256-WFC5MFUt1zrXGoflBjxNozzlns8tjjyd7zkWlkVlrC0=",
+        "lastModified": 1736907339,
+        "narHash": "sha256-X+83zxKELbJBkH/32tXiDlx2hrdYdB0/ju3VFcscmbY=",
         "owner": "karthink",
         "repo": "gptel",
-        "rev": "7cac2195e653ea3b960af1986d4a758a84209bda",
+        "rev": "87e181ee4c36856aab64b1c6ef0e5756a6a591fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                        |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`87e181ee`](https://github.com/karthink/gptel/commit/87e181ee4c36856aab64b1c6ef0e5756a6a591fb) | `` gptel: Handle pending calls/call results in chat buffers `` |
| [`82e06c0c`](https://github.com/karthink/gptel/commit/82e06c0ccaaf3223ee24ddad8d2a95833c1d3106) | `` gptel: Run callback with pending tool calls ``              |
| [`6416d4a8`](https://github.com/karthink/gptel/commit/6416d4a857001d13a2fc251b55fe28094a0700f5) | `` gptel: Add controls to confirm/include tool calls ``        |
| [`4ffcf9cf`](https://github.com/karthink/gptel/commit/4ffcf9cfd77594fc3b8ef340fc7c9864677562f9) | `` gptel: Indicate tools in gptel-mode header-line ``          |
| [`24819543`](https://github.com/karthink/gptel/commit/248195439947489b4659e295e378c65b901b4698) | `` gptel-transient: Add tool selection UI ``                   |
| [`77f8b5f5`](https://github.com/karthink/gptel/commit/77f8b5f5cac79892a749c5707cc25988a1b8c239) | `` gptel: Bump transient required version to 0.7.4 ``          |
| [`7d09ad32`](https://github.com/karthink/gptel/commit/7d09ad32ed8aa56268030749565d2487b5f077ac) | `` gptel: Add a registry for tools ``                          |
| [`a9c6c3f5`](https://github.com/karthink/gptel/commit/a9c6c3f5d03beb37ab3cbd0d7073fbb2f2c92818) | `` gptel: Separate gptel-request and gptel-send handlers ``    |
| [`f45df0be`](https://github.com/karthink/gptel/commit/f45df0beaf030797acba1076e93ef56303ffaa24) | `` gptel: Add a diagnostic display for latest request ``       |