### PR TITLE
chore(flake/nixos-hardware): `dfad538f` -> `34b64e4e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -528,11 +528,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1737751639,
-        "narHash": "sha256-ZEbOJ9iT72iwqXsiEMbEa8wWjyFvRA9Ugx8utmYbpz4=",
+        "lastModified": 1738391520,
+        "narHash": "sha256-6HI58PKjddsC0RA0gBQlt6ox47oH//jLUHwx05RO8g0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "dfad538f751a5aa5d4436d9781ab27a6128ec9d4",
+        "rev": "34b64e4e1ddb14e3ffc7db8d4a781396dbbab773",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`34b64e4e`](https://github.com/NixOS/nixos-hardware/commit/34b64e4e1ddb14e3ffc7db8d4a781396dbbab773) | `` dell-inspiron-3442: init ``                    |
| [`21fa5853`](https://github.com/NixOS/nixos-hardware/commit/21fa58535d4a77283e4a85dccaf05dd0cf7af800) | `` apple/t2: kernel 6.12.4 -> 6.13 ``             |
| [`95c8efc0`](https://github.com/NixOS/nixos-hardware/commit/95c8efc0cb78ed190c03c6bd97f6dbbcdc0caaf8) | `` apple/t2: remove apple_set_os loader option `` |
| [`3009bcb0`](https://github.com/NixOS/nixos-hardware/commit/3009bcb058c036bf8312079da701146663dcf971) | `` lenovo/thinkpad/t490s: init ``                 |