### PR TITLE
chore(flake/nur): `5a9dbaee` -> `03732dc5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1737805563,
-        "narHash": "sha256-FeO6Gxl9XaWq4Ys/bc1VeWOlhrhep1U9MZmOeGc8+v8=",
+        "lastModified": 1737816726,
+        "narHash": "sha256-R/VvHkGSpr3iEdU+3W67Y+bgBaH68SbXhp2wBocTl/w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5a9dbaee1ccf4ca6dca5e3c32ac0f2d33455a8b3",
+        "rev": "03732dc5ba625019dfd975212760cf42523ce277",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`03732dc5`](https://github.com/nix-community/NUR/commit/03732dc5ba625019dfd975212760cf42523ce277) | `` automatic update `` |
| [`c6263c7c`](https://github.com/nix-community/NUR/commit/c6263c7cd058422eff8f76566de7d8852397d854) | `` automatic update `` |