### PR TITLE
chore(flake/emacs-overlay): `4e9632a6` -> `773caf72`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1739957290,
-        "narHash": "sha256-Qg4I6ir9XfV+ZOi5YeuLPvUmIbkeXK8OvjoFf+qn1/I=",
+        "lastModified": 1739985679,
+        "narHash": "sha256-RNSBmvYN6LoE7QXl+kv6CG5Se4BjxJ0HiQ/AEzmgopE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4e9632a65f5be82a51decac2020b0b360215f456",
+        "rev": "773caf72c0ccfb793883b03f65b4a2919c9e1a10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`773caf72`](https://github.com/nix-community/emacs-overlay/commit/773caf72c0ccfb793883b03f65b4a2919c9e1a10) | `` Updated emacs ``  |
| [`4b75a5af`](https://github.com/nix-community/emacs-overlay/commit/4b75a5af90db4a751447c02b289897f5b712bb09) | `` Updated melpa ``  |
| [`6fca983d`](https://github.com/nix-community/emacs-overlay/commit/6fca983dce156512d0e0dda49a4852c1c1874900) | `` Updated elpa ``   |
| [`cb720535`](https://github.com/nix-community/emacs-overlay/commit/cb720535c94cab344eed4df0d59f29465ec2691d) | `` Updated nongnu `` |