### PR TITLE
chore(flake/home-manager): `bdf73272` -> `ed030a78`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740161702,
-        "narHash": "sha256-dUwfoRhWT22JjXn0iqmMWKsutELwSL01EdKeA9TXsHA=",
+        "lastModified": 1740283128,
+        "narHash": "sha256-R61wtNknWWejnl+K0l4sxu/wnLNFbNe44tNM2zbj5yE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bdf73272a8408fedc7ca86d5ea47192f6d2dad54",
+        "rev": "ed030a787938cae01d693ebaad52bbb672a4a69d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                      |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`ed030a78`](https://github.com/nix-community/home-manager/commit/ed030a787938cae01d693ebaad52bbb672a4a69d) | `` chromium: optional nativeMessagingHosts (#6515) ``                        |
| [`3b6550f7`](https://github.com/nix-community/home-manager/commit/3b6550f710e754bc9f58c09583f2fa51d9fd14ed) | `` git: add option to use riff as diff tool (#5748) ``                       |
| [`6b7cd508`](https://github.com/nix-community/home-manager/commit/6b7cd50812e884a559481c7905317005a968ec08) | `` tests: test librewolf the same way firefox is tested ``                   |
| [`7f9ba30a`](https://github.com/nix-community/home-manager/commit/7f9ba30a28f02e51c4785b2cc32bf573f8eac021) | `` tests: check that all firefox derivatives can be installed ``             |
| [`fb568d75`](https://github.com/nix-community/home-manager/commit/fb568d75cf6c81f30d49eeb73787e9b56454ba16) | `` targets/darwin: allow configuring application linking (#4809) ``          |
| [`cb3f6e9b`](https://github.com/nix-community/home-manager/commit/cb3f6e9b59d3a5e51ef9f7da2b8418d5c72aaef8) | `` htop: write-protect entire configuration directory ``                     |
| [`61d8f836`](https://github.com/nix-community/home-manager/commit/61d8f8366fc327a42cc212d62dfff06ae0c3f195) | `` htop: export defaultFields into lib ``                                    |
| [`546949fe`](https://github.com/nix-community/home-manager/commit/546949fea16cf75b4f670c75a5251afee3e5b20f) | `` tests/dircolors: test zsh path ``                                         |
| [`89b89340`](https://github.com/nix-community/home-manager/commit/89b89340556e6347f494ff45fd8f136f2741b4a4) | `` tests/dircolors: add xdg config test ``                                   |
| [`c327afbf`](https://github.com/nix-community/home-manager/commit/c327afbfd859fee74162e22a4275888f5deb89e3) | `` dircolors: refactor preferXdgDirectories ``                               |
| [`413e9b35`](https://github.com/nix-community/home-manager/commit/413e9b35f17b2f24fd3a7ecbfc1237d9c3d502fd) | `` dircolors: respect preferXdgDirectories if set ``                         |
| [`61d8fc9a`](https://github.com/nix-community/home-manager/commit/61d8fc9af0f8568ffaff93e4001cb607f88790f9) | `` firefox: Allow to add PKCS11 modules (#5608) ``                           |
| [`90504b9a`](https://github.com/nix-community/home-manager/commit/90504b9a893b64c308640c3b7475a480d113fb2b) | `` thunderbird: allow managing feed accounts (#5613) ``                      |
| [`7ceacd98`](https://github.com/nix-community/home-manager/commit/7ceacd98a9fc99743ae7d9a5c0a4ea7c72314da6) | `` wpaperd: add systemd service; move to services/ from programs/ (#6302) `` |
| [`e860bd49`](https://github.com/nix-community/home-manager/commit/e860bd49eaa577089de22d370f6126ee4f6e7914) | `` vscode: add profiles support (#5640) ``                                   |
| [`4949081d`](https://github.com/nix-community/home-manager/commit/4949081d1ee37ebb1ca9fbef289955d85aace405) | `` jqp: add module (#5716) ``                                                |
| [`a51e94e5`](https://github.com/nix-community/home-manager/commit/a51e94e51c7df10f078a2530ce125df7410b4f33) | `` clipse: add module (#5777) ``                                             |
| [`34d524f3`](https://github.com/nix-community/home-manager/commit/34d524f3edcf3a04c00ad2c09c24ec9d35d937f9) | `` imapnotify-accounts: remove with lib ``                                   |
| [`dd21b9af`](https://github.com/nix-community/home-manager/commit/dd21b9afd5fefb0c80c3962869703acb3c56a5f2) | `` imapnotify: add extraArgs option to imapnotify-accounts ``                |
| [`f4a07823`](https://github.com/nix-community/home-manager/commit/f4a07823a298deff0efb0db30f9318511de7c232) | `` chromium: add nativeMessagingHosts option (#6019) ``                      |
| [`2b382e49`](https://github.com/nix-community/home-manager/commit/2b382e499aa2fa7ac78bdf1cee079d45fb3a0334) | `` earthly: init module (#6265) ``                                           |
| [`c31b4e33`](https://github.com/nix-community/home-manager/commit/c31b4e330e40a4fbf55ceb59741bd75bbb9c622c) | `` accounts/email: provide realName option for alias (#6106) ``              |
| [`f0f0d1ad`](https://github.com/nix-community/home-manager/commit/f0f0d1ade22b51eaaf4d16e6b3f4990d8c348f3e) | `` docs: update copyright year ``                                            |
| [`439a125a`](https://github.com/nix-community/home-manager/commit/439a125afef8c97308ec0c6db75d38e15d92208d) | `` tests: remove with lib (#6511) ``                                         |
| [`e495cd8c`](https://github.com/nix-community/home-manager/commit/e495cd8c805a050d404abcb658cfe8cdaf589990) | `` tests/firefox: add profiles-extensions (#6510) ``                         |
| [`765cb91e`](https://github.com/nix-community/home-manager/commit/765cb91e9d5ab06ed8c92c25fc0e51d6c11d43cb) | `` psd: add missing module config options (#6230) ``                         |
| [`62d038f4`](https://github.com/nix-community/home-manager/commit/62d038f499b94d406df790dec04e201d222e5098) | `` nushell: reenable test ``                                                 |
| [`f0837fa6`](https://github.com/nix-community/home-manager/commit/f0837fa6730ad497f0329722263e2ef4683b09cf) | `` flake.lock: Update ``                                                     |
| [`e512de47`](https://github.com/nix-community/home-manager/commit/e512de4722831c850ec0681f69510fcba44f582d) | `` wluma: init module (#6463) ``                                             |
| [`9f74e14a`](https://github.com/nix-community/home-manager/commit/9f74e14a2d9af4c6f2024cca7813b830b020f45e) | `` fcitx5: make boot after graphical session (#6432) ``                      |
| [`6eed33a3`](https://github.com/nix-community/home-manager/commit/6eed33a3acb933224917964879634826716a3e5d) | `` jetbrains-remote: do not fail if files do not exist yet (#6502) ``        |
| [`dde2fba6`](https://github.com/nix-community/home-manager/commit/dde2fba628af2891e2e1ba8abb8be4e597edd49e) | `` home-cursor: add sway support (#6459) ``                                  |
| [`148a6b55`](https://github.com/nix-community/home-manager/commit/148a6b55651ac794f5c20bbd76780b4d8fed4334) | `` Translate using Weblate (Catalan) ``                                      |