### PR TITLE
chore(flake/srvos): `54aae80b` -> `6eb9f48a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -884,11 +884,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739438633,
-        "narHash": "sha256-7nTfMqYkc7WQwmB6m2zo2m2DEmNqrfyE+Pdisr7cTTI=",
+        "lastModified": 1739753812,
+        "narHash": "sha256-zrdDM2wruRklLfdOCPbQ3E1n0lf92pqass3dtzwYr1k=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "54aae80b7526d234658632d251e9bf278b58b7ef",
+        "rev": "6eb9f48ae6f452827cf611dd020ca1f33b115ebf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`6eb9f48a`](https://github.com/nix-community/srvos/commit/6eb9f48ae6f452827cf611dd020ca1f33b115ebf) | `` dev/private/flake.lock: Update `` |
| [`66bc0ad7`](https://github.com/nix-community/srvos/commit/66bc0ad7f045c3a6fb68f2a26af1414deea99121) | `` flake.lock: Update ``             |