### PR TITLE
chore(flake/emacs-overlay): `849f0e08` -> `ad169255`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1738950277,
-        "narHash": "sha256-D8AWtPEbyFBoz5s+9vH4bAEr5xzrfw5ftfWtsaTNzZQ=",
+        "lastModified": 1738983652,
+        "narHash": "sha256-sks4Q/bywfDMtN5V0r+/98SxXn1uSoQlXfe0aAq38Mc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "849f0e08654c40c8da1c3d830caf5497eb366f93",
+        "rev": "ad16925507732f4f57f6cc5595bdfa90d2692278",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`ad169255`](https://github.com/nix-community/emacs-overlay/commit/ad16925507732f4f57f6cc5595bdfa90d2692278) | `` Updated emacs ``        |
| [`1568d60d`](https://github.com/nix-community/emacs-overlay/commit/1568d60da7fcbb1fd524d6b044b9ddce14c32dbc) | `` Updated melpa ``        |
| [`be3cfb0a`](https://github.com/nix-community/emacs-overlay/commit/be3cfb0a089b93aa28338340e0eb4133fc340aa9) | `` Updated elpa ``         |
| [`bbcfcbd4`](https://github.com/nix-community/emacs-overlay/commit/bbcfcbd4d34f24a71dc4cd2aea333b606007b4c9) | `` Updated nongnu ``       |
| [`08d6d24e`](https://github.com/nix-community/emacs-overlay/commit/08d6d24e34281b5b3529e29b168591f2fdfa21c6) | `` Updated flake inputs `` |