### PR TITLE
chore(flake/emacs-overlay): `497be68b` -> `32a95da7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1738116516,
-        "narHash": "sha256-tfaHVqHUIQd1GKBuOB5iqYbJV9sgGJn+h0i+Qi2wDRY=",
+        "lastModified": 1738171058,
+        "narHash": "sha256-FzhIIO/D0dIHCss5SkQL2J6Jqur48wAD4OPwCYJo8Gk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "497be68b191fb8e35dfb015a3ded3b00b82da144",
+        "rev": "32a95da7a2c59af7c3cc899e7f4659d15f9e703d",
         "type": "github"
       },
       "original": {
@@ -603,11 +603,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1737885640,
-        "narHash": "sha256-GFzPxJzTd1rPIVD4IW+GwJlyGwBDV1Tj5FLYwDQQ9sM=",
+        "lastModified": 1738023785,
+        "narHash": "sha256-BPHmb3fUwdHkonHyHi1+x89eXB3kA1jffIpwPVJIVys=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4e96537f163fad24ed9eb317798a79afc85b51b7",
+        "rev": "2b4230bf03deb33103947e2528cac2ed516c5c89",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`32a95da7`](https://github.com/nix-community/emacs-overlay/commit/32a95da7a2c59af7c3cc899e7f4659d15f9e703d) | `` Updated emacs ``        |
| [`8b23f27b`](https://github.com/nix-community/emacs-overlay/commit/8b23f27bc4e80b3b9e29aea6cdb64b651cf28076) | `` Updated melpa ``        |
| [`73bb0adf`](https://github.com/nix-community/emacs-overlay/commit/73bb0adf1b38b8b75fe7701f71938857f629f6b8) | `` Updated elpa ``         |
| [`df053c8f`](https://github.com/nix-community/emacs-overlay/commit/df053c8fcf35c4da7beede9e3602bd6403fe8cb2) | `` Updated nongnu ``       |
| [`0f163b9e`](https://github.com/nix-community/emacs-overlay/commit/0f163b9ed898d12dfc5c5eafc4d4555f92c7b0e8) | `` Updated flake inputs `` |
| [`5b88577d`](https://github.com/nix-community/emacs-overlay/commit/5b88577d054c2bf3ccefc65474daa0aa74d2507c) | `` Updated melpa ``        |