### PR TITLE
chore(flake/home-manager): `0c0b0ac8` -> `bdf73272`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740060750,
-        "narHash": "sha256-FOC9OzJ5Ckh6VjzGSRh4F3UCUOdM8NrzQT19PQcQJ44=",
+        "lastModified": 1740161702,
+        "narHash": "sha256-dUwfoRhWT22JjXn0iqmMWKsutELwSL01EdKeA9TXsHA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0c0b0ac8af6ca76b1fcb514483a9bd73c18f1e8c",
+        "rev": "bdf73272a8408fedc7ca86d5ea47192f6d2dad54",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                       |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`bdf73272`](https://github.com/nix-community/home-manager/commit/bdf73272a8408fedc7ca86d5ea47192f6d2dad54) | `` swayimg: add module (#6506) ``                                             |
| [`1a78a4c7`](https://github.com/nix-community/home-manager/commit/1a78a4c7fe9d484c1de9ff0e46007f1970fd0a73) | `` firefox: fix build failure when package is null ``                         |
| [`fad54a64`](https://github.com/nix-community/home-manager/commit/fad54a641a4419b6dbfabdcf33911bebc87f97f3) | `` tests: check thunderbird with and without native messaging hosts ``        |
| [`63146593`](https://github.com/nix-community/home-manager/commit/63146593a928d3b77d0e92e82dbc6d959da8cd12) | `` tests: don't override scraping of nixpkgs for thunderbird suite ``         |
| [`5f5ff397`](https://github.com/nix-community/home-manager/commit/5f5ff39778171e3667ec3ea15bdacdce0edc1242) | `` firefox: remove with keyword use ``                                        |
| [`4eef1979`](https://github.com/nix-community/home-manager/commit/4eef19791387f387c6be83663d67ab5d06187494) | `` thunderbird, firefox: don't create native host dirs when program is off `` |
| [`e5e485e7`](https://github.com/nix-community/home-manager/commit/e5e485e73c6e28ba54af4f45ed13f80e0706418f) | `` thunderbird: separate test case for firefox+thunderbird setup ``           |
| [`7e81c581`](https://github.com/nix-community/home-manager/commit/7e81c581a51e8e4aa30002332385034437655860) | `` thunderbird, firefox: fix file conflict for native messaging hosts ``      |
| [`fadb9cba`](https://github.com/nix-community/home-manager/commit/fadb9cba44957ed623ffc22bc87ddb73d86e6e66) | `` Reapply "thunderbird: add native host support (#6292)" (#6371) ``          |
| [`3c822853`](https://github.com/nix-community/home-manager/commit/3c82285348bc811b723014cf4dba2f87e7ffc885) | `` vinegar: add module (#6494) ``                                             |