### PR TITLE
chore(flake/emacs-overlay): `6f91e1aa` -> `759b7252`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1740017479,
-        "narHash": "sha256-GHNxxrtpWRIJygwtcww2Jo2TSzidlU5DG2SJDggemKo=",
+        "lastModified": 1740071991,
+        "narHash": "sha256-0oNsNqkQsKf/uZY3OPZLSqT3/RWVM7XsqTf0YiycZi0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6f91e1aa56760a4f5f81cf8259b428cb987e295d",
+        "rev": "759b725256597a6b3020f56988ad12562e6d02c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`759b7252`](https://github.com/nix-community/emacs-overlay/commit/759b725256597a6b3020f56988ad12562e6d02c6) | `` Updated emacs ``  |
| [`5926d0cc`](https://github.com/nix-community/emacs-overlay/commit/5926d0cc91ca83ec68a86ea4550224af0c44d959) | `` Updated melpa ``  |
| [`f9830d78`](https://github.com/nix-community/emacs-overlay/commit/f9830d78de821c22aabbd55b1a9ba57f7a79ce37) | `` Updated elpa ``   |
| [`e1ed34a7`](https://github.com/nix-community/emacs-overlay/commit/e1ed34a710acba33ec8b802acba255f4ccadaa2a) | `` Updated nongnu `` |
| [`ad562828`](https://github.com/nix-community/emacs-overlay/commit/ad562828e30f625181cec2a1be61ef28229f8e34) | `` Updated emacs ``  |
| [`fc19ce22`](https://github.com/nix-community/emacs-overlay/commit/fc19ce22940d2fec85101c2511df7f872f757ccf) | `` Updated melpa ``  |