### PR TITLE
chore(flake/nur): `03732dc5` -> `595e1849`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -682,11 +682,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1737632463,
-        "narHash": "sha256-38J9QfeGSej341ouwzqf77WIHAScihAKCt8PQJ+NH28=",
+        "lastModified": 1737746512,
+        "narHash": "sha256-nU6AezEX4EuahTO1YopzueAXfjFfmCHylYEFCagduHU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0aa475546ed21629c4f5bbf90e38c846a99ec9e9",
+        "rev": "825479c345a7f806485b7f00dbe3abb50641b083",
         "type": "github"
       },
       "original": {
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1737816726,
-        "narHash": "sha256-R/VvHkGSpr3iEdU+3W67Y+bgBaH68SbXhp2wBocTl/w=",
+        "lastModified": 1737848713,
+        "narHash": "sha256-W8OEe5Hze2HoKWaisyNUyDKzhDr7FIROCbx11/Ye7JQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "03732dc5ba625019dfd975212760cf42523ce277",
+        "rev": "595e18494dbdd9aea05784d11572824ae5949359",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`595e1849`](https://github.com/nix-community/NUR/commit/595e18494dbdd9aea05784d11572824ae5949359) | `` automatic update `` |
| [`768f4406`](https://github.com/nix-community/NUR/commit/768f4406d8b8847c0b74e9cd08d2a8e0b8bf2df1) | `` automatic update `` |
| [`83b5a10f`](https://github.com/nix-community/NUR/commit/83b5a10fa785f0924fae431ffdea2b12de23e789) | `` automatic update `` |
| [`4a6b776d`](https://github.com/nix-community/NUR/commit/4a6b776db0b963d28aa73f293d9976d9b5a55d00) | `` automatic update `` |
| [`98414456`](https://github.com/nix-community/NUR/commit/984144561c46dd2cb82b0b7aaf9926751a87a0e3) | `` automatic update `` |
| [`3014ce09`](https://github.com/nix-community/NUR/commit/3014ce091e2a77387f750e8d782b95c278b2814d) | `` automatic update `` |
| [`30542384`](https://github.com/nix-community/NUR/commit/305423847c726b90793cfa498ee38e51de23b901) | `` automatic update `` |
| [`bc4ab6ed`](https://github.com/nix-community/NUR/commit/bc4ab6ed1bc031924e054e98bf3324ba8b4d8df8) | `` automatic update `` |