### PR TITLE
chore(flake/srvos): `6d69a63f` -> `7d5a4aaa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -884,11 +884,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737939419,
-        "narHash": "sha256-v2fz0KNXQF7yq1VTHKaF/dNpuUz1GgIMeimORSStg/E=",
+        "lastModified": 1738198321,
+        "narHash": "sha256-lhnHBXO9Y8xEn92JqxjancdL8Gh16ONuxZp60iZfmX4=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "6d69a63fcb3a9b213ebd3b8754e71d2691fe3fbf",
+        "rev": "7d5a4aaadac9ff63f9ed4347df95175aceee5079",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`7d5a4aaa`](https://github.com/nix-community/srvos/commit/7d5a4aaadac9ff63f9ed4347df95175aceee5079) | `` dev/private/flake.lock: Update `` |
| [`c2e29d24`](https://github.com/nix-community/srvos/commit/c2e29d24a3e1c058dde7ec7d3ea50f64394da436) | `` flake.lock: Update ``             |