### PR TITLE
chore(flake/nur): `d4026234` -> `2215ad5c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1739894119,
-        "narHash": "sha256-C0dux4VlslB8CwZWVIt8OnJVJKhirRKiBvQDFMwwQ/U=",
+        "lastModified": 1739903703,
+        "narHash": "sha256-w2tTcjx39lJoPDaFbIxi+INIjAKE0jbIx9TNjj9ghmg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d4026234d502e623b211aeebc3f2a6ab5d20d9ed",
+        "rev": "2215ad5c4347f522523715e809f5f2022509f504",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                     |
| -------------------------------------------------------------------------------------------------- | --------------------------- |
| [`2215ad5c`](https://github.com/nix-community/NUR/commit/2215ad5c4347f522523715e809f5f2022509f504) | `` add wrvsrx repository `` |
| [`aefef58e`](https://github.com/nix-community/NUR/commit/aefef58e09ba07005f0a46541836453d8e212d62) | `` automatic update ``      |