### PR TITLE
chore(flake/srvos): `8e257cc0` -> `54aae80b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -884,11 +884,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739149457,
-        "narHash": "sha256-777RrYhdblwYBDruc5xaRdheTGyBMOdjcJmc67d98es=",
+        "lastModified": 1739438633,
+        "narHash": "sha256-7nTfMqYkc7WQwmB6m2zo2m2DEmNqrfyE+Pdisr7cTTI=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "8e257cc0810b5aa0f1a8841d8bdbb10eda07ae16",
+        "rev": "54aae80b7526d234658632d251e9bf278b58b7ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`54aae80b`](https://github.com/nix-community/srvos/commit/54aae80b7526d234658632d251e9bf278b58b7ef) | `` nginx: disable zstd (#611) ``     |
| [`02f6ebf3`](https://github.com/nix-community/srvos/commit/02f6ebf3421677bd8e810814ec6026631136792b) | `` dev/private/flake.lock: Update `` |
| [`b63eb7ce`](https://github.com/nix-community/srvos/commit/b63eb7ce9ad2116535cc21a5fb5e85ffcbbdf241) | `` flake.lock: Update ``             |