### PR TITLE
chore(flake/nur): `3a2e4e4c` -> `14ae15af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1739689495,
-        "narHash": "sha256-2gL81Qx6BikeoQdRAm8QuKGWg6MWRB4txT12WTOzLLw=",
+        "lastModified": 1739719530,
+        "narHash": "sha256-mLZso3wT4moRIirU9l6VKsmANmxTY3KJNaPnIEW/Bfw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3a2e4e4c3a0d1b937c5d2d7aeb25145f6fe789eb",
+        "rev": "14ae15af41c5d06f6520deaca17a9205c5478206",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`14ae15af`](https://github.com/nix-community/NUR/commit/14ae15af41c5d06f6520deaca17a9205c5478206) | `` automatic update `` |
| [`9f31a73d`](https://github.com/nix-community/NUR/commit/9f31a73dce4791d431ac2d51c61dc2c0ac5cfb9f) | `` automatic update `` |
| [`bd961bcd`](https://github.com/nix-community/NUR/commit/bd961bcd64d627ab66e8f89ddcb9f6798956415f) | `` automatic update `` |
| [`57a7d7b1`](https://github.com/nix-community/NUR/commit/57a7d7b18e9a9a9727f06ed0130b3c5f54c1cc04) | `` automatic update `` |
| [`e1f86baa`](https://github.com/nix-community/NUR/commit/e1f86baa19ac560266d5e726d512563c5ace1480) | `` automatic update `` |