### PR TITLE
chore(flake/treefmt-nix): `13c913f5` -> `d1ed3b38`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1155,11 +1155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736154270,
-        "narHash": "sha256-p2r8xhQZ3TYIEKBoiEhllKWQqWNJNoT9v64Vmg4q8Zw=",
+        "lastModified": 1737103437,
+        "narHash": "sha256-uPNWcYbhY2fjY3HOfRCR5jsfzdzemhfxLSxwjXYXqNc=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "13c913f5deb3a5c08bb810efd89dc8cb24dd968b",
+        "rev": "d1ed3b385f8130e392870cfb1dbfaff8a63a1899",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                            |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`a7829bb0`](https://github.com/numtide/treefmt-nix/commit/a7829bb0c193c1595e36e1c034591646dc5598c5) | `` add katexochen as maintainer `` |
| [`97871d41`](https://github.com/numtide/treefmt-nix/commit/97871d416166803134ba64597a1006f3f670fbde) | `` pinact: init (#300) ``          |