### PR TITLE
chore(flake/nur): `5128cf79` -> `edda9f08`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1740174476,
-        "narHash": "sha256-a7BqCnEOLyFAW7GYej7nQOXtbHZe9QNtHmlcYP0xrQU=",
+        "lastModified": 1740196838,
+        "narHash": "sha256-227FaDHB170PKrXisOZaunvqE1VKm7rSAwOub/v0frc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5128cf795f0f565506346599f0de1d6c1c5dfa28",
+        "rev": "edda9f08f279bbacd389a8a1b099101185a2265e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`edda9f08`](https://github.com/nix-community/NUR/commit/edda9f08f279bbacd389a8a1b099101185a2265e) | `` automatic update `` |
| [`c730bf6c`](https://github.com/nix-community/NUR/commit/c730bf6c124d3bbb66ee6aac920d5ad7f0e15759) | `` automatic update `` |
| [`93be748a`](https://github.com/nix-community/NUR/commit/93be748a381ae0c5e97b64ffe9bafaa77312a974) | `` automatic update `` |