### PR TITLE
chore(flake/nur): `d2c5d7e4` -> `2ebe2b3c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1739096927,
-        "narHash": "sha256-YhYnVv7y5GgTt/DHZHxJ+oDih0Zm//lesnhQ4aL/QTU=",
+        "lastModified": 1739141262,
+        "narHash": "sha256-sOPVQn37Vehd/Er+jcO99WYFeOFxbDmpl0mAq3uJxxU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d2c5d7e47b9ff13b2b23d1aafc3a19b1aeceb676",
+        "rev": "2ebe2b3cf4643b66ab8362c9139454aac7daeed1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2ebe2b3c`](https://github.com/nix-community/NUR/commit/2ebe2b3cf4643b66ab8362c9139454aac7daeed1) | `` automatic update `` |
| [`a24b01ee`](https://github.com/nix-community/NUR/commit/a24b01eea4760ba2c958f459ec070797d6127b68) | `` automatic update `` |
| [`96cbfc8c`](https://github.com/nix-community/NUR/commit/96cbfc8c1a7bb531a74d65b4fff7287a1138db6f) | `` automatic update `` |
| [`ebf81656`](https://github.com/nix-community/NUR/commit/ebf8165674ea65eb4ee6e565c8b2e05a813031d7) | `` automatic update `` |
| [`5efb7220`](https://github.com/nix-community/NUR/commit/5efb72209df7e3e39b2b47f11beaa269d47270c2) | `` automatic update `` |
| [`0af5696d`](https://github.com/nix-community/NUR/commit/0af5696d5dfabdc7273441cb033db12761325898) | `` automatic update `` |
| [`09169b39`](https://github.com/nix-community/NUR/commit/09169b39525e21e9025117c394ae981301ad7aba) | `` automatic update `` |
| [`0be76f54`](https://github.com/nix-community/NUR/commit/0be76f5468c929db520a01b6b764cf9da9fa4605) | `` automatic update `` |
| [`953d83b1`](https://github.com/nix-community/NUR/commit/953d83b127944d8d6f98a2720c82a70bdc73256b) | `` automatic update `` |
| [`3d82d257`](https://github.com/nix-community/NUR/commit/3d82d2570f66611ba23f052287e72074fa74691a) | `` automatic update `` |
| [`b457c763`](https://github.com/nix-community/NUR/commit/b457c76371f82a97d3fc4d22bec0ea3338d460e5) | `` automatic update `` |