### PR TITLE
chore(flake/sops-nix): `015d461c` -> `4c125190`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -864,11 +864,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737411508,
-        "narHash": "sha256-j9IdflJwRtqo9WpM0OfAZml47eBblUHGNQTe62OUqTw=",
+        "lastModified": 1738291974,
+        "narHash": "sha256-wkwYJc8cKmmQWUloyS9KwttBnja2ONRuJQDEsmef320=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "015d461c16678fc02a2f405eb453abb509d4e1d4",
+        "rev": "4c1251904d8a08c86ac6bc0d72cc09975e89aef7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                           |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`4c125190`](https://github.com/Mic92/sops-nix/commit/4c1251904d8a08c86ac6bc0d72cc09975e89aef7) | `` fix import keys hook using unbound variable `` |