### PR TITLE
chore(flake/home-manager): `b0bd29bb` -> `ba4a1a11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739198052,
-        "narHash": "sha256-fvAgCGK2phagbKv2S4YH4AIM566TKasfWMqYl3c3mPQ=",
+        "lastModified": 1739233400,
+        "narHash": "sha256-fldFwXHP9Ndy/ADMDWNTpfWNsLdhZ8PP4DQyr1Igfo4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b0bd29bb4b8df265b13bbb4a6639afa74faaa831",
+        "rev": "ba4a1a110204c27805d1a1b5c8b24b3a0da4d063",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`ba4a1a11`](https://github.com/nix-community/home-manager/commit/ba4a1a110204c27805d1a1b5c8b24b3a0da4d063) | `` ludusavi: create Ludusavi module (#5626) ``                                             |
| [`e5854b98`](https://github.com/nix-community/home-manager/commit/e5854b98cd759b91c83ba5caa5ff32f274f1dc78) | `` flake-module: change type from lazyAttrsOf raw to lazyAttrsOf deferredModule (#6408) `` |
| [`5795f792`](https://github.com/nix-community/home-manager/commit/5795f792abf38e4f2701b4f7454deeb8e2575ae4) | `` yazi: organization tweak ``                                                             |
| [`b34b5668`](https://github.com/nix-community/home-manager/commit/b34b56689dcc75294e14e8c95db4e054a4e9573f) | `` yazi: remove with lib ``                                                                |
| [`c0d06189`](https://github.com/nix-community/home-manager/commit/c0d06189f27f9cd0f97c13a0e75c4fd12c7e9d61) | `` kitty: assert can't enable shell integrations when mode is null ``                      |
| [`fc3cd1e4`](https://github.com/nix-community/home-manager/commit/fc3cd1e40870cb40692d1272468fa5e187d07591) | `` kitty: allow not setting shell_integration ``                                           |
| [`a3c9e881`](https://github.com/nix-community/home-manager/commit/a3c9e88177f0dc4a2662b5324572425f59129f11) | `` nushell: temporarily disable test ``                                                    |
| [`0f9e9230`](https://github.com/nix-community/home-manager/commit/0f9e92302a6bd86087e8b6f1a539d1d1f0ccbe62) | `` neovim: re-enable test ``                                                               |
| [`cf2ea71e`](https://github.com/nix-community/home-manager/commit/cf2ea71e6877dddd9b94812fcb21a19f21f3d351) | `` flake.lock: Update ``                                                                   |