### PR TITLE
chore(flake/nur): `69e22ae8` -> `6ced3aa7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -682,11 +682,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1739214665,
-        "narHash": "sha256-26L8VAu3/1YRxS8MHgBOyOM8xALdo6N0I04PgorE7UM=",
+        "lastModified": 1739446958,
+        "narHash": "sha256-+/bYK3DbPxMIvSL4zArkMX0LQvS7rzBKXnDXLfKyRVc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "64e75cd44acf21c7933d61d7721e812eac1b5a0a",
+        "rev": "2ff53fe64443980e139eaa286017f53f88336dd0",
         "type": "github"
       },
       "original": {
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1739490898,
-        "narHash": "sha256-bpmq0U1tUwSqJApTqYgQXkvmgeFQ/ldfbXcADu7pSXU=",
+        "lastModified": 1739519565,
+        "narHash": "sha256-coB/rCQx3FOIyBSa9nLfchlkGDL7ehHZc8U7CJ7YhP4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "69e22ae85d38b44b7af3c65bd09ab101e0393a16",
+        "rev": "6ced3aa7dffa39ccfb771ac90c39756f9558d489",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6ced3aa7`](https://github.com/nix-community/NUR/commit/6ced3aa7dffa39ccfb771ac90c39756f9558d489) | `` automatic update `` |
| [`dd12c7d0`](https://github.com/nix-community/NUR/commit/dd12c7d06808f284058b6a50120f54d69569be5b) | `` automatic update `` |
| [`0b053a96`](https://github.com/nix-community/NUR/commit/0b053a968807afddd7432826f31e673837b11221) | `` automatic update `` |
| [`80847021`](https://github.com/nix-community/NUR/commit/808470216f09a71e809c9f8f70e5a231ea18252e) | `` automatic update `` |
| [`7b267b20`](https://github.com/nix-community/NUR/commit/7b267b2063307126df74b719e8bd2d52ae3fb64c) | `` automatic update `` |
| [`91548436`](https://github.com/nix-community/NUR/commit/9154843611e9088bcdc2ff49c6842f657adad061) | `` automatic update `` |
| [`252d7f14`](https://github.com/nix-community/NUR/commit/252d7f14b8ca21e4c9712b713fca9853d94013d2) | `` automatic update `` |
| [`563bc62b`](https://github.com/nix-community/NUR/commit/563bc62bd2d7c89415e41b5e8f5f65fb69ee3041) | `` automatic update `` |
| [`33946c56`](https://github.com/nix-community/NUR/commit/33946c5657decbc0da24f64c750e391cdb38c729) | `` automatic update `` |
| [`cc771525`](https://github.com/nix-community/NUR/commit/cc771525dedc25ffdc68640b333aa38ca9aeac71) | `` automatic update `` |
| [`07385dd5`](https://github.com/nix-community/NUR/commit/07385dd540f7b2185a77836b8ddc8719712b1846) | `` automatic update `` |