### PR TITLE
chore(flake/nur): `8dc161fb` -> `fdbcb6e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1738151145,
-        "narHash": "sha256-/JrpHB28vXKG/2kpoLbgY/T0FIshWdLEJ+HHObU2Ueo=",
+        "lastModified": 1738180320,
+        "narHash": "sha256-gHObDkbj/QX0aFSitg5HVrAEDwdGnV2GxgsQOOB/w4U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8dc161fb573d6c8295a119befb763eaeb3806ea3",
+        "rev": "fdbcb6e5417f5a0aafb289fcf53481a0e3821e9c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fdbcb6e5`](https://github.com/nix-community/NUR/commit/fdbcb6e5417f5a0aafb289fcf53481a0e3821e9c) | `` automatic update `` |
| [`55de07e8`](https://github.com/nix-community/NUR/commit/55de07e838a896f7110d1c3f6b4e3595f16b9de5) | `` automatic update `` |
| [`6762c320`](https://github.com/nix-community/NUR/commit/6762c320e9bc88957e0ba7b41254ed7630283d80) | `` automatic update `` |
| [`625e6e62`](https://github.com/nix-community/NUR/commit/625e6e6253e998c21e97a7911b68f1cbc62adb56) | `` automatic update `` |
| [`c66995c0`](https://github.com/nix-community/NUR/commit/c66995c0f9de5576209f9b7d2c4455caa44ba8ef) | `` automatic update `` |
| [`15c73414`](https://github.com/nix-community/NUR/commit/15c73414811efa494be8092d22a78bae7cdc3f35) | `` automatic update `` |
| [`7e2ca07d`](https://github.com/nix-community/NUR/commit/7e2ca07db0689990c6baf152ddc8c169d95af4f5) | `` automatic update `` |
| [`70e8dd0f`](https://github.com/nix-community/NUR/commit/70e8dd0fef6799884662d76782eb534cbbe6a103) | `` automatic update `` |