### PR TITLE
chore(flake/srvos): `6eb9f48a` -> `f6ddf92b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -884,11 +884,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739753812,
-        "narHash": "sha256-zrdDM2wruRklLfdOCPbQ3E1n0lf92pqass3dtzwYr1k=",
+        "lastModified": 1740012831,
+        "narHash": "sha256-u6Y5ttXBuQ+tyyCei07QnbNL6Gydv55OpoGh4fXzTqg=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "6eb9f48ae6f452827cf611dd020ca1f33b115ebf",
+        "rev": "f6ddf92bc61e021ea05c971a055624509ffac429",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`f6ddf92b`](https://github.com/nix-community/srvos/commit/f6ddf92bc61e021ea05c971a055624509ffac429) | `` dev/private/flake.lock: Update `` |
| [`d6debc6b`](https://github.com/nix-community/srvos/commit/d6debc6bd2ee0138809ebe7fb12c860b92ecad96) | `` flake.lock: Update ``             |