### PR TITLE
chore(flake/nur): `c46c8369` -> `1c718529`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1738059992,
-        "narHash": "sha256-VeNLLucQTlED2cqD3uofh968tm7u7UgwCdY5+jo/BSc=",
+        "lastModified": 1738121352,
+        "narHash": "sha256-/zTcxOuUlorG5xuVqZM74AEqyoUuvAGFgf7ZRsY0fB0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c46c836963685acbd2430439f859b60f230b3643",
+        "rev": "1c718529e3d4d262ad378d25faa009019d9f4a1a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1c718529`](https://github.com/nix-community/NUR/commit/1c718529e3d4d262ad378d25faa009019d9f4a1a) | `` automatic update `` |
| [`c18edf4b`](https://github.com/nix-community/NUR/commit/c18edf4bd86b9c8272f8e85edc0d88aadbd0cae3) | `` automatic update `` |
| [`7c6cc3ef`](https://github.com/nix-community/NUR/commit/7c6cc3ef0c9487104dccf36d15e4153586e02b31) | `` automatic update `` |
| [`3fdbb477`](https://github.com/nix-community/NUR/commit/3fdbb477c3a1325862cb8238dbbba7e05d33554b) | `` automatic update `` |
| [`97496616`](https://github.com/nix-community/NUR/commit/9749661663bff263eb630f3a7f200e8b5a6ce3da) | `` automatic update `` |
| [`46d45ab1`](https://github.com/nix-community/NUR/commit/46d45ab1273f9a47ea20c2b147b1b3c74dab33c1) | `` automatic update `` |
| [`d145ea9e`](https://github.com/nix-community/NUR/commit/d145ea9eab67415adf1b8b03fea87f3f4a6cb39e) | `` automatic update `` |
| [`53c77b89`](https://github.com/nix-community/NUR/commit/53c77b897102c1b83a0a6f06b45f81d98372d5a6) | `` automatic update `` |
| [`99799270`](https://github.com/nix-community/NUR/commit/997992706702477984466ddca986e0d1ff74e3af) | `` automatic update `` |
| [`36df140b`](https://github.com/nix-community/NUR/commit/36df140bac0acd509a2b45ce70bfaa8974829801) | `` automatic update `` |