### PR TITLE
chore(flake/nur): `e353ac4b` -> `3c6b2c53`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1739589581,
-        "narHash": "sha256-8/3jzauKwx4xZQf2yol/E1YDRfHTt5/tYEK3n5+Py4A=",
+        "lastModified": 1739634597,
+        "narHash": "sha256-Y7ygVQP/boTMSacck19bQU/gyCCzIsY12mT+ZGnt9Qo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e353ac4b999db166ad92074ca66f2394d65aeb1d",
+        "rev": "3c6b2c533b5492228320cd101a87a26795c628ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3c6b2c53`](https://github.com/nix-community/NUR/commit/3c6b2c533b5492228320cd101a87a26795c628ef) | `` automatic update `` |
| [`bd8c68f1`](https://github.com/nix-community/NUR/commit/bd8c68f17e0777d805666e128089698f3f943b87) | `` automatic update `` |
| [`b9aeca8d`](https://github.com/nix-community/NUR/commit/b9aeca8d75e0ef4c57ffd7b2722466c9ebb2bfa5) | `` automatic update `` |
| [`573adb7f`](https://github.com/nix-community/NUR/commit/573adb7fdf777ec9017bc1d5060ecda0ab2c32dc) | `` automatic update `` |
| [`946bcaaf`](https://github.com/nix-community/NUR/commit/946bcaaf78d5569b80c81db7f3ef382f15d33063) | `` automatic update `` |
| [`ce07ba78`](https://github.com/nix-community/NUR/commit/ce07ba78cb6422f2e45cd3e3b7776bc61c0c21b6) | `` automatic update `` |
| [`cb61452a`](https://github.com/nix-community/NUR/commit/cb61452a3950fa7dc9987e908cffe63da16ed93b) | `` automatic update `` |
| [`cfc98e94`](https://github.com/nix-community/NUR/commit/cfc98e94d127ee15f3db843ae86b3f0811b378ce) | `` automatic update `` |
| [`3030a1a5`](https://github.com/nix-community/NUR/commit/3030a1a53619dbbe0686d2319dca0476ab1f64e3) | `` automatic update `` |