### PR TITLE
chore(flake/darwin): `62ba0a22` -> `349a74c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737926801,
-        "narHash": "sha256-un7IETRNjUm83jM5Gd/7BO4rCzzkom46O0FDMo5toaI=",
+        "lastModified": 1738033138,
+        "narHash": "sha256-qlIM8A3bdL9c6PexhpS+QyZLO9y/8a3V75HVyJgDE5Q=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "62ba0a22426721c94e08f0779ed8235d5672869b",
+        "rev": "349a74c66c596ef97ee97b4d80a3ca61227b6120",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                     |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
| [`cc9c8408`](https://github.com/LnL7/nix-darwin/commit/cc9c8408bb9f29b4afe919eff4ad922d054cf591) | `` Revert "{activation-scripts,activate-system}: purify environment" ``     |
| [`3509925a`](https://github.com/LnL7/nix-darwin/commit/3509925a8634f08b764922577d169757b94df97b) | `` readme: make `darwin-rebuild` use more explicit ``                       |
| [`2733527a`](https://github.com/LnL7/nix-darwin/commit/2733527a586bad9939edc829017acdbc99654d9b) | `` {environment,readme}: default configuration path to `/etc/nix-darwin` `` |
| [`5bc4677c`](https://github.com/LnL7/nix-darwin/commit/5bc4677c03b61213912de654a9409d225fd9fe07) | `` readme: reduce duplication in installation instructions ``               |
| [`4bff4bc8`](https://github.com/LnL7/nix-darwin/commit/4bff4bc8ae105dbc3a56ed5255fbde9495cbf4c1) | `` {activation-scripts,activate-system}: purify environment ``              |
| [`ff80eacd`](https://github.com/LnL7/nix-darwin/commit/ff80eacd0f756fa2c410f9128b114eeb0b4e5bc5) | `` activation-scripts: remove `_status` ``                                  |
| [`0e87d3d3`](https://github.com/LnL7/nix-darwin/commit/0e87d3d3914321ceea5b10a87f48b6ff6179e190) | `` activate-system: don’t `KeepAlive` ``                                    |
| [`2119dd10`](https://github.com/LnL7/nix-darwin/commit/2119dd10f65e376dd42f32b0f7ec43577f48129a) | `` checks: remove `darwinChanges` ``                                        |
| [`1e16e2a9`](https://github.com/LnL7/nix-darwin/commit/1e16e2a9c25b5a15040686be6f07d0ce67043260) | `` ci: use the PR head as `<darwin>` for install test ``                    |