### PR TITLE
chore(flake/home-manager): `7abcf59a` -> `f2d32e46`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738667255,
-        "narHash": "sha256-sMMQb9NydZqQ/MvvtPp+Ny0W9P0Jk0moU7SrTBlO5Vo=",
+        "lastModified": 1738709900,
+        "narHash": "sha256-8Bo5xFlCH5q72ExvAnH7TzStMlLZldKOSLMClRSfmTc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7abcf59a365430b36f84eaa452a466b11e469e33",
+        "rev": "f2d32e46fac9d51da6912948ae1156044c71774b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`f2d32e46`](https://github.com/nix-community/home-manager/commit/f2d32e46fac9d51da6912948ae1156044c71774b) | `` broot: use hjson-go ``                                       |
| [`7a3f0b3b`](https://github.com/nix-community/home-manager/commit/7a3f0b3b8df1b913890f5fad04d34f2af91da858) | `` tests: rework derivation stubbing ``                         |
| [`c5c2cbc8`](https://github.com/nix-community/home-manager/commit/c5c2cbc866fecc75175259bcda02c4c0e00c00ee) | `` ci: tweak test command slightly ``                           |
| [`24bb01ea`](https://github.com/nix-community/home-manager/commit/24bb01ea170a6705c6700be3fa7438b394523ea4) | `` tests: avoid unnecessary test script interpolation ``        |
| [`1e47f710`](https://github.com/nix-community/home-manager/commit/1e47f7101fedd857e561782d00d4cb1f6b69e7df) | `` gpg-agent: no-allow-external-cache option (#6387) ``         |
| [`78576b81`](https://github.com/nix-community/home-manager/commit/78576b817fdd88a75c6adf512e9ba20551662cef) | `` home-manager: add lib support for non-flake users (#5429) `` |