### PR TITLE
chore(flake/nur): `6ced3aa7` -> `da237154`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1739519565,
-        "narHash": "sha256-coB/rCQx3FOIyBSa9nLfchlkGDL7ehHZc8U7CJ7YhP4=",
+        "lastModified": 1739533682,
+        "narHash": "sha256-cBypEXBDsumP5XdxSX798XLmdj9XKsPXBsIrGGqFkDQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6ced3aa7dffa39ccfb771ac90c39756f9558d489",
+        "rev": "da237154b2e472023dba29109fa33a7981bf9c56",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`da237154`](https://github.com/nix-community/NUR/commit/da237154b2e472023dba29109fa33a7981bf9c56) | `` automatic update `` |
| [`3dbf4fd5`](https://github.com/nix-community/NUR/commit/3dbf4fd56c35b0cdbe21861f015056c1e944f73a) | `` automatic update `` |
| [`c0a16603`](https://github.com/nix-community/NUR/commit/c0a16603fa2fb7311fcec232b65c107e5363e054) | `` automatic update `` |