### PR TITLE
chore(flake/sops-nix): `553c7cb2` -> `4c4fb93f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1043,11 +1043,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736808430,
-        "narHash": "sha256-wlgdf/n7bJMLBheqt1jmPoxJFrUP6FByKQFXuM9YvIk=",
+        "lastModified": 1737107480,
+        "narHash": "sha256-GXUE9+FgxoZU8v0p6ilBJ8NH7k8nKmZjp/7dmMrCv3o=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "553c7cb22fed19fd60eb310423fdc93045c51ba8",
+        "rev": "4c4fb93f18b9072c6fa1986221f9a3d7bf1fe4b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                  |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`4c4fb93f`](https://github.com/Mic92/sops-nix/commit/4c4fb93f18b9072c6fa1986221f9a3d7bf1fe4b6) | `` docs: expand a bit on user secrets + impermanence. `` |