### PR TITLE
chore(flake/nur): `da237154` -> `0d4c07bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1739533682,
-        "narHash": "sha256-cBypEXBDsumP5XdxSX798XLmdj9XKsPXBsIrGGqFkDQ=",
+        "lastModified": 1739562611,
+        "narHash": "sha256-YKw4sV2bHkyHiS03REG27T/26QrvJ9VxBMelB7r6sRE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "da237154b2e472023dba29109fa33a7981bf9c56",
+        "rev": "0d4c07bb0a1524767f4fd7cc80f98a27bb52c676",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0d4c07bb`](https://github.com/nix-community/NUR/commit/0d4c07bb0a1524767f4fd7cc80f98a27bb52c676) | `` automatic update `` |
| [`20a1b434`](https://github.com/nix-community/NUR/commit/20a1b434aa4c881e8c41800805bc7b3c240ebc2f) | `` automatic update `` |
| [`a69f8f0c`](https://github.com/nix-community/NUR/commit/a69f8f0c7c2c9e19046c41570770f90914eb7d56) | `` automatic update `` |
| [`1efb9bda`](https://github.com/nix-community/NUR/commit/1efb9bdabed09ce3c16d3c1a5ef69daebb475a68) | `` automatic update `` |
| [`66b299a2`](https://github.com/nix-community/NUR/commit/66b299a2781844cff955d829c2d98f38051b51f9) | `` automatic update `` |
| [`dd5d3c39`](https://github.com/nix-community/NUR/commit/dd5d3c39b706a94e62e3f519d1f6c4dfcc11daae) | `` automatic update `` |
| [`63bee790`](https://github.com/nix-community/NUR/commit/63bee790fd93d8e221ce8c3206fe8fcf2cde98dc) | `` automatic update `` |
| [`dfd76b2e`](https://github.com/nix-community/NUR/commit/dfd76b2e457a14e94b08e1a7ad023112ed5ecb28) | `` automatic update `` |
| [`c2299b58`](https://github.com/nix-community/NUR/commit/c2299b5818fcfc8ab929efb7bf57f077312d7742) | `` automatic update `` |
| [`895639c7`](https://github.com/nix-community/NUR/commit/895639c7a98d8cc62d435a9b45e37d1defa1c90f) | `` automatic update `` |
| [`35198d73`](https://github.com/nix-community/NUR/commit/35198d73b581574847341314fff8a99ba3d122bb) | `` automatic update `` |