### PR TITLE
chore(flake/nixpkgs): `9abb87b5` -> `eb62e6aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1736798957,
-        "narHash": "sha256-qwpCtZhSsSNQtK4xYGzMiyEDhkNzOCz/Vfu4oL2ETsQ=",
+        "lastModified": 1736883708,
+        "narHash": "sha256-uQ+NQ0/xYU0N1CnXsa2zghgNaOPxWpMJXSUJJ9W7140=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9abb87b552b7f55ac8916b6fc9e5cb486656a2f3",
+        "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                              |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
| [`eb62e6aa`](https://github.com/NixOS/nixpkgs/commit/eb62e6aa39ea67e0b8018ba8ea077efe65807dc8) | `` pigz: add meta.mainProgram ``                                                                     |
| [`1342a23c`](https://github.com/NixOS/nixpkgs/commit/1342a23c67e71c33c65b895c2e6a96b57576d954) | `` openvpn-auth-ldap: unpin LLVM17 (#373193) ``                                                      |
| [`a8bbac6f`](https://github.com/NixOS/nixpkgs/commit/a8bbac6f1e5f72b3d116ed74ed15adef282c5a06) | `` xssproxy: 1.1.0 -> 1.1.1 (#373773) ``                                                             |
| [`edccf51c`](https://github.com/NixOS/nixpkgs/commit/edccf51c1cb9202ee43999fc02ce83e68dbecc36) | `` rsync: apply patches for 6 vulnerabilities ``                                                     |
| [`94cde4b3`](https://github.com/NixOS/nixpkgs/commit/94cde4b3e53c2c0bf2c1da58ae7abc42487580ed) | `` update waypipe to version 10.0 ``                                                                 |
| [`24c79d2b`](https://github.com/NixOS/nixpkgs/commit/24c79d2bf58b10a8b3bfd022d48465d0c21ea065) | `` nixos-facter: 0.3.0 -> 0.3.1 ``                                                                   |
| [`c8d6153f`](https://github.com/NixOS/nixpkgs/commit/c8d6153f3b0cfb11998fbaf811eba5180f6ba87a) | `` libnids: fix cross build ``                                                                       |
| [`eb03a25d`](https://github.com/NixOS/nixpkgs/commit/eb03a25d8eac2f9192a246ace9f86a0804ed8c44) | `` ocamlPackages.owl: re-enable tests ``                                                             |
| [`ee9e485b`](https://github.com/NixOS/nixpkgs/commit/ee9e485baa2ea71daa982575f497c5681a02afa7) | `` jaq: 2.0.1 -> 2.1.0 ``                                                                            |
| [`403f98f7`](https://github.com/NixOS/nixpkgs/commit/403f98f7d277da1f551be8512f0c636a358c1d69) | `` containerd: fix meta.changelog ``                                                                 |
| [`8021ceef`](https://github.com/NixOS/nixpkgs/commit/8021ceef0c07b71a5d6fe3bb5dee89e8aaaa3389) | `` pixi: 0.40.0 -> 0.40.1 ``                                                                         |
| [`cb3b8609`](https://github.com/NixOS/nixpkgs/commit/cb3b86099bb33b02b7f10582f24cbd2c404ed990) | `` disko: 1.10.0 -> 1.11.0 ``                                                                        |
| [`8d144f89`](https://github.com/NixOS/nixpkgs/commit/8d144f8945735f76e39fe9994be1145285bb14c5) | `` ciftilib: unbreak ``                                                                              |
| [`6d892712`](https://github.com/NixOS/nixpkgs/commit/6d892712cfab0bd59ff82d1491ee7b53f27e4a02) | `` nixos/tests/pleroma: fix DB provision race condition ``                                           |
| [`66639d6a`](https://github.com/NixOS/nixpkgs/commit/66639d6a7e3aafe762551621fbcd84cefe16872c) | `` pleroma: 2.7.0 -> 2.8.0 ``                                                                        |
| [`337c0bd8`](https://github.com/NixOS/nixpkgs/commit/337c0bd8b49512c573d766829306e3bd283671ae) | `` wslu: 4.1.3 -> 4.1.4 ``                                                                           |
| [`f1eaa3de`](https://github.com/NixOS/nixpkgs/commit/f1eaa3de819f15a242de3bcea6e5950b04e78c4f) | `` spatialite-gui: remove obsolete darwin tweaks ``                                                  |
| [`e642c8ca`](https://github.com/NixOS/nixpkgs/commit/e642c8ca2543b0931a603e3c64959cd3d8d17a91) | `` osmium-tool: 1.16.0 → 1.17.0 ``                                                                   |
| [`88b08dfa`](https://github.com/NixOS/nixpkgs/commit/88b08dfa5fa4569faba2001883c8be62f69383a7) | `` usql: 0.19.15 -> 0.19.16 ``                                                                       |
| [`a9fc0b6e`](https://github.com/NixOS/nixpkgs/commit/a9fc0b6eea3fe8270cf378e0fcec50682ee062c7) | `` terraform-providers.kubectl: 1.18.0 -> 1.19.0 ``                                                  |
| [`e5b0c411`](https://github.com/NixOS/nixpkgs/commit/e5b0c411a43459b42afb28a995d912b94841e777) | `` nixos/etc-overlay: fix chmod call in activation script ``                                         |
| [`e09179f7`](https://github.com/NixOS/nixpkgs/commit/e09179f70fcebb5f3bf3883f8f19da1b6b56135a) | `` trivy: 0.58.1 -> 0.58.2 ``                                                                        |
| [`1a4453f9`](https://github.com/NixOS/nixpkgs/commit/1a4453f96587afc9ff7726ca36387262b06e21c9) | `` vpl-gpu-rt: 24.4.4 -> 25.1.0 ``                                                                   |
| [`d2922c02`](https://github.com/NixOS/nixpkgs/commit/d2922c029b128ed88dd2dd7ec97a6951c87c99bf) | `` xorg.xf86videonouveau: fix build ``                                                               |
| [`33438343`](https://github.com/NixOS/nixpkgs/commit/334383432b652000d05d21c814b6c39a6315ec28) | `` auto-cpufreq: patch missing shell file ``                                                         |
| [`48cbc005`](https://github.com/NixOS/nixpkgs/commit/48cbc005a387299e778c392c54cb5ba030c91f95) | `` nextcloud-client: 3.15.2 -> 3.15.3 ``                                                             |
| [`f84e2fa9`](https://github.com/NixOS/nixpkgs/commit/f84e2fa942d3098ab31bda444e41061acdf9028c) | `` ocamlPackages.elpi: 2.0.6 -> 2.0.7 ``                                                             |
| [`819f4ef0`](https://github.com/NixOS/nixpkgs/commit/819f4ef0611de5566bf8ea58bfe263296132566f) | `` pantheon.elementary-dock: Add updateScript ``                                                     |
| [`f50d0b54`](https://github.com/NixOS/nixpkgs/commit/f50d0b5498dfbfcd0615d7dae9bf71639b33c6e8) | `` sing-box: 1.10.6 -> 1.10.7 ``                                                                     |
| [`42c5f795`](https://github.com/NixOS/nixpkgs/commit/42c5f7950a6b31ae905a7109332fb1762cb1eba9) | `` rs-tftpd: 0.3.2 -> 0.3.3 ``                                                                       |
| [`aa0d8d74`](https://github.com/NixOS/nixpkgs/commit/aa0d8d748c1034cb4ce7ed262e8f148b44cab729) | `` home-manager: 0-unstable-2025-01-02 -> 0-unstable-2025-01-13 ``                                   |
| [`6486939a`](https://github.com/NixOS/nixpkgs/commit/6486939aa79729d21c5e25cbfb42b910d26d26c4) | `` python312Packages.databricks-sql-connector: 3.7.0 -> 3.7.1 ``                                     |
| [`17a45b66`](https://github.com/NixOS/nixpkgs/commit/17a45b666aa030049075cae9d7178e4355c7f020) | `` narsil: 1.4.0 -> bbc8fc5efd779ec885045f9b8d903d0df1bec1b2 ``                                      |
| [`491cbe11`](https://github.com/NixOS/nixpkgs/commit/491cbe116831ca6a46e797a3b4b9f7a5bfc94c20) | `` lomiri.lomiri-sounds: 22.02 -> 25.01 ``                                                           |
| [`cc426050`](https://github.com/NixOS/nixpkgs/commit/cc4260500c5f91a8fbd68cdecc8c031046fdf27d) | `` ocamlPackages.merlin: Update for OCaml 5.2 and 4.14 ``                                            |
| [`86758397`](https://github.com/NixOS/nixpkgs/commit/86758397f8b5f6a87e9042da857113e9593fb7e0) | `` the-legend-of-edgar: 1.36-unstable-2023-07-11 -> 1.37 ``                                          |
| [`59e142e2`](https://github.com/NixOS/nixpkgs/commit/59e142e2f88a9e20ab83c9779141586034f03d54) | `` poetryPlugins.poetry-plugin-export: 1.8.0 -> 1.9.0 ``                                             |
| [`cfd43ead`](https://github.com/NixOS/nixpkgs/commit/cfd43ead56226631f767be51c689df46c5ccccfe) | `` python312Packages.rmsd: enable tests ``                                                           |
| [`270356aa`](https://github.com/NixOS/nixpkgs/commit/270356aa6021c84e83ed332113bfab393af630cb) | `` python312Packages.rmsd: switch to pypa builder ``                                                 |
| [`6dceb2db`](https://github.com/NixOS/nixpkgs/commit/6dceb2db13a5c33f7843383e2250805fcb152075) | `` python312Packages.binance-connector: switch to pypa builder ``                                    |
| [`f47d2a2f`](https://github.com/NixOS/nixpkgs/commit/f47d2a2faf27f0c055c154c9595a5f31b91cb157) | `` python312Packages.qdrant-client: 1.12.1 -> 1.12.2 ``                                              |
| [`92cebeba`](https://github.com/NixOS/nixpkgs/commit/92cebeba0af46ba33bf2988ad68ee49173252a34) | `` python312Packages.eris: init at 1.0.0 ``                                                          |
| [`3264ea8b`](https://github.com/NixOS/nixpkgs/commit/3264ea8b39e869c7202044a6d755552cdb7438d6) | `` spatialite-gui: move to pkgs/by-name ``                                                           |
| [`4210a20c`](https://github.com/NixOS/nixpkgs/commit/4210a20cd04f76f22f6af916067369c91aa00d12) | `` spatialite_gui: rename package to spatialite-gui ``                                               |
| [`4deaf01a`](https://github.com/NixOS/nixpkgs/commit/4deaf01a8886e1f15f763a08f7075943c431cc0d) | `` containerd: 2.0.1 -> 2.0.2 ``                                                                     |
| [`62bcaff5`](https://github.com/NixOS/nixpkgs/commit/62bcaff544dbfc481229b24820db0f2f9c00d367) | `` srec2bin: init at 1.51 ``                                                                         |
| [`31bcc931`](https://github.com/NixOS/nixpkgs/commit/31bcc9316230c52a7690a0c74bc15335cfa326c7) | `` python312Packages.cleanlab: fix patch ``                                                          |
| [`a77e72e1`](https://github.com/NixOS/nixpkgs/commit/a77e72e111209f591b999ee67ce9690c5ff3fbe1) | `` azure-cli-extensions.healthcareapis: 1.0.0 -> 1.0.1 ``                                            |
| [`f7e68e25`](https://github.com/NixOS/nixpkgs/commit/f7e68e254462dace3a489704a8e32568daaea8d2) | `` azure-cli-extensions.durabletask: 1.0.0b1 -> 1.0.0b2 ``                                           |
| [`ca57fed3`](https://github.com/NixOS/nixpkgs/commit/ca57fed3b2b77807e2ffa7963e842548702ff2e9) | `` azure-cli-extensions.spring: 1.26.0 -> 1.26.1 ``                                                  |
| [`07f80e19`](https://github.com/NixOS/nixpkgs/commit/07f80e194502505fc9a9ad4431cc7cadebf88231) | `` azure-cli-extensions.connectedvmware: 1.2.0 -> 1.2.1 ``                                           |
| [`72729462`](https://github.com/NixOS/nixpkgs/commit/72729462bb5f22a5189090038726b52a528bdefe) | `` azure-cli-extensions.maintenance: 1.7.0b1 -> 1.7.0b2 ``                                           |
| [`c97d3b19`](https://github.com/NixOS/nixpkgs/commit/c97d3b197b1f3df5390d0d7d070dcf32a14ce2f7) | `` azure-cli-extensions.databricks: 1.0.1 -> 1.1.0 ``                                                |
| [`65f77e5b`](https://github.com/NixOS/nixpkgs/commit/65f77e5bd47dc77f997d330d7684eb151dc37c8d) | `` azure-cli-extensions.datamigration: 1.0.0b2 -> 1.0.0b3 ``                                         |
| [`9044f490`](https://github.com/NixOS/nixpkgs/commit/9044f4905bf5d91dccb85f05e5789fa488c606c7) | `` azure-cli-extensions.subscription: 1.0.0b1 -> 1.0.0b2 ``                                          |
| [`9b853cf2`](https://github.com/NixOS/nixpkgs/commit/9b853cf2092490130e898a77adbdb6422e7a26eb) | `` azure-cli-extensions.devcenter: 6.1.0 -> 6.2.0 ``                                                 |
| [`b8cb5d0b`](https://github.com/NixOS/nixpkgs/commit/b8cb5d0b4cd592a5ed94a2e31ab58de273e3e78a) | `` azure-cli-extensions.mcc: 1.0.0b1 -> 1.0.0b2 ``                                                   |
| [`76a92232`](https://github.com/NixOS/nixpkgs/commit/76a92232655575c9ca217e8f47d70eb46e4f903c) | `` azure-cli-extensions.amg: 2.5.3 -> 2.5.4 ``                                                       |
| [`6019ef7e`](https://github.com/NixOS/nixpkgs/commit/6019ef7e23032f6dee8dd13e24b47ffcc15b6ae3) | `` azure-cli-extensions.eventgrid: 1.0.0b1 -> 1.0.0b2 ``                                             |
| [`b049d015`](https://github.com/NixOS/nixpkgs/commit/b049d0151f3f50d7e1097ff345ec19cdd8d005cf) | `` azure-cli-extensions.playwright-cli-extension: init at 1.0.0b1 ``                                 |
| [`7b2bfeb2`](https://github.com/NixOS/nixpkgs/commit/7b2bfeb2fc0470a676c84465749db5b7b0bb7c29) | `` azure-cli: 2.67.0 -> 2.68.0 ``                                                                    |
| [`8ee57a92`](https://github.com/NixOS/nixpkgs/commit/8ee57a925ec9eb76871109012fda005140c53fa3) | `` systemctl-tui: 0.3.8 -> 0.3.9 ``                                                                  |
| [`9bfe9c98`](https://github.com/NixOS/nixpkgs/commit/9bfe9c98e7cb4cd548e22221a463737e764bcfa4) | `` python312Packages.fastexcel: init at 0.12.1 ``                                                    |
| [`47f7fa60`](https://github.com/NixOS/nixpkgs/commit/47f7fa609429ae1adf8d70840612ccd518360ff5) | `` tfsec: 1.28.12 -> 1.28.13 ``                                                                      |
| [`76bad48f`](https://github.com/NixOS/nixpkgs/commit/76bad48f56019df37eb817132530b2bfb88d379f) | `` sqldef: 0.17.25 -> 0.17.27 ``                                                                     |
| [`1e8be90a`](https://github.com/NixOS/nixpkgs/commit/1e8be90a09eaf5e08e2d33ab72f233f25d7d9bfc) | `` goread: 1.7.2 -> 1.7.3 ``                                                                         |
| [`786f2bca`](https://github.com/NixOS/nixpkgs/commit/786f2bca12049e4eb94bab8e05da42cd55a1465b) | `` civo: 1.1.93 -> 1.1.95 ``                                                                         |
| [`2c4f8004`](https://github.com/NixOS/nixpkgs/commit/2c4f8004e28ee1416d9aac1975a1f3a67efea1ff) | `` python312Packages.dbt-bigquery: 1.9.0 -> 1.9.1 ``                                                 |
| [`364c67ed`](https://github.com/NixOS/nixpkgs/commit/364c67edf7d597b41ba56da57dc3eda5b6774776) | `` goose: 3.24.0 -> 3.24.1 ``                                                                        |
| [`a8aaba98`](https://github.com/NixOS/nixpkgs/commit/a8aaba982c69c26f1fce4547521643e22e0bd406) | `` glooctl: 1.18.2 -> 1.18.5 ``                                                                      |
| [`174397b3`](https://github.com/NixOS/nixpkgs/commit/174397b317855ae0885d39f323196789c0db8619) | `` gerrit: 3.11.0 -> 3.11.1 ``                                                                       |
| [`429b850e`](https://github.com/NixOS/nixpkgs/commit/429b850ef4923b61f8964da93c30138e232ba9eb) | `` gerrit: Add Felix Singer as maintainer ``                                                         |
| [`8b0e43bd`](https://github.com/NixOS/nixpkgs/commit/8b0e43bdc0c7645fd133ecd95385cdc66bb6d176) | `` cargo-xwin: 0.18.3 -> 0.18.4 ``                                                                   |
| [`89367772`](https://github.com/NixOS/nixpkgs/commit/89367772410f4f5cab31df53cc707e7bba768857) | `` pluto: 5.21.0 -> 5.21.1 ``                                                                        |
| [`ce8389bd`](https://github.com/NixOS/nixpkgs/commit/ce8389bdd5c1db42f13a9608e0afcb7378da726a) | `` zed-editor: 0.168.2 -> 0.168.3 ``                                                                 |
| [`4a2d913a`](https://github.com/NixOS/nixpkgs/commit/4a2d913a86cac79aed8c2be3acc73b419abbfde5) | `` honggfuzz: unpin LLVM16 (#371796) ``                                                              |
| [`0ea511ed`](https://github.com/NixOS/nixpkgs/commit/0ea511edaf43518423e5732237610df82bd7bc9c) | `` nomino: 1.4.0 -> 1.5.0 ``                                                                         |
| [`4ba6d670`](https://github.com/NixOS/nixpkgs/commit/4ba6d670f1f6376ba5aed31b41f87b297dec00e0) | `` imgproxy: 3.27.0 -> 3.27.1 ``                                                                     |
| [`a0d3b709`](https://github.com/NixOS/nixpkgs/commit/a0d3b709372632c368683f9662da371f735d8ea2) | `` kotlin-native: 1.9.24 -> 2.1.0 ``                                                                 |
| [`e427b8da`](https://github.com/NixOS/nixpkgs/commit/e427b8dae3b1e4c09338a08a45994d74074df282) | `` tippecanoe: 2.73.0 -> 2.74.0 ``                                                                   |
| [`c41261b1`](https://github.com/NixOS/nixpkgs/commit/c41261b1a9c24d9c60d03fef4abce803e803a1be) | `` cargo-leptos: 0.2.24 -> 0.2.25 ``                                                                 |
| [`3e80aaa7`](https://github.com/NixOS/nixpkgs/commit/3e80aaa762af3045d21b1348a814690ac5da67f2) | `` mark: 11.3.1 -> 12.0.0 ``                                                                         |
| [`3c391c50`](https://github.com/NixOS/nixpkgs/commit/3c391c507eaa0eecb5ae074a290c85b9191e5945) | `` tile38: 1.34.0 -> 1.34.1 ``                                                                       |
| [`f99cd8fe`](https://github.com/NixOS/nixpkgs/commit/f99cd8fe96e4bb295bc9ecff7bf59f4e8397d62a) | `` nixpacks: 1.30.0 -> 1.31.0 ``                                                                     |
| [`9d225eb8`](https://github.com/NixOS/nixpkgs/commit/9d225eb87aec5a6733a3b41b5e31f730dda94df3) | `` regal: 0.29.2 -> 0.30.0 ``                                                                        |
| [`624d136b`](https://github.com/NixOS/nixpkgs/commit/624d136b93b854c8b0251907fc96618d00b7c1b5) | `` go-task: only generate shell completions when possible ``                                         |
| [`ae561f4e`](https://github.com/NixOS/nixpkgs/commit/ae561f4e390bf1384f9415ba5f19d4028bb6577b) | `` gdal: 3.10.0 -> 3.10.1 ``                                                                         |
| [`490e1244`](https://github.com/NixOS/nixpkgs/commit/490e124401eb93399653deea2ec3955b69b56f29) | `` plugdata: 0.8.0 -> 0.9.1 ``                                                                       |
| [`30f497ec`](https://github.com/NixOS/nixpkgs/commit/30f497ec779b990952ba0a7c551cce5bb9e77e5e) | `` kubedock: 0.17.1 -> 0.18.0 ``                                                                     |
| [`6477277a`](https://github.com/NixOS/nixpkgs/commit/6477277a79d19ac852b79d000bb6ce02c6f4adbb) | `` zfs_2_3: init at 2.3.0 ``                                                                         |
| [`40e0f723`](https://github.com/NixOS/nixpkgs/commit/40e0f7233b33aabebc42167a5e16d386a45972c9) | `` zfs_unstable: 2.3.0-rc5 -> 2.3.0 ``                                                               |
| [`683cd2ec`](https://github.com/NixOS/nixpkgs/commit/683cd2ecdff49d712f9d645dbaf10644c76d7f96) | `` chart-testing: 3.11.0 -> 3.12.0 ``                                                                |
| [`fe69203e`](https://github.com/NixOS/nixpkgs/commit/fe69203e6f90cc309f471a6367a04ebd7380d0ee) | `` autodock-vina: 1.2.5 -> 1.2.6 ``                                                                  |
| [`ad0441c0`](https://github.com/NixOS/nixpkgs/commit/ad0441c05289fd03752918ad7a1354655503946c) | `` archiver: tag with knownVulnerabilities for CVE-2024-0406 ``                                      |
| [`50c1e88e`](https://github.com/NixOS/nixpkgs/commit/50c1e88e70a480d7061541c40f0b9d23f0222721) | `` firefox-bin-unwrapped: 134.0 -> 134.0.1 ``                                                        |
| [`d5743495`](https://github.com/NixOS/nixpkgs/commit/d574349587e685bab0e46534aec02881f6741b96) | `` firefox-unwrapped: 134.0 -> 134.0.1 ``                                                            |
| [`5bd1937f`](https://github.com/NixOS/nixpkgs/commit/5bd1937f1e1bf78ce873f6ee742771a22e756b74) | `` python312Packages.blake3: 1.0.0 -> 1.0.2 ``                                                       |
| [`53c25a89`](https://github.com/NixOS/nixpkgs/commit/53c25a89d5dbfbe77d7559dbcb03738cd13c9813) | `` python312Packages.rising: remove at 0.3.0 ``                                                      |
| [`df13bea6`](https://github.com/NixOS/nixpkgs/commit/df13bea6f478c1c8e4be79c46415522ac761691b) | `` dnsperf: add musl fix (#370881) ``                                                                |
| [`79db1dc7`](https://github.com/NixOS/nixpkgs/commit/79db1dc70a9ef1bf5e284b57fca44b4440be81cd) | `` aider-chat: refactor (make it available as both a python package and an application) (#373160) `` |
| [`3c547e60`](https://github.com/NixOS/nixpkgs/commit/3c547e6031725e4446e7752d5b0ab27efd3db4ef) | `` newlib: add installation of libgloss for embedded targets (#367275) ``                            |
| [`66de2196`](https://github.com/NixOS/nixpkgs/commit/66de21965a6c8f9e91916a6f9aec5e6d86066dbe) | `` python313Packages.jsonconversion: disable failing test on Python 3.13 ``                          |
| [`a18259ad`](https://github.com/NixOS/nixpkgs/commit/a18259add71f4d79d2f414e260c10fcbeaaab039) | `` python312Packages.jsonconversion: relax numpy ``                                                  |
| [`f0a28b7f`](https://github.com/NixOS/nixpkgs/commit/f0a28b7ff060190c9a0044ab072c0923c0d982d2) | `` python312Packages.amiibo-py: drop ``                                                              |
| [`30ad2116`](https://github.com/NixOS/nixpkgs/commit/30ad2116fc0b496a9a7d959a6d858b634b91bf30) | `` freerdp3: 3.9.0 -> 3.10.3 ``                                                                      |
| [`67fe3ca9`](https://github.com/NixOS/nixpkgs/commit/67fe3ca9701750a4701c78ccd0cbb7650ea5dd90) | `` python313Packages.habiticalib: 0.3.2 -> 0.3.3 ``                                                  |
| [`58c5aeb5`](https://github.com/NixOS/nixpkgs/commit/58c5aeb53cbcecf554f1540251e25c2427693c5a) | `` nixos/libvirtd: Add proper UEFI support ``                                                        |