### PR TITLE
chore(flake/emacs-overlay): `76d66ccb` -> `66b6a800`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1739179087,
-        "narHash": "sha256-7iAofEcULUuG9qy8yYX8YsvCpCjfuR89EgRnSj2mCZg=",
+        "lastModified": 1739207663,
+        "narHash": "sha256-H0Z/Uxh1EIoZRzpXgezQPekp3ccFd/WdUVinILVnM+Y=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "76d66ccb5d6e8d58967e9716454fb0e2b3ed9d29",
+        "rev": "66b6a800edf6c6ef58d021b81ab7e6a10ae34834",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`66b6a800`](https://github.com/nix-community/emacs-overlay/commit/66b6a800edf6c6ef58d021b81ab7e6a10ae34834) | `` Updated emacs ``  |
| [`fc60f8b4`](https://github.com/nix-community/emacs-overlay/commit/fc60f8b46ef1ef6c1542a740ca6916deab3b3416) | `` Updated melpa ``  |
| [`4580261f`](https://github.com/nix-community/emacs-overlay/commit/4580261f8d9fdbde765a6657a526e99deb4148c5) | `` Updated elpa ``   |
| [`c490d049`](https://github.com/nix-community/emacs-overlay/commit/c490d0493f0f9efb38ccbb2b42989018083d8621) | `` Updated nongnu `` |