### PR TITLE
chore(flake/nur): `3a612ff6` -> `9fa21879`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1737923528,
-        "narHash": "sha256-SdENh9Ehi0Lm75O+InuNBICoEr1MHFt/jaioVclud74=",
+        "lastModified": 1737943717,
+        "narHash": "sha256-JR+pLqfi13qVmSh+rzVcu4BssNnERoClB+HPRrBtGkg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3a612ff68d51e051129d4d0aa17d25b64ecf55c8",
+        "rev": "9fa2187952b1050eb4da2d969f0c7a267697dace",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9fa21879`](https://github.com/nix-community/NUR/commit/9fa2187952b1050eb4da2d969f0c7a267697dace) | `` automatic update `` |
| [`03402e28`](https://github.com/nix-community/NUR/commit/03402e287403b88ae308b9bff17b6c014daf71cc) | `` automatic update `` |
| [`d8b236e8`](https://github.com/nix-community/NUR/commit/d8b236e8d1ecd476478d45d5fcad21af4a2c46ca) | `` automatic update `` |
| [`ed80721b`](https://github.com/nix-community/NUR/commit/ed80721b5a8b820df9148520e03e3e8aa5671a55) | `` automatic update `` |