### PR TITLE
chore(flake/emacs-overlay): `096d802c` -> `80ccdb81`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1739294132,
-        "narHash": "sha256-TG0f3kbydzLERVmcRTzeWdo6oKOGOTPUZDfVrKvSjdc=",
+        "lastModified": 1739326040,
+        "narHash": "sha256-4y1SkHV198ONtFRos10y75rSO+ZXxMuIdHadCVXRoYc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "096d802c6545f32eb718483ef66ae8013abf9a36",
+        "rev": "80ccdb81a7e20a618aa9be869e90cb083925459f",
         "type": "github"
       },
       "original": {
@@ -603,11 +603,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1739055578,
-        "narHash": "sha256-2MhC2Bgd06uI1A0vkdNUyDYsMD0SLNGKtD8600mZ69A=",
+        "lastModified": 1739206421,
+        "narHash": "sha256-PwQASeL2cGVmrtQYlrBur0U20Xy07uSWVnFup2PHnDs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a45fa362d887f4d4a7157d95c28ca9ce2899b70e",
+        "rev": "44534bc021b85c8d78e465021e21f33b856e2540",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`80ccdb81`](https://github.com/nix-community/emacs-overlay/commit/80ccdb81a7e20a618aa9be869e90cb083925459f) | `` Updated emacs ``        |
| [`52b6b413`](https://github.com/nix-community/emacs-overlay/commit/52b6b41397b27cd10e866dea9ba04bc50ea2bea0) | `` Updated melpa ``        |
| [`3d098f31`](https://github.com/nix-community/emacs-overlay/commit/3d098f31c121b8051ccad6e80a549050a7496120) | `` Updated elpa ``         |
| [`96a88d24`](https://github.com/nix-community/emacs-overlay/commit/96a88d2499742c1f1c5efae2bcf715dec276db7e) | `` Updated nongnu ``       |
| [`5447db0b`](https://github.com/nix-community/emacs-overlay/commit/5447db0b785fe0954475e50fb09a89a6c72ab20b) | `` Updated flake inputs `` |