### PR TITLE
chore(flake/home-manager): `947eef9e` -> `bf9a1a06`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739002622,
-        "narHash": "sha256-PtJV5OYQF7XO6XkDYypsYJS3+OsgYaYSmkO3I/A7lZo=",
+        "lastModified": 1739044880,
+        "narHash": "sha256-l+bzq9rsBIQQnBtGayJeOS30L53+mYPjgfQALi20XDg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "947eef9e99c42346cf0aac2bebe1cd94924c173b",
+        "rev": "bf9a1a068919ccdfa7d130873936c5fd4c826e85",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`bf9a1a06`](https://github.com/nix-community/home-manager/commit/bf9a1a068919ccdfa7d130873936c5fd4c826e85) | `` Translate using Weblate (Swedish) ``    |
| [`90a4374b`](https://github.com/nix-community/home-manager/commit/90a4374b174edb88a2e36889ee39ce45a186c7f6) | `` Translate using Weblate (Portuguese) `` |