### PR TITLE
chore(flake/emacs-overlay): `e48d296c` -> `501c905c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1738516271,
-        "narHash": "sha256-RGNdH+MCSmMOFvTbuDlHAN1IyGSzbgk34YtAsFB6EWg=",
+        "lastModified": 1738548382,
+        "narHash": "sha256-yV7FmfZr1WKJyh7wMbwjIqIFYAQMSucXWyqJWCclNc0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e48d296c3c6fb18dae58a8f017f254f3a430ee83",
+        "rev": "501c905c37fbfaef6ae9b64cd2ff9d90f1383212",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`501c905c`](https://github.com/nix-community/emacs-overlay/commit/501c905c37fbfaef6ae9b64cd2ff9d90f1383212) | `` Updated emacs ``  |
| [`025aa96d`](https://github.com/nix-community/emacs-overlay/commit/025aa96db4a0fed4b70332b587343fae38bc734e) | `` Updated melpa ``  |
| [`a5ac7ca0`](https://github.com/nix-community/emacs-overlay/commit/a5ac7ca091f5c5b3704269155dbde1e401f345e9) | `` Updated elpa ``   |
| [`fd3dd6a1`](https://github.com/nix-community/emacs-overlay/commit/fd3dd6a1e1f4b8d51062851852c396265937a71f) | `` Updated nongnu `` |