### PR TITLE
chore(flake/gptel): `b59306cf` -> `ca66e8f4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -367,11 +367,11 @@
     "gptel": {
       "flake": false,
       "locked": {
-        "lastModified": 1737274917,
-        "narHash": "sha256-Z2NGxGeyiUv+owIgEtTx/b/BbZgf5vIh8Bvc5YxCo20=",
+        "lastModified": 1737329595,
+        "narHash": "sha256-52P/oR1uqrregEc0mHgZ9fmk22Tq9JEp8lFwFW/dxCY=",
         "owner": "karthink",
         "repo": "gptel",
-        "rev": "b59306cf8f4d540ce5e94744bc1a3d1465f429e3",
+        "rev": "ca66e8f42f20c8ebdd95830457ada3a506264583",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                           |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`ca66e8f4`](https://github.com/karthink/gptel/commit/ca66e8f42f20c8ebdd95830457ada3a506264583) | `` gptel: Set tool-use capability flag for models ``              |
| [`2e7c864d`](https://github.com/karthink/gptel/commit/2e7c864d93646229b3f1468d1ec950c6f73db106) | `` gptel: Handle Ollama + streaming + tool-use incompatibility `` |
| [`e7da2d8f`](https://github.com/karthink/gptel/commit/e7da2d8fc774c447b268ef86325639cbd42b76c9) | `` README: Add tool-use description ``                            |