### PR TITLE
chore(flake/nixos-hardware): `9bdd53f5` -> `2eccff41`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -528,11 +528,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1738638143,
-        "narHash": "sha256-ZYMe4c4OCtIUBn5hx15PEGr0+B1cNEpl2dsaLxwY2W0=",
+        "lastModified": 1738816619,
+        "narHash": "sha256-5yRlg48XmpcX5b5HesdGMOte+YuCy9rzQkJz+imcu6I=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "9bdd53f5908453e4d03f395eb1615c3e9a351f70",
+        "rev": "2eccff41bab80839b1d25b303b53d339fbb07087",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                  |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`2eccff41`](https://github.com/NixOS/nixos-hardware/commit/2eccff41bab80839b1d25b303b53d339fbb07087) | `` framework/13-inch/intel-core-ultra-series1: Add Intel NPU firmware `` |
| [`d1f201fc`](https://github.com/NixOS/nixos-hardware/commit/d1f201fc627098d764ed00f736864ce673f5975e) | `` radxa: add remark about kernel. ``                                    |
| [`68cc7a87`](https://github.com/NixOS/nixos-hardware/commit/68cc7a876b1d997cd590b0f7d6bebc723a385349) | `` radxa/rock-4c-plus: init ``                                           |
| [`52047449`](https://github.com/NixOS/nixos-hardware/commit/52047449bf5b6854a7ea5d769cffc0f1833b0e22) | `` rockchip/rk3399: init ``                                              |
| [`c5666d9c`](https://github.com/NixOS/nixos-hardware/commit/c5666d9cd61ce774e8492cbafe65afe3656edd2d) | `` surface: linux 6.12.11 -> 6.12.12 ``                                  |
| [`d85ec4b3`](https://github.com/NixOS/nixos-hardware/commit/d85ec4b3c6d2253f58cb1b28bda1213fbde66fe9) | `` hardkernel/odroid-h4: init ``                                         |
| [`240f698f`](https://github.com/NixOS/nixos-hardware/commit/240f698fc8ff5dd089416e0dd34ad762373b6e5c) | `` Added profile for Dell G3 3579 laptop ``                              |
| [`d9819a67`](https://github.com/NixOS/nixos-hardware/commit/d9819a6791f7e7eec0bbbaf1b79d2e0c1879b183) | `` Update default.nix ``                                                 |
| [`da7014af`](https://github.com/NixOS/nixos-hardware/commit/da7014af5d1a09f91d7125246ad967a99d412b2d) | `` Revert "framework/13-inch/12th-gen-intel: add hdmi audio fix" ``      |