### PR TITLE
chore(flake/treefmt-nix): `4f09b473` -> `3d0579f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -961,11 +961,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738953846,
-        "narHash": "sha256-yrK3Hjcr8F7qS/j2F+r7C7o010eVWWlm4T1PrbKBOxQ=",
+        "lastModified": 1739829690,
+        "narHash": "sha256-mL1szCeIsjh6Khn3nH2cYtwO5YXG6gBiTw1A30iGeDU=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "4f09b473c936d41582dd744e19f34ec27592c5fd",
+        "rev": "3d0579f5cc93436052d94b73925b48973a104204",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                      |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`3d0579f5`](https://github.com/numtide/treefmt-nix/commit/3d0579f5cc93436052d94b73925b48973a104204) | `` All GLSL extensions to clangfmt (#315) `` |