### PR TITLE
chore(flake/emacs-overlay): `9bb2d793` -> `096d802c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1739239803,
-        "narHash": "sha256-OnhAYYi1bCTAbgOE7SzuAAtkeSSwP7r4xI0qIDprS6w=",
+        "lastModified": 1739294132,
+        "narHash": "sha256-TG0f3kbydzLERVmcRTzeWdo6oKOGOTPUZDfVrKvSjdc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9bb2d793316aeb2951f2b2dd9a8cefb66ee5e904",
+        "rev": "096d802c6545f32eb718483ef66ae8013abf9a36",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`096d802c`](https://github.com/nix-community/emacs-overlay/commit/096d802c6545f32eb718483ef66ae8013abf9a36) | `` Updated emacs ``  |
| [`9bbc62c7`](https://github.com/nix-community/emacs-overlay/commit/9bbc62c7dc4107e4a04c8a30f2b17d09069f07f8) | `` Updated melpa ``  |
| [`f69abd1d`](https://github.com/nix-community/emacs-overlay/commit/f69abd1dadc4e7823a3db12538fba2d2eeca4905) | `` Updated elpa ``   |
| [`08eb6156`](https://github.com/nix-community/emacs-overlay/commit/08eb61561a369afa53d914c92fc4dec41068dffb) | `` Updated nongnu `` |
| [`20e2333e`](https://github.com/nix-community/emacs-overlay/commit/20e2333eb7184318ddfa0c9269a8e509b6de85d6) | `` Updated emacs ``  |
| [`84e1abab`](https://github.com/nix-community/emacs-overlay/commit/84e1abab380d830c96b6d8e953443df1045d32e0) | `` Updated melpa ``  |