### PR TITLE
chore(flake/home-manager): `ba4a1a11` -> `83bd3a26`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739233400,
-        "narHash": "sha256-fldFwXHP9Ndy/ADMDWNTpfWNsLdhZ8PP4DQyr1Igfo4=",
+        "lastModified": 1739314552,
+        "narHash": "sha256-ggVf2BclyIW3jexc/uvgsgJH4e2cuG6Nyg54NeXgbFI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ba4a1a110204c27805d1a1b5c8b24b3a0da4d063",
+        "rev": "83bd3a26ac0526ae04fa74df46738bb44b89dcdd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`83bd3a26`](https://github.com/nix-community/home-manager/commit/83bd3a26ac0526ae04fa74df46738bb44b89dcdd) | `` email: add migadu.com flavor ``                                     |
| [`f0a31d38`](https://github.com/nix-community/home-manager/commit/f0a31d38e6de48970ce1fe93e6ea343e20a9c80a) | `` neomutt: fix default for 'map' in macros/binds (#6429) ``           |
| [`8f351726`](https://github.com/nix-community/home-manager/commit/8f351726c5841d86854e7fa6003ea472352f5208) | `` git-worktree-switcher: use lib.hm.shell.mkShellIntegrationOption `` |
| [`9c8169b4`](https://github.com/nix-community/home-manager/commit/9c8169b4466391999b1ad5ea86be4e79d560af52) | `` git-worktree-switcher: init module ``                               |
| [`59fe145f`](https://github.com/nix-community/home-manager/commit/59fe145f0bb7cfde99f148140a47a54deb8cc23f) | `` eww: make configDir optional (#6282) ``                             |