### PR TITLE
chore(flake/nur): `2320814f` -> `827aa6ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1739792859,
-        "narHash": "sha256-Em/PKyBgW5xWjEE7u2P+aAeH3TrQpPyHJdYY5zHvv64=",
+        "lastModified": 1739796551,
+        "narHash": "sha256-XcTK29rOc0WxcSJDHUK8JQege9CzSVVAcjHdswOVFPA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2320814fdba2500856c915569f39cc90ea562685",
+        "rev": "827aa6eeaf92cc085f84947f6c32002792b67497",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`827aa6ee`](https://github.com/nix-community/NUR/commit/827aa6eeaf92cc085f84947f6c32002792b67497) | `` automatic update `` |