### PR TITLE
chore(flake/home-manager): `9d0d48f4` -> `5cfbf5cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739802995,
-        "narHash": "sha256-kZv0upOigS/4sUEgZuZd6/uO6s8X8oYOLk9/sGMsl+c=",
+        "lastModified": 1739845242,
+        "narHash": "sha256-rNMXpDubNWGLTs45MuoH9YHtXfXye/fn2u4YMSTPt9I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9d0d48f4c3d2fb1a8c8607da143bb567a741d914",
+        "rev": "5cfbf5cc37a3bd1da07ae84eea1b828909c4456b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`5cfbf5cc`](https://github.com/nix-community/home-manager/commit/5cfbf5cc37a3bd1da07ae84eea1b828909c4456b) | `` flake: don't import modules (#6481) ``             |
| [`69dfc316`](https://github.com/nix-community/home-manager/commit/69dfc316c5b5f2de1d68e477393fecbf19a0cdba) | `` mise: enable nushell integration (#6363) ``        |
| [`6c93eea8`](https://github.com/nix-community/home-manager/commit/6c93eea85daddd0dc8d4a3a687473461f3122961) | `` firefox: add HPSaucii maintainer ``                |
| [`27ffa351`](https://github.com/nix-community/home-manager/commit/27ffa35178bc6f359293a8809d32c5da23aaabc7) | `` firefox: add support for configuring extensions `` |
| [`3a0cf8f1`](https://github.com/nix-community/home-manager/commit/3a0cf8f1aae507ec9bb8c141369458ca0244a01b) | `` maintainers: add HPsaucii ``                       |
| [`edad23eb`](https://github.com/nix-community/home-manager/commit/edad23ebc1bcc226ef5eb57c8d779b9b425adca1) | `` mako: add max-history option (#6009) ``            |
| [`f4f6dd26`](https://github.com/nix-community/home-manager/commit/f4f6dd26985f1e44721325cb6d783d0cf4cd4dbc) | `` git: fix setting format on >=25.05 (#6480) ``      |