### PR TITLE
chore(flake/nixos-cosmic): `c09628bd` -> `6a676dd6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -498,11 +498,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1737737985,
-        "narHash": "sha256-qQvUk3zPDV5IsnPAQAYxLm479hOj3zlZy4k+0PzzyMg=",
+        "lastModified": 1737855483,
+        "narHash": "sha256-x8WUQbThGRhX+WGl+D8kzEJzZStR+SGlVdzfEEEr6pA=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "c09628bdaecece885ee78614245a077fe3805f0a",
+        "rev": "6a676dd63790edd7e79410ccc7b0cd52454b83fc",
         "type": "github"
       },
       "original": {
@@ -619,11 +619,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1737569578,
-        "narHash": "sha256-6qY0pk2QmUtBT9Mywdvif0i/CLVgpCjMUn6g9vB+f3M=",
+        "lastModified": 1737672001,
+        "narHash": "sha256-YnHJJ19wqmibLQdUeq9xzE6CjrMA568KN/lFPuSVs4I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "47addd76727f42d351590c905d9d1905ca895b82",
+        "rev": "035f8c0853c2977b24ffc4d0a42c74f00b182cd8",
         "type": "github"
       },
       "original": {
@@ -650,11 +650,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1737632463,
-        "narHash": "sha256-38J9QfeGSej341ouwzqf77WIHAScihAKCt8PQJ+NH28=",
+        "lastModified": 1737746512,
+        "narHash": "sha256-nU6AezEX4EuahTO1YopzueAXfjFfmCHylYEFCagduHU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0aa475546ed21629c4f5bbf90e38c846a99ec9e9",
+        "rev": "825479c345a7f806485b7f00dbe3abb50641b083",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                                                                          |
| ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
| [`6a676dd6`](https://github.com/lilyinstarlight/nixos-cosmic/commit/6a676dd63790edd7e79410ccc7b0cd52454b83fc) | `` flake: update inputs (#619) ``                                                                                |
| [`e277b916`](https://github.com/lilyinstarlight/nixos-cosmic/commit/e277b9162637a85f45c4564d687729797f560637) | `` cosmic-workspaces-epoch: 1.0.0-alpha.5.1-unstable-2025-01-24 -> 1.0.0-alpha.5.1-unstable-2025-01-24 (#618) `` |
| [`48ac5cfa`](https://github.com/lilyinstarlight/nixos-cosmic/commit/48ac5cfacefbd0faf15d081d60ea58cb1f0057df) | `` flake: update inputs (#617) ``                                                                                |
| [`411d3fe1`](https://github.com/lilyinstarlight/nixos-cosmic/commit/411d3fe1d2ae285e8977f739fb30882b6c6552d5) | `` pkgs: update cosmic (#616) ``                                                                                 |