### PR TITLE
chore(flake/darwin): `87131f51` -> `46d0fa4d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -103,11 +103,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737162735,
-        "narHash": "sha256-5T+HkouTMGaRm0rh3kgD4Z1O7ONKfgjyoPQH5rSyreU=",
+        "lastModified": 1737423230,
+        "narHash": "sha256-WEOiNmkcmlaeXy2HGW1PYxYmCPiHdsI7a7SpjhBYxRg=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "87131f51f8256952d1a306b5521cedc2dc61aa08",
+        "rev": "46d0fa4ded0a7532f19870f9bbedaf62269fe3f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                    |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
| [`87b61d66`](https://github.com/LnL7/nix-darwin/commit/87b61d666632de823338039e6a10785b15519ae4) | `` eval-config: omit `enableNixpkgsReleaseCheck` from `lib.evalModules` `` |
| [`5665d6c0`](https://github.com/LnL7/nix-darwin/commit/5665d6c05ef73b904e3a8bc37c35b7be1d923f4d) | `` darwin-rebuild: pass `${extraBuildFlags[@]}` to `nix-instantiate` ``    |
| [`94adbd62`](https://github.com/LnL7/nix-darwin/commit/94adbd6259190f49104f2edfe82d8e8c2073be05) | `` darwin-uninstaller: remove `darwin` channel from `root` too ``          |
| [`e1976612`](https://github.com/LnL7/nix-darwin/commit/e1976612f0054a8143f37e7ef25c4ef4b88b44bd) | `` system: tweak ShellCheck settings ``                                    |