### PR TITLE
chore(flake/home-manager): `cefb1889` -> `0db5c8bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737575492,
-        "narHash": "sha256-qa/D3NC1JoApnUuLrq1gseBmIxeg6icm/ojPgggMDVQ=",
+        "lastModified": 1737630279,
+        "narHash": "sha256-wJQCxyMRc4P26zDrHmZiRD5bbfcJpqPG3e2djdGG3pk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cefb1889b96ddd1dac3dd4734e894f4cadab7802",
+        "rev": "0db5c8bfcce78583ebbde0b2abbc95ad93445f7c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`0db5c8bf`](https://github.com/nix-community/home-manager/commit/0db5c8bfcce78583ebbde0b2abbc95ad93445f7c) | `` ghostty: add keybinds to settings example `` |
| [`01d01729`](https://github.com/nix-community/home-manager/commit/01d0172933845daaf3392f6b8c3953995e912f6e) | `` wezterm: update expected test result ``      |
| [`b17008a7`](https://github.com/nix-community/home-manager/commit/b17008a795066bd3b4da86d7614a3be0efb0092e) | `` swayr: update expected test result ``        |
| [`4806e9c0`](https://github.com/nix-community/home-manager/commit/4806e9c021e8f1d78b0bb7bc4ecc75d27a31a4bb) | `` flake.lock: Update ``                        |
| [`1757aca1`](https://github.com/nix-community/home-manager/commit/1757aca1640bebd7495f2784844f21a8dd712f8d) | `` go: stub systemd dependency in test ``       |