### PR TITLE
chore(flake/emacs-overlay): `84447d57` -> `6e04073e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1738289233,
-        "narHash": "sha256-n2LxA18F5ZMt+FKKegWGCUA2VjmMENJLTFA8MUCgFTU=",
+        "lastModified": 1738377543,
+        "narHash": "sha256-EQCzEcRZCksjwckHC9lDQ2J2cXUtF3XP0EbJiE4Y3zE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "84447d574a9a21f6e3b04fce7c7279afb15f24c3",
+        "rev": "6e04073ea3d01fde5003e4fe0fd326286f921583",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`6e04073e`](https://github.com/nix-community/emacs-overlay/commit/6e04073ea3d01fde5003e4fe0fd326286f921583) | `` Updated emacs ``  |
| [`a7d107bc`](https://github.com/nix-community/emacs-overlay/commit/a7d107bce5ede7f7a7bbc5f3cfba4a66db58d391) | `` Updated melpa ``  |
| [`b043aa17`](https://github.com/nix-community/emacs-overlay/commit/b043aa179e5f6e2cab982a7a1a829aa62eaf0152) | `` Updated elpa ``   |
| [`40146848`](https://github.com/nix-community/emacs-overlay/commit/401468485c283e01395926beba2ffd7e0d25fd57) | `` Updated nongnu `` |
| [`49b92479`](https://github.com/nix-community/emacs-overlay/commit/49b92479d543bfc85fc7935a390e32fa023bc08c) | `` Updated emacs ``  |
| [`54930bbf`](https://github.com/nix-community/emacs-overlay/commit/54930bbffe2cf9f14e057d1825b7195b0301c152) | `` Updated melpa ``  |
| [`6bca7e49`](https://github.com/nix-community/emacs-overlay/commit/6bca7e496460a9cd4c2956579c57aae43328f4fd) | `` Updated elpa ``   |
| [`b4a599b9`](https://github.com/nix-community/emacs-overlay/commit/b4a599b9b780571fbe60be00e85e83307cdb66f4) | `` Updated nongnu `` |
| [`393224b4`](https://github.com/nix-community/emacs-overlay/commit/393224b463dab363543ac2b6c96f41777516221c) | `` Updated emacs ``  |
| [`1300f8d7`](https://github.com/nix-community/emacs-overlay/commit/1300f8d7b20f3d0df0be8a0e0132b6abc1b1c576) | `` Updated melpa ``  |