### PR TITLE
chore(flake/nix-index-database): `744d3306` -> `79b7b8ea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -453,11 +453,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737257306,
-        "narHash": "sha256-lEGgpA4kGafc76+Amnz+gh1L/cwUS2pePFlf22WEyh8=",
+        "lastModified": 1737861961,
+        "narHash": "sha256-LIRtMvAwLGb8pBoamzgEF67oKlNPz4LuXiRPVZf+TpE=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "744d330659e207a1883d2da0141d35e520eb87bd",
+        "rev": "79b7b8eae3243fc5aa9aad34ba6b9bbb2266f523",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`79b7b8ea`](https://github.com/nix-community/nix-index-database/commit/79b7b8eae3243fc5aa9aad34ba6b9bbb2266f523) | `` update generated.nix to release 2025-01-26-030915 `` |
| [`a07b10ac`](https://github.com/nix-community/nix-index-database/commit/a07b10ac6326546b93920b6345ee18f41bba6849) | `` flake.lock: Update ``                                |