### PR TITLE
chore(flake/home-manager): `b15e9ec6` -> `662fa98b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739735835,
-        "narHash": "sha256-S4VskZCNjRX6saW7GtVb4MD3kWdfvRvLurLj9QcM4Wg=",
+        "lastModified": 1739756364,
+        "narHash": "sha256-r8RxE0W3uhJ6unzbIddWTAzrpP9tMnmbj0F+DF+CTSM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b15e9ec6769d770879759f086dd4e51fae7f2394",
+        "rev": "662fa98bf488daa82ce8dc2bc443872952065ab9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`662fa98b`](https://github.com/nix-community/home-manager/commit/662fa98bf488daa82ce8dc2bc443872952065ab9) | `` nixpkgs-disabled: warn instead of assert (#6466) `` |
| [`25870c66`](https://github.com/nix-community/home-manager/commit/25870c6600660c93c5aa10f0f328a5eecd60150b) | `` nixos/common: fix `options` reference (#6473) ``    |