### PR TITLE
chore(flake/emacs-overlay): `ad169255` -> `5b1779b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1738983652,
-        "narHash": "sha256-sks4Q/bywfDMtN5V0r+/98SxXn1uSoQlXfe0aAq38Mc=",
+        "lastModified": 1739007688,
+        "narHash": "sha256-vtSZo/L0J/VqrCzNUcdsQ1GNRFlINKJnX90KyyrjPCU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ad16925507732f4f57f6cc5595bdfa90d2692278",
+        "rev": "5b1779b13077a122dba393d0b0c148a0e5bf16f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`5b1779b1`](https://github.com/nix-community/emacs-overlay/commit/5b1779b13077a122dba393d0b0c148a0e5bf16f6) | `` Updated emacs ``        |
| [`8607d39d`](https://github.com/nix-community/emacs-overlay/commit/8607d39d386a84ad7652ab1d1f9ae328861a4cd6) | `` Updated melpa ``        |
| [`6444d227`](https://github.com/nix-community/emacs-overlay/commit/6444d227d432cf4efa7c58803a2bcef3b84d41cc) | `` Updated flake inputs `` |