### PR TITLE
chore(flake/nur): `969d715b` -> `24a92e2a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -682,11 +682,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1738680400,
-        "narHash": "sha256-ooLh+XW8jfa+91F1nhf9OF7qhuA/y1ChLx6lXDNeY5U=",
+        "lastModified": 1738824222,
+        "narHash": "sha256-U3SNq+waitGIotmgg/Et3J7o4NvUtP2gb2VhME5QXiw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "799ba5bffed04ced7067a91798353d360788b30d",
+        "rev": "550e11f27ba790351d390d9eca3b80ad0f0254e7",
         "type": "github"
       },
       "original": {
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1738946749,
-        "narHash": "sha256-wrhBITq5x6ti+aGXhatgekY/6eohg6EvuE9U7+SmbxM=",
+        "lastModified": 1738968502,
+        "narHash": "sha256-r27SjjhjJGQcWrr6CwXxRHtQ3/J1mn8V+CUbB+UPmF4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "969d715bc97f1b286bac91c01f17b8372db178ec",
+        "rev": "24a92e2a9246c0db8308767239519e11ff7e076a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`24a92e2a`](https://github.com/nix-community/NUR/commit/24a92e2a9246c0db8308767239519e11ff7e076a) | `` automatic update `` |
| [`b745825b`](https://github.com/nix-community/NUR/commit/b745825b022cae4f46b66b645ffb178429af42b7) | `` automatic update `` |
| [`35c32e0e`](https://github.com/nix-community/NUR/commit/35c32e0e7d1d0ff7036944e68ae1268078ea36dc) | `` automatic update `` |
| [`589f1034`](https://github.com/nix-community/NUR/commit/589f1034d9ee9b6387be5185b998c8c9e19791fd) | `` automatic update `` |
| [`31fa428e`](https://github.com/nix-community/NUR/commit/31fa428e5cda56b9e3e7cdc836167ba188ed8fc7) | `` automatic update `` |