### PR TITLE
chore(flake/sops-nix): `4c125190` -> `07af005b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -864,11 +864,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738291974,
-        "narHash": "sha256-wkwYJc8cKmmQWUloyS9KwttBnja2ONRuJQDEsmef320=",
+        "lastModified": 1739262228,
+        "narHash": "sha256-7JAGezJ0Dn5qIyA2+T4Dt/xQgAbhCglh6lzCekTVMeU=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "4c1251904d8a08c86ac6bc0d72cc09975e89aef7",
+        "rev": "07af005bb7d60c7f118d9d9f5530485da5d1e975",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                           |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`07af005b`](https://github.com/Mic92/sops-nix/commit/07af005bb7d60c7f118d9d9f5530485da5d1e975) | `` update vendorHash ``                                           |
| [`935f5a43`](https://github.com/Mic92/sops-nix/commit/935f5a433043ea4b9b7a705489c5d54d300a5499) | `` build(deps): bump golang.org/x/crypto from 0.32.0 to 0.33.0 `` |
| [`c2717649`](https://github.com/Mic92/sops-nix/commit/c2717649e7629bfb502b2568af782544d854f20a) | `` update vendorHash ``                                           |
| [`d4d1d6fa`](https://github.com/Mic92/sops-nix/commit/d4d1d6fac8595c61f976e36b0b2a121c16a5c1af) | `` build(deps): bump golang.org/x/sys from 0.29.0 to 0.30.0 ``    |