### PR TITLE
chore(flake/nixpkgs_jj-fzf): `982a7814` -> `3656b0bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -853,11 +853,11 @@
     },
     "nixpkgs_jj-fzf": {
       "locked": {
-        "lastModified": 1731385239,
-        "narHash": "sha256-8Zemz7W5B5R85WoW72dzE+SMYhyYetV5Iccs69hDRKs=",
+        "lastModified": 1737149195,
+        "narHash": "sha256-dbs5JHDC1gC7m6oZTAwU78lw2BMVz0lYcEMAUPEn0hk=",
         "owner": "bbigras",
         "repo": "nixpkgs",
-        "rev": "982a781409bc03db970c36d5ba7a75827c78bf0c",
+        "rev": "3656b0bbdccc75d9f2af9efa0955350d9358ee2c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                              |
| ------------------------------------------------------------------------------------------------ | ------------------------------------ |
| [`3656b0bb`](https://github.com/bbigras/nixpkgs/commit/3656b0bbdccc75d9f2af9efa0955350d9358ee2c) | `` jj-fzf: 0.24.0 -> 20250111-git `` |
| [`4ea225c4`](https://github.com/bbigras/nixpkgs/commit/4ea225c4dc44e8d6181e94b5a54a1e85ec54ff49) | `` jj-fzf: 0.23.0 -> 0.24.0 ``       |
| [`f4d87ebc`](https://github.com/bbigras/nixpkgs/commit/f4d87ebcc2ce06f7a51fd58565cb88b681746567) | `` jj-fzf: init at 0.23.0 ``         |