### PR TITLE
chore(flake/nixos-hardware): `2eccff41` -> `3e2ea8a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -528,11 +528,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1738816619,
-        "narHash": "sha256-5yRlg48XmpcX5b5HesdGMOte+YuCy9rzQkJz+imcu6I=",
+        "lastModified": 1739798439,
+        "narHash": "sha256-GyipmjbbQEaosel/+wq1xihCKbv0/e1LU00x/8b/fP4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "2eccff41bab80839b1d25b303b53d339fbb07087",
+        "rev": "3e2ea8a49d4d76276b0f4e2041df8ca5c0771371",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                           |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`3e2ea8a4`](https://github.com/NixOS/nixos-hardware/commit/3e2ea8a49d4d76276b0f4e2041df8ca5c0771371) | `` feat: Add support for Dell XPS 15-9530 with NVIDIA graphics `` |
| [`08c94a8b`](https://github.com/NixOS/nixos-hardware/commit/08c94a8b62d784a610cbaa5d2da8a13b405c2c4f) | `` docs: Add README file for Dell XPS 15 9530 ``                  |
| [`e47365f3`](https://github.com/NixOS/nixos-hardware/commit/e47365f377fddfaae2a62109ed3dfd8922c6795f) | `` purism/librem/5r4: kernel: 6.6.29-librem5 -> 6.6.74-librem5 `` |
| [`ba378463`](https://github.com/NixOS/nixos-hardware/commit/ba37846397c388e04db79c9f5bf8cb09ac68ea51) | `` purism/librem/5r4: update renamed pulseaudio option ``         |
| [`4f90da50`](https://github.com/NixOS/nixos-hardware/commit/4f90da509bd7f249ca36e145c4752a798b886641) | `` surface: linux 6.12.12 -> 6.12.14 ``                           |