### PR TITLE
chore(flake/nur): `595e1849` -> `2943013d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1737848713,
-        "narHash": "sha256-W8OEe5Hze2HoKWaisyNUyDKzhDr7FIROCbx11/Ye7JQ=",
+        "lastModified": 1737874317,
+        "narHash": "sha256-pXQC1+qYKSrnA/ouqVJhQoxT/1FmkPUet7Z58yejmmM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "595e18494dbdd9aea05784d11572824ae5949359",
+        "rev": "2943013db655c01d0e4126d8d68ba2036e8de18d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2943013d`](https://github.com/nix-community/NUR/commit/2943013db655c01d0e4126d8d68ba2036e8de18d) | `` automatic update `` |
| [`aceeb505`](https://github.com/nix-community/NUR/commit/aceeb50509915d0535ef1393c7d4151720cf490a) | `` automatic update `` |
| [`ea759a65`](https://github.com/nix-community/NUR/commit/ea759a65d0b12056237334ca03082fa49c4b963d) | `` automatic update `` |
| [`36dbf0de`](https://github.com/nix-community/NUR/commit/36dbf0de141a438dfe5fffb1f1da4810f72e3735) | `` automatic update `` |
| [`96c04c21`](https://github.com/nix-community/NUR/commit/96c04c216e5becc59f3565d1ea6f9d8855d9ac35) | `` automatic update `` |
| [`acea95ca`](https://github.com/nix-community/NUR/commit/acea95cabb132baa12ae34e382116cffc20b5cc7) | `` automatic update `` |
| [`66c0e424`](https://github.com/nix-community/NUR/commit/66c0e4240faf6dbc6f5270e0aeb4469ff0308327) | `` automatic update `` |
| [`a46b5671`](https://github.com/nix-community/NUR/commit/a46b5671b4379a020fd0c908c2dc1ce38a05cdb9) | `` automatic update `` |
| [`872fda80`](https://github.com/nix-community/NUR/commit/872fda80e82927a8ddeeea093d72e7bb94f66625) | `` automatic update `` |