### PR TITLE
chore(flake/nixos-hardware): `cb3173dc` -> `61c79181`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -651,11 +651,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1737306472,
-        "narHash": "sha256-+X9KAryvDsIE7lQ0FdfiD1u33nOVgsgufedqspf77N4=",
+        "lastModified": 1737359802,
+        "narHash": "sha256-utplyRM6pqnN940gfaLFBb9oUCSzkan86IvmkhsVlN8=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "cb3173dc5c746fa95bca1f035a7e4d2b588894ac",
+        "rev": "61c79181e77ef774ab0468b28a24bc2647d498d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                      |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`61c79181`](https://github.com/NixOS/nixos-hardware/commit/61c79181e77ef774ab0468b28a24bc2647d498d6) | `` feat: HP probook 440G5 config ``                                          |
| [`b5399578`](https://github.com/NixOS/nixos-hardware/commit/b5399578399a07741f5a9025445e9e886d4f8d71) | `` update readme to mention power profile / nvidia-powerd troubleshooting `` |
| [`1f23785a`](https://github.com/NixOS/nixos-hardware/commit/1f23785afe405ae924daa395f6000310397f395c) | `` lenovo-legion-16ach6h: enable nvidia.powerd to unlock more gpu power ``   |
| [`3883dfe5`](https://github.com/NixOS/nixos-hardware/commit/3883dfe5eead7cbf48c1582297b4ab23e6cb0f31) | `` gpd/pocket-4: init ``                                                     |
| [`b31613ae`](https://github.com/NixOS/nixos-hardware/commit/b31613ae1087d086d98647a8f7f12d0200c33bad) | `` omen/15-ce002ns: Init ``                                                  |
| [`4c0d42b5`](https://github.com/NixOS/nixos-hardware/commit/4c0d42b582bc05dad64c97c7c27d32306f4283b9) | `` framework: refactor kmod for improved AMD support ``                      |