### PR TITLE
chore(flake/emacs-overlay): `388f3558` -> `3a93a0a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1739438051,
-        "narHash": "sha256-Gau7wioN4GA9/koJmzaq8/dTz+OIdVAqW0fbd/KXUVs=",
+        "lastModified": 1739553792,
+        "narHash": "sha256-W/VqlGtMXv4cQ1V5j1Sbfu59x8DWntEkTJWJNHo9P+Q=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "388f3558cc759d1686c2e0001cd52c4c89a6d44e",
+        "rev": "3a93a0a8f94fd52260b39aefc05e7bc667ded0ab",
         "type": "github"
       },
       "original": {
@@ -603,11 +603,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1739206421,
-        "narHash": "sha256-PwQASeL2cGVmrtQYlrBur0U20Xy07uSWVnFup2PHnDs=",
+        "lastModified": 1739357830,
+        "narHash": "sha256-9xim3nJJUFbVbJCz48UP4fGRStVW5nv4VdbimbKxJ3I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "44534bc021b85c8d78e465021e21f33b856e2540",
+        "rev": "0ff09db9d034a04acd4e8908820ba0b410d7a33a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`3a93a0a8`](https://github.com/nix-community/emacs-overlay/commit/3a93a0a8f94fd52260b39aefc05e7bc667ded0ab) | `` Updated emacs ``        |
| [`9262057c`](https://github.com/nix-community/emacs-overlay/commit/9262057cc86e7512d742a1c1ae9d7d118bb82d48) | `` Updated melpa ``        |
| [`55002e9e`](https://github.com/nix-community/emacs-overlay/commit/55002e9eb67d3e5aa6783a46da5f70ce804ebb03) | `` Updated elpa ``         |
| [`7b9cb254`](https://github.com/nix-community/emacs-overlay/commit/7b9cb25425a6bcc5a5e8b4e4a5be2ee0400bec78) | `` Updated nongnu ``       |
| [`24720cc6`](https://github.com/nix-community/emacs-overlay/commit/24720cc605015be05e56b9402dd022c397be0b89) | `` Updated emacs ``        |
| [`5a593ca1`](https://github.com/nix-community/emacs-overlay/commit/5a593ca15d1bb84a5ae2c12fba347309b6f0aeff) | `` Updated melpa ``        |
| [`e9a20ce4`](https://github.com/nix-community/emacs-overlay/commit/e9a20ce4908add82fd2f31d85bd6844ba0c0a8e9) | `` Updated emacs ``        |
| [`b98ec2bd`](https://github.com/nix-community/emacs-overlay/commit/b98ec2bd221d27671ed99a0b59f66317955a1fee) | `` Updated melpa ``        |
| [`aa543ab6`](https://github.com/nix-community/emacs-overlay/commit/aa543ab67245e3109fd0d396bddc89ffd22b0e36) | `` Updated elpa ``         |
| [`911c0cf1`](https://github.com/nix-community/emacs-overlay/commit/911c0cf1bc533951594eab080db23094c830c322) | `` Updated nongnu ``       |
| [`fb6fcbfc`](https://github.com/nix-community/emacs-overlay/commit/fb6fcbfc802e2d4e5e458c385bfba76cb5ffff92) | `` Updated flake inputs `` |
| [`56f3570e`](https://github.com/nix-community/emacs-overlay/commit/56f3570e6a3cfa13a7255c7b39c4a8427367e646) | `` Updated emacs ``        |
| [`141bb2ab`](https://github.com/nix-community/emacs-overlay/commit/141bb2ab7b30a4d50ac6c23bc3eb37ee45258607) | `` Updated melpa ``        |
| [`8cf8f68c`](https://github.com/nix-community/emacs-overlay/commit/8cf8f68ca90dc05d7ecd4feb7f36beaf2f5fbd18) | `` Updated elpa ``         |
| [`4d002846`](https://github.com/nix-community/emacs-overlay/commit/4d002846f8cce10370e846846909b582e8ae540e) | `` Updated nongnu ``       |
| [`9196c8d5`](https://github.com/nix-community/emacs-overlay/commit/9196c8d59c9110238c98c38cbb452ed49ef35ce3) | `` Updated flake inputs `` |