### PR TITLE
chore(flake/nur): `2943013d` -> `b9839a65`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1737874317,
-        "narHash": "sha256-pXQC1+qYKSrnA/ouqVJhQoxT/1FmkPUet7Z58yejmmM=",
+        "lastModified": 1737906330,
+        "narHash": "sha256-DVL5AN8vzn+3uV3uCxxvGWZcgFzQL1SdFs30ez+rHT8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2943013db655c01d0e4126d8d68ba2036e8de18d",
+        "rev": "b9839a658614551c69e84c2bfafaa4efbb873e82",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b9839a65`](https://github.com/nix-community/NUR/commit/b9839a658614551c69e84c2bfafaa4efbb873e82) | `` automatic update `` |
| [`0d239c6d`](https://github.com/nix-community/NUR/commit/0d239c6d2cd196da5213576dda1e38b863b1a161) | `` automatic update `` |
| [`f6896878`](https://github.com/nix-community/NUR/commit/f6896878b8620b2e2bfddc6022ec092e564c8efd) | `` automatic update `` |
| [`ee6e560d`](https://github.com/nix-community/NUR/commit/ee6e560d3cbfdbb2d92d1d95c83aaa434ed42dc5) | `` automatic update `` |
| [`5ee047c2`](https://github.com/nix-community/NUR/commit/5ee047c2c9ca4400689d913843351c2c7e4f56fb) | `` automatic update `` |
| [`3b5418e0`](https://github.com/nix-community/NUR/commit/3b5418e0dcbb1ef77eedfcf74267f5458c1b52f0) | `` automatic update `` |
| [`e05dbeb1`](https://github.com/nix-community/NUR/commit/e05dbeb1dd69b28ce28d9ad2209dcd2a6db0fe8b) | `` automatic update `` |
| [`5249513d`](https://github.com/nix-community/NUR/commit/5249513d4a2943769fb71dd898e5d8a52a17fb3e) | `` automatic update `` |
| [`b55dbbc6`](https://github.com/nix-community/NUR/commit/b55dbbc679a31155f51782ec09105b57394c8aa4) | `` automatic update `` |
| [`61f6fc42`](https://github.com/nix-community/NUR/commit/61f6fc4251575263981c68fce2c92402c68ccefc) | `` automatic update `` |