### PR TITLE
chore(flake/treefmt-nix): `bebf27d0` -> `64dbb922`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -961,11 +961,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738070913,
-        "narHash": "sha256-j6jC12vCFsTGDmY2u1H12lMr62fnclNjuCtAdF1a4Nk=",
+        "lastModified": 1738680491,
+        "narHash": "sha256-8X7tR3kFGkE7WEF5EXVkt4apgaN85oHZdoTGutCFs6I=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "bebf27d00f7d10ba75332a0541ac43676985dea3",
+        "rev": "64dbb922d51a42c0ced6a7668ca008dded61c483",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                  |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`64dbb922`](https://github.com/numtide/treefmt-nix/commit/64dbb922d51a42c0ced6a7668ca008dded61c483) | `` just: include just modules (#305) ``                  |
| [`b49eb4ab`](https://github.com/numtide/treefmt-nix/commit/b49eb4abf4801b6497d9bdabe70666ab139e7c15) | `` zprint: change args ordering (#308) ``                |
| [`79fbd2cc`](https://github.com/numtide/treefmt-nix/commit/79fbd2cc9ab5bffad8e30eb87e04a85bc49e267c) | `` README: add supported nix versions ``                 |
| [`4aea2e44`](https://github.com/numtide/treefmt-nix/commit/4aea2e44ed77abc119ac7cfb08d81e9cc208e37c) | `` nixfmt: add support for --width and --strict flags `` |