### PR TITLE
chore(flake/emacs-overlay): `1daea5dd` -> `4ebe4c89`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1737770462,
-        "narHash": "sha256-d+VpkYISLIBRvSFUCyPbpcanPCheC7THbW2cbgTlb/s=",
+        "lastModified": 1737825153,
+        "narHash": "sha256-R1p2ZXOydII+MT/SpeOXBjo/dgfD/gIArge2YAgSw38=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1daea5ddf4cebd26c500f265edbeb62d679c7ff7",
+        "rev": "4ebe4c890e7c8662ae31192359a56b0505cf10ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`4ebe4c89`](https://github.com/nix-community/emacs-overlay/commit/4ebe4c890e7c8662ae31192359a56b0505cf10ba) | `` Updated emacs ``  |
| [`c20a5eb3`](https://github.com/nix-community/emacs-overlay/commit/c20a5eb334931573788c1f9d70743964397d375e) | `` Updated melpa ``  |
| [`20492c75`](https://github.com/nix-community/emacs-overlay/commit/20492c753b4f3b30fda02056f507e29ef38d3fa6) | `` Updated elpa ``   |
| [`1a34d6be`](https://github.com/nix-community/emacs-overlay/commit/1a34d6be1f8b1f4f5ab11bc74d64c472c442094a) | `` Updated nongnu `` |