### PR TITLE
chore(flake/emacs-overlay): `3c3d53a6` -> `497be68b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1738055761,
-        "narHash": "sha256-PhMIuZboby800p4kXzo+0pq9zyR1r714A6N4Xz7wnn4=",
+        "lastModified": 1738116516,
+        "narHash": "sha256-tfaHVqHUIQd1GKBuOB5iqYbJV9sgGJn+h0i+Qi2wDRY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3c3d53a6a1d65959bcfd3045fa7411da9c1f3ead",
+        "rev": "497be68b191fb8e35dfb015a3ded3b00b82da144",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`497be68b`](https://github.com/nix-community/emacs-overlay/commit/497be68b191fb8e35dfb015a3ded3b00b82da144) | `` Updated emacs ``  |
| [`e728886e`](https://github.com/nix-community/emacs-overlay/commit/e728886ee1aeb0b7bb5766656e05161d672c6b8c) | `` Updated melpa ``  |
| [`7d96066f`](https://github.com/nix-community/emacs-overlay/commit/7d96066f80c93ecc62620e925d1fb8edfa6dbbc6) | `` Updated elpa ``   |
| [`7aa72a6f`](https://github.com/nix-community/emacs-overlay/commit/7aa72a6f74d275f0941b6eb07527c41d17db467e) | `` Updated nongnu `` |
| [`7ec38a36`](https://github.com/nix-community/emacs-overlay/commit/7ec38a3697c36f10e8a821dec4ad4e21763e6421) | `` Updated emacs ``  |
| [`ff85c55a`](https://github.com/nix-community/emacs-overlay/commit/ff85c55a42b1fc68931f2091eff261942f893ded) | `` Updated melpa ``  |
| [`593e672c`](https://github.com/nix-community/emacs-overlay/commit/593e672c83daa6791775de9457125cf6a5468db8) | `` Updated elpa ``   |
| [`9995fbcd`](https://github.com/nix-community/emacs-overlay/commit/9995fbcdd1cdf0864524ce716087e0dafa5ce8a9) | `` Updated nongnu `` |