### PR TITLE
chore(flake/nixpkgs): `64e75cd4` -> `2ff53fe6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -666,11 +666,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1739214665,
-        "narHash": "sha256-26L8VAu3/1YRxS8MHgBOyOM8xALdo6N0I04PgorE7UM=",
+        "lastModified": 1739446958,
+        "narHash": "sha256-+/bYK3DbPxMIvSL4zArkMX0LQvS7rzBKXnDXLfKyRVc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64e75cd44acf21c7933d61d7721e812eac1b5a0a",
+        "rev": "2ff53fe64443980e139eaa286017f53f88336dd0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`af683181`](https://github.com/NixOS/nixpkgs/commit/af6831814d528fe0d1477eca76006c2183ac8f0d) | `` sympa: Add missing UnicodeUTF8 dependency ``                                             |
| [`c1bdbaa9`](https://github.com/NixOS/nixpkgs/commit/c1bdbaa9c40b1c90194148ea858e7e1258a95c05) | `` snort: init at 3.6.3.0 ``                                                                |
| [`ba3b6a7f`](https://github.com/NixOS/nixpkgs/commit/ba3b6a7fe81d4d41bf88228d7fc7dfe80630ae11) | `` snort: rename to snort2 ``                                                               |
| [`e889770f`](https://github.com/NixOS/nixpkgs/commit/e889770f0081d6969e7e095fa42ec80fc57b3629) | `` libdaq: init at 3.0.18 ``                                                                |
| [`d6d21ca2`](https://github.com/NixOS/nixpkgs/commit/d6d21ca240f3218f6fcad295e45f5b1526b388f3) | `` vimPlugins.lze: 0.7.9 -> 0.7.11 ``                                                       |
| [`943e2eeb`](https://github.com/NixOS/nixpkgs/commit/943e2eebd6515392e421cf798df6310023b6573a) | `` python312Packages.microsoft-kiota-authentication-azure: 1.9.1 -> 1.9.2 ``                |
| [`e6c437f1`](https://github.com/NixOS/nixpkgs/commit/e6c437f1d87baaeb4d313a1d3b03ee8f6f0ae162) | `` python312Packages.microsoft-kiota-serialization-form: 1.9.1 -> 1.9.2 ``                  |
| [`c97c8139`](https://github.com/NixOS/nixpkgs/commit/c97c81390d4ab57eba36829400f32d54440b19ed) | `` python312Packages.dsmr-parser: 1.4.2 -> 1.4.3 ``                                         |
| [`2f4ee1e6`](https://github.com/NixOS/nixpkgs/commit/2f4ee1e6645e34dfd8e39121255525e673639551) | `` h2o: add optional mruby support ``                                                       |
| [`51d457d4`](https://github.com/NixOS/nixpkgs/commit/51d457d48fba666c6b7836b6bb3f1318cde26fe3) | `` python312Packages.jupyter-ydoc: 3.0.2 -> 3.0.3 ``                                        |
| [`8b57c1dc`](https://github.com/NixOS/nixpkgs/commit/8b57c1dcaa370285eb17ece77e60bf054fac0ede) | `` python312Packages.pycrdt-websocket: 0.15.1 -> 0.15.3 ``                                  |
| [`751529d3`](https://github.com/NixOS/nixpkgs/commit/751529d3b07d1694ff5b61ea6e1cf5008ab09ce1) | `` libyang: 3.4.2 -> 3.7.8 ``                                                               |
| [`57859891`](https://github.com/NixOS/nixpkgs/commit/5785989193c8d810cc1758a47e73a24823e021b9) | `` asmjit: unstable-2023-04-28 -> unstable-2025-02-12 ``                                    |
| [`2cbbe29f`](https://github.com/NixOS/nixpkgs/commit/2cbbe29f20dff808e4482fa6c4ae6ca3e41ffcba) | `` python312Packages.pycrdt: 0.10.9 -> 0.12.8 ``                                            |
| [`b2415c56`](https://github.com/NixOS/nixpkgs/commit/b2415c564541f15cb577727fb0be66216fb4121c) | `` nginxModules.zstd: 0.1.1 -> 2024-04-22 ``                                                |
| [`3d229753`](https://github.com/NixOS/nixpkgs/commit/3d229753d66bd46ca0cf307f72786daa520dc5ff) | `` mstflint_access: 4.30.0-1 -> 4.31.0-1; mstflint: 4.30.0-1 -> 4.31.0-1 ``                 |
| [`39bd82fb`](https://github.com/NixOS/nixpkgs/commit/39bd82fb954433d6a04bd2fcee76d1e6345cfcdd) | `` uv: 0.5.30 -> 0.5.31 ``                                                                  |
| [`94878cc3`](https://github.com/NixOS/nixpkgs/commit/94878cc319d39919f50d3a64b82f6edf25295cef) | `` smartmontools: update drivedb rev 5388 -> 5661 ``                                        |
| [`cab22b67`](https://github.com/NixOS/nixpkgs/commit/cab22b674f9b958fb9b636adc662e457d0c98445) | `` python312Packages.metaflow: init at 2.13.9 ``                                            |
| [`bb7d35e5`](https://github.com/NixOS/nixpkgs/commit/bb7d35e53ab9ce4d147da02e11b7cb17b28c9552) | `` maintainers: add kr7x ``                                                                 |
| [`4274ff3b`](https://github.com/NixOS/nixpkgs/commit/4274ff3b5075254534ff6dba8e53362b0b17b28c) | `` dotherside: init at 0.9.0 ``                                                             |
| [`74e5990b`](https://github.com/NixOS/nixpkgs/commit/74e5990bc730783a9d38ee7b215a0fdcedd97c97) | `` python3Packages.odc-stac: init at 0.3.11 ``                                              |
| [`a52a8d77`](https://github.com/NixOS/nixpkgs/commit/a52a8d77d543c5cf01e2216a0df2fd83f9e1d6c1) | `` google-amber: unstable-2024-08-21 -> unstable-2025-02-03 (#381140) ``                    |
| [`7a919198`](https://github.com/NixOS/nixpkgs/commit/7a9191988f86e6fb5f957519eab7d4488fbfa80f) | `` python312Packages.open-hypergraphs: init at 0.1.2 ``                                     |
| [`3b65e736`](https://github.com/NixOS/nixpkgs/commit/3b65e736c1146fa416598f6b2e8d1ab94b1fa534) | `` taproot-assets: 0.5.0 -> 0.5.1 ``                                                        |
| [`f04dfa39`](https://github.com/NixOS/nixpkgs/commit/f04dfa398db34fc56d27a88880a012ecd4166c81) | `` skopeo: 1.17.0 -> 1.18.0 ``                                                              |
| [`3c8536f7`](https://github.com/NixOS/nixpkgs/commit/3c8536f7ee1b9418978f9b4ec97647a3af59335a) | `` openbsd.rc: init ``                                                                      |
| [`8b08408e`](https://github.com/NixOS/nixpkgs/commit/8b08408e9794f94e932b9cfd844c1d14dabdf2b8) | `` openbsd.makedev: init ``                                                                 |
| [`ffecf553`](https://github.com/NixOS/nixpkgs/commit/ffecf553ecffe27c0d5f88d70fc44dce940db7eb) | `` freebsd.makefs: uncomment code which can copy device info from an mtree ``               |
| [`9f355b12`](https://github.com/NixOS/nixpkgs/commit/9f355b12e5502ab60e40e7eaa713f6cf3c52df88) | `` openbsd.libc: add libkvm ``                                                              |
| [`598aa1f9`](https://github.com/NixOS/nixpkgs/commit/598aa1f95454c62d8f3f5d088834cbf8b36903a5) | `` xz: run autoreconfHook on OpenBSD ``                                                     |
| [`8a3176ac`](https://github.com/NixOS/nixpkgs/commit/8a3176ac2775b40ae62a80b574f2ed01c55ad677) | `` git-sync: enable automatic package update ``                                             |
| [`4ec54a16`](https://github.com/NixOS/nixpkgs/commit/4ec54a16d6acfbf1be9473253bb0a74c1aef5b3e) | `` git-sync: 0-unstable-2024-02-15 → 0-unstable-2024-11-30 ``                               |
| [`80ab7b56`](https://github.com/NixOS/nixpkgs/commit/80ab7b5622da71bd02eb9768f712192cda29491f) | `` steamguard-cli: 0.15.0 -> 0.16.0 ``                                                      |
| [`8ec9c084`](https://github.com/NixOS/nixpkgs/commit/8ec9c084ceb4ba1ded50070325d574317c83a9e3) | `` pulldown-cmark: 0.12.2 -> 0.13.0 ``                                                      |
| [`fd640fe6`](https://github.com/NixOS/nixpkgs/commit/fd640fe6a92bd829e0794873990d91141c1a3d2d) | `` wyoming-satellite: 1.3.0 -> 1.4.1 ``                                                     |
| [`be6f48bc`](https://github.com/NixOS/nixpkgs/commit/be6f48bc3942ec2a2a26778365f6b4ca7ad696d4) | `` nixos-render-docs: move pytestCheckHook to nativeCheckInputs ``                          |
| [`5485a051`](https://github.com/NixOS/nixpkgs/commit/5485a051be4bac12d34e73cbebeab53b430f6ee8) | `` nixos-rebuild-ng: add missing autospec ``                                                |
| [`4bbce7c4`](https://github.com/NixOS/nixpkgs/commit/4bbce7c4bc5312619302c01d77a89e7fb1c76240) | `` python312Packages.google-cloud-artifact-registry: 1.14.0 -> 1.15.0 ``                    |
| [`ae88fbbd`](https://github.com/NixOS/nixpkgs/commit/ae88fbbda13761f951ecb4e5d6a52c9e1ba8dc32) | `` home-assistant: 2025.2.2 -> 2025.2.3 ``                                                  |
| [`abe0554c`](https://github.com/NixOS/nixpkgs/commit/abe0554c2f242ef7ccbd5c28553851536addfc90) | `` python313Packages.zeroconf: 0.143.0 -> 0.144.1 ``                                        |
| [`ae9a4e7b`](https://github.com/NixOS/nixpkgs/commit/ae9a4e7bb62ed28c838d23de7b5ebd6ea667f91b) | `` python313Packages.sentry-sdk_1: 1.45.0 -> 1.45.1 ``                                      |
| [`076dd7b5`](https://github.com/NixOS/nixpkgs/commit/076dd7b56f9c7893d24319e6bae84061e7de533d) | `` python313Packages.pyenphase: 1.23.1 -> 1.25.4 ``                                         |
| [`23655aa6`](https://github.com/NixOS/nixpkgs/commit/23655aa62f4f15860c978b29ee17e34f165f282e) | `` python313Packages.hass-nabucasa: 0.89.0 -> 0.90.0 ``                                     |
| [`c2d04bc4`](https://github.com/NixOS/nixpkgs/commit/c2d04bc487c782da9004f8f1d055ac04aa2bf191) | `` python313Packages.deebot-client: 12.0.0 -> 12.1.0 ``                                     |
| [`d6e849ee`](https://github.com/NixOS/nixpkgs/commit/d6e849ee03d1849bd5151c651e66a8731a0c4891) | `` nixos-rebuild-ng: {assert_called_with,assert_has_calls} -> {call_args,call_args_list} `` |
| [`914f4e54`](https://github.com/NixOS/nixpkgs/commit/914f4e549a2ab540d8449e45f2dd8958e4ef46f2) | `` wcslib: fix noBrokenSymlinks ``                                                          |
| [`a73aa4df`](https://github.com/NixOS/nixpkgs/commit/a73aa4dff895f3415b5fad6df58c82a57223211e) | `` cables: 0.5.2 -> 0.5.6 ``                                                                |
| [`b6f382b9`](https://github.com/NixOS/nixpkgs/commit/b6f382b94c2d4335099ff623f412d2382278e1ae) | `` p3x-onenote: 2024.10.117 -> 2025.4.124 ``                                                |
| [`3063e2da`](https://github.com/NixOS/nixpkgs/commit/3063e2dafd95b414bdc304c6a1f07cbfb78a3c89) | `` dinish: 4.005 -> 4.006 ``                                                                |
| [`9b55ba2c`](https://github.com/NixOS/nixpkgs/commit/9b55ba2caad82598a3fde2dec1422776005b7cdf) | `` python312Packages.ssh2-python: 1.1.2 -> 1.1.2.post1 ``                                   |
| [`97bee299`](https://github.com/NixOS/nixpkgs/commit/97bee299fe8d4db90b0b0924f693dd540e5a6c5d) | `` aporetic: 1.0.0 -> 1.1.0 ``                                                              |
| [`e17baf2e`](https://github.com/NixOS/nixpkgs/commit/e17baf2e9f74eac61f0de2b7c9c8de18f6bc727b) | `` lowfi: fix source hash, switch to useFetchCargoVendor ``                                 |
| [`dc9233d9`](https://github.com/NixOS/nixpkgs/commit/dc9233d9284e2f0fef002096a3bdfd5558f0d971) | `` linux-firmware: 20250109 -> 20250211 ``                                                  |
| [`4851d059`](https://github.com/NixOS/nixpkgs/commit/4851d05999aaa96b14e90e8280508d1ec4f2518c) | `` nixos/lighttpd/cgit: fix documentation link formatting ``                                |
| [`c58bf61f`](https://github.com/NixOS/nixpkgs/commit/c58bf61fc22cf85414083703ee13ea4a7613fabd) | `` nixos/zitadel: fix documentation link formatting ``                                      |
| [`839a4277`](https://github.com/NixOS/nixpkgs/commit/839a4277250b1ac62cb5923be61c25440eb6c85a) | `` nixos/youtrack: fix documentation link formatting ``                                     |
| [`f552ef98`](https://github.com/NixOS/nixpkgs/commit/f552ef9849d8702da7bcfdbfede05aa5f7234522) | `` nixos/stirling-pdf: fix documentation link formatting ``                                 |
| [`28968693`](https://github.com/NixOS/nixpkgs/commit/28968693a92e9cabd87b768a0a7494ca6418b579) | `` nixos/slskd: fix documentation link formatting ``                                        |
| [`d907fcd3`](https://github.com/NixOS/nixpkgs/commit/d907fcd3f1796a86e6908e0c47ed339223a15d56) | `` nixos/screego: fix documentation link formatting ``                                      |
| [`f40ba2f2`](https://github.com/NixOS/nixpkgs/commit/f40ba2f28ced4e82447f5c836f411a7e9920a02f) | `` nixos/plausible: fix documentation link formatting ``                                    |
| [`600900c7`](https://github.com/NixOS/nixpkgs/commit/600900c77c39e6a2c268e1bf65591d73f4fc8cdf) | `` nixos/peering-manager: fix documentation link formatting ``                              |
| [`88b108f3`](https://github.com/NixOS/nixpkgs/commit/88b108f32863886efd6f1ad1037aa29eec38dfa1) | `` nixos/outline: fix documentation link formatting ``                                      |
| [`aea7a63d`](https://github.com/NixOS/nixpkgs/commit/aea7a63d8f87553e9fdb2a790cdba5be97a10bf7) | `` nixos/nextjs-ollama-llm-ui: fix documentation link formatting ``                         |
| [`82d4e008`](https://github.com/NixOS/nixpkgs/commit/82d4e0086fc90067e7c02221b96bc0c755653503) | `` nixos/nextcloud: fix documentation link formatting ``                                    |
| [`fe6a8e7b`](https://github.com/NixOS/nixpkgs/commit/fe6a8e7b09ed8b896eda654b0903fdf4ce65d470) | `` nixos/mattermost: fix documentation link formatting ``                                   |
| [`c3abba57`](https://github.com/NixOS/nixpkgs/commit/c3abba577a85e23e14880b11c39bc36b1776de90) | `` nixos/mastodon: fix documentation link formatting ``                                     |
| [`91283c6f`](https://github.com/NixOS/nixpkgs/commit/91283c6fe73d176cda0db9bb4ac01219c660a2e4) | `` nixos/kimai: fix documentation link formatting ``                                        |
| [`384a6720`](https://github.com/NixOS/nixpkgs/commit/384a6720d72a2a7357d5d187a6bc0683c26637b5) | `` nixos/invidious: fix documentation link formatting ``                                    |
| [`40371dd1`](https://github.com/NixOS/nixpkgs/commit/40371dd1315954151979f24fb198ba168565ecec) | `` nixos/gotify-server: fix documentation link formatting ``                                |
| [`16d33236`](https://github.com/NixOS/nixpkgs/commit/16d3323694a2bd11a0cf87ea8e7140068f08994f) | `` nixos/gancio: fix documentation link formatting ``                                       |
| [`be2c87ee`](https://github.com/NixOS/nixpkgs/commit/be2c87eea09018b33bbade3e3df141e9e2911e32) | `` nixos/flarum: fix documentation link formatting ``                                       |
| [`b9203eca`](https://github.com/NixOS/nixpkgs/commit/b9203ecad9e5e6d54743a98c46bd83d1d4a02608) | `` nixos/engelsystem: fix documentation link formatting ``                                  |
| [`370bb6bd`](https://github.com/NixOS/nixpkgs/commit/370bb6bd6045f682604c6d6dcaa161b5d366ab50) | `` nixos/discourse: fix documentation link formatting ``                                    |
| [`79ea0ba6`](https://github.com/NixOS/nixpkgs/commit/79ea0ba6026ad9763a88f9ec86cdce392cd82cf4) | `` nixos/dependency-track: fix documentation link formatting ``                             |
| [`9f0c8c6e`](https://github.com/NixOS/nixpkgs/commit/9f0c8c6e9e864563bcee354c1e19a13f06bbadd1) | `` nixos/cryptpad: fix documentation link formatting ``                                     |
| [`d73589e6`](https://github.com/NixOS/nixpkgs/commit/d73589e65ea7e2cd0a463f886411f8eb59af8a47) | `` nixos/changedetection-io: fix documentation link formatting ``                           |
| [`e0de6da1`](https://github.com/NixOS/nixpkgs/commit/e0de6da14a10fc40509d3e2a8b0c26d50755b22f) | `` nixos/wivrn: fix documentation link formatting ``                                        |
| [`956a5ced`](https://github.com/NixOS/nixpkgs/commit/956a5cedd43110d4c9b95501721094bb1031058a) | `` nixos/tempo: fix documentation link formatting ``                                        |
| [`6aa47a42`](https://github.com/NixOS/nixpkgs/commit/6aa47a42fe534c0ff3040ed0c1145c738af2e82c) | `` nixos/zerotierone: fix documentation link formatting ``                                  |
| [`f3acac42`](https://github.com/NixOS/nixpkgs/commit/f3acac425df038a3d8b6eae8acfb0c471d8d7e26) | `` nixos/wg-access-server: fix documentation link formatting ``                             |
| [`af8af807`](https://github.com/NixOS/nixpkgs/commit/af8af80782014a9c705c5cac4c156c6f8742cf39) | `` nixos/opengfw: fix documentation link formatting ``                                      |
| [`3dd73303`](https://github.com/NixOS/nixpkgs/commit/3dd73303bbfd17ad4f3d85898448f8f729d5f209) | `` nixos/headscale: fix documentation link formatting ``                                    |
| [`f53cf94c`](https://github.com/NixOS/nixpkgs/commit/f53cf94cab4970b212e0ec850b55bb9904846c66) | `` nixos/firewall: fix documentation link formatting ``                                     |
| [`70c805c6`](https://github.com/NixOS/nixpkgs/commit/70c805c634a2708325a0517b406f34a48900d778) | `` nixos/epmd: fix documentation link formatting ``                                         |
| [`5d48ee0d`](https://github.com/NixOS/nixpkgs/commit/5d48ee0d4bad4d5e653e5967d865677322ec315d) | `` nixos/deconz: fix documentation link formatting ``                                       |
| [`91980b93`](https://github.com/NixOS/nixpkgs/commit/91980b93cf0e46603607302cc5750fce2d114c84) | `` nixos/ddns-updater: fix documentation link formatting ``                                 |
| [`7e6083be`](https://github.com/NixOS/nixpkgs/commit/7e6083be99988cc9126a682f779b8988f38375cc) | `` nixos/ddclient: fix documentation link formatting ``                                     |
| [`85ca769c`](https://github.com/NixOS/nixpkgs/commit/85ca769c726c0acf44ac3a8a71f761a0ad2af079) | `` nixos/coturn: fix documentation link formatting ``                                       |
| [`ce335f7a`](https://github.com/NixOS/nixpkgs/commit/ce335f7a6c5f9e27c8d8385d772092fd2dcf4dd1) | `` nixos/atticd: fix documentation link formatting ``                                       |
| [`5fb7bc8c`](https://github.com/NixOS/nixpkgs/commit/5fb7bc8c5f7e0a1f30329a4a6790c076689a1561) | `` nixos/3proxy: fix documentation link formatting ``                                       |
| [`961e7dd1`](https://github.com/NixOS/nixpkgs/commit/961e7dd1dbbd2d4e969f9c5e348fa1085e59b1a7) | `` nixos/nghttpx: fix documentation link formatting ``                                      |
| [`5194bc27`](https://github.com/NixOS/nixpkgs/commit/5194bc27aecd4fea29e787c12a1a0281ade86d08) | `` nixos/glusterfs: fix documentation link formatting ``                                    |
| [`e5df3a75`](https://github.com/NixOS/nixpkgs/commit/e5df3a75077f68200a665b7f12ecaa77d1836d33) | `` nixos/scrutiny: fix documentation link formatting ``                                     |
| [`d4151d6a`](https://github.com/NixOS/nixpkgs/commit/d4151d6a2ea8e0350f32969ccac87b2dc3ad90bd) | `` nixos/osquery: fix documentation link formatting ``                                      |
| [`376f9ab6`](https://github.com/NixOS/nixpkgs/commit/376f9ab6821c820c2cf2eda76953eaa9969746a3) | `` nixos/opentelemetry-collector: fix documentation link formatting ``                      |
| [`fc931a84`](https://github.com/NixOS/nixpkgs/commit/fc931a8419b9c26d3c0ae797691a25425943ab12) | `` nixos/longview: fix documentation link formatting ``                                     |
| [`27971205`](https://github.com/NixOS/nixpkgs/commit/27971205fd2cdbeaa8565204c45fe73120355fad) | `` nixos/librenms: fix documentation link formatting ``                                     |
| [`4ac1cca6`](https://github.com/NixOS/nixpkgs/commit/4ac1cca61ad1f0c6ca59a69b718f9a3f84a470a4) | `` nixos/glances: fix documentation link formatting ``                                      |
| [`359c9a41`](https://github.com/NixOS/nixpkgs/commit/359c9a41d5c66acf5c0bfde6205ee11577d475c9) | `` nixos/bosun: fix documentation link formatting ``                                        |
| [`77ee6059`](https://github.com/NixOS/nixpkgs/commit/77ee6059486c56c19aa5b2949a56d8629dce023f) | `` nixos/prometheus: fix documentation link formatting ``                                   |
| [`fa7399c6`](https://github.com/NixOS/nixpkgs/commit/fa7399c6505aef5c77dfd6865b8cb79be26ff1e7) | `` nixos/prometheus/exporters: fix documentation link formatting ``                         |
| [`f2ed0726`](https://github.com/NixOS/nixpkgs/commit/f2ed072641757c29c6b14ce4aa1a2bc577161b93) | `` nixos/uhub: fix documentation link formatting ``                                         |
| [`2b78a852`](https://github.com/NixOS/nixpkgs/commit/2b78a852e6987961e44e662a3bfadda2004c93eb) | `` nixos/pinnwand: fix documentation link formatting ``                                     |
| [`a4959c46`](https://github.com/NixOS/nixpkgs/commit/a4959c465e9a9c7500ef7e49031e6173b02e6fd3) | `` nixos/open-webui: fix documentation link formatting ``                                   |
| [`32579269`](https://github.com/NixOS/nixpkgs/commit/32579269a42496872c1e51f3b52637cc65a69068) | `` nixos/ollama: fix documentation link formatting ``                                       |
| [`612dc958`](https://github.com/NixOS/nixpkgs/commit/612dc95881490057e3c041a401d1950d7dde2072) | `` nixos/nitter: fix documentation link formatting ``                                       |
| [`61a15a28`](https://github.com/NixOS/nixpkgs/commit/61a15a28f90d65ba8fe037803b680bf7999fe1ab) | `` nixos/languagetool: fix documentation link formatting ``                                 |
| [`d8e1beec`](https://github.com/NixOS/nixpkgs/commit/d8e1beecaaa33f854863982f25a789e9c8810369) | `` nixos/invidious-router: fix documentation link formatting ``                             |
| [`6e62a270`](https://github.com/NixOS/nixpkgs/commit/6e62a2703ac77f006c1131f0b7403193ac21d047) | `` nixos/input-remapper: fix documentation link formatting ``                               |
| [`28b67e4c`](https://github.com/NixOS/nixpkgs/commit/28b67e4c43bf146bfe652169a24acde889f80d90) | `` nixos/homepage-dashboard: fix documentation link formatting ``                           |
| [`44f86c53`](https://github.com/NixOS/nixpkgs/commit/44f86c533107ffa20526b33886ba265decc364a9) | `` nixos/gitlab: fix documentation link formatting ``                                       |
| [`d3f92fba`](https://github.com/NixOS/nixpkgs/commit/d3f92fba7f20aca0a32b1d8ed819bdfbf87cecea) | `` nixos/dysnomia: fix documentation link formatting ``                                     |
| [`d1905f4a`](https://github.com/NixOS/nixpkgs/commit/d1905f4a064e6df9f836b3f087cf4d2b07b74868) | `` nixos/bepasty: fix documentation link formatting ``                                      |
| [`52bab06c`](https://github.com/NixOS/nixpkgs/commit/52bab06cd005544f81c363720ccb8f8d7b64db55) | `` nixos/sourcehut: fix documentation link formatting ``                                    |
| [`1d57cecb`](https://github.com/NixOS/nixpkgs/commit/1d57cecb746646fdb7584454c3bf778f0007faf0) | `` nixos/evcc: fix documentation link formatting ``                                         |
| [`c5a30a0d`](https://github.com/NixOS/nixpkgs/commit/c5a30a0de7ccba4e825d62b5a0e1c56897b3d0f0) | `` nixos/supergfxd: fix documentation link formatting ``                                    |
| [`48be34d0`](https://github.com/NixOS/nixpkgs/commit/48be34d02dd1f54bf757aeea823598ea87910c81) | `` nixos/display: fix documentation link formatting ``                                      |
| [`0bf7fb12`](https://github.com/NixOS/nixpkgs/commit/0bf7fb12184d7eafe561110d816af40feaf1e001) | `` nixos/asusd: fix documentation link formatting ``                                        |
| [`4185cf8a`](https://github.com/NixOS/nixpkgs/commit/4185cf8ade72351e14152de9027a4634232f4512) | `` nixos/mchprs: fix documentation link formatting ``                                       |
| [`38000bd8`](https://github.com/NixOS/nixpkgs/commit/38000bd86b983bc492deb7ecdfe8cc87affa8729) | `` path-of-building: fix missing dependency ``                                              |
| [`8c0cd03d`](https://github.com/NixOS/nixpkgs/commit/8c0cd03d07938fd318c24160425b54942d13cc33) | `` python312Packages.spacy-transformers: 1.3.6 -> 1.3.8 ``                                  |
| [`42f41dba`](https://github.com/NixOS/nixpkgs/commit/42f41dba33db2dd3fc74e7493a47125e99ed790f) | `` kdePackages.kwin: backport patch recommended by upstream ``                              |
| [`835eed69`](https://github.com/NixOS/nixpkgs/commit/835eed699a89ffa19aeda0afeb17d15a54fe1c0c) | `` path-of-building.data: 2.49.2 -> 2.50.0 ``                                               |
| [`cd0f0637`](https://github.com/NixOS/nixpkgs/commit/cd0f0637025118e47c9b2db9eb6eb765c23a2372) | `` openbsd.shutdown: Set paths for halt, reboot, wall ``                                    |
| [`f3f5493b`](https://github.com/NixOS/nixpkgs/commit/f3f5493bce5467e1c22b664d94ca38f85509b6cf) | `` openbsd.wall: init ``                                                                    |
| [`e08317b1`](https://github.com/NixOS/nixpkgs/commit/e08317b18d899402db370f6d8a7c16baf2f68be7) | `` openbsd.reboot: init ``                                                                  |
| [`4e1dd62c`](https://github.com/NixOS/nixpkgs/commit/4e1dd62cc9d6c71cdd6a0167b9dc02fc2c7e99a2) | `` gotosocial: 0.17.3 -> 0.17.4 ``                                                          |
| [`8442e980`](https://github.com/NixOS/nixpkgs/commit/8442e980a9861ef1ffaf48ec3365ad017872bda6) | `` remind: 05.02.03 -> 05.03.01 ``                                                          |
| [`e4e065b7`](https://github.com/NixOS/nixpkgs/commit/e4e065b719b628b0296236f63354bf41185d5be3) | `` grimblast: 0.1-unstable-2025-01-29 -> 0.1-unstable-2025-02-10 ``                         |