### PR TITLE
chore(flake/home-manager): `5031c6d2` -> `6d3163ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739470101,
-        "narHash": "sha256-NxNe32VB4XI/xIXrsKmIfrcgtEx5r/5s52pL3CpEcA4=",
+        "lastModified": 1739571712,
+        "narHash": "sha256-0UdSDV/TBY+GuxXLbrLq3l2Fq02ciyKCIMy4qmnfJXQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5031c6d2978109336637977c165f82aa49fa16a7",
+        "rev": "6d3163aea47fdb1fe19744e91306a2ea4f602292",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                    |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`6d3163ae`](https://github.com/nix-community/home-manager/commit/6d3163aea47fdb1fe19744e91306a2ea4f602292) | `` git: change stateVersion check for compatiblity (#6453) ``              |
| [`67b9f9de`](https://github.com/nix-community/home-manager/commit/67b9f9de22c78bd1d2cf45583bfb18470d1d3ef8) | `` vscode: add windsurf directories (#6427) ``                             |
| [`582d3cd4`](https://github.com/nix-community/home-manager/commit/582d3cd42df7d2c7565d77119106336ea46e33df) | `` yubikey-agent: init service module (#6446) ``                           |
| [`9daae9a6`](https://github.com/nix-community/home-manager/commit/9daae9a67af7b4d341e2c806fa274a9c0925d7cf) | `` nixos/common: forward `nix.enable` from the OS configuration (#6383) `` |
| [`7da01bc4`](https://github.com/nix-community/home-manager/commit/7da01bc47ad48d696c96fcfd63d10063855d5486) | `` git: support alternate signing methods (#5516) ``                       |