### PR TITLE
chore(flake/nur): `0d4c07bb` -> `e353ac4b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1739562611,
-        "narHash": "sha256-YKw4sV2bHkyHiS03REG27T/26QrvJ9VxBMelB7r6sRE=",
+        "lastModified": 1739589581,
+        "narHash": "sha256-8/3jzauKwx4xZQf2yol/E1YDRfHTt5/tYEK3n5+Py4A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0d4c07bb0a1524767f4fd7cc80f98a27bb52c676",
+        "rev": "e353ac4b999db166ad92074ca66f2394d65aeb1d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e353ac4b`](https://github.com/nix-community/NUR/commit/e353ac4b999db166ad92074ca66f2394d65aeb1d) | `` automatic update `` |
| [`b6969624`](https://github.com/nix-community/NUR/commit/b6969624ed82b9420bc8a36eded611bd7bc56d82) | `` automatic update `` |
| [`9f571f72`](https://github.com/nix-community/NUR/commit/9f571f72b4eab45743bd936a6587c7ee139c475b) | `` automatic update `` |
| [`e69e98ac`](https://github.com/nix-community/NUR/commit/e69e98ac2e17849ec64747c6024ebe99868be98b) | `` automatic update `` |
| [`f7d618e9`](https://github.com/nix-community/NUR/commit/f7d618e93f70a8c249f69a3a716da022c2f31c16) | `` automatic update `` |
| [`ba7879d4`](https://github.com/nix-community/NUR/commit/ba7879d4948dbd91b35bab1ac5d8ffa7b0dd99be) | `` automatic update `` |
| [`4478e301`](https://github.com/nix-community/NUR/commit/4478e3012d27a82e1bca847e9405ca3bd221d1aa) | `` automatic update `` |