### PR TITLE
chore(flake/darwin): `49b807fa` -> `ae406c04`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738277753,
-        "narHash": "sha256-iyFcCOk0mmDiv4ut9mBEuMxMZIym3++0qN1rQBg8FW0=",
+        "lastModified": 1738743987,
+        "narHash": "sha256-O3bnAfsObto6l2tQOmQlrO6Z2kD6yKwOWfs7pA0CpOc=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "49b807fa7c37568d7fbe2aeaafb9255c185412f9",
+        "rev": "ae406c04577ff9a64087018c79b4fdc02468c87c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                                |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
| [`7c72c013`](https://github.com/LnL7/nix-darwin/commit/7c72c013b160627540b8b465a05ba258f47a16d8) | `` nixpkgs: make config.nixpkgs.{buildPlatform,hostPlatform} write only ``             |
| [`5084b332`](https://github.com/LnL7/nix-darwin/commit/5084b33265f1c14551af63e61ec8bb75fec3ccbc) | `` git-blame-ignore-revs: add `nixpkgs` module formatting commit ``                    |
| [`dc1c716d`](https://github.com/LnL7/nix-darwin/commit/dc1c716ded39758062ed7e6bc410ad274119de9f) | `` nixpkgs: format with `nixfmt` ``                                                    |
| [`80eddf2b`](https://github.com/LnL7/nix-darwin/commit/80eddf2bf743620faab78d06846d9478fb21aa3b) | `` nixpkgs: show definition files in `config` assertion ``                             |
| [`e84e84a2`](https://github.com/LnL7/nix-darwin/commit/e84e84a2566a1b431686c9c5ed45b01e1fdcf831) | `` nixpkgs: fix `config` assertion text ``                                             |
| [`bd1d4676`](https://github.com/LnL7/nix-darwin/commit/bd1d46766afb73b87b0e07172ca6a00a036d03da) | `` nixpkgs: remove `with lib;` ``                                                      |
| [`320bf025`](https://github.com/LnL7/nix-darwin/commit/320bf025d22ae9c50a410bef27596b945be65889) | `` nixpkgs: link to Nixpkgs manual for global configuration options ``                 |
| [`6b81859e`](https://github.com/LnL7/nix-darwin/commit/6b81859ed0e35f052043384c7febb853176bc500) | `` nixpkgs: fix determination for cross-compiled nix-darwin system ``                  |
| [`2df9e481`](https://github.com/LnL7/nix-darwin/commit/2df9e4811008fca085d15f67b51cd7bc497a17bb) | `` nixpkgs: use less confusing example systems ``                                      |
| [`3cd3a79f`](https://github.com/LnL7/nix-darwin/commit/3cd3a79f9ba7f6c3421f4f7fd557b4c8666e7183) | `` nixpkgs: Rewrite overlays option docs ``                                            |
| [`962eb3f1`](https://github.com/LnL7/nix-darwin/commit/962eb3f1c0c2d5e4ac92eb8bfc91333d3b1cb0e7) | `` nixpkgs: assert that nixpkgs.config is not set when pkgs is passed in externally `` |
| [`5b0cffee`](https://github.com/LnL7/nix-darwin/commit/5b0cffeec2973101432f7a6ce5644e73ca661618) | `` nixpkgs: fix undefined variable in assertion ``                                     |