### PR TITLE
chore(flake/emacs-overlay): `0d9f55d2` -> `1ea7ab3b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1738016495,
-        "narHash": "sha256-j30tsTE7srcqKGqeguecWimc8kgbHVak/pV4JstE6Jk=",
+        "lastModified": 1738029950,
+        "narHash": "sha256-CqlOn2vpMNBcyPbQvXFtyMVTL53FKOdCnVLQu502Q1U=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0d9f55d26372c847d822f17421eaeb1f470dc9e0",
+        "rev": "1ea7ab3b2f3555765d73ccbc2271ed4c45e50155",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`1ea7ab3b`](https://github.com/nix-community/emacs-overlay/commit/1ea7ab3b2f3555765d73ccbc2271ed4c45e50155) | `` Updated emacs ``  |
| [`87fe07e0`](https://github.com/nix-community/emacs-overlay/commit/87fe07e0d861d4161152f753cbf1bedfa8b39569) | `` Updated melpa ``  |
| [`e0f7a48b`](https://github.com/nix-community/emacs-overlay/commit/e0f7a48bb47646cb4d134085c2a4351b06786bbf) | `` Updated elpa ``   |
| [`76c3d04c`](https://github.com/nix-community/emacs-overlay/commit/76c3d04c25e5fe40c54011317f696173454def08) | `` Updated nongnu `` |