### PR TITLE
chore(flake/nur): `37f8ad3e` -> `2bacb5f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1740048753,
-        "narHash": "sha256-2t/4U/39d8kvon9g+qqHd2Mjo5uu2T4r+CMHWX1oU+M=",
+        "lastModified": 1740079924,
+        "narHash": "sha256-wuugkYBFLL8snybgY5g2DXujI0ssm1jRpCMbyEZgkCU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "37f8ad3ed97ec483592c40a1d816f0e3b80cbdcf",
+        "rev": "2bacb5f1028bc2f410e3678a8f84bb17a15f4f2d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2bacb5f1`](https://github.com/nix-community/NUR/commit/2bacb5f1028bc2f410e3678a8f84bb17a15f4f2d) | `` automatic update `` |
| [`a20ee5e6`](https://github.com/nix-community/NUR/commit/a20ee5e688ff39f289e191299913cfa07d87d045) | `` automatic update `` |
| [`e1e326d3`](https://github.com/nix-community/NUR/commit/e1e326d3437e7aef09ab4d62f99450ba3ce74698) | `` automatic update `` |
| [`86b71ef1`](https://github.com/nix-community/NUR/commit/86b71ef14fff48d7c19097bfee104ddc72a977a9) | `` automatic update `` |