### PR TITLE
chore(flake/emacs-overlay): `759b7252` -> `1e16548e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1740071991,
-        "narHash": "sha256-0oNsNqkQsKf/uZY3OPZLSqT3/RWVM7XsqTf0YiycZi0=",
+        "lastModified": 1740103652,
+        "narHash": "sha256-wfiBVm0xPFOQIqc8rNJDrRRdV1CAqhhtTlk7nprm/ek=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "759b725256597a6b3020f56988ad12562e6d02c6",
+        "rev": "1e16548eb941484f83c854504631e7a70282a0ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`1e16548e`](https://github.com/nix-community/emacs-overlay/commit/1e16548eb941484f83c854504631e7a70282a0ca) | `` Updated emacs ``  |
| [`d4bb0f57`](https://github.com/nix-community/emacs-overlay/commit/d4bb0f5705e60ce5923dd28c27d36072fea92546) | `` Updated melpa ``  |
| [`ca7043dc`](https://github.com/nix-community/emacs-overlay/commit/ca7043dc160e28e08924e2d3e7a9a15d6229f9a6) | `` Updated elpa ``   |
| [`f97767b1`](https://github.com/nix-community/emacs-overlay/commit/f97767b1869d55e78aa2353528c717cf2f47d5cb) | `` Updated nongnu `` |