### PR TITLE
chore(flake/emacs-overlay): `773caf72` -> `6f91e1aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1739985679,
-        "narHash": "sha256-RNSBmvYN6LoE7QXl+kv6CG5Se4BjxJ0HiQ/AEzmgopE=",
+        "lastModified": 1740017479,
+        "narHash": "sha256-GHNxxrtpWRIJygwtcww2Jo2TSzidlU5DG2SJDggemKo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "773caf72c0ccfb793883b03f65b4a2919c9e1a10",
+        "rev": "6f91e1aa56760a4f5f81cf8259b428cb987e295d",
         "type": "github"
       },
       "original": {
@@ -603,11 +603,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1739758141,
-        "narHash": "sha256-uq6A2L7o1/tR6VfmYhZWoVAwb3gTy7j4Jx30MIrH0rE=",
+        "lastModified": 1739923778,
+        "narHash": "sha256-BqUY8tz0AQ4to2Z4+uaKczh81zsGZSYxjgvtw+fvIfM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c618e28f70257593de75a7044438efc1c1fc0791",
+        "rev": "36864ed72f234b9540da4cf7a0c49e351d30d3f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`6f91e1aa`](https://github.com/nix-community/emacs-overlay/commit/6f91e1aa56760a4f5f81cf8259b428cb987e295d) | `` Updated emacs ``        |
| [`233de5f1`](https://github.com/nix-community/emacs-overlay/commit/233de5f17c1bdf62be3d8054916686f9d2fccb11) | `` Updated melpa ``        |
| [`4443f457`](https://github.com/nix-community/emacs-overlay/commit/4443f45710cf56df88b1f465e7952eae552979ec) | `` Updated elpa ``         |
| [`be0fef5a`](https://github.com/nix-community/emacs-overlay/commit/be0fef5a7f07d4ec14e5354800d340e3f24c246c) | `` Updated nongnu ``       |
| [`599c3ed9`](https://github.com/nix-community/emacs-overlay/commit/599c3ed9bce96e8e35654a34bb214c5c7194fa32) | `` Updated flake inputs `` |