### PR TITLE
chore(flake/gptel): `e2bef37e` -> `b59306cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -367,11 +367,11 @@
     "gptel": {
       "flake": false,
       "locked": {
-        "lastModified": 1737273323,
-        "narHash": "sha256-yNVqfvYZzcdAAiF/3TySAdex7OCHM8TYMoRKKfrzbeo=",
+        "lastModified": 1737274917,
+        "narHash": "sha256-Z2NGxGeyiUv+owIgEtTx/b/BbZgf5vIh8Bvc5YxCo20=",
         "owner": "karthink",
         "repo": "gptel",
-        "rev": "e2bef37efdd4f55d97d33969c8020d06c33f8cbe",
+        "rev": "b59306cf8f4d540ce5e94744bc1a3d1465f429e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                |
| ----------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`b59306cf`](https://github.com/karthink/gptel/commit/b59306cf8f4d540ce5e94744bc1a3d1465f429e3) | `` README: Add tool-use description `` |