### PR TITLE
chore(flake/emacs-overlay): `969abb73` -> `714895eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1738574175,
-        "narHash": "sha256-5eAdRQf9tG9YQq4SUcvESFVGn1fpIABB9noTTjPYH7c=",
+        "lastModified": 1738602907,
+        "narHash": "sha256-NlbKUoLHTNTsFE/o7SRszh0HDUXLad9yqR1XbxjpSzU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "969abb7370a3957d80cbbca57f5ee8a66a0e73ac",
+        "rev": "714895ebc7583064d471784c7372b6ad476ee4ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`714895eb`](https://github.com/nix-community/emacs-overlay/commit/714895ebc7583064d471784c7372b6ad476ee4ab) | `` Updated emacs ``  |
| [`7020fb5a`](https://github.com/nix-community/emacs-overlay/commit/7020fb5a9bd99b6c0114314365f2780ad1bebf15) | `` Updated melpa ``  |
| [`31f66b0e`](https://github.com/nix-community/emacs-overlay/commit/31f66b0e448ba6829aa7807ff456addee2598faa) | `` Updated elpa ``   |
| [`b741206d`](https://github.com/nix-community/emacs-overlay/commit/b741206d6417476ca65c4211308e38f7b4c13800) | `` Updated nongnu `` |