### PR TITLE
chore(flake/nixos-hardware): `93680277` -> `dfad538f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -528,11 +528,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1737590910,
-        "narHash": "sha256-qM/y6Dtpu9Wmf5HqeZajQdn+cS0aljdYQQQnrvx+LJE=",
+        "lastModified": 1737751639,
+        "narHash": "sha256-ZEbOJ9iT72iwqXsiEMbEa8wWjyFvRA9Ugx8utmYbpz4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "9368027715d8dde4b84c79c374948b5306fdd2db",
+        "rev": "dfad538f751a5aa5d4436d9781ab27a6128ec9d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`dfad538f`](https://github.com/NixOS/nixos-hardware/commit/dfad538f751a5aa5d4436d9781ab27a6128ec9d4) | `` dell/latitude/7420: init ``                                         |
| [`76590935`](https://github.com/NixOS/nixos-hardware/commit/7659093598c593aafb3e3ecd6a1ea9e6e2023faf) | `` gpd/pocket-4: default kernel version to 6.12 to fix amdgpu error `` |
| [`c2aa5756`](https://github.com/NixOS/nixos-hardware/commit/c2aa5756c0ee18607c38f7db54a424e98618b0b3) | `` onenetbook/4: update stylus patch for 6.12 ``                       |
| [`3a123626`](https://github.com/NixOS/nixos-hardware/commit/3a123626d98d332c7cac5b5ca185d94a115a5464) | `` surface: linux 6.12.9 -> 6.12.11 ``                                 |
| [`cbefe8bd`](https://github.com/NixOS/nixos-hardware/commit/cbefe8bde7399864cb100f9dc115edd818cbab3b) | `` Fix doc build by adding missing defaultText ``                      |