### PR TITLE
chore(flake/home-manager): `1e364297` -> `97d7946b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -431,11 +431,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737188535,
-        "narHash": "sha256-O2ttwW1/dUc/Y+Rf48Njtr4tZpRJhy8FhafikekIjMY=",
+        "lastModified": 1737221749,
+        "narHash": "sha256-igllW0yG+UbetvhT11jnt9RppSHXYgMykYhZJeqfHs0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1e36429705f9af2d00a517ba46a4f21ef8a8194f",
+        "rev": "97d7946b5e107dd03cc82f21165251d4e0159655",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`97d7946b`](https://github.com/nix-community/home-manager/commit/97d7946b5e107dd03cc82f21165251d4e0159655) | `` {hypridle, hyrpaper}: remove with lib; (#6318) ``    |
| [`1c75a4c1`](https://github.com/nix-community/home-manager/commit/1c75a4c151dfe417c73ae3f87a6eba0b009c438c) | `` syncthing: have tray wait for bar to load (#6290) `` |