### PR TITLE
chore(flake/emacs-overlay): `66b6a800` -> `9bb2d793`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1739207663,
-        "narHash": "sha256-H0Z/Uxh1EIoZRzpXgezQPekp3ccFd/WdUVinILVnM+Y=",
+        "lastModified": 1739239803,
+        "narHash": "sha256-OnhAYYi1bCTAbgOE7SzuAAtkeSSwP7r4xI0qIDprS6w=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "66b6a800edf6c6ef58d021b81ab7e6a10ae34834",
+        "rev": "9bb2d793316aeb2951f2b2dd9a8cefb66ee5e904",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`9bb2d793`](https://github.com/nix-community/emacs-overlay/commit/9bb2d793316aeb2951f2b2dd9a8cefb66ee5e904) | `` Updated emacs ``  |
| [`6c678971`](https://github.com/nix-community/emacs-overlay/commit/6c6789714c116cf6a5bf702b97bda2009db5a969) | `` Updated melpa ``  |
| [`7b512de1`](https://github.com/nix-community/emacs-overlay/commit/7b512de162fb12311393c88d558e2e3452eeb7f2) | `` Updated elpa ``   |
| [`d0dc89d5`](https://github.com/nix-community/emacs-overlay/commit/d0dc89d556140e723afa628fd0efdab5e03eb86f) | `` Updated nongnu `` |