### PR TITLE
chore(flake/gptel): `da66b37c` -> `a502ca54`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -315,11 +315,11 @@
     "gptel": {
       "flake": false,
       "locked": {
-        "lastModified": 1737395953,
-        "narHash": "sha256-L3IPB5ru+JOJDfyTMKUPNBngGEWI2epBnYvcfssqUeg=",
+        "lastModified": 1739599597,
+        "narHash": "sha256-gus/0vAmuqWNUMTBCBacWsejKFh74fWMJ1hjp7ASI1o=",
         "owner": "karthink",
         "repo": "gptel",
-        "rev": "da66b37c75a48d1db075ce9dd525121e58a2c9af",
+        "rev": "a502ca547c22e51c9c6a21227c5744b17c4fd1c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                        |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`a502ca54`](https://github.com/karthink/gptel/commit/a502ca547c22e51c9c6a21227c5744b17c4fd1c3) | `` gptel-transient: Report what is being sent from kill-ring (#642) ``         |
| [`970debee`](https://github.com/karthink/gptel/commit/970debee285412efecca781d9229906e68b1ebc8) | `` gptel-transient: Use proper ellipsis for consistent UI (#640) ``            |
| [`7425ec9f`](https://github.com/karthink/gptel/commit/7425ec9f6c3ec5627b15b6c218650f9cccecaa95) | `` gptel-transient: Fix face related bug (#638) ``                             |
| [`86678ed2`](https://github.com/karthink/gptel/commit/86678ed24cc9734ac7ae460f9848da10e4d71ff1) | `` gptel-gemini: Update models (#639) ``                                       |
| [`285856ec`](https://github.com/karthink/gptel/commit/285856ec8cca28696b6aa3edc236bd0c25cce701) | `` gptel-transient: Ensure user enters a number when prompted (#637) ``        |
| [`9f3acc32`](https://github.com/karthink/gptel/commit/9f3acc3217f7be30fb2d150746c5340e654155f6) | `` gptel: Check gptel-org-convert-response in query buffer ``                  |
| [`49c71676`](https://github.com/karthink/gptel/commit/49c7167646245691e07b283ce8f1f3920acf81bd) | `` gptel: Small documentation tweaks (#625) ``                                 |
| [`edf834a4`](https://github.com/karthink/gptel/commit/edf834a448f1ee68bbd3117145668a3401817bc3) | `` gptel-transient: Provide description of send action (#627) ``               |
| [`7b48146a`](https://github.com/karthink/gptel/commit/7b48146a74e5286151c024100294661a2e99c8fa) | `` gptel-org: Make gptel--convert-markdown->org noninteractive ``              |
| [`48a5c132`](https://github.com/karthink/gptel/commit/48a5c13259a4843b5470c1182bc4966731eb1147) | `` gptel: Ignore debug when handling tool calls ``                             |
| [`fc938121`](https://github.com/karthink/gptel/commit/fc9381219654f81992e13c6a52355254c578a60c) | `` gptel: Don't run callback if response is empty ``                           |
| [`bca2b84b`](https://github.com/karthink/gptel/commit/bca2b84be6e32f01a6d375dec70f99f4bf9c6660) | `` README: Fix typo in tool use example (#632) ``                              |
| [`d57eb989`](https://github.com/karthink/gptel/commit/d57eb9896eb1d1f9dc19a420c3e88498f2898780) | `` gptel-transient: Improve parsing of crowdsourced prompts CSV file (#615) `` |
| [`2dd3e317`](https://github.com/karthink/gptel/commit/2dd3e317bf4af82cddfa1d1b127c04c17589c878) | `` gptel: Linting and minor documentation tweaks ``                            |
| [`2da449eb`](https://github.com/karthink/gptel/commit/2da449ebade2425fbf43e5648350e7a907462a18) | `` gptel-transient: Fix read-only behaviour in gptel--edit-directive (#622) `` |
| [`43e7c330`](https://github.com/karthink/gptel/commit/43e7c330d809e123946b62efc590527ca510b2a2) | `` gptel-transient: Make gptel--edit-directive more flexible ``                |
| [`ae1cc572`](https://github.com/karthink/gptel/commit/ae1cc572475214f383d90269125283ca79c5874b) | `` gptel-transient: unmark before editing crowdsourced prompt (#618) ``        |
| [`2c853bb5`](https://github.com/karthink/gptel/commit/2c853bb523cbb0e8ceba0d8fe18299162705fcd7) | `` gptel-openai: Make gptel-get-backend removable ``                           |
| [`4ab198a9`](https://github.com/karthink/gptel/commit/4ab198a904f1706a8daede1145386db4dc960aa1) | `` gptel: Change buffer parser property-search method ``                       |
| [`3f64c6de`](https://github.com/karthink/gptel/commit/3f64c6def44f49dc8cd3a6bb143f0b54a8568225) | `` gptel-context: Make gptel-context-remove-all interactive (#587) ``          |
| [`7ff67c18`](https://github.com/karthink/gptel/commit/7ff67c188ae061a71146a987cfe24818985c91fd) | `` gptel-transient: Improve directive/system message editing (#616) ``         |
| [`cc53a81c`](https://github.com/karthink/gptel/commit/cc53a81c1b282afa1db70036807dc2a93543f556) | `` gptel-transient: unmark before editing crowdsourced prompt ``               |
| [`e235f1da`](https://github.com/karthink/gptel/commit/e235f1da8cc5cd9c2db1947c64ec4fb138575de6) | `` gptel: Make gptel-model definition dynamic (#606) ``                        |
| [`aa649b01`](https://github.com/karthink/gptel/commit/aa649b013322a62d29e7507e22234f8000c68c48) | `` gptel-org: Improve link-scanning robustness (#594) ``                       |
| [`b6dd0b9d`](https://github.com/karthink/gptel/commit/b6dd0b9d79aaad53a4ca756ebe7daff1885df2a9) | `` gptel: Don't move point when updating fontification (#607) ``               |
| [`60906871`](https://github.com/karthink/gptel/commit/6090687150e4781e93c1d736e2b8d1e6be60054f) | `` gptel-context: Use default when reading buffer (#595) ``                    |
| [`6dcccc62`](https://github.com/karthink/gptel/commit/6dcccc620674482f28f323fe2825ed22e5015e0b) | `` gptel-org: Update required Org version notice (#602) ``                     |
| [`1e273226`](https://github.com/karthink/gptel/commit/1e27322633b97145cef3c6f432e1d71ef5db518f) | `` gptel-openai: Update tool call options for reasoning models ``              |
| [`5f616d12`](https://github.com/karthink/gptel/commit/5f616d123ac4686803ab28e88b5ce28cfa6bf38b) | `` gptel: Make response separator customizable (#599) ``                       |
| [`5f72e98c`](https://github.com/karthink/gptel/commit/5f72e98cfa1edd10bd8d06d7ada41869bafce014) | `` gptel-anthropic: Encode object args in tools correctly ``                   |
| [`c530f8a6`](https://github.com/karthink/gptel/commit/c530f8a6ac4f76ecda3f71294dee9b8d503246c1) | `` gptel-openai: Encode object args in tools correctly (#600) ``               |
| [`553a4035`](https://github.com/karthink/gptel/commit/553a4035004ef9153df8fcc3fda5593351f55fb7) | `` gptel-openai: Add support for o3-mini ``                                    |
| [`8296f34b`](https://github.com/karthink/gptel/commit/8296f34b0b043616290101adb8ff4687b1cbad52) | `` gptel-rewrite: Allow dispatch menu as default rewrite action ``             |
| [`693f623c`](https://github.com/karthink/gptel/commit/693f623c46e917ca7ae138cd58cdce1f8d2b6c5e) | `` gptel-transient: Handle unsetting temperature ``                            |
| [`e1c01f86`](https://github.com/karthink/gptel/commit/e1c01f86e602be606915ce18440fb775f8384e77) | `` gptel: Pass nil result through to model (#596) ``                           |
| [`c7184598`](https://github.com/karthink/gptel/commit/c7184598201fb2879e3729d4d08ccd4ff4ec18f6) | `` gptel-rewrite: Collect rewrite text after hook (#564) ``                    |
| [`ff2bc1b8`](https://github.com/karthink/gptel/commit/ff2bc1b8e94269f4a590ba34f4096e1fe58d0e93) | `` gptel-rewrite: Add post-rewrite hook (#564) ``                              |
| [`682e6624`](https://github.com/karthink/gptel/commit/682e6624d54c738a431e76dd2eb1acd285ea5f33) | `` gptel: Fontify org-src blocks explicitly (#550) ``                          |
| [`7076b364`](https://github.com/karthink/gptel/commit/7076b364bb16ad132baffe2879387dbda0de2d89) | `` gptel: substitute-command-keys in context buffer (#589) ``                  |
| [`75397f9f`](https://github.com/karthink/gptel/commit/75397f9f960a7684b0985736346b107f82a44467) | `` gptel: Keep cursor inside tool confirmation overlay ``                      |
| [`de0dedbe`](https://github.com/karthink/gptel/commit/de0dedbe31703e2235278868821a3cc364061f74) | `` gptel-openai-extras: Add gptel-perplexity backend (#581) ``                 |
| [`3474a41f`](https://github.com/karthink/gptel/commit/3474a41f009c86bf98be7d368f37aafcc266cf4f) | `` gptel-curl: Disable ahead-of-time dispatch for parsers ``                   |
| [`b81ca7b1`](https://github.com/karthink/gptel/commit/b81ca7b16ee96eb270dd4a0a83d98a34d20b6ea5) | `` gptel: Add getter functions for backends and tools ``                       |
| [`ea78412a`](https://github.com/karthink/gptel/commit/ea78412ac14d1aba2219b265983ba2efd4d12657) | `` gptel: Breaking change to tool-call internal API ``                         |
| [`43c42e27`](https://github.com/karthink/gptel/commit/43c42e27634a5a705b0589aaa9047ae906a1faeb) | `` gptel-rewrite: Fix mark deactivation timing (#577) ``                       |
| [`68c00262`](https://github.com/karthink/gptel/commit/68c00262293f254c2d2fc2fb868d24506f1e5e65) | `` gptel-curl: Find response parser from parent classes ``                     |
| [`c913e2a3`](https://github.com/karthink/gptel/commit/c913e2a35a42509a9ea6086ab5abcdcfeb6ac7d5) | `` gptel-test: Update submodule ``                                             |
| [`af6b114c`](https://github.com/karthink/gptel/commit/af6b114cfb9b88f08923b96fb2c2e68fbdaaf85b) | `` gptel-org: Handle markdown converter edge case ``                           |