### PR TITLE
chore(flake/srvos): `61cc2047` -> `1910ec73`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -884,11 +884,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736810122,
-        "narHash": "sha256-29Mp0xa3jXF33Qu92hd/uPz1HZWBestpEKmgG4RyzCo=",
+        "lastModified": 1737673068,
+        "narHash": "sha256-j1f1LsgjSrE4X1dMx0FncagOHGnqY5BJJoSkzYWPbeg=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "61cc2047ad1a4c52ef18d117ac8e6ccfc0e38ea5",
+        "rev": "1910ec7346df1f6e1d2536c42c380c9a9ae58765",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                   |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`1910ec73`](https://github.com/nix-community/srvos/commit/1910ec7346df1f6e1d2536c42c380c9a9ae58765) | `` detect-hostname-change: make shellcheck happy ``       |
| [`ebf8d27a`](https://github.com/nix-community/srvos/commit/ebf8d27a44dd02adfa3a5b48c842ea4fa5642198) | `` dev/private/flake.lock: Update ``                      |
| [`ed48fd2d`](https://github.com/nix-community/srvos/commit/ed48fd2daf78e6729e1fe97cbfe1740a6c4d22d0) | `` flake.lock: Update ``                                  |
| [`3351e1b5`](https://github.com/nix-community/srvos/commit/3351e1b562741fa08736ccfb244c34c5a86a54c7) | `` detect-hostname-change: improve installer detection `` |
| [`db870137`](https://github.com/nix-community/srvos/commit/db87013780628b2e8387a3b4ccd3bc7bda0af447) | `` dev/private/flake.lock: Update ``                      |
| [`e92e90b9`](https://github.com/nix-community/srvos/commit/e92e90b9b4290015136a4f49a127f9ef0f00d3f4) | `` flake.lock: Update ``                                  |
| [`7c706977`](https://github.com/nix-community/srvos/commit/7c70697783a3a6eb4be6cfb93b7bb9827c923bb1) | `` prometheus: fix vmstat_pgmajfault ``                   |
| [`dd3d5c51`](https://github.com/nix-community/srvos/commit/dd3d5c51ffca2531b26af30e38f9b6cbce219bfd) | `` dev/private/flake.lock: Update ``                      |
| [`47ea7272`](https://github.com/nix-community/srvos/commit/47ea72721880ce24ed30819d72accc1799ee25e1) | `` flake.lock: Update ``                                  |