### PR TITLE
chore(flake/nixos-hardware): `8870dcaf` -> `b6786066`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -667,11 +667,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1736441705,
-        "narHash": "sha256-OL7leZ6KBhcDF3nEKe4aZVfIm6xQpb1Kb+mxySIP93o=",
+        "lastModified": 1736978406,
+        "narHash": "sha256-oMr3PVIQ8XPDI8/x6BHxsWEPBRU98Pam6KGVwUh8MPk=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "8870dcaff63dfc6647fb10648b827e9d40b0a337",
+        "rev": "b678606690027913f3434dea3864e712b862dde5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                                      |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
| [`b6786066`](https://github.com/NixOS/nixos-hardware/commit/b678606690027913f3434dea3864e712b862dde5) | `` lenovo-z13-gen2: networking.networkmanager.fccUnlockScripts → networking.modemmanager.fccUnlockScripts `` |
| [`06c52bbc`](https://github.com/NixOS/nixos-hardware/commit/06c52bbc795a853d3c84ae2226652f3aa3b51db9) | `` Lenovo IdeaCentre K330 ``                                                                                 |