### PR TITLE
chore(flake/home-manager): `801ddd86` -> `dae6d346`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738378034,
-        "narHash": "sha256-mldSa2NhDlnjqeSSFTNnkXIDrCLltpJfhrHUMBBKEiY=",
+        "lastModified": 1738428726,
+        "narHash": "sha256-OUoEgorFHBVnqQ2lITqs6MGN7MH4t/8hLEO29OKu6CM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "801ddd8693481866c2cfb1efd44ddbae778ea572",
+        "rev": "dae6d3460c8bab3ac9f38a86affe45b32818e764",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                               |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`dae6d346`](https://github.com/nix-community/home-manager/commit/dae6d3460c8bab3ac9f38a86affe45b32818e764) | `` git: add default value null to programs.git.signing.key (#6032) `` |
| [`8544cd09`](https://github.com/nix-community/home-manager/commit/8544cd092047a7e92d0dce011108a563de7fc0f2) | `` lapce: add module (#5752) ``                                       |
| [`055c6705`](https://github.com/nix-community/home-manager/commit/055c67056d87577a39af4144ad5eadb093cfb97d) | `` fcitx5: add waylandFrontend option to not set env vars (#5431) ``  |