### PR TITLE
chore(flake/nur): `b9839a65` -> `3a612ff6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -682,11 +682,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1737746512,
-        "narHash": "sha256-nU6AezEX4EuahTO1YopzueAXfjFfmCHylYEFCagduHU=",
+        "lastModified": 1737885589,
+        "narHash": "sha256-Zf0hSrtzaM1DEz8//+Xs51k/wdSajticVrATqDrfQjg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "825479c345a7f806485b7f00dbe3abb50641b083",
+        "rev": "852ff1d9e153d8875a83602e03fdef8a63f0ecf8",
         "type": "github"
       },
       "original": {
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1737906330,
-        "narHash": "sha256-DVL5AN8vzn+3uV3uCxxvGWZcgFzQL1SdFs30ez+rHT8=",
+        "lastModified": 1737923528,
+        "narHash": "sha256-SdENh9Ehi0Lm75O+InuNBICoEr1MHFt/jaioVclud74=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b9839a658614551c69e84c2bfafaa4efbb873e82",
+        "rev": "3a612ff68d51e051129d4d0aa17d25b64ecf55c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3a612ff6`](https://github.com/nix-community/NUR/commit/3a612ff68d51e051129d4d0aa17d25b64ecf55c8) | `` automatic update `` |
| [`4f397bc8`](https://github.com/nix-community/NUR/commit/4f397bc82cfb5263c1727c7cc261780815dffb86) | `` automatic update `` |
| [`41e12d5d`](https://github.com/nix-community/NUR/commit/41e12d5d84c83d85f122b8e9097fb7d390242154) | `` automatic update `` |
| [`2004369d`](https://github.com/nix-community/NUR/commit/2004369d160b931f539a03aa84a237cf48a53cfe) | `` automatic update `` |
| [`72076a2a`](https://github.com/nix-community/NUR/commit/72076a2a2ab1764183d9ff9dd0e137882e424359) | `` automatic update `` |
| [`a936aca5`](https://github.com/nix-community/NUR/commit/a936aca5704c961e30212c42c2032d1256feef32) | `` automatic update `` |