### PR TITLE
chore(flake/srvos): `9c9423e8` -> `8e257cc0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -884,11 +884,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738803210,
-        "narHash": "sha256-28/+C9I0z/R1Z64rTn25biIHZ9QEt4rlGr7tYb0186A=",
+        "lastModified": 1739149457,
+        "narHash": "sha256-777RrYhdblwYBDruc5xaRdheTGyBMOdjcJmc67d98es=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "9c9423e8f947af2ec80b1d9da677e1dd166e3377",
+        "rev": "8e257cc0810b5aa0f1a8841d8bdbb10eda07ae16",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`8e257cc0`](https://github.com/nix-community/srvos/commit/8e257cc0810b5aa0f1a8841d8bdbb10eda07ae16) | `` fix stateVersion ``               |
| [`840ac6a3`](https://github.com/nix-community/srvos/commit/840ac6a3ef3252acd2e73ebb2b051c9e3d05232f) | `` dev/private/flake.lock: Update `` |
| [`ee121af9`](https://github.com/nix-community/srvos/commit/ee121af9fd18635e73040a13f08174d37f995095) | `` flake.lock: Update ``             |