### PR TITLE
chore(flake/emacs-overlay): `5b1779b1` -> `3e356346`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1739007688,
-        "narHash": "sha256-vtSZo/L0J/VqrCzNUcdsQ1GNRFlINKJnX90KyyrjPCU=",
+        "lastModified": 1739121105,
+        "narHash": "sha256-Kn9uuOouk9Xtb+1FZNTbDGaomEsKZNG3IA/w61N7b8o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5b1779b13077a122dba393d0b0c148a0e5bf16f6",
+        "rev": "3e35634650753a5644cf07148cf49df1f023efce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`3e356346`](https://github.com/nix-community/emacs-overlay/commit/3e35634650753a5644cf07148cf49df1f023efce) | `` Updated emacs ``        |
| [`a3a8f640`](https://github.com/nix-community/emacs-overlay/commit/a3a8f64036679fbdac85f94058c0849ba0ed2015) | `` Updated melpa ``        |
| [`909a7b97`](https://github.com/nix-community/emacs-overlay/commit/909a7b974edcdccd9696a03182fab846ce3a50ae) | `` Updated elpa ``         |
| [`a0dac4c5`](https://github.com/nix-community/emacs-overlay/commit/a0dac4c5cd0df16d552c030e9ef8a4cfeea895eb) | `` Updated nongnu ``       |
| [`70518f71`](https://github.com/nix-community/emacs-overlay/commit/70518f71b346044308d0c42fdbb79263bd85bf8f) | `` Updated emacs ``        |
| [`6cc967bc`](https://github.com/nix-community/emacs-overlay/commit/6cc967bc5867561fbb4ee6e8ea8f4b5de71a740a) | `` Updated melpa ``        |
| [`6c02db1d`](https://github.com/nix-community/emacs-overlay/commit/6c02db1d65ff3c8d1a871c50bd2cdf3b4822fafd) | `` Updated emacs ``        |
| [`42d13c0f`](https://github.com/nix-community/emacs-overlay/commit/42d13c0f389aa455b55476fdd16347e512c44679) | `` Updated melpa ``        |
| [`ce509b25`](https://github.com/nix-community/emacs-overlay/commit/ce509b25a8d65cebd8ee5722423151690b4e5e70) | `` Updated elpa ``         |
| [`8906677e`](https://github.com/nix-community/emacs-overlay/commit/8906677ebdd9e7a70a46fade8f5eca26c7893a2a) | `` Updated nongnu ``       |
| [`1332b6ab`](https://github.com/nix-community/emacs-overlay/commit/1332b6ab2cccc0f12f7ce10a7ae09421ec88c0de) | `` Updated flake inputs `` |
| [`0bfadcfd`](https://github.com/nix-community/emacs-overlay/commit/0bfadcfd92855d3eb7e5c6401aff2ba348b1e7b7) | `` Updated emacs ``        |
| [`84d0eecc`](https://github.com/nix-community/emacs-overlay/commit/84d0eecc7ba8201a2afba980f57eb1e5b081516e) | `` Updated melpa ``        |
| [`21b6b2d9`](https://github.com/nix-community/emacs-overlay/commit/21b6b2d9c0d96a74d0c9f0302eb3cec0fba3570b) | `` Updated elpa ``         |
| [`c9b90161`](https://github.com/nix-community/emacs-overlay/commit/c9b9016134bcc0ef644c10cc52157c7636808180) | `` Updated nongnu ``       |