### PR TITLE
chore(flake/emacs-overlay): `8d99adb2` -> `88f3cba3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1739352041,
-        "narHash": "sha256-EH0lhdcdm3vWpHTPGIy24TVMfaNhh+eD2wt9wo+nNeY=",
+        "lastModified": 1739380704,
+        "narHash": "sha256-pIv4L+fvaaOHa1SsH2ePECvChmcr6T3AheFMtyn5rMI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8d99adb21eab7b97c4004af67ea640ed245215a1",
+        "rev": "88f3cba36d23f40c7e6b868d0b80555c55cdc3a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`88f3cba3`](https://github.com/nix-community/emacs-overlay/commit/88f3cba36d23f40c7e6b868d0b80555c55cdc3a5) | `` Updated emacs ``  |
| [`a2eaa98f`](https://github.com/nix-community/emacs-overlay/commit/a2eaa98fe318a49b2c1bfd6eca0f00f6e1f1dce0) | `` Updated melpa ``  |
| [`4c869359`](https://github.com/nix-community/emacs-overlay/commit/4c869359d3490374563b56bbf42db92293982e4b) | `` Updated elpa ``   |
| [`4a4fdc8b`](https://github.com/nix-community/emacs-overlay/commit/4a4fdc8b9a6f6230cd9e7cab52c9f01477003a09) | `` Updated nongnu `` |