### PR TITLE
chore(flake/nur): `24a92e2a` -> `c29d8f7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1738968502,
-        "narHash": "sha256-r27SjjhjJGQcWrr6CwXxRHtQ3/J1mn8V+CUbB+UPmF4=",
+        "lastModified": 1738986267,
+        "narHash": "sha256-mGZRvF262nBMIS76IJm8dm1/hkoBQg0lm0ToJlbtKaw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "24a92e2a9246c0db8308767239519e11ff7e076a",
+        "rev": "c29d8f7d6b284c175c7747cc53cc9aa468445183",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c29d8f7d`](https://github.com/nix-community/NUR/commit/c29d8f7d6b284c175c7747cc53cc9aa468445183) | `` automatic update `` |
| [`3680f5c2`](https://github.com/nix-community/NUR/commit/3680f5c26f924c7903e684b93c96b743316a31da) | `` automatic update `` |
| [`443f430d`](https://github.com/nix-community/NUR/commit/443f430d53cd0dcb5fd3019a9da4bfa138b50540) | `` automatic update `` |
| [`78bf1dcd`](https://github.com/nix-community/NUR/commit/78bf1dcdda66a1cabee1cf2904026869520ea126) | `` automatic update `` |
| [`556f881a`](https://github.com/nix-community/NUR/commit/556f881a29218e8be9f96ddbaeb0c985cd22731e) | `` automatic update `` |
| [`7e965985`](https://github.com/nix-community/NUR/commit/7e965985e1704592088c5a034c3f3c3391fc115b) | `` automatic update `` |
| [`46556b91`](https://github.com/nix-community/NUR/commit/46556b910ab3a636b5d725a0bb15852df4556d93) | `` automatic update `` |
| [`b510ccaf`](https://github.com/nix-community/NUR/commit/b510ccaf39c5b7626d90dfb32966f04ad95174b9) | `` automatic update `` |