### PR TITLE
chore(flake/emacs-overlay): `32a95da7` -> `65eacdb3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1738171058,
-        "narHash": "sha256-FzhIIO/D0dIHCss5SkQL2J6Jqur48wAD4OPwCYJo8Gk=",
+        "lastModified": 1738257595,
+        "narHash": "sha256-dTgNrcqq4qkkhTBdeGUhrQ6MtE1gjB4UBG627N33Lvo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "32a95da7a2c59af7c3cc899e7f4659d15f9e703d",
+        "rev": "65eacdb31336e6af536e4be8c37b8fc462b9d206",
         "type": "github"
       },
       "original": {
@@ -603,11 +603,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1738023785,
-        "narHash": "sha256-BPHmb3fUwdHkonHyHi1+x89eXB3kA1jffIpwPVJIVys=",
+        "lastModified": 1738163270,
+        "narHash": "sha256-B/7Y1v4y+msFFBW1JAdFjNvVthvNdJKiN6EGRPnqfno=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2b4230bf03deb33103947e2528cac2ed516c5c89",
+        "rev": "59e618d90c065f55ae48446f307e8c09565d5ab0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`65eacdb3`](https://github.com/nix-community/emacs-overlay/commit/65eacdb31336e6af536e4be8c37b8fc462b9d206) | `` Updated emacs ``        |
| [`36c166e4`](https://github.com/nix-community/emacs-overlay/commit/36c166e434efe7be41c195f625167d5b029cd21b) | `` Updated melpa ``        |
| [`13d1a6c6`](https://github.com/nix-community/emacs-overlay/commit/13d1a6c633b44096f6e01f8d866eeefce029efc5) | `` Updated elpa ``         |
| [`2c1e575c`](https://github.com/nix-community/emacs-overlay/commit/2c1e575cf906a8caffbcb2637e22b354194cf6ef) | `` Updated nongnu ``       |
| [`1e3650ba`](https://github.com/nix-community/emacs-overlay/commit/1e3650ba7abda10b95625c63aa7f8a13dffc49a3) | `` Updated flake inputs `` |
| [`bf817bb8`](https://github.com/nix-community/emacs-overlay/commit/bf817bb80b020ffdeee5769867b8862026bd5312) | `` Updated emacs ``        |
| [`78979aea`](https://github.com/nix-community/emacs-overlay/commit/78979aeab724d4a9a6c4c31194cf947c0397d69b) | `` Updated melpa ``        |
| [`a8f67a6a`](https://github.com/nix-community/emacs-overlay/commit/a8f67a6a631761a897cb40a69782e00e8677e9e5) | `` Updated emacs ``        |
| [`48b0cc35`](https://github.com/nix-community/emacs-overlay/commit/48b0cc35316cb0c07ef56e98e428ca28c667f88e) | `` Updated melpa ``        |
| [`1647b845`](https://github.com/nix-community/emacs-overlay/commit/1647b8455c375d8beffab1bde467789b96923e5b) | `` Updated elpa ``         |
| [`1ea14c73`](https://github.com/nix-community/emacs-overlay/commit/1ea14c733f3ac4969dbcf9d4a6371de5df9f9824) | `` Updated nongnu ``       |
| [`3b0a54b3`](https://github.com/nix-community/emacs-overlay/commit/3b0a54b3b5f721ac34ae3c7aae892c4124b71e03) | `` Updated flake inputs `` |