### PR TITLE
chore(flake/nur): `210845b8` -> `160b085a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -682,11 +682,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1738546358,
-        "narHash": "sha256-nLivjIygCiqLp5QcL7l56Tca/elVqM9FG1hGd9ZSsrg=",
+        "lastModified": 1738680400,
+        "narHash": "sha256-ooLh+XW8jfa+91F1nhf9OF7qhuA/y1ChLx6lXDNeY5U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c6e957d81b96751a3d5967a0fd73694f303cc914",
+        "rev": "799ba5bffed04ced7067a91798353d360788b30d",
         "type": "github"
       },
       "original": {
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1738706674,
-        "narHash": "sha256-5Rj9VhwsX9knL+r6Jl6Gg/WZ3/e1NJJ65A+g3lS1kxA=",
+        "lastModified": 1738712484,
+        "narHash": "sha256-bm23E8lHJntAEj0MDaSAL8MT1NOI9sfISGaGcxeGoj0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "210845b8b9aa555f387cffca26409277078b491c",
+        "rev": "160b085afaac103dec684b19c0ca4a56186c6fe0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`160b085a`](https://github.com/nix-community/NUR/commit/160b085afaac103dec684b19c0ca4a56186c6fe0) | `` automatic update `` |
| [`6c3aecff`](https://github.com/nix-community/NUR/commit/6c3aecff60b207d3d96c02d88e85474ba4d7d403) | `` automatic update `` |
| [`53d3573c`](https://github.com/nix-community/NUR/commit/53d3573c7d13a9121bcbcdd90698b3fd0a39bd90) | `` automatic update `` |
| [`9172e289`](https://github.com/nix-community/NUR/commit/9172e289a86718503946c95754a0807d569c658e) | `` automatic update `` |
| [`eb2dcf0d`](https://github.com/nix-community/NUR/commit/eb2dcf0d06aecc9466c27d454527fb9d20e02d8d) | `` automatic update `` |
| [`5999abfc`](https://github.com/nix-community/NUR/commit/5999abfc1d7c1f26a64260f4774e572fd798e485) | `` automatic update `` |