### PR TITLE
chore(flake/emacs-overlay): `ac68198c` -> `4e9632a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1739930872,
-        "narHash": "sha256-nrzASJq/l+p63O5fCBgNb0qDxurnLkwz310VWuNlPZ4=",
+        "lastModified": 1739957290,
+        "narHash": "sha256-Qg4I6ir9XfV+ZOi5YeuLPvUmIbkeXK8OvjoFf+qn1/I=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ac68198cb33b20aaae32527d3810a86acb796bd6",
+        "rev": "4e9632a65f5be82a51decac2020b0b360215f456",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`4e9632a6`](https://github.com/nix-community/emacs-overlay/commit/4e9632a65f5be82a51decac2020b0b360215f456) | `` Updated emacs ``        |
| [`ba87bc36`](https://github.com/nix-community/emacs-overlay/commit/ba87bc36bef058c43f7b01cea988a00d70294b5f) | `` Updated melpa ``        |
| [`9f30fb22`](https://github.com/nix-community/emacs-overlay/commit/9f30fb22dc6473cdf4afc6b1d38d70b8606cc4b1) | `` Updated flake inputs `` |