### PR TITLE
chore(flake/gptel): `a502ca54` -> `b2e54046`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -315,11 +315,11 @@
     "gptel": {
       "flake": false,
       "locked": {
-        "lastModified": 1739599597,
-        "narHash": "sha256-gus/0vAmuqWNUMTBCBacWsejKFh74fWMJ1hjp7ASI1o=",
+        "lastModified": 1739718451,
+        "narHash": "sha256-8cggTJtWr79ILWttiKWJH5iVcbt8U9vITwV9joNOTgE=",
         "owner": "karthink",
         "repo": "gptel",
-        "rev": "a502ca547c22e51c9c6a21227c5744b17c4fd1c3",
+        "rev": "b2e54046fef11566a087587f37d7ea5b194c2074",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                        |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`b2e54046`](https://github.com/karthink/gptel/commit/b2e54046fef11566a087587f37d7ea5b194c2074) | `` test: Update test module ``                                 |
| [`f02c03c6`](https://github.com/karthink/gptel/commit/f02c03c6473a520f6fab096e347fc3a038678c70) | `` gptel-transient: Handle read-only regions when replacing `` |
| [`c7fa45a5`](https://github.com/karthink/gptel/commit/c7fa45a50000f0f4071520bc907c0c687f26260a) | `` test: Update test module ``                                 |
| [`65846e7e`](https://github.com/karthink/gptel/commit/65846e7ebdf08483d63386ba53c631a0fcc0ee8a) | `` gptel: Linting and formatting, use when-let* ``             |