### PR TITLE
chore(flake/darwin): `678b2264` -> `6ab392f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739548217,
-        "narHash": "sha256-rlv64erpr36xdmMDPgf9rhRXBYZ0BZb5nrw2ZPSk1sQ=",
+        "lastModified": 1739933872,
+        "narHash": "sha256-UhuvTR4OrWR+WBaRCZm4YMkvjJhZ1KZo/jRjE41m+Ek=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "678b22642abde2ee77ae2218ab41d802f010e5b0",
+        "rev": "6ab392f626a19f1122d1955c401286e1b7cf6b53",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                     |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------- |
| [`e21d0798`](https://github.com/LnL7/nix-darwin/commit/e21d07988b30adbd5b77d16f9fa40b7d5fc00a09) | `` dock: refactor persistent-apps option `` |
| [`02ba211e`](https://github.com/LnL7/nix-darwin/commit/02ba211ea19fb4e5a5da2e24a6ebbed526f5231d) | `` dock: allow setting tile-types ``        |