### PR TITLE
chore(flake/nur): `a3232c6b` -> `c46c8369`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1738007268,
-        "narHash": "sha256-i9jbFTAyRk8vhuna7pENLoUUb2DUbWpmQxaWvXroPB0=",
+        "lastModified": 1738059992,
+        "narHash": "sha256-VeNLLucQTlED2cqD3uofh968tm7u7UgwCdY5+jo/BSc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a3232c6b44fd2de7508117a6bd50a64fe42390af",
+        "rev": "c46c836963685acbd2430439f859b60f230b3643",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c46c8369`](https://github.com/nix-community/NUR/commit/c46c836963685acbd2430439f859b60f230b3643) | `` automatic update `` |
| [`5519cbe8`](https://github.com/nix-community/NUR/commit/5519cbe81ee306e404856a8974db940cb17d22da) | `` automatic update `` |
| [`560eb11f`](https://github.com/nix-community/NUR/commit/560eb11fb5e82a6393915aa8514b6b5638e3afd6) | `` automatic update `` |
| [`005914be`](https://github.com/nix-community/NUR/commit/005914be97fda97cd494d409c57e62283c583fec) | `` automatic update `` |
| [`b9cdec8c`](https://github.com/nix-community/NUR/commit/b9cdec8c1c4ceb96b9076b78d07619c4fc65e682) | `` automatic update `` |
| [`d1ca561e`](https://github.com/nix-community/NUR/commit/d1ca561e10056c92e94ad5d89b45ad327e286ab8) | `` automatic update `` |
| [`144d70ab`](https://github.com/nix-community/NUR/commit/144d70ab3915bfaef58c42270b369e232e3b37c2) | `` automatic update `` |
| [`3a551475`](https://github.com/nix-community/NUR/commit/3a5514751941809d58e30cee6118105a1300d334) | `` automatic update `` |
| [`42fa69de`](https://github.com/nix-community/NUR/commit/42fa69de88ad2376f72e60dd6070ed6c34086213) | `` automatic update `` |
| [`949fdd32`](https://github.com/nix-community/NUR/commit/949fdd329067106a84cc3739474a37257a500f4a) | `` automatic update `` |
| [`d2a1261a`](https://github.com/nix-community/NUR/commit/d2a1261a304ac97473a3671668ed6e6780122eb2) | `` automatic update `` |