### PR TITLE
chore(flake/emacs-overlay): `88f3cba3` -> `8a91f48b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1739380704,
-        "narHash": "sha256-pIv4L+fvaaOHa1SsH2ePECvChmcr6T3AheFMtyn5rMI=",
+        "lastModified": 1739414090,
+        "narHash": "sha256-a3RrKwEPoNh68CPqNIhTqhmd8gFwyF16LGuc3jT2W7s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "88f3cba36d23f40c7e6b868d0b80555c55cdc3a5",
+        "rev": "8a91f48b10b4ef312f483af4fc2ca768f05118b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`8a91f48b`](https://github.com/nix-community/emacs-overlay/commit/8a91f48b10b4ef312f483af4fc2ca768f05118b6) | `` Updated emacs ``  |
| [`2a6a8976`](https://github.com/nix-community/emacs-overlay/commit/2a6a8976401f01bdf866385f00c4205e6818b316) | `` Updated melpa ``  |
| [`9868eea1`](https://github.com/nix-community/emacs-overlay/commit/9868eea14531e913b38c5767e0a12ed14e6b862b) | `` Updated elpa ``   |
| [`057dca0b`](https://github.com/nix-community/emacs-overlay/commit/057dca0b0e4c6ac953b05fbb46ac00a17e593f18) | `` Updated nongnu `` |