### PR TITLE
chore(flake/sops-nix): `4c4fb93f` -> `015d461c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1026,11 +1026,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737107480,
-        "narHash": "sha256-GXUE9+FgxoZU8v0p6ilBJ8NH7k8nKmZjp/7dmMrCv3o=",
+        "lastModified": 1737411508,
+        "narHash": "sha256-j9IdflJwRtqo9WpM0OfAZml47eBblUHGNQTe62OUqTw=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "4c4fb93f18b9072c6fa1986221f9a3d7bf1fe4b6",
+        "rev": "015d461c16678fc02a2f405eb453abb509d4e1d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                     |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`015d461c`](https://github.com/Mic92/sops-nix/commit/015d461c16678fc02a2f405eb453abb509d4e1d4) | `` update vendorHash ``                                                     |
| [`1bf611bd`](https://github.com/Mic92/sops-nix/commit/1bf611bd66b77511265b0d37df6a3d7d5748c726) | `` build(deps): bump github.com/ProtonMail/go-crypto from 1.1.4 to 1.1.5 `` |