### PR TITLE
chore(flake/emacs-overlay): `80ccdb81` -> `8d99adb2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1739326040,
-        "narHash": "sha256-4y1SkHV198ONtFRos10y75rSO+ZXxMuIdHadCVXRoYc=",
+        "lastModified": 1739352041,
+        "narHash": "sha256-EH0lhdcdm3vWpHTPGIy24TVMfaNhh+eD2wt9wo+nNeY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "80ccdb81a7e20a618aa9be869e90cb083925459f",
+        "rev": "8d99adb21eab7b97c4004af67ea640ed245215a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`8d99adb2`](https://github.com/nix-community/emacs-overlay/commit/8d99adb21eab7b97c4004af67ea640ed245215a1) | `` Updated emacs `` |
| [`944d35f6`](https://github.com/nix-community/emacs-overlay/commit/944d35f6f9bdf31e899b579c0f940f8875eb6e7f) | `` Updated melpa `` |