### PR TITLE
chore(flake/home-manager): `662fa98b` -> `c1ea92cd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739756364,
-        "narHash": "sha256-r8RxE0W3uhJ6unzbIddWTAzrpP9tMnmbj0F+DF+CTSM=",
+        "lastModified": 1739790043,
+        "narHash": "sha256-4gK4zdNDQ4PyGFs7B6zp9iPIBy9E+bVJiZ0XAmncvgQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "662fa98bf488daa82ce8dc2bc443872952065ab9",
+        "rev": "c1ea92cdfb85bd7b0995b550581d9fd1c3370bf9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`c1ea92cd`](https://github.com/nix-community/home-manager/commit/c1ea92cdfb85bd7b0995b550581d9fd1c3370bf9) | `` nh: change flake option type to singleLineStr (#6468) `` |
| [`5c5697b8`](https://github.com/nix-community/home-manager/commit/5c5697b82a8a34f9ce39dd18690c6ef623565fc4) | `` git: support not configuring signing.format (#6478) ``   |
| [`30b9cd6f`](https://github.com/nix-community/home-manager/commit/30b9cd6f1a69921e59e71df1214604be62636284) | `` mpv: drop old wrapMpv compatibility (#6024) ``           |