### PR TITLE
chore(flake/srvos): `7d5a4aaa` -> `9c9423e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -884,11 +884,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738198321,
-        "narHash": "sha256-lhnHBXO9Y8xEn92JqxjancdL8Gh16ONuxZp60iZfmX4=",
+        "lastModified": 1738803210,
+        "narHash": "sha256-28/+C9I0z/R1Z64rTn25biIHZ9QEt4rlGr7tYb0186A=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "7d5a4aaadac9ff63f9ed4347df95175aceee5079",
+        "rev": "9c9423e8f947af2ec80b1d9da677e1dd166e3377",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`9c9423e8`](https://github.com/nix-community/srvos/commit/9c9423e8f947af2ec80b1d9da677e1dd166e3377) | `` dev/private/flake.lock: Update `` |
| [`1aed8e23`](https://github.com/nix-community/srvos/commit/1aed8e2354f41f5d20c2e8cb6b6e65e3e32d739c) | `` flake.lock: Update ``             |