### PR TITLE
chore(flake/nur): `2c9c2fdd` -> `d2c5d7e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1739086323,
-        "narHash": "sha256-ts8pfVu/suXMvNGsN1ZXXunR77tfQaWs++s27so6viY=",
+        "lastModified": 1739096927,
+        "narHash": "sha256-YhYnVv7y5GgTt/DHZHxJ+oDih0Zm//lesnhQ4aL/QTU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2c9c2fdd4287f8f4409684662984a194ab8a8c89",
+        "rev": "d2c5d7e47b9ff13b2b23d1aafc3a19b1aeceb676",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d2c5d7e4`](https://github.com/nix-community/NUR/commit/d2c5d7e47b9ff13b2b23d1aafc3a19b1aeceb676) | `` automatic update `` |
| [`f2b3ef23`](https://github.com/nix-community/NUR/commit/f2b3ef2381c98de045f40867a327377636ae42b2) | `` automatic update `` |