### PR TITLE
chore(flake/darwin): `ae406c04` -> `0b6f96a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738743987,
-        "narHash": "sha256-O3bnAfsObto6l2tQOmQlrO6Z2kD6yKwOWfs7pA0CpOc=",
+        "lastModified": 1739034224,
+        "narHash": "sha256-Mj/8jDzh1KNmUhWqEeVlW3hO9MZkxqioJGnmR7rivaE=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "ae406c04577ff9a64087018c79b4fdc02468c87c",
+        "rev": "0b6f96a6b9efcfa8d3cc8023008bcbcd1b9bc1a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                             |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
| [`d634e28f`](https://github.com/LnL7/nix-darwin/commit/d634e28f67b5e1fc82b3ea107fbd9b3a3abf3a7b) | `` users: use `launchctl managername` to determine session type ``                  |
| [`0824c138`](https://github.com/LnL7/nix-darwin/commit/0824c13801d18722a5dd7827f575f5c42e80ad43) | `` checks: fix macOS version check exit code ``                                     |
| [`da331139`](https://github.com/LnL7/nix-darwin/commit/da3311397a1a2ba1a02f026cce1700a3556279cc) | `` Revert "nixpkgs: make config.nixpkgs.{buildPlatform,hostPlatform} write only" `` |
| [`3f6f5124`](https://github.com/LnL7/nix-darwin/commit/3f6f512406d852afa0e54118b2002896da66fd3e) | `` users: fix typo ``                                                               |