### PR TITLE
chore(flake/nur): `4b903a51` -> `5128cf79`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1740106872,
-        "narHash": "sha256-EKlwfDK2c29ZvbJy0b7tGWOkFtxCkLd21ZXaCbI0BCw=",
+        "lastModified": 1740174476,
+        "narHash": "sha256-a7BqCnEOLyFAW7GYej7nQOXtbHZe9QNtHmlcYP0xrQU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4b903a51f88af45c4d95badf4dcee405c472fcbd",
+        "rev": "5128cf795f0f565506346599f0de1d6c1c5dfa28",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5128cf79`](https://github.com/nix-community/NUR/commit/5128cf795f0f565506346599f0de1d6c1c5dfa28) | `` automatic update `` |
| [`1e28c6bb`](https://github.com/nix-community/NUR/commit/1e28c6bb3ed7dc355ceffa0ad0e54a0a3be66be6) | `` automatic update `` |
| [`6b8867b9`](https://github.com/nix-community/NUR/commit/6b8867b9ac94f3302bf073f15c5750072c705141) | `` automatic update `` |
| [`db0c1eb2`](https://github.com/nix-community/NUR/commit/db0c1eb290fc9894549789f2caf6821b7a9ff256) | `` automatic update `` |
| [`49b96917`](https://github.com/nix-community/NUR/commit/49b9691731e984e5ea1f7d867bb3d6506ed4be7f) | `` automatic update `` |
| [`aea44f7d`](https://github.com/nix-community/NUR/commit/aea44f7d32fcb76cc8276abdf6ad72340327d211) | `` automatic update `` |
| [`70404a03`](https://github.com/nix-community/NUR/commit/70404a03f7ecdf82df5044c3d0f1b9aa47014409) | `` automatic update `` |
| [`d1b47086`](https://github.com/nix-community/NUR/commit/d1b47086aee845628b483a8c50dd2849b1bd7210) | `` automatic update `` |
| [`db9cfde6`](https://github.com/nix-community/NUR/commit/db9cfde6b65fa112bd70f4de2541f05e0b542684) | `` automatic update `` |
| [`3c1eedf0`](https://github.com/nix-community/NUR/commit/3c1eedf004673d4f60394a8fe21dcc6a0e915bba) | `` automatic update `` |
| [`a0ce55b5`](https://github.com/nix-community/NUR/commit/a0ce55b58490c3d737666646ea0da3ab00ac45fc) | `` automatic update `` |
| [`432ad3e1`](https://github.com/nix-community/NUR/commit/432ad3e17ef6e4173a17405d3aed3e27dee0ce4b) | `` automatic update `` |
| [`b652eda3`](https://github.com/nix-community/NUR/commit/b652eda3449aac62211a80f9bb7126d981e66140) | `` automatic update `` |
| [`e3fa171b`](https://github.com/nix-community/NUR/commit/e3fa171b4a5c0dce5079c7be83f713afb2633dc9) | `` automatic update `` |
| [`10b870d9`](https://github.com/nix-community/NUR/commit/10b870d9016786753eb84a237ad6283ad4637df8) | `` automatic update `` |
| [`883d1900`](https://github.com/nix-community/NUR/commit/883d1900bad792b7e9c6717cd5e7be92b19a7d3f) | `` automatic update `` |
| [`3be1af7d`](https://github.com/nix-community/NUR/commit/3be1af7d3670e1d917576fe6e06407c8b68634f3) | `` automatic update `` |
| [`70e2f3c6`](https://github.com/nix-community/NUR/commit/70e2f3c64558bdcc6e87e3e56048ed7ed59aaaea) | `` automatic update `` |
| [`7534d6d4`](https://github.com/nix-community/NUR/commit/7534d6d41a8d080acb9e2b6eafb827e0b2ff1260) | `` automatic update `` |
| [`4d30a87d`](https://github.com/nix-community/NUR/commit/4d30a87d44fc3dcdc4bcc919fee637469427d3ce) | `` automatic update `` |
| [`626b1c1d`](https://github.com/nix-community/NUR/commit/626b1c1d12453c94e255a6240897d1aeda64f579) | `` automatic update `` |
| [`061731c1`](https://github.com/nix-community/NUR/commit/061731c1a7261c5821f8f377a6a804a4a6277493) | `` automatic update `` |
| [`ed95e937`](https://github.com/nix-community/NUR/commit/ed95e93799d3c73cb3fa31ba0efeb0c97efdcfb9) | `` automatic update `` |
| [`b53d3dbc`](https://github.com/nix-community/NUR/commit/b53d3dbc04689887cd90fae619f42145081f3a02) | `` automatic update `` |