### PR TITLE
chore(flake/emacs-overlay): `4ebe4c89` -> `b8e32860`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1737825153,
-        "narHash": "sha256-R1p2ZXOydII+MT/SpeOXBjo/dgfD/gIArge2YAgSw38=",
+        "lastModified": 1737911494,
+        "narHash": "sha256-XnQRqqRZZ5x28y4vy3yL25dMJk9s6wxnmwKQBfUlQCw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4ebe4c890e7c8662ae31192359a56b0505cf10ba",
+        "rev": "b8e32860b5c94c75e9efb1779b9b5a4bd4a7d655",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------- |
| [`b8e32860`](https://github.com/nix-community/emacs-overlay/commit/b8e32860b5c94c75e9efb1779b9b5a4bd4a7d655) | `` Updated emacs ``                    |
| [`1a7f8823`](https://github.com/nix-community/emacs-overlay/commit/1a7f882361bd552a05f33d35d0fdcec2a9dbb930) | `` Updated melpa ``                    |
| [`01d3541a`](https://github.com/nix-community/emacs-overlay/commit/01d3541ae87abe1a366c91642a518589d173946a) | `` Updated elpa ``                     |
| [`b6b40f5d`](https://github.com/nix-community/emacs-overlay/commit/b6b40f5d7ef0dc1c4a542ec5c819861701688552) | `` Updated nongnu ``                   |
| [`da7d94da`](https://github.com/nix-community/emacs-overlay/commit/da7d94da6f050424aba1f75d698bb9cc92abbf14) | `` Updated melpa ``                    |
| [`cda2a038`](https://github.com/nix-community/emacs-overlay/commit/cda2a0386cc568f2b5f22bb554fbe9f2e0b4b3b5) | `` Updated emacs ``                    |
| [`e1a127d2`](https://github.com/nix-community/emacs-overlay/commit/e1a127d279c42a3d935db6ab8771d5967b85c499) | `` Updated emacs ``                    |
| [`289bb67c`](https://github.com/nix-community/emacs-overlay/commit/289bb67c6d068e5af0cb4ee7223e9ef7c29a55b3) | `` Updated melpa ``                    |
| [`86d525f8`](https://github.com/nix-community/emacs-overlay/commit/86d525f88fcfc1355520a7be177231a88c5590ba) | `` Add emacs-igc and emacs-igc-pgtk `` |
| [`32f47ddd`](https://github.com/nix-community/emacs-overlay/commit/32f47dddc4d9b3a56b9bdc30ff981b698479a0bf) | `` Updated elpa ``                     |
| [`01d02e46`](https://github.com/nix-community/emacs-overlay/commit/01d02e46b9ee80a62c75e2f7bfecb87d1bba7c8a) | `` Updated nongnu ``                   |
| [`6e33a4eb`](https://github.com/nix-community/emacs-overlay/commit/6e33a4eb8a77201138c17e6da664f5adfe6ae633) | `` Updated flake inputs ``             |