### PR TITLE
chore(flake/emacs-overlay): `38cde30c` -> `33b94573`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1740129365,
-        "narHash": "sha256-SN2R1HKQsVHq0O9/Ilyi7221kIXUjlQawuk9BhysnE8=",
+        "lastModified": 1740189964,
+        "narHash": "sha256-80FEyl0zRoBA3fnuJA1MtsZb3hI3WRFE5OFAYr6tLTA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "38cde30c151765ba64e8e7b0b47ec35ecbbbdb02",
+        "rev": "33b945739322cb13a351114563ffad9c4f67968c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`33b94573`](https://github.com/nix-community/emacs-overlay/commit/33b945739322cb13a351114563ffad9c4f67968c) | `` Updated emacs ``  |
| [`7e41e738`](https://github.com/nix-community/emacs-overlay/commit/7e41e7387833e0787c3651a860c5b697d1595bc3) | `` Updated melpa ``  |
| [`c3775b4a`](https://github.com/nix-community/emacs-overlay/commit/c3775b4a82a884d8e88d13b431d5b2bd034d2cc9) | `` Updated elpa ``   |
| [`dce84a0c`](https://github.com/nix-community/emacs-overlay/commit/dce84a0c7c5457627fb63597cbe62db18f73c475) | `` Updated nongnu `` |
| [`5087fd2d`](https://github.com/nix-community/emacs-overlay/commit/5087fd2de336359f61e50a608f4d50fd4c3ef10f) | `` Updated emacs ``  |
| [`5fffd529`](https://github.com/nix-community/emacs-overlay/commit/5fffd529d5235d2bd4b13857562906b643c1c4b6) | `` Updated melpa ``  |
| [`85c49bdb`](https://github.com/nix-community/emacs-overlay/commit/85c49bdbbbea83bbe8f605cb5ef504df008a7a36) | `` Updated elpa ``   |
| [`ca734695`](https://github.com/nix-community/emacs-overlay/commit/ca73469546221017f1183e1312803b6e2c7d02eb) | `` Updated nongnu `` |