### PR TITLE
chore(flake/emacs-overlay): `6e04073e` -> `2c113c71`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1738377543,
-        "narHash": "sha256-EQCzEcRZCksjwckHC9lDQ2J2cXUtF3XP0EbJiE4Y3zE=",
+        "lastModified": 1738401115,
+        "narHash": "sha256-fPlNjx90JW7gMr19XlY2zEVJTFnV1nmhaJBdSmZ0efY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6e04073ea3d01fde5003e4fe0fd326286f921583",
+        "rev": "2c113c718a7cbe167e6e5ac7f9228f02c815c8e5",
         "type": "github"
       },
       "original": {
@@ -603,11 +603,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1738163270,
-        "narHash": "sha256-B/7Y1v4y+msFFBW1JAdFjNvVthvNdJKiN6EGRPnqfno=",
+        "lastModified": 1738277201,
+        "narHash": "sha256-6L+WXKCw5mqnUIExvqkD99pJQ41xgyCk6z/H9snClwk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "59e618d90c065f55ae48446f307e8c09565d5ab0",
+        "rev": "666e1b3f09c267afd66addebe80fb05a5ef2b554",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`2c113c71`](https://github.com/nix-community/emacs-overlay/commit/2c113c718a7cbe167e6e5ac7f9228f02c815c8e5) | `` Updated emacs ``        |
| [`f1a63305`](https://github.com/nix-community/emacs-overlay/commit/f1a6330580de72bab1974fcdc22ae1157f4195ea) | `` Updated melpa ``        |
| [`7d4eee10`](https://github.com/nix-community/emacs-overlay/commit/7d4eee101a9d0cb8d5ef9aa808e69a90e001208a) | `` Updated flake inputs `` |