### PR TITLE
chore(flake/home-manager): `0dfec9de` -> `12851ae7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -447,11 +447,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736883540,
-        "narHash": "sha256-dgPgoPUSg8cGAMqbhQRkww665sZtgzpWXxWjlyqhv94=",
+        "lastModified": 1737075266,
+        "narHash": "sha256-u1gk5I1an975FOAMMdS6oBKnSIsZza5ZKhaeBZAskVo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0dfec9deb275854a56c97c356c40ef72e3a2e632",
+        "rev": "12851ae7467bad8ef422b20806ab4d6d81e12d29",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                            |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`12851ae7`](https://github.com/nix-community/home-manager/commit/12851ae7467bad8ef422b20806ab4d6d81e12d29) | `` thunderbird: Enable tests for Darwin (#6324) `` |