### PR TITLE
chore(flake/srvos): `1910ec73` -> `6d69a63f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -884,11 +884,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737673068,
-        "narHash": "sha256-j1f1LsgjSrE4X1dMx0FncagOHGnqY5BJJoSkzYWPbeg=",
+        "lastModified": 1737939419,
+        "narHash": "sha256-v2fz0KNXQF7yq1VTHKaF/dNpuUz1GgIMeimORSStg/E=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "1910ec7346df1f6e1d2536c42c380c9a9ae58765",
+        "rev": "6d69a63fcb3a9b213ebd3b8754e71d2691fe3fbf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`6d69a63f`](https://github.com/nix-community/srvos/commit/6d69a63fcb3a9b213ebd3b8754e71d2691fe3fbf) | `` dev/private/flake.lock: Update `` |
| [`eaedd287`](https://github.com/nix-community/srvos/commit/eaedd287c7366eb1569f926e5a59c8f27c3a1734) | `` flake.lock: Update ``             |