### PR TITLE
chore(flake/emacs-overlay): `d1a312c5` -> `849f0e08`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1738919824,
-        "narHash": "sha256-FvaTbPs4O4NmE71xjb/lNSsNAkyXUnm7NU/bY86oUws=",
+        "lastModified": 1738950277,
+        "narHash": "sha256-D8AWtPEbyFBoz5s+9vH4bAEr5xzrfw5ftfWtsaTNzZQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d1a312c524fe9f1a6836fc3fd63c6fd09f795abb",
+        "rev": "849f0e08654c40c8da1c3d830caf5497eb366f93",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`849f0e08`](https://github.com/nix-community/emacs-overlay/commit/849f0e08654c40c8da1c3d830caf5497eb366f93) | `` Updated emacs ``  |
| [`15150761`](https://github.com/nix-community/emacs-overlay/commit/1515076129d7104cf3b43ea7f54bbd04a49af6a6) | `` Updated melpa ``  |
| [`f5ef1413`](https://github.com/nix-community/emacs-overlay/commit/f5ef1413cddc9c62bea01fd2bf85c211e6b7c3eb) | `` Updated elpa ``   |
| [`59997c63`](https://github.com/nix-community/emacs-overlay/commit/59997c63608b3ba0ccb68beb589969cafd952477) | `` Updated nongnu `` |