### PR TITLE
chore(flake/lanzaboote): `93e6f0d7` -> `64d20cb2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -505,11 +505,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1734994463,
-        "narHash": "sha256-S9MgfQjNt4J3I7obdLOVY23h+Yl/hnyibwGfOl+1uOE=",
+        "lastModified": 1737299073,
+        "narHash": "sha256-hOydnO9trHDo3qURqLSDdmE/pHNWDzlhkmyZ/gcBX2s=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "93e6f0d77548be8757c11ebda5c4235ef4f3bc67",
+        "rev": "64d20cb2afaad8b73f4e38de41d27fb30a782bb5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                     |
| --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`0952e5c7`](https://github.com/nix-community/lanzaboote/commit/0952e5c7412f4e14119ca745a4809965da1e5ec2) | `` fix(tool): parse osrel sections without trailing null `` |