### PR TITLE
chore(flake/nur): `827aa6ee` -> `4fa0ae58`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -682,11 +682,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1739580444,
-        "narHash": "sha256-+/bSz4EAVbqz8/HsIGLroF8aNaO8bLRL7WfACN+24g4=",
+        "lastModified": 1739736696,
+        "narHash": "sha256-zON2GNBkzsIyALlOCFiEBcIjI4w38GYOb+P+R4S8Jsw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8bb37161a0488b89830168b81c48aed11569cb93",
+        "rev": "d74a2335ac9c133d6bbec9fc98d91a77f1604c1f",
         "type": "github"
       },
       "original": {
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1739796551,
-        "narHash": "sha256-XcTK29rOc0WxcSJDHUK8JQege9CzSVVAcjHdswOVFPA=",
+        "lastModified": 1739822111,
+        "narHash": "sha256-1PsZf4/HbmFlUpwFP8+ARBl12GGOJ3+F2iKsQWfUmt4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "827aa6eeaf92cc085f84947f6c32002792b67497",
+        "rev": "4fa0ae583717c3d7f2ad10d09775846fc685e993",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4fa0ae58`](https://github.com/nix-community/NUR/commit/4fa0ae583717c3d7f2ad10d09775846fc685e993) | `` automatic update `` |
| [`0c24b409`](https://github.com/nix-community/NUR/commit/0c24b4093952b94fcbb0feed71b06856f4297cdd) | `` automatic update `` |
| [`7f1b151c`](https://github.com/nix-community/NUR/commit/7f1b151c64a80b412eac8d044f8a370646a07986) | `` automatic update `` |
| [`28b64116`](https://github.com/nix-community/NUR/commit/28b641165f1acf124afe9f852c4b91a1209e9180) | `` automatic update `` |
| [`2c232a6d`](https://github.com/nix-community/NUR/commit/2c232a6d1082a7c723c951d27fac7d323937c6fc) | `` automatic update `` |
| [`781ae51e`](https://github.com/nix-community/NUR/commit/781ae51ede60bf3207d6a78084f76037fe6bfbe2) | `` automatic update `` |
| [`09d810ef`](https://github.com/nix-community/NUR/commit/09d810ef9b92e13d3a3584d9794c7d40e62f3160) | `` automatic update `` |
| [`4ac88b6e`](https://github.com/nix-community/NUR/commit/4ac88b6e59e614f3b6cbf730decda8f786f84e68) | `` automatic update `` |
| [`04ec2ad6`](https://github.com/nix-community/NUR/commit/04ec2ad6316133425bd2bac7af6bdd2dbfbb5e67) | `` automatic update `` |