### PR TITLE
chore(flake/nur): `4dff81fd` -> `4e61b0bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -928,11 +928,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1736974055,
-        "narHash": "sha256-ordp2Xy3qJrqSZGEvmydloKBjlITb14+E2z2tF3kttg=",
+        "lastModified": 1736981618,
+        "narHash": "sha256-6Alt5Q6z5cNDOnf1H8khJqkqjM4vdwFFK6bionEJICg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4dff81fd8603cf7592a7b4dedc0ae7952d288e82",
+        "rev": "4e61b0bc280756a0bfa61b1775e2e070bc6b07ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4e61b0bc`](https://github.com/nix-community/NUR/commit/4e61b0bc280756a0bfa61b1775e2e070bc6b07ee) | `` automatic update `` |