### PR TITLE
chore(flake/gptel): `6220aec8` -> `e2bef37e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -367,11 +367,11 @@
     "gptel": {
       "flake": false,
       "locked": {
-        "lastModified": 1737228910,
-        "narHash": "sha256-PfgVSOQ4nKLd/TJD4+gCi3oJRPIKakO30ffseCCQ8Y8=",
+        "lastModified": 1737273323,
+        "narHash": "sha256-yNVqfvYZzcdAAiF/3TySAdex7OCHM8TYMoRKKfrzbeo=",
         "owner": "karthink",
         "repo": "gptel",
-        "rev": "6220aec81c6a275ea5fa579d4749d0a9e8257c5e",
+        "rev": "e2bef37efdd4f55d97d33969c8020d06c33f8cbe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                        |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`e2bef37e`](https://github.com/karthink/gptel/commit/e2bef37efdd4f55d97d33969c8020d06c33f8cbe) | `` README: Add tool-use description ``                         |
| [`730a9b7b`](https://github.com/karthink/gptel/commit/730a9b7b57f119907ab4c8f718b97cc528a91aed) | `` gptel: Handle pending calls/call results in chat buffers `` |
| [`7837da90`](https://github.com/karthink/gptel/commit/7837da9091d4474c17860f1869df12410ea39fb3) | `` gptel: Run callback with pending tool calls ``              |