### PR TITLE
chore(flake/emacs-overlay): `119c1e60` -> `b19f5700`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1739585438,
-        "narHash": "sha256-gyPjqDLiZ8MM0bo6hpNv/aqhrKPCGaasUWpc8vQIfnA=",
+        "lastModified": 1739639880,
+        "narHash": "sha256-kJIvbH9+yue+4kDJ23+/051bGf29zvAsZZUmzEXIcp4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "119c1e609911a1a24af83e342fa4e2b11faa2096",
+        "rev": "b19f57002c6428aa6c057d5ba8ab5caa5c2777ed",
         "type": "github"
       },
       "original": {
@@ -603,11 +603,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1739357830,
-        "narHash": "sha256-9xim3nJJUFbVbJCz48UP4fGRStVW5nv4VdbimbKxJ3I=",
+        "lastModified": 1739484910,
+        "narHash": "sha256-wjWLzdM7PIq4ZAe7k3vyjtgVJn6b0UeodtRFlM/6W5U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0ff09db9d034a04acd4e8908820ba0b410d7a33a",
+        "rev": "0b73e36b1962620a8ac551a37229dd8662dac5c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`b19f5700`](https://github.com/nix-community/emacs-overlay/commit/b19f57002c6428aa6c057d5ba8ab5caa5c2777ed) | `` Updated emacs ``        |
| [`e786c72d`](https://github.com/nix-community/emacs-overlay/commit/e786c72d165992ad3447356581f81662282ab91b) | `` Updated melpa ``        |
| [`defe89aa`](https://github.com/nix-community/emacs-overlay/commit/defe89aacf73954b2afe39742cfd4fd8ae29c1d6) | `` Updated elpa ``         |
| [`4f15fdfa`](https://github.com/nix-community/emacs-overlay/commit/4f15fdfa8fc61db80bc680dde4c6d923d9da5e53) | `` Updated nongnu ``       |
| [`d475ac96`](https://github.com/nix-community/emacs-overlay/commit/d475ac967ec0149952fc7cdebe4d91afcc71d5d0) | `` Updated flake inputs `` |
| [`15fe2e79`](https://github.com/nix-community/emacs-overlay/commit/15fe2e796e097c4fda4ed481401ae80f2b714525) | `` Updated emacs ``        |
| [`dce38f81`](https://github.com/nix-community/emacs-overlay/commit/dce38f8164f7c9d6ff4255df45c597394de9e359) | `` Updated melpa ``        |