### PR TITLE
chore(flake/emacs-overlay): `1ea7ab3b` -> `3c3d53a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1738029950,
-        "narHash": "sha256-CqlOn2vpMNBcyPbQvXFtyMVTL53FKOdCnVLQu502Q1U=",
+        "lastModified": 1738055761,
+        "narHash": "sha256-PhMIuZboby800p4kXzo+0pq9zyR1r714A6N4Xz7wnn4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1ea7ab3b2f3555765d73ccbc2271ed4c45e50155",
+        "rev": "3c3d53a6a1d65959bcfd3045fa7411da9c1f3ead",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`3c3d53a6`](https://github.com/nix-community/emacs-overlay/commit/3c3d53a6a1d65959bcfd3045fa7411da9c1f3ead) | `` Updated emacs `` |
| [`9caa7acd`](https://github.com/nix-community/emacs-overlay/commit/9caa7acdd6434064bb0ff899f7b87fc955399553) | `` Updated melpa `` |