### PR TITLE
chore(flake/emacs-overlay): `2c113c71` -> `a7f332f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1738401115,
-        "narHash": "sha256-fPlNjx90JW7gMr19XlY2zEVJTFnV1nmhaJBdSmZ0efY=",
+        "lastModified": 1738487447,
+        "narHash": "sha256-ijAfzHCr489cenoBBcmBn3huyeoitLx1f/9t2LaOwmE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2c113c718a7cbe167e6e5ac7f9228f02c815c8e5",
+        "rev": "a7f332f6e0813c9d0f53fe6539be1e7a65fff2e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`a7f332f6`](https://github.com/nix-community/emacs-overlay/commit/a7f332f6e0813c9d0f53fe6539be1e7a65fff2e4) | `` Updated emacs ``        |
| [`b357c15f`](https://github.com/nix-community/emacs-overlay/commit/b357c15f993289f99d93683f68a3566b3cc89f84) | `` Updated melpa ``        |
| [`ff7476cf`](https://github.com/nix-community/emacs-overlay/commit/ff7476cfaab15541bb4eb769b50dc213c86fcf70) | `` Updated emacs ``        |
| [`612d55ca`](https://github.com/nix-community/emacs-overlay/commit/612d55ca04d52588122ce011fd2a98c12a32723d) | `` Updated melpa ``        |
| [`44ae5ad1`](https://github.com/nix-community/emacs-overlay/commit/44ae5ad163002c91d3f897a2dc369f42a5974f93) | `` Updated elpa ``         |
| [`e7d4ad3f`](https://github.com/nix-community/emacs-overlay/commit/e7d4ad3f3aad64c637756bfaecb65f1697e9edcf) | `` Updated nongnu ``       |
| [`2ea5345a`](https://github.com/nix-community/emacs-overlay/commit/2ea5345a3b286ccb9b03e33117903cd231787ccc) | `` Updated flake inputs `` |
| [`0e90dd66`](https://github.com/nix-community/emacs-overlay/commit/0e90dd66704c0f06531cf10829c2704b2c017be9) | `` Updated emacs ``        |
| [`7e2397cd`](https://github.com/nix-community/emacs-overlay/commit/7e2397cd915221afd6d2d0ba372e01c0797f0f7c) | `` Updated melpa ``        |
| [`635dd541`](https://github.com/nix-community/emacs-overlay/commit/635dd541608e440cba25c39cbce6c8adb4930a34) | `` Updated elpa ``         |
| [`ed14de81`](https://github.com/nix-community/emacs-overlay/commit/ed14de81fe63a9c2e8a944176bc91f6fc6b872bf) | `` Updated nongnu ``       |