### PR TITLE
chore(flake/emacs-overlay): `27a75333` -> `ac68198c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1739899089,
-        "narHash": "sha256-c4unvat02RCCVSoA2m+b5ueGpLSgHPNINiEQHnfclnM=",
+        "lastModified": 1739930872,
+        "narHash": "sha256-nrzASJq/l+p63O5fCBgNb0qDxurnLkwz310VWuNlPZ4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "27a753338e52cb2ad04b534861054f415e596b42",
+        "rev": "ac68198cb33b20aaae32527d3810a86acb796bd6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`ac68198c`](https://github.com/nix-community/emacs-overlay/commit/ac68198cb33b20aaae32527d3810a86acb796bd6) | `` Updated emacs ``  |
| [`4b2cfb13`](https://github.com/nix-community/emacs-overlay/commit/4b2cfb13bd1434c917b50ecc0ff8557946df0019) | `` Updated melpa ``  |
| [`99cd9760`](https://github.com/nix-community/emacs-overlay/commit/99cd97600e9ad11d1ba24fcc390f4bf305c95f84) | `` Updated elpa ``   |
| [`a02e9c9d`](https://github.com/nix-community/emacs-overlay/commit/a02e9c9d3a2cc1613a8fdb745ccac93611164bea) | `` Updated nongnu `` |