### PR TITLE
chore(flake/home-manager): `eb44c160` -> `b15e9ec6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739676861,
-        "narHash": "sha256-X86ptHMNVuu1Z9leL0YV2E/oxD2IgPYrYANPcvFYpNo=",
+        "lastModified": 1739735835,
+        "narHash": "sha256-S4VskZCNjRX6saW7GtVb4MD3kWdfvRvLurLj9QcM4Wg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "eb44c1601ed99896525e983bc9b15eb8b4d5879e",
+        "rev": "b15e9ec6769d770879759f086dd4e51fae7f2394",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`b15e9ec6`](https://github.com/nix-community/home-manager/commit/b15e9ec6769d770879759f086dd4e51fae7f2394) | `` flake-module: set _class (#6461) ``                     |
| [`e5bc9c2a`](https://github.com/nix-community/home-manager/commit/e5bc9c2af1dca75271aeaeb39035ce7a6125c395) | `` git: reduce priority of signing.format (#6465) ``       |
| [`ec130e70`](https://github.com/nix-community/home-manager/commit/ec130e700959ee10b63eedbc87758d20264a9588) | `` firefox: correct vendorPath of firefox forks (#6421) `` |