### PR TITLE
chore(flake/emacs-overlay): `a7f332f6` -> `e48d296c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1738487447,
-        "narHash": "sha256-ijAfzHCr489cenoBBcmBn3huyeoitLx1f/9t2LaOwmE=",
+        "lastModified": 1738516271,
+        "narHash": "sha256-RGNdH+MCSmMOFvTbuDlHAN1IyGSzbgk34YtAsFB6EWg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a7f332f6e0813c9d0f53fe6539be1e7a65fff2e4",
+        "rev": "e48d296c3c6fb18dae58a8f017f254f3a430ee83",
         "type": "github"
       },
       "original": {
@@ -603,11 +603,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1738277201,
-        "narHash": "sha256-6L+WXKCw5mqnUIExvqkD99pJQ41xgyCk6z/H9snClwk=",
+        "lastModified": 1738435198,
+        "narHash": "sha256-5+Hmo4nbqw8FrW85FlNm4IIrRnZ7bn0cmXlScNsNRLo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "666e1b3f09c267afd66addebe80fb05a5ef2b554",
+        "rev": "f6687779bf4c396250831aa5a32cbfeb85bb07a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`e48d296c`](https://github.com/nix-community/emacs-overlay/commit/e48d296c3c6fb18dae58a8f017f254f3a430ee83) | `` Updated emacs ``        |
| [`99fc7bf4`](https://github.com/nix-community/emacs-overlay/commit/99fc7bf47112954e851da89e06b824fbc25e9859) | `` Updated melpa ``        |
| [`154ff4be`](https://github.com/nix-community/emacs-overlay/commit/154ff4be52034cb91cf074b758516431a04d472a) | `` Updated elpa ``         |
| [`f4bf81c0`](https://github.com/nix-community/emacs-overlay/commit/f4bf81c0b81c77eb4aad1a7f9a8eb7e00018546b) | `` Updated nongnu ``       |
| [`3b77afd3`](https://github.com/nix-community/emacs-overlay/commit/3b77afd355f01fe690ba8ab2de31c5e6bedac6b5) | `` Updated flake inputs `` |