### PR TITLE
chore(flake/nixos-hardware): `61c79181` -> `93680277`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -528,11 +528,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1737359802,
-        "narHash": "sha256-utplyRM6pqnN940gfaLFBb9oUCSzkan86IvmkhsVlN8=",
+        "lastModified": 1737590910,
+        "narHash": "sha256-qM/y6Dtpu9Wmf5HqeZajQdn+cS0aljdYQQQnrvx+LJE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "61c79181e77ef774ab0468b28a24bc2647d498d6",
+        "rev": "9368027715d8dde4b84c79c374948b5306fdd2db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                            |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`6209032a`](https://github.com/NixOS/nixos-hardware/commit/6209032a7c5c88f5c8fcd94a0b13f8177d828729) | `` fix the unused module error accross all imx8 `` |
| [`63c0f02c`](https://github.com/NixOS/nixos-hardware/commit/63c0f02ce5d85f721871dda4be86894ba6b555dd) | `` nxp-imx: fix unused modules errors ``           |