### PR TITLE
chore(flake/nur): `e64f98bc` -> `e4cbe85f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1738194310,
-        "narHash": "sha256-0H/bcSD7W4FWvSWq5Jnv751zcUeySpbQb536XCxfEo4=",
+        "lastModified": 1738209019,
+        "narHash": "sha256-w0D8PdncWGjIGTWGApYNxgKSrZGcvRi9qFOar0I5Acg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e64f98bca5b42c3a3107ad74df96f1e001ce97f8",
+        "rev": "e4cbe85ffa2b9ecbd80aded528ca7b64445b244d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e4cbe85f`](https://github.com/nix-community/NUR/commit/e4cbe85ffa2b9ecbd80aded528ca7b64445b244d) | `` automatic update `` |
| [`786f76aa`](https://github.com/nix-community/NUR/commit/786f76aa54fe6471db99202fa6a138ea1aaa31ca) | `` automatic update `` |
| [`c53ed386`](https://github.com/nix-community/NUR/commit/c53ed386366d32df01bac821e517fc8b3801eb43) | `` automatic update `` |
| [`2e77a214`](https://github.com/nix-community/NUR/commit/2e77a214e3d8f04c4c2af21b551ce42a595dc452) | `` automatic update `` |