### PR TITLE
chore(flake/emacs-ultra-scroll): `64ad7be0` -> `2e3b9997`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -182,11 +182,11 @@
     "emacs-ultra-scroll": {
       "flake": false,
       "locked": {
-        "lastModified": 1736790890,
-        "narHash": "sha256-lHz0AypoMYdlOQ/7hMw2Jy7LVG8S1CmK60PH1x5dJnM=",
+        "lastModified": 1737229840,
+        "narHash": "sha256-9+3T5tXPRuRtENt/Rr0Ss3LZJlTOwpGePbREqofN2j0=",
         "owner": "jdtsmith",
         "repo": "ultra-scroll",
-        "rev": "64ad7be02e11317576498dabb15c92cf31e2c04c",
+        "rev": "2e3b9997ae1a469e878feaa0af23a23685a0fbed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                    |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------ |
| [`2e3b9997`](https://github.com/jdtsmith/ultra-scroll/commit/2e3b9997ae1a469e878feaa0af23a23685a0fbed) | `` NEWS for 0.3.1 ``                       |
| [`e710966a`](https://github.com/jdtsmith/ultra-scroll/commit/e710966ac7e605aff3251d0747c7792452ce77ec) | `` Bump version ``                         |
| [`23d8b75d`](https://github.com/jdtsmith/ultra-scroll/commit/23d8b75df3c46aa261e8da7abcb65dc1295cfefc) | `` README: document hide-functions ``      |
| [`d500ab82`](https://github.com/jdtsmith/ultra-scroll/commit/d500ab829b3d53fb60606baa29df6c4a7caba09c) | `` implement hide-functions ``             |
| [`aac572c3`](https://github.com/jdtsmith/ultra-scroll/commit/aac572c37a533fc74ff7de58a59dae0cf283dd4b) | `` gc-percentage: improve custom labels `` |