### PR TITLE
chore(flake/nur): `edda9f08` -> `6cec53b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1740196838,
-        "narHash": "sha256-227FaDHB170PKrXisOZaunvqE1VKm7rSAwOub/v0frc=",
+        "lastModified": 1740219286,
+        "narHash": "sha256-IvYKRrx24/yDQvQk/1pJhm2ngxjSTBqi2g5Ly8pgkxA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "edda9f08f279bbacd389a8a1b099101185a2265e",
+        "rev": "6cec53b34684074b57e92c4a017160a8ae7b7b37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6cec53b3`](https://github.com/nix-community/NUR/commit/6cec53b34684074b57e92c4a017160a8ae7b7b37) | `` automatic update `` |
| [`8146925b`](https://github.com/nix-community/NUR/commit/8146925bb1742cf77c2da58c1bcfc7a5982e8f51) | `` automatic update `` |
| [`1cc6ce30`](https://github.com/nix-community/NUR/commit/1cc6ce305efb7cf0faee4f4b267d44049737b49a) | `` automatic update `` |
| [`35cc96a3`](https://github.com/nix-community/NUR/commit/35cc96a38e78a66b7c6ac1af49c0e14299dad13a) | `` automatic update `` |
| [`8e05db71`](https://github.com/nix-community/NUR/commit/8e05db712232906bc764b0dab6e69885d194b9ec) | `` automatic update `` |