### PR TITLE
chore(flake/emacs-overlay): `ec094137` -> `d1a312c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1738893995,
-        "narHash": "sha256-WRmAqjSnKTWvVvvLvA/b/mX8Voxv/LVnVsZgX+CZN44=",
+        "lastModified": 1738919824,
+        "narHash": "sha256-FvaTbPs4O4NmE71xjb/lNSsNAkyXUnm7NU/bY86oUws=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ec094137fed63ffe5503b8434071f6b755494927",
+        "rev": "d1a312c524fe9f1a6836fc3fd63c6fd09f795abb",
         "type": "github"
       },
       "original": {
@@ -603,11 +603,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1738702386,
-        "narHash": "sha256-nJj8f78AYAxl/zqLiFGXn5Im1qjFKU8yBPKoWEeZN5M=",
+        "lastModified": 1738843498,
+        "narHash": "sha256-7x+Q4xgFj9UxZZO9aUDCR8h4vyYut4zPUvfj3i+jBHE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "030ba1976b7c0e1a67d9716b17308ccdab5b381e",
+        "rev": "f5a32fa27df91dfc4b762671a0e0a859a8a0058f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`d1a312c5`](https://github.com/nix-community/emacs-overlay/commit/d1a312c524fe9f1a6836fc3fd63c6fd09f795abb) | `` Updated emacs ``        |
| [`35357ca3`](https://github.com/nix-community/emacs-overlay/commit/35357ca3a046eb7fa72fa8e433496434895af36c) | `` Updated melpa ``        |
| [`62e6f266`](https://github.com/nix-community/emacs-overlay/commit/62e6f266d6fc1443d83457c65ef4b860d2f3835a) | `` Updated flake inputs `` |