### PR TITLE
chore(flake/nur): `1c718529` -> `8dc161fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1738121352,
-        "narHash": "sha256-/zTcxOuUlorG5xuVqZM74AEqyoUuvAGFgf7ZRsY0fB0=",
+        "lastModified": 1738151145,
+        "narHash": "sha256-/JrpHB28vXKG/2kpoLbgY/T0FIshWdLEJ+HHObU2Ueo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1c718529e3d4d262ad378d25faa009019d9f4a1a",
+        "rev": "8dc161fb573d6c8295a119befb763eaeb3806ea3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8dc161fb`](https://github.com/nix-community/NUR/commit/8dc161fb573d6c8295a119befb763eaeb3806ea3) | `` automatic update `` |
| [`d221a29d`](https://github.com/nix-community/NUR/commit/d221a29d4b156f902fd43c95ae242b406fc01846) | `` automatic update `` |
| [`bd1c56c4`](https://github.com/nix-community/NUR/commit/bd1c56c466901f2ca71efebfe518dcacbda4e8de) | `` automatic update `` |
| [`2a16abae`](https://github.com/nix-community/NUR/commit/2a16abae2fdaaf0fad9b93500b5e4aba956e5de1) | `` automatic update `` |
| [`df2dc36b`](https://github.com/nix-community/NUR/commit/df2dc36bfecd0c54b70651e7f63770a3adbf56ce) | `` automatic update `` |
| [`d3697f50`](https://github.com/nix-community/NUR/commit/d3697f5024f1cd78908d550d183c4266c23289ec) | `` automatic update `` |
| [`cee35b5e`](https://github.com/nix-community/NUR/commit/cee35b5efe9f7bed6e553fba1f275f2827778d99) | `` automatic update `` |
| [`639cd488`](https://github.com/nix-community/NUR/commit/639cd48858d689fa728d4ef0094c980303c193e1) | `` automatic update `` |
| [`4a9d9286`](https://github.com/nix-community/NUR/commit/4a9d92865fd5f83d083d843a4107023f5a6b324b) | `` automatic update `` |
| [`fd6824aa`](https://github.com/nix-community/NUR/commit/fd6824aa672049ef000eef84100e5b3a405c9a36) | `` automatic update `` |
| [`0f073c75`](https://github.com/nix-community/NUR/commit/0f073c75528319da37d669399336dab5d0a7d255) | `` automatic update `` |