### PR TITLE
chore(flake/nixos-cosmic): `5516035b` -> `d63e6b46`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -498,11 +498,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1739909000,
-        "narHash": "sha256-DsepQ7ApA4li8td4QFTmX2qs4gvCLfoN7Mlaifmji7Y=",
+        "lastModified": 1742006448,
+        "narHash": "sha256-8OmMOm7MeuhBYYIu9an/OaeH9+mJLXKVj2g/TY8qAg0=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "5516035bb36dbb19f2bbe7b9cea6922db395e100",
+        "rev": "d63e6b46e0d080fa7cab2cb3ee37b46873615fa3",
         "type": "github"
       },
       "original": {
@@ -622,11 +622,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1739624908,
-        "narHash": "sha256-f84lBmLl4tkDp1ZU5LBTSFzlxXP4926DVW3KnXrke10=",
+        "lastModified": 1741862977,
+        "narHash": "sha256-prZ0M8vE/ghRGGZcflvxCu40ObKaB+ikn74/xQoNrGQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a60651b217d2e529729cbc7d989c19f3941b9250",
+        "rev": "cdd2ef009676ac92b715ff26630164bb88fec4e0",
         "type": "github"
       },
       "original": {
@@ -653,11 +653,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1739580444,
-        "narHash": "sha256-+/bSz4EAVbqz8/HsIGLroF8aNaO8bLRL7WfACN+24g4=",
+        "lastModified": 1741851582,
+        "narHash": "sha256-cPfs8qMccim2RBgtKGF+x9IBCduRvd/N5F4nYpU0TVE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8bb37161a0488b89830168b81c48aed11569cb93",
+        "rev": "6607cf789e541e7873d40d3a8f7815ea92204f32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                                            |
| ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`d63e6b46`](https://github.com/lilyinstarlight/nixos-cosmic/commit/d63e6b46e0d080fa7cab2cb3ee37b46873615fa3) | `` pkgs: update cosmic (#713) ``                                                   |
| [`21efbc71`](https://github.com/lilyinstarlight/nixos-cosmic/commit/21efbc7120177bfec45df9ead5d2736e8bc794d9) | `` flake: update inputs (#712) ``                                                  |
| [`24785e84`](https://github.com/lilyinstarlight/nixos-cosmic/commit/24785e84d4b3844936caffe2c56994bdef9a9300) | `` pkgs: update cosmic (#711) ``                                                   |
| [`05f8b43a`](https://github.com/lilyinstarlight/nixos-cosmic/commit/05f8b43a311b3a1f914af89a94480b19d2eceac6) | `` flake: update inputs (#709) ``                                                  |
| [`f836bde4`](https://github.com/lilyinstarlight/nixos-cosmic/commit/f836bde4e0e9f0f89bce896f519299106557fa44) | `` pkgs: update cosmic (#708) ``                                                   |
| [`5af413f4`](https://github.com/lilyinstarlight/nixos-cosmic/commit/5af413f4e97073783ed2dc11fd134ffc7771414d) | `` flake: update inputs (#707) ``                                                  |
| [`b36c8d4e`](https://github.com/lilyinstarlight/nixos-cosmic/commit/b36c8d4e57e57be9eaf1c820f61f63f60cd3b876) | `` ci: bump cachix/cachix-action from 15 to 16 (#706) ``                           |
| [`56ef4fe3`](https://github.com/lilyinstarlight/nixos-cosmic/commit/56ef4fe3b1890e9ae29f1dc8dcd38775b2c40820) | `` pkgs: update cosmic (#705) ``                                                   |
| [`f34eb24f`](https://github.com/lilyinstarlight/nixos-cosmic/commit/f34eb24fb96780df1437a201948df785d77b3b8a) | `` flake: update inputs (#703) ``                                                  |
| [`fb227261`](https://github.com/lilyinstarlight/nixos-cosmic/commit/fb2272618c5032db0d237ad86b7039a0e30f52b6) | `` pkgs: update cosmic (#702) ``                                                   |
| [`364761eb`](https://github.com/lilyinstarlight/nixos-cosmic/commit/364761eb5ba3f1514446b6a0eb8e8651c5bc4c67) | `` pkgs: update cosmic (#700) ``                                                   |
| [`ad225743`](https://github.com/lilyinstarlight/nixos-cosmic/commit/ad2257430e16a120c3b27c499122b632ed496509) | `` flake: update inputs (#701) ``                                                  |
| [`bf3d41b9`](https://github.com/lilyinstarlight/nixos-cosmic/commit/bf3d41b9fc89883823ce9fadbec1b44f2cdd1fac) | `` flake: update inputs (#699) ``                                                  |
| [`3721f567`](https://github.com/lilyinstarlight/nixos-cosmic/commit/3721f567dc4d508ecaed8a9a6b9d673cb313b236) | `` pkgs: update cosmic (#698) ``                                                   |
| [`5be89641`](https://github.com/lilyinstarlight/nixos-cosmic/commit/5be89641d8b9190460af05d59f6dbe4cb8695399) | `` cosmic-files: re-enable checks (#693) ``                                        |
| [`c7b55dc5`](https://github.com/lilyinstarlight/nixos-cosmic/commit/c7b55dc5e0e010e28b01d61e5b261160dcf01f5a) | `` flake: update inputs (#697) ``                                                  |
| [`8522280e`](https://github.com/lilyinstarlight/nixos-cosmic/commit/8522280e59847b06610d8585fb53e73b87e5f688) | `` pkgs: update cosmic (#696) ``                                                   |
| [`b60b139b`](https://github.com/lilyinstarlight/nixos-cosmic/commit/b60b139bf22f5d941b626594981d698502dfc500) | `` flake: update inputs (#695) ``                                                  |
| [`26677c04`](https://github.com/lilyinstarlight/nixos-cosmic/commit/26677c041e1b4b8aa9126accf3797348c1975123) | `` pkgs: update cosmic (#692) ``                                                   |
| [`cd46ebf6`](https://github.com/lilyinstarlight/nixos-cosmic/commit/cd46ebf6ff7fd1eda1f37fdca1cca1dccab5c4f2) | `` flake: update inputs (#689) ``                                                  |
| [`230110df`](https://github.com/lilyinstarlight/nixos-cosmic/commit/230110dfca5317645bc21fa2f6882eab9a7b5788) | `` pkgs: update cosmic (#690) ``                                                   |
| [`f3f91440`](https://github.com/lilyinstarlight/nixos-cosmic/commit/f3f91440dfd18518445d9ab757cf3e540c7fd6ab) | `` pkgs: update cosmic (#687) ``                                                   |
| [`dba95629`](https://github.com/lilyinstarlight/nixos-cosmic/commit/dba95629ddebe2e598a6112a34c3fb7f77d61f2b) | `` flake: update inputs (#685) ``                                                  |
| [`afcfe175`](https://github.com/lilyinstarlight/nixos-cosmic/commit/afcfe175db766715bf31c92395ee810e3b3bbaf3) | `` xdg-desktop-portal-cosmic: use `make install` for installing files (#680) ``    |
| [`d0811a70`](https://github.com/lilyinstarlight/nixos-cosmic/commit/d0811a7043eb3ff8b1f842ed7b47d1a300e58610) | `` cosmic-session: update substitution pattern for start-cosmic script (#681) ``   |
| [`04a3663d`](https://github.com/lilyinstarlight/nixos-cosmic/commit/04a3663de9d08d435de114111f1a091b84df0722) | `` flake: update inputs (#678) ``                                                  |
| [`c1ddac09`](https://github.com/lilyinstarlight/nixos-cosmic/commit/c1ddac0949f103149c1b88f3dc92edae44f7f099) | `` pkgs: update cosmic (#679) ``                                                   |
| [`7e02381d`](https://github.com/lilyinstarlight/nixos-cosmic/commit/7e02381dc8a7702481c5bcbb18d2759211a80de4) | `` pkgs: update cosmic (#677) ``                                                   |
| [`c5a9b54c`](https://github.com/lilyinstarlight/nixos-cosmic/commit/c5a9b54c1ed6586e60ed6acd2178704ce1824c19) | `` pkgs: update cosmic (#676) ``                                                   |
| [`5a87ae1a`](https://github.com/lilyinstarlight/nixos-cosmic/commit/5a87ae1a2d9a868bc16819e2a3a97452abb52c9c) | `` libcosmicAppHook: prefer `stdenv.hostPlatform.isDarwin` (#674) ``               |
| [`8ae033bb`](https://github.com/lilyinstarlight/nixos-cosmic/commit/8ae033bb5a41441fc44f31424c348e7d4f1ba380) | `` flake: update inputs (#675) ``                                                  |
| [`f22809d3`](https://github.com/lilyinstarlight/nixos-cosmic/commit/f22809d3391400050ca4709db65f80417ccb1915) | `` pkgs: update cosmic (#672) ``                                                   |
| [`e8413501`](https://github.com/lilyinstarlight/nixos-cosmic/commit/e8413501a60d226b2dccd2ab6cd43d0747c99a1a) | `` pkgs: update cosmic (#671) ``                                                   |
| [`12033b9e`](https://github.com/lilyinstarlight/nixos-cosmic/commit/12033b9ea7759e0a05f58cad12fbe71006e2eafb) | `` flake: update inputs (#670) ``                                                  |
| [`52522b98`](https://github.com/lilyinstarlight/nixos-cosmic/commit/52522b9882a9b01fecd12d7de24ffbb69c5b72cd) | `` flake: update inputs (#669) ``                                                  |
| [`42f72583`](https://github.com/lilyinstarlight/nixos-cosmic/commit/42f72583bc88c8409894f52516adf29139d0d171) | `` flake: update inputs (#668) ``                                                  |
| [`80952def`](https://github.com/lilyinstarlight/nixos-cosmic/commit/80952def5b97be37f69a9774163911b47980623a) | `` pkgs: update cosmic (#667) ``                                                   |
| [`f3accf6a`](https://github.com/lilyinstarlight/nixos-cosmic/commit/f3accf6aa7235dc5b9530a8d6c2077603bb0c5de) | `` pkgs: update cosmic (#665) ``                                                   |
| [`feabcf77`](https://github.com/lilyinstarlight/nixos-cosmic/commit/feabcf777dca2ddb8b6039dbc907b013812d97ed) | `` nixos/cosmic: add new fonts ``                                                  |
| [`4be261f1`](https://github.com/lilyinstarlight/nixos-cosmic/commit/4be261f1b28465016f1476beabcd67fa000b04a5) | `` xdg-desktop-portal-cosmic: readd vergen env ``                                  |
| [`1c5381e3`](https://github.com/lilyinstarlight/nixos-cosmic/commit/1c5381e3642edea59334d9fa1875bded159bcca0) | `` flake: update inputs (#660) ``                                                  |
| [`ab4304fb`](https://github.com/lilyinstarlight/nixos-cosmic/commit/ab4304fbca6cd8697b4329cd23c389959fdb2fb6) | `` xdg-desktop-portal-cosmic: remove vergen env ``                                 |
| [`53a9ac48`](https://github.com/lilyinstarlight/nixos-cosmic/commit/53a9ac48e77780e5fc93cdad4cd5d2ea3d4d4263) | `` treewide: remove unnecessary vergen env variables (#658) ``                     |
| [`53191caa`](https://github.com/lilyinstarlight/nixos-cosmic/commit/53191caad09ebac3c27f6c54bc3e72d71e8667d4) | `` ci: pin store paths during merge queue ``                                       |
| [`5a5ad54c`](https://github.com/lilyinstarlight/nixos-cosmic/commit/5a5ad54c54d44fa507aa8167f32a95b0aee4ca70) | `` ci: move flake workflow further from cosmic workflow to reduce wasted builds `` |
| [`ca158e1d`](https://github.com/lilyinstarlight/nixos-cosmic/commit/ca158e1d3824b4b4cbaaf258a6a9123a21d9049c) | `` pkgs: update cosmic (#664) ``                                                   |