### PR TITLE
chore(flake/emacs-overlay): `52f31b67` -> `ec094137`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1738659674,
-        "narHash": "sha256-KAgZccXkBOxrB7+OR1PrzRpEO/Om1ahSfOaZLt5qjUo=",
+        "lastModified": 1738893995,
+        "narHash": "sha256-WRmAqjSnKTWvVvvLvA/b/mX8Voxv/LVnVsZgX+CZN44=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "52f31b67d641dbb79ded6253e2731c48a79b8de9",
+        "rev": "ec094137fed63ffe5503b8434071f6b755494927",
         "type": "github"
       },
       "original": {
@@ -603,11 +603,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1738574474,
-        "narHash": "sha256-rvyfF49e/k6vkrRTV4ILrWd92W+nmBDfRYZgctOyolQ=",
+        "lastModified": 1738702386,
+        "narHash": "sha256-nJj8f78AYAxl/zqLiFGXn5Im1qjFKU8yBPKoWEeZN5M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fecfeb86328381268e29e998ddd3ebc70bbd7f7c",
+        "rev": "030ba1976b7c0e1a67d9716b17308ccdab5b381e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`ec094137`](https://github.com/nix-community/emacs-overlay/commit/ec094137fed63ffe5503b8434071f6b755494927) | `` Updated emacs ``        |
| [`55549fb7`](https://github.com/nix-community/emacs-overlay/commit/55549fb7cc17bd4b772bee3b6eecb0152db31801) | `` Updated melpa ``        |
| [`f7ad53b9`](https://github.com/nix-community/emacs-overlay/commit/f7ad53b9e50d15e72eb0f6d56defe3a841a45977) | `` Updated elpa ``         |
| [`1d19c188`](https://github.com/nix-community/emacs-overlay/commit/1d19c1885c8807e044eb861162ee0120b6749dea) | `` Updated emacs ``        |
| [`7882f1b3`](https://github.com/nix-community/emacs-overlay/commit/7882f1b342e9170d89dc45d5915e7596409044cb) | `` Updated melpa ``        |
| [`be1fc044`](https://github.com/nix-community/emacs-overlay/commit/be1fc044a82b9c6901e2da382a2234b8502b4f11) | `` Updated elpa ``         |
| [`a2828925`](https://github.com/nix-community/emacs-overlay/commit/a2828925c87502bfd319541d7082112a64628612) | `` Updated nongnu ``       |
| [`590d6eca`](https://github.com/nix-community/emacs-overlay/commit/590d6ecac05c53ae8a87af317efa06f4a99ab116) | `` Updated emacs ``        |
| [`1d0b6f62`](https://github.com/nix-community/emacs-overlay/commit/1d0b6f6290644c764ab1dffb1fee2d0702cd9d0e) | `` Updated melpa ``        |
| [`c4d38ecc`](https://github.com/nix-community/emacs-overlay/commit/c4d38eccd88f3c740a03d9f04af2fa14efa2e802) | `` Updated elpa ``         |
| [`1fb9e197`](https://github.com/nix-community/emacs-overlay/commit/1fb9e19710b4d1b4c26bda5855d0d5ba1587d510) | `` Updated nongnu ``       |
| [`ed5cb1be`](https://github.com/nix-community/emacs-overlay/commit/ed5cb1becdad3465ca08dd8ef0b156ae4390505f) | `` Updated emacs ``        |
| [`22ec5d70`](https://github.com/nix-community/emacs-overlay/commit/22ec5d70287ef483e8149dd288136394f606478d) | `` Updated melpa ``        |
| [`4b0189c8`](https://github.com/nix-community/emacs-overlay/commit/4b0189c89c572ac95ea2c4dc6da64cb92c4c59d1) | `` Updated elpa ``         |
| [`592a8d7a`](https://github.com/nix-community/emacs-overlay/commit/592a8d7aeb04c3f3129882f44d7179dd09411f35) | `` Updated nongnu ``       |
| [`abfa104f`](https://github.com/nix-community/emacs-overlay/commit/abfa104fff496f9eb7a091728af73067ccf8802d) | `` Updated emacs ``        |
| [`1d2b5233`](https://github.com/nix-community/emacs-overlay/commit/1d2b5233e20b6876a8328e20aa28f8e5c80af2a4) | `` Updated melpa ``        |
| [`54996435`](https://github.com/nix-community/emacs-overlay/commit/54996435624bb4e2ff4af3364cd1dfd4e1e14a4d) | `` Updated flake inputs `` |
| [`9af406ea`](https://github.com/nix-community/emacs-overlay/commit/9af406ea66edc730a2c64cf82b74a03513b94f5e) | `` Updated emacs ``        |
| [`de230458`](https://github.com/nix-community/emacs-overlay/commit/de230458610866f11773e0d33b7e97dbc0d44d56) | `` Updated melpa ``        |
| [`efc32276`](https://github.com/nix-community/emacs-overlay/commit/efc3227671b728430c3ccb1facca69a2e28c8fe9) | `` Updated elpa ``         |
| [`7b66dfa4`](https://github.com/nix-community/emacs-overlay/commit/7b66dfa401ccf9feeb20a2373b6033fa55e8dac7) | `` Updated nongnu ``       |
| [`6eea1e35`](https://github.com/nix-community/emacs-overlay/commit/6eea1e3527f5ed2e8527413ae6644a9a4f921113) | `` Updated flake inputs `` |
| [`c5aa853f`](https://github.com/nix-community/emacs-overlay/commit/c5aa853ffd1d4ded1a409cb41e282436606dde17) | `` Updated emacs ``        |
| [`15593a66`](https://github.com/nix-community/emacs-overlay/commit/15593a66be927b04922b53cc9610de17000abdee) | `` Updated melpa ``        |
| [`52f13caa`](https://github.com/nix-community/emacs-overlay/commit/52f13caa3c3570bc59582578593b8fafd40f8aaa) | `` Updated nongnu ``       |