### PR TITLE
chore(flake/nixos-cosmic): `40534c1b` -> `6ec08f11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -621,11 +621,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1736997002,
-        "narHash": "sha256-EPbAFUXgu3agihgA+MJlQe6J18SIEZ4cRm+zhNRbGfo=",
+        "lastModified": 1737250613,
+        "narHash": "sha256-0QcnnQZ/il9UPVmhJtDqjPDCCcW5vTCz7QaLu+rlrRQ=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "40534c1bc524aa8c433a7a30318d7e20bddb33fb",
+        "rev": "6ec08f11bbf0e936ad82f1bb532f3757f8b5e3c2",
         "type": "github"
       },
       "original": {
@@ -758,11 +758,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1736867362,
-        "narHash": "sha256-i/UJ5I7HoqmFMwZEH6vAvBxOrjjOJNU739lnZnhUln8=",
+        "lastModified": 1737165118,
+        "narHash": "sha256-s40Kk/OulP3J/1JvC3VT16U4r/Xw6Qdi7SRw3LYkPWs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9c6b49aeac36e2ed73a8c472f1546f6d9cf1addc",
+        "rev": "6a3ae7a5a12fb8cac2d59d7df7cbd95f9b2f0566",
         "type": "github"
       },
       "original": {
@@ -789,11 +789,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1736883708,
-        "narHash": "sha256-uQ+NQ0/xYU0N1CnXsa2zghgNaOPxWpMJXSUJJ9W7140=",
+        "lastModified": 1737062831,
+        "narHash": "sha256-Tbk1MZbtV2s5aG+iM99U8FqwxU/YNArMcWAv6clcsBc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+        "rev": "5df43628fdf08d642be8ba5b3625a6c70731c19c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                               |
| ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`6ec08f11`](https://github.com/lilyinstarlight/nixos-cosmic/commit/6ec08f11bbf0e936ad82f1bb532f3757f8b5e3c2) | `` flake: update inputs (#605) ``                                     |
| [`3d104e57`](https://github.com/lilyinstarlight/nixos-cosmic/commit/3d104e57bd1e6374830ee55d377e15d835d84963) | `` flake: update inputs (#603) ``                                     |
| [`8b9f10df`](https://github.com/lilyinstarlight/nixos-cosmic/commit/8b9f10df78e9d4993a147816cfdb5ce60934bd54) | `` pkgs: update cosmic (#602) ``                                      |
| [`1c6b22a4`](https://github.com/lilyinstarlight/nixos-cosmic/commit/1c6b22a4ac06e2005c3317ee83f04ab642dc8570) | `` flake: update inputs (#601) ``                                     |
| [`d4af911b`](https://github.com/lilyinstarlight/nixos-cosmic/commit/d4af911bd337ab3eb2f7c0b798338e2b5d5cf5c6) | `` pkgs: update cosmic (#600) ``                                      |
| [`c92ead1a`](https://github.com/lilyinstarlight/nixos-cosmic/commit/c92ead1ab77f8be697a44ca855d06c5957ee2a62) | `` libcosmicAppHook: remove now-unnecessary dependencies (#597) ``    |
| [`808c4fe0`](https://github.com/lilyinstarlight/nixos-cosmic/commit/808c4fe0acab5097a0617840868a6f20f55d4ee5) | `` ci: revert temporary unstable/stable builder type change (#598) `` |