### PR TITLE
chore(flake/nur): `8348d89f` -> `1427b0a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -682,11 +682,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1739020877,
-        "narHash": "sha256-mIvECo/NNdJJ/bXjNqIh8yeoSjVLAuDuTUzAo7dzs8Y=",
+        "lastModified": 1739214665,
+        "narHash": "sha256-26L8VAu3/1YRxS8MHgBOyOM8xALdo6N0I04PgorE7UM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a79cfe0ebd24952b580b1cf08cd906354996d547",
+        "rev": "64e75cd44acf21c7933d61d7721e812eac1b5a0a",
         "type": "github"
       },
       "original": {
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1739229047,
-        "narHash": "sha256-sSTgA86wdk8d544c2+gzrfvVPHQF4mbsomvLOW2thn0=",
+        "lastModified": 1739475901,
+        "narHash": "sha256-s/0RfbemqINTPLYUZB6jnp2O7FNLsAAtAvSCZMnH4Lw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8348d89f30598a73fee7efb4b5d34c3de201e71b",
+        "rev": "1427b0a98c51198503c525bc91d452507b56032c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                        |
| -------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`1427b0a9`](https://github.com/nix-community/NUR/commit/1427b0a98c51198503c525bc91d452507b56032c) | `` automatic update ``                         |
| [`9716d3d5`](https://github.com/nix-community/NUR/commit/9716d3d51de1eaa8fc75a66d446e1d8d4c4e4cc5) | `` automatic update ``                         |
| [`901397f9`](https://github.com/nix-community/NUR/commit/901397f95f57fb077f5a5c3a4726f17c0ec86d3a) | `` automatic update ``                         |
| [`1643a8a0`](https://github.com/nix-community/NUR/commit/1643a8a0acf93d6e8fd79b01bb2e53d84fae48c8) | `` automatic update ``                         |
| [`707fe498`](https://github.com/nix-community/NUR/commit/707fe498c2a1a8a54e43d2c974d8b3df907ad595) | `` automatic update ``                         |
| [`4afb70a7`](https://github.com/nix-community/NUR/commit/4afb70a7cea1fa6f8b072ef262d425e10839114d) | `` automatic update ``                         |
| [`cff37b74`](https://github.com/nix-community/NUR/commit/cff37b744dee6a22c20a5bbbcd81625705390a1f) | `` automatic update ``                         |
| [`b8901571`](https://github.com/nix-community/NUR/commit/b890157155fb46d4aebeca5bad62fd494588ddd5) | `` automatic update ``                         |
| [`b86ac4fa`](https://github.com/nix-community/NUR/commit/b86ac4fa42bcf08f99b7949533e55d51c66055eb) | `` automatic update ``                         |
| [`1766dbe0`](https://github.com/nix-community/NUR/commit/1766dbe04355e75b2e79c849705a2c309830114c) | `` automatic update ``                         |
| [`758a1afc`](https://github.com/nix-community/NUR/commit/758a1afc05d32745f0ea73415f9f8593930d18c2) | `` automatic update ``                         |
| [`ec0089b2`](https://github.com/nix-community/NUR/commit/ec0089b259236422b7221ba8677dc6ed471cbe8d) | `` automatic update ``                         |
| [`12987913`](https://github.com/nix-community/NUR/commit/12987913ee03c895092b330c556289308e57eaf0) | `` automatic update ``                         |
| [`f56ac35e`](https://github.com/nix-community/NUR/commit/f56ac35e16f32e2183647d46c6d4edad1c1091ae) | `` automatic update ``                         |
| [`f4cc951c`](https://github.com/nix-community/NUR/commit/f4cc951c2358537afe895f672436a84a0cb11445) | `` automatic update ``                         |
| [`59b63b52`](https://github.com/nix-community/NUR/commit/59b63b52023a2ae25858dd44b0e4ee073ba99804) | `` automatic update ``                         |
| [`39f98ac5`](https://github.com/nix-community/NUR/commit/39f98ac5b6665a5a0174dc1f93d6148bfb76e0f0) | `` automatic update ``                         |
| [`6fe20bad`](https://github.com/nix-community/NUR/commit/6fe20bad4f79612028016e07971300126957f144) | `` automatic update ``                         |
| [`b25981a0`](https://github.com/nix-community/NUR/commit/b25981a022a21a3b419fe2227f7f1cecb158bd3f) | `` automatic update ``                         |
| [`b975d85c`](https://github.com/nix-community/NUR/commit/b975d85c22be8b6c5078169b768c44b5501cc5cf) | `` automatic update ``                         |
| [`0ae24cb2`](https://github.com/nix-community/NUR/commit/0ae24cb24110a205d9c7581e73114335c02f4e71) | `` automatic update ``                         |
| [`45b736c6`](https://github.com/nix-community/NUR/commit/45b736c6b687ff369418dbe3dc63ac520d5200fd) | `` Fix update-nur-combined.sh permissions ``   |
| [`309e1cb5`](https://github.com/nix-community/NUR/commit/309e1cb534efde16c5979e95b6412006ff14a801) | `` Don't re-trigger on self-push ``            |
| [`f5d54374`](https://github.com/nix-community/NUR/commit/f5d54374e06d98d3dad3de0f2b0b2cab5482fc25) | `` Add fetch-depth 0 to combined update job `` |
| [`1afc5890`](https://github.com/nix-community/NUR/commit/1afc5890a0befb9c06c9f5240ac29d7745c1127c) | `` Fix typo in nur-combined update script ``   |
| [`18efd7e4`](https://github.com/nix-community/NUR/commit/18efd7e4cce6bebeffc5fcd4c7777527a36c24ef) | `` automatic update ``                         |
| [`b73f89bf`](https://github.com/nix-community/NUR/commit/b73f89bf9cba652a4403a6e37343a53e68d5d774) | `` yet more CI fixes ``                        |