### PR TITLE
chore(flake/emacs-overlay): `c78232a1` -> `0d9f55d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1737943625,
-        "narHash": "sha256-62D66uB/UKO5zFzjTveoi/wBdlGtmFUoK/WH/rKJSvc=",
+        "lastModified": 1738016495,
+        "narHash": "sha256-j30tsTE7srcqKGqeguecWimc8kgbHVak/pV4JstE6Jk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c78232a115e112a366e7a087c9db4657876cb87c",
+        "rev": "0d9f55d26372c847d822f17421eaeb1f470dc9e0",
         "type": "github"
       },
       "original": {
@@ -603,11 +603,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1737672001,
-        "narHash": "sha256-YnHJJ19wqmibLQdUeq9xzE6CjrMA568KN/lFPuSVs4I=",
+        "lastModified": 1737885640,
+        "narHash": "sha256-GFzPxJzTd1rPIVD4IW+GwJlyGwBDV1Tj5FLYwDQQ9sM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "035f8c0853c2977b24ffc4d0a42c74f00b182cd8",
+        "rev": "4e96537f163fad24ed9eb317798a79afc85b51b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                 |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------- |
| [`0d9f55d2`](https://github.com/nix-community/emacs-overlay/commit/0d9f55d26372c847d822f17421eaeb1f470dc9e0) | `` Fix src hash for timu-macos-theme `` |
| [`2251b6ce`](https://github.com/nix-community/emacs-overlay/commit/2251b6ce66de3f27aaf26779f2dc8c7b99402014) | `` Updated emacs ``                     |
| [`ed3bfdeb`](https://github.com/nix-community/emacs-overlay/commit/ed3bfdeb3186d836366d4b9d4ff28527cca9b541) | `` Updated melpa ``                     |
| [`ffb60eaf`](https://github.com/nix-community/emacs-overlay/commit/ffb60eaf3a77e32133340de5298b35beef3b0c09) | `` Updated elpa ``                      |
| [`637f7754`](https://github.com/nix-community/emacs-overlay/commit/637f775460733493ed9f6d7b87e7a44777f51118) | `` Updated nongnu ``                    |
| [`48779394`](https://github.com/nix-community/emacs-overlay/commit/48779394ffa6cab042b3ae9b894e3cf2d4f86e2d) | `` Updated emacs ``                     |
| [`ac838c63`](https://github.com/nix-community/emacs-overlay/commit/ac838c634493191fbe70a96b93d86378a7ad8cc4) | `` Updated melpa ``                     |
| [`5684de38`](https://github.com/nix-community/emacs-overlay/commit/5684de38908c100f4588ee1dc7eb89962052295b) | `` Updated flake inputs ``              |