### PR TITLE
chore(flake/emacs-ultra-scroll): `2e3b9997` -> `2c517bf9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
     "emacs-ultra-scroll": {
       "flake": false,
       "locked": {
-        "lastModified": 1737229840,
-        "narHash": "sha256-9+3T5tXPRuRtENt/Rr0Ss3LZJlTOwpGePbREqofN2j0=",
+        "lastModified": 1737932205,
+        "narHash": "sha256-U2QTbxkch/oGdXXnzf2EPX3Ga3VYmQlnjC/JKBq5DEI=",
         "owner": "jdtsmith",
         "repo": "ultra-scroll",
-        "rev": "2e3b9997ae1a469e878feaa0af23a23685a0fbed",
+        "rev": "2c517bf9b61bf432f706ff8a585ba453c7476be2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                         |
| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
| [`2c517bf9`](https://github.com/jdtsmith/ultra-scroll/commit/2c517bf9b61bf432f706ff8a585ba453c7476be2) | `` re-enable make-cursor-line-fully-visible and bump version `` |