### PR TITLE
chore(flake/emacs-overlay): `b51c3cce` -> `27a75333`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1739814150,
-        "narHash": "sha256-xvG8k1Gfmm+2wpvzNikGj53BTg+Ay03aM5M68Y0caI8=",
+        "lastModified": 1739899089,
+        "narHash": "sha256-c4unvat02RCCVSoA2m+b5ueGpLSgHPNINiEQHnfclnM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b51c3cceb739735185e06878bb05c2a0a3c16b9b",
+        "rev": "27a753338e52cb2ad04b534861054f415e596b42",
         "type": "github"
       },
       "original": {
@@ -603,11 +603,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1739624908,
-        "narHash": "sha256-f84lBmLl4tkDp1ZU5LBTSFzlxXP4926DVW3KnXrke10=",
+        "lastModified": 1739758141,
+        "narHash": "sha256-uq6A2L7o1/tR6VfmYhZWoVAwb3gTy7j4Jx30MIrH0rE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a60651b217d2e529729cbc7d989c19f3941b9250",
+        "rev": "c618e28f70257593de75a7044438efc1c1fc0791",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`27a75333`](https://github.com/nix-community/emacs-overlay/commit/27a753338e52cb2ad04b534861054f415e596b42) | `` Updated emacs ``        |
| [`c9366f20`](https://github.com/nix-community/emacs-overlay/commit/c9366f203ab37518ba6614149428d060608dd4bc) | `` Updated melpa ``        |
| [`d3b44edf`](https://github.com/nix-community/emacs-overlay/commit/d3b44edf424120461ea2c3e4f0db3857d19fa21d) | `` Updated elpa ``         |
| [`311b0c96`](https://github.com/nix-community/emacs-overlay/commit/311b0c968b9092e64df961150b78e82ec34582ac) | `` Updated nongnu ``       |
| [`044b275c`](https://github.com/nix-community/emacs-overlay/commit/044b275cd7f349b0d8e4890e2131316ccc22d98b) | `` Updated emacs ``        |
| [`0246e477`](https://github.com/nix-community/emacs-overlay/commit/0246e477a9015e6f15de303393b3cc3144104b94) | `` Updated melpa ``        |
| [`53b218d3`](https://github.com/nix-community/emacs-overlay/commit/53b218d3d3d187724e86b2a63ce9a960d005faac) | `` Updated emacs ``        |
| [`ec02bf2e`](https://github.com/nix-community/emacs-overlay/commit/ec02bf2e195fceaa06f3407f11e2c97c7d25f6c0) | `` Updated melpa ``        |
| [`ba40c1a6`](https://github.com/nix-community/emacs-overlay/commit/ba40c1a645cfde6c367aa5575dabec813e171f51) | `` Updated nongnu ``       |
| [`e0df9cff`](https://github.com/nix-community/emacs-overlay/commit/e0df9cfff486aab3d855689c67b3ecba5e8f3570) | `` Updated elpa ``         |
| [`2882bd00`](https://github.com/nix-community/emacs-overlay/commit/2882bd003d1dd23e9089acc47fc4e5491a898cd9) | `` Updated flake inputs `` |