### PR TITLE
chore(flake/emacs-overlay): `3a93a0a8` -> `119c1e60`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1739553792,
-        "narHash": "sha256-W/VqlGtMXv4cQ1V5j1Sbfu59x8DWntEkTJWJNHo9P+Q=",
+        "lastModified": 1739585438,
+        "narHash": "sha256-gyPjqDLiZ8MM0bo6hpNv/aqhrKPCGaasUWpc8vQIfnA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3a93a0a8f94fd52260b39aefc05e7bc667ded0ab",
+        "rev": "119c1e609911a1a24af83e342fa4e2b11faa2096",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`119c1e60`](https://github.com/nix-community/emacs-overlay/commit/119c1e609911a1a24af83e342fa4e2b11faa2096) | `` Updated emacs ``  |
| [`09e66f60`](https://github.com/nix-community/emacs-overlay/commit/09e66f60f120756c309328a1910b143bd3eef8d5) | `` Updated melpa ``  |
| [`c0c562c3`](https://github.com/nix-community/emacs-overlay/commit/c0c562c3488b11f20ec78a5f538e1517d47ccf44) | `` Updated elpa ``   |
| [`9cf919c9`](https://github.com/nix-community/emacs-overlay/commit/9cf919c9a1b50235109de97e19ba9ca6ae58a52e) | `` Updated nongnu `` |