### PR TITLE
chore(flake/nur): `74e4e762` -> `5a9dbaee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1737778329,
-        "narHash": "sha256-tLTyEJCATaGy5Utf2ajJz6PfMpMN0Fi2I3/pGhgJmhA=",
+        "lastModified": 1737805563,
+        "narHash": "sha256-FeO6Gxl9XaWq4Ys/bc1VeWOlhrhep1U9MZmOeGc8+v8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "74e4e762ebc3ec0aafb71892f43eed0b30071776",
+        "rev": "5a9dbaee1ccf4ca6dca5e3c32ac0f2d33455a8b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5a9dbaee`](https://github.com/nix-community/NUR/commit/5a9dbaee1ccf4ca6dca5e3c32ac0f2d33455a8b3) | `` automatic update `` |
| [`6b1f6c16`](https://github.com/nix-community/NUR/commit/6b1f6c161fa658bc774b3b60dc8215e65b3a816b) | `` automatic update `` |
| [`5d972bf0`](https://github.com/nix-community/NUR/commit/5d972bf0100f9ff02db0293e439b0244665080b6) | `` automatic update `` |