### PR TITLE
chore(flake/emacs-overlay): `714895eb` -> `9fd9faae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1738602907,
-        "narHash": "sha256-NlbKUoLHTNTsFE/o7SRszh0HDUXLad9yqR1XbxjpSzU=",
+        "lastModified": 1738634711,
+        "narHash": "sha256-oUTrGApaII+SB93j6mlZd+43hGWBZtqtDRtpwyjFZ3E=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "714895ebc7583064d471784c7372b6ad476ee4ab",
+        "rev": "9fd9faae20df9454e37a71e05ce589a2c8f3fa66",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`9fd9faae`](https://github.com/nix-community/emacs-overlay/commit/9fd9faae20df9454e37a71e05ce589a2c8f3fa66) | `` Updated emacs ``  |
| [`80e7e1b9`](https://github.com/nix-community/emacs-overlay/commit/80e7e1b95c0035dd74c8b9ace558bc7007a01ace) | `` Updated melpa ``  |
| [`9f020975`](https://github.com/nix-community/emacs-overlay/commit/9f0209759b360b3045dc7b99acdf90e49f3a291a) | `` Updated elpa ``   |
| [`a9e3f738`](https://github.com/nix-community/emacs-overlay/commit/a9e3f738c29a111b08b4ab1ab3f63826d1bf489c) | `` Updated nongnu `` |