### PR TITLE
chore(flake/darwin): `46d0fa4d` -> `65cc1fa8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -103,11 +103,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737423230,
-        "narHash": "sha256-WEOiNmkcmlaeXy2HGW1PYxYmCPiHdsI7a7SpjhBYxRg=",
+        "lastModified": 1737504076,
+        "narHash": "sha256-/B4XJnzYU/6K1ZZOBIgsa3K4pqDJrnC2579c44c+4rI=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "46d0fa4ded0a7532f19870f9bbedaf62269fe3f7",
+        "rev": "65cc1fa8e36ceff067daf6cfb142331f02f524d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                        |
| ------------------------------------------------------------------------------------------------ | ------------------------------ |
| [`c3954c51`](https://github.com/LnL7/nix-darwin/commit/c3954c51c4a02a9ed5455252c09b7b1690cb59bf) | `` checks: remove `runLink` `` |