### PR TITLE
chore(flake/nix-index-database): `271e5bd7` -> `744d3306`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -576,11 +576,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736652904,
-        "narHash": "sha256-8uolHABgroXqzs03QdulHp8H9e5kWQZnnhcda1MKbBM=",
+        "lastModified": 1737257306,
+        "narHash": "sha256-lEGgpA4kGafc76+Amnz+gh1L/cwUS2pePFlf22WEyh8=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "271e5bd7c57e1f001693799518b10a02d1123b12",
+        "rev": "744d330659e207a1883d2da0141d35e520eb87bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`744d3306`](https://github.com/nix-community/nix-index-database/commit/744d330659e207a1883d2da0141d35e520eb87bd) | `` update generated.nix to release 2025-01-19-031135 `` |
| [`5b1c0594`](https://github.com/nix-community/nix-index-database/commit/5b1c05942acc51e9cb5a4ad214b2292f8401af67) | `` flake.lock: Update ``                                |