### PR TITLE
chore(flake/agenix): `f6291c59` -> `e600439e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,11 +16,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723293904,
-        "narHash": "sha256-b+uqzj+Wa6xgMS9aNbX4I+sXeb5biPDi39VgvSFqFvU=",
+        "lastModified": 1736955230,
+        "narHash": "sha256-uenf8fv2eG5bKM8C/UvFaiJMZ4IpUFaQxk9OH5t/1gA=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "f6291c5935fdc4e0bef208cfc0dcab7e3f7a1c41",
+        "rev": "e600439ec4c273cf11e06fe4d9d906fb98fa097c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                               |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`4d0d81e6`](https://github.com/ryantm/agenix/commit/4d0d81e6061f1add4af464618491439f6d819118) | `` fix: bad indentation in ci ``                                      |
| [`96b7e4f9`](https://github.com/ryantm/agenix/commit/96b7e4f9eb4db2763db2699322fa2a544184d1eb) | `` contrib: improve readability of age.identityPaths default value `` |
| [`989ade28`](https://github.com/ryantm/agenix/commit/989ade28509c66d7abfa53613359d332ae506222) | `` feat: dynamically determine architecture in ci ``                  |
| [`302ab0c1`](https://github.com/ryantm/agenix/commit/302ab0c1726d87b8405cf8c2d1e9c122b8e2ace9) | `` fix: bump to macOS-15 in CI ``                                     |
| [`cce0ff47`](https://github.com/ryantm/agenix/commit/cce0ff472cee1c6e583ff7ee9889c2b1a1af7270) | `` fix: bad age.identityPaths default value on darwin ``              |