### PR TITLE
chore(flake/nixos-hardware): `b6786066` -> `cb3173dc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -651,11 +651,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1736978406,
-        "narHash": "sha256-oMr3PVIQ8XPDI8/x6BHxsWEPBRU98Pam6KGVwUh8MPk=",
+        "lastModified": 1737306472,
+        "narHash": "sha256-+X9KAryvDsIE7lQ0FdfiD1u33nOVgsgufedqspf77N4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "b678606690027913f3434dea3864e712b862dde5",
+        "rev": "cb3173dc5c746fa95bca1f035a7e4d2b588894ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                              |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`cb3173dc`](https://github.com/NixOS/nixos-hardware/commit/cb3173dc5c746fa95bca1f035a7e4d2b588894ac) | `` include Dell Latitude 549 in flake.nix (#1316) `` |
| [`abe22227`](https://github.com/NixOS/nixos-hardware/commit/abe22227d7e8ef0077ba863804b3755545fbf5f7) | `` xiaomi/redmibook/16-pro-2024: init ``             |