### PR TITLE
chore(flake/nixos-cosmic): `779ac61e` -> `51b9cce0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -498,11 +498,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1738300151,
-        "narHash": "sha256-M7YaNlK7HFG5+GKj07gOTIzEx+4KEDkLPmhlvneUBnk=",
+        "lastModified": 1738343111,
+        "narHash": "sha256-y9st4Y0p5ry+6QdlIGeqxAA6rbEIOO1uXdAc5jxV2Bc=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "779ac61eb10761c271767217ac171434751f20d2",
+        "rev": "51b9cce097da369550f45ac07879274dc8be81e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                           |
| ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`51b9cce0`](https://github.com/lilyinstarlight/nixos-cosmic/commit/51b9cce097da369550f45ac07879274dc8be81e4) | `` pkgs: rename some cosmic-ext- apps to match upstream (#612) `` |
| [`19fcc87f`](https://github.com/lilyinstarlight/nixos-cosmic/commit/19fcc87f1bf3510f5c1fde33f1a79e5ef945af05) | `` nixos/cosmic: add tray.target ``                               |
| [`b074af96`](https://github.com/lilyinstarlight/nixos-cosmic/commit/b074af96c2808117f3ec4763758a772a72bdfda0) | `` quick-webapps: fix bump build (#632) ``                        |