### PR TITLE
chore(flake/nur): `e4cbe85f` -> `abab056b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1738209019,
-        "narHash": "sha256-w0D8PdncWGjIGTWGApYNxgKSrZGcvRi9qFOar0I5Acg=",
+        "lastModified": 1738238671,
+        "narHash": "sha256-WcHVGRdLMsrUjzgmStCUzR+5wTmnXgzYNP0Rccro6Xw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e4cbe85ffa2b9ecbd80aded528ca7b64445b244d",
+        "rev": "abab056b7631a40002033e97b2a8aee782b5abf8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`abab056b`](https://github.com/nix-community/NUR/commit/abab056b7631a40002033e97b2a8aee782b5abf8) | `` automatic update `` |
| [`5bfee3ae`](https://github.com/nix-community/NUR/commit/5bfee3ae9ea87b03f07b2e38d9a6523362f4acb1) | `` automatic update `` |
| [`9e08e3a7`](https://github.com/nix-community/NUR/commit/9e08e3a73ad38495ac57d317fe82f5d79cd6d28c) | `` automatic update `` |
| [`5fbdcf7c`](https://github.com/nix-community/NUR/commit/5fbdcf7c9d4d6ff27a9b4833038718c1dc8e84ae) | `` automatic update `` |
| [`6668a406`](https://github.com/nix-community/NUR/commit/6668a4066e11f7fe713a90c590a0931dfeb50f1d) | `` automatic update `` |
| [`426905c6`](https://github.com/nix-community/NUR/commit/426905c68424d40a05f96282dd515769e09745c3) | `` automatic update `` |