### PR TITLE
chore(flake/nur): `3c6b2c53` -> `a3eb209a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1739634597,
-        "narHash": "sha256-Y7ygVQP/boTMSacck19bQU/gyCCzIsY12mT+ZGnt9Qo=",
+        "lastModified": 1739648866,
+        "narHash": "sha256-H5YB2CLR6uLXLDXpUUE6NWYc2mHrzZ0Itu8N3Fo2CZE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3c6b2c533b5492228320cd101a87a26795c628ef",
+        "rev": "a3eb209a608558fd41e4dfeba0a1c6f9339908d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a3eb209a`](https://github.com/nix-community/NUR/commit/a3eb209a608558fd41e4dfeba0a1c6f9339908d4) | `` automatic update `` |
| [`2e972f7b`](https://github.com/nix-community/NUR/commit/2e972f7b48e91f30a7e32f5f3d0998fa4c37bd9a) | `` automatic update `` |