### PR TITLE
chore(flake/catppuccin): `d4e258e2` -> `b7a9a2d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1739283129,
-        "narHash": "sha256-GXJllf1wY7tOF6uei9S3PnSEghFbnJP1vkxM0kkMOoI=",
+        "lastModified": 1739745225,
+        "narHash": "sha256-b/F1VUckXuZmvXjNPIdOFRSBR9gMIrKLG/r0xZ1uFBY=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "d4e258e29075a86a82dacaf4f5e0985935ae4658",
+        "rev": "b7a9a2d0b6c2d2a01d6e2685bd91bf543dce3b91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                               |
| ----------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`b7a9a2d0`](https://github.com/catppuccin/nix/commit/b7a9a2d0b6c2d2a01d6e2685bd91bf543dce3b91) | `` refactor: console -> tty (#472) `` |