### PR TITLE
chore(flake/emacs-overlay): `65eacdb3` -> `84447d57`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1738257595,
-        "narHash": "sha256-dTgNrcqq4qkkhTBdeGUhrQ6MtE1gjB4UBG627N33Lvo=",
+        "lastModified": 1738289233,
+        "narHash": "sha256-n2LxA18F5ZMt+FKKegWGCUA2VjmMENJLTFA8MUCgFTU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "65eacdb31336e6af536e4be8c37b8fc462b9d206",
+        "rev": "84447d574a9a21f6e3b04fce7c7279afb15f24c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`84447d57`](https://github.com/nix-community/emacs-overlay/commit/84447d574a9a21f6e3b04fce7c7279afb15f24c3) | `` Updated emacs ``  |
| [`8094f314`](https://github.com/nix-community/emacs-overlay/commit/8094f3145d551c7b99bf5b749d4525be0a9d0cce) | `` Updated melpa ``  |
| [`373c03bb`](https://github.com/nix-community/emacs-overlay/commit/373c03bb4cda176516b304ccb4481e0101c964ee) | `` Updated elpa ``   |
| [`c27a3c54`](https://github.com/nix-community/emacs-overlay/commit/c27a3c5433fcab75e9eb66cc81d7ce1503905526) | `` Updated nongnu `` |