### PR TITLE
chore(flake/emacs-overlay): `501c905c` -> `969abb73`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1738548382,
-        "narHash": "sha256-yV7FmfZr1WKJyh7wMbwjIqIFYAQMSucXWyqJWCclNc0=",
+        "lastModified": 1738574175,
+        "narHash": "sha256-5eAdRQf9tG9YQq4SUcvESFVGn1fpIABB9noTTjPYH7c=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "501c905c37fbfaef6ae9b64cd2ff9d90f1383212",
+        "rev": "969abb7370a3957d80cbbca57f5ee8a66a0e73ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`969abb73`](https://github.com/nix-community/emacs-overlay/commit/969abb7370a3957d80cbbca57f5ee8a66a0e73ac) | `` Updated emacs `` |
| [`6c57210f`](https://github.com/nix-community/emacs-overlay/commit/6c57210f1f5564c837784b86a724e4bfba055585) | `` Updated melpa `` |