### PR TITLE
chore(flake/nur): `abab056b` -> `cb6bec76`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1738238671,
-        "narHash": "sha256-WcHVGRdLMsrUjzgmStCUzR+5wTmnXgzYNP0Rccro6Xw=",
+        "lastModified": 1738266343,
+        "narHash": "sha256-7iXg8E5U17ggagVDR6bCnozjvynaQwlAKRFm0Mxxoqw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "abab056b7631a40002033e97b2a8aee782b5abf8",
+        "rev": "cb6bec76e22a4320b0fb2b37f54bb10123d1deb2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cb6bec76`](https://github.com/nix-community/NUR/commit/cb6bec76e22a4320b0fb2b37f54bb10123d1deb2) | `` automatic update `` |
| [`2a4c8bc1`](https://github.com/nix-community/NUR/commit/2a4c8bc15056585d661584c4441bb766427c5640) | `` automatic update `` |
| [`5caeb674`](https://github.com/nix-community/NUR/commit/5caeb6744cd9a201a82908f6deafac63b7ef234e) | `` automatic update `` |
| [`33c03d78`](https://github.com/nix-community/NUR/commit/33c03d78db3207191c0231c4fa3c51be95abd891) | `` automatic update `` |
| [`947654f9`](https://github.com/nix-community/NUR/commit/947654f99124fcfc0d2703557815495a03584f76) | `` automatic update `` |