### PR TITLE
chore(flake/nixos-cosmic): `9644b5c1` -> `40534c1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -637,11 +637,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1736865264,
-        "narHash": "sha256-LryQObl8W9RsmW0H0fHNRNxt3gpJ3ZsBtJVh9LivFtI=",
+        "lastModified": 1736997002,
+        "narHash": "sha256-EPbAFUXgu3agihgA+MJlQe6J18SIEZ4cRm+zhNRbGfo=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "9644b5c16e0333cf2ed4af404afd0a654c4e4d77",
+        "rev": "40534c1bc524aa8c433a7a30318d7e20bddb33fb",
         "type": "github"
       },
       "original": {
@@ -774,11 +774,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1736684107,
-        "narHash": "sha256-vH5mXxEvZeoGNkqKoCluhTGfoeXCZ1seYhC2pbMN0sg=",
+        "lastModified": 1736867362,
+        "narHash": "sha256-i/UJ5I7HoqmFMwZEH6vAvBxOrjjOJNU739lnZnhUln8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "635e887b48521e912a516625eee7df6cf0eba9c1",
+        "rev": "9c6b49aeac36e2ed73a8c472f1546f6d9cf1addc",
         "type": "github"
       },
       "original": {
@@ -805,11 +805,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1736701207,
-        "narHash": "sha256-jG/+MvjVY7SlTakzZ2fJ5dC3V1PrKKrUEOEE30jrOKA=",
+        "lastModified": 1736883708,
+        "narHash": "sha256-uQ+NQ0/xYU0N1CnXsa2zghgNaOPxWpMJXSUJJ9W7140=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ed4a395ea001367c1f13d34b1e01aa10290f67d6",
+        "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                                                        |
| ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| [`40534c1b`](https://github.com/lilyinstarlight/nixos-cosmic/commit/40534c1bc524aa8c433a7a30318d7e20bddb33fb) | `` flake: update inputs (#596) ``                                                              |
| [`ec1e03dc`](https://github.com/lilyinstarlight/nixos-cosmic/commit/ec1e03dc63901f85a8756037ca66d219bbb28aae) | `` ci: temporarily make both unstable/stable builder types the same to avoid blocked builds `` |
| [`bd40b6e6`](https://github.com/lilyinstarlight/nixos-cosmic/commit/bd40b6e6c1c3e618da16adb4f622ce2c99377c1d) | `` pkgs: update cosmic (#595) ``                                                               |
| [`0dc33f0e`](https://github.com/lilyinstarlight/nixos-cosmic/commit/0dc33f0eb391a1a942a358a01b47f763703d7097) | `` pkgs: update cosmic (#589) ``                                                               |
| [`375a2d1d`](https://github.com/lilyinstarlight/nixos-cosmic/commit/375a2d1d66129932490fa5b2217713a285161181) | `` flake: update inputs (#594) ``                                                              |
| [`da3ae5c5`](https://github.com/lilyinstarlight/nixos-cosmic/commit/da3ae5c528bd216ac52ced3e8fdd9e18cdd7146f) | `` ci: fix nix-installer issues harder ``                                                      |
| [`d0b64e7f`](https://github.com/lilyinstarlight/nixos-cosmic/commit/d0b64e7f4f86d3ff61f380145f39c647c45540c0) | `` ci: fix nix-installer issues ``                                                             |
| [`180e251b`](https://github.com/lilyinstarlight/nixos-cosmic/commit/180e251b3b76a5ac6f82f0fbf0168fec2bc7ef01) | `` andromeda: init at 0-unstable-2025-01-11 ``                                                 |