### PR TITLE
chore(flake/darwin): `a6746213` -> `678b2264`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739302241,
-        "narHash": "sha256-NXQXFU6HOschZ+8ZKrNOlwlHelez8vPl+dCiUaJ82/U=",
+        "lastModified": 1739548217,
+        "narHash": "sha256-rlv64erpr36xdmMDPgf9rhRXBYZ0BZb5nrw2ZPSk1sQ=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "a6746213b138fe7add88b19bafacd446de574ca7",
+        "rev": "678b22642abde2ee77ae2218ab41d802f010e5b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                      |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
| [`5926058a`](https://github.com/LnL7/nix-darwin/commit/5926058aecd67ec1bf5030b5a419c260876ea9ba) | `` nix: place `extra-`prefixed settings after their non-prefixed variants `` |
| [`731910af`](https://github.com/LnL7/nix-darwin/commit/731910af010086c4dbe23eb6ae79d81bcec703aa) | `` {activation-scripts,activate-system}: check `gcroots` before linking ``   |
| [`cd445c54`](https://github.com/LnL7/nix-darwin/commit/cd445c546561d5ca4e9124cb4668ce80939ac0c9) | `` nix: catch reads of unmanaged defaults ``                                 |
| [`d677e3e8`](https://github.com/LnL7/nix-darwin/commit/d677e3e844e21789c6f39a90aacadf6dc777ca42) | `` nix-tools: only pass `config.nix.nixPath` through if `nix.enable` ``      |
| [`42e16f31`](https://github.com/LnL7/nix-darwin/commit/42e16f31c6faf29a51a2aa15aeff64934bf5d157) | `` cachix-agent: check for `nix.enable` ``                                   |
| [`e3bde158`](https://github.com/LnL7/nix-darwin/commit/e3bde1588bc6b4cf774197228330139338a4a12c) | `` github-runner: check for `nix.enable` ``                                  |
| [`f4e2805e`](https://github.com/LnL7/nix-darwin/commit/f4e2805e19f84420538590ff4e91b1bfa2e79784) | `` ofborg: check for `nix.enable` ``                                         |
| [`aba0c60e`](https://github.com/LnL7/nix-darwin/commit/aba0c60ebab549f69ece1622d99ffc5e6ad81af3) | `` lorri: check for `nix.enable` ``                                          |
| [`57c93ffe`](https://github.com/LnL7/nix-darwin/commit/57c93ffe6cbb627e5c9d10ceae7b31e68ba945ac) | `` hercules-ci-agent: check for `nix.enable` ``                              |
| [`147ed950`](https://github.com/LnL7/nix-darwin/commit/147ed950e382ef45d083f060b4529df817077069) | `` nixpkgs-flake: check for `nix.enable` ``                                  |
| [`7cca8f95`](https://github.com/LnL7/nix-darwin/commit/7cca8f95f7761bff239066306148714e560cbc2e) | `` linux-builder: check for `nix.enable` ``                                  |
| [`0176a508`](https://github.com/LnL7/nix-darwin/commit/0176a5082ba8450e1480204a824ed188cdc81600) | `` nix-optimise: check for `nix.enable` ``                                   |
| [`fc9367a9`](https://github.com/LnL7/nix-darwin/commit/fc9367a9ec8ce3527291fc3bfc1b12c0260bc676) | `` nix-gc: check for `nix.enable` ``                                         |