### PR TITLE
chore(flake/emacs-overlay): `783cff85` -> `b51c3cce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1739784040,
-        "narHash": "sha256-ClWxBsyfs3NrJzrEuHbTMDvOdwldSKPIM3BqN9/Kw9E=",
+        "lastModified": 1739814150,
+        "narHash": "sha256-xvG8k1Gfmm+2wpvzNikGj53BTg+Ay03aM5M68Y0caI8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "783cff85c13e857ab95b441020621ea64e7a9843",
+        "rev": "b51c3cceb739735185e06878bb05c2a0a3c16b9b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`b51c3cce`](https://github.com/nix-community/emacs-overlay/commit/b51c3cceb739735185e06878bb05c2a0a3c16b9b) | `` Updated emacs ``        |
| [`f46d961b`](https://github.com/nix-community/emacs-overlay/commit/f46d961b45787fd1bd9b46226d094ef7dbc5a2ac) | `` Updated melpa ``        |
| [`c41ad03e`](https://github.com/nix-community/emacs-overlay/commit/c41ad03ebbfcb81a2ab77f877fdaa6e8e88bafef) | `` Updated elpa ``         |
| [`021d41d8`](https://github.com/nix-community/emacs-overlay/commit/021d41d8d933d33146a5b90e216087b9bc4741b6) | `` Updated nongnu ``       |
| [`cfa522cb`](https://github.com/nix-community/emacs-overlay/commit/cfa522cbf861b4d78ab360b023ea992c165ba3fb) | `` Updated flake inputs `` |