### PR TITLE
chore(flake/emacs-overlay): `33b94573` -> `920cd4e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1740189964,
-        "narHash": "sha256-80FEyl0zRoBA3fnuJA1MtsZb3hI3WRFE5OFAYr6tLTA=",
+        "lastModified": 1740302110,
+        "narHash": "sha256-rQY2wY+KTGIH2oZFyqdsODjqmOJqyn+0BNURADQHi/s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "33b945739322cb13a351114563ffad9c4f67968c",
+        "rev": "920cd4e86af18bd67a60013d80a79ff2cd7a176b",
         "type": "github"
       },
       "original": {
@@ -603,11 +603,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1739923778,
-        "narHash": "sha256-BqUY8tz0AQ4to2Z4+uaKczh81zsGZSYxjgvtw+fvIfM=",
+        "lastModified": 1740162160,
+        "narHash": "sha256-SSYxFhqCOb3aiPb6MmN68yEzBIltfom8IgRz7phHscM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "36864ed72f234b9540da4cf7a0c49e351d30d3f1",
+        "rev": "11415c7ae8539d6292f2928317ee7a8410b28bb9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------- |
| [`920cd4e8`](https://github.com/nix-community/emacs-overlay/commit/920cd4e86af18bd67a60013d80a79ff2cd7a176b) | `` Updated emacs ``                    |
| [`8970d33b`](https://github.com/nix-community/emacs-overlay/commit/8970d33b560a366d41a5f5867782cfab25f79f17) | `` Updated melpa ``                    |
| [`dcb9bed7`](https://github.com/nix-community/emacs-overlay/commit/dcb9bed7a8cc9e98586f4535d8ddadade5b1b0b2) | `` Updated emacs ``                    |
| [`50069039`](https://github.com/nix-community/emacs-overlay/commit/500690394a759611ceda396b800fe845ae661204) | `` Updated melpa ``                    |
| [`829a6fa0`](https://github.com/nix-community/emacs-overlay/commit/829a6fa087927f783ff151e23da149cc7a840ca7) | `` Updated elpa ``                     |
| [`f8f80c7c`](https://github.com/nix-community/emacs-overlay/commit/f8f80c7c85c7ceb7c0248967543c88ff18893ffc) | `` Updated nongnu ``                   |
| [`79f1e193`](https://github.com/nix-community/emacs-overlay/commit/79f1e19358130a73a057c11bfedb10974a28f1aa) | `` Updated flake inputs ``             |
| [`f6f9a60d`](https://github.com/nix-community/emacs-overlay/commit/f6f9a60d81a5c651e6d0f59153e38f30a6d30063) | `` Updated melpa ``                    |
| [`7df2b725`](https://github.com/nix-community/emacs-overlay/commit/7df2b725e16d70b5ccd949a5abf1370fcad7f1f9) | `` Updated emacs ``                    |
| [`f004ea60`](https://github.com/nix-community/emacs-overlay/commit/f004ea60b2c4646b8beceb218bb058140b69be49) | `` Updated melpa ``                    |
| [`38861b2e`](https://github.com/nix-community/emacs-overlay/commit/38861b2e34a2075608d3d6c88a126d276fc9b8a3) | `` Updated elpa ``                     |
| [`d30068dd`](https://github.com/nix-community/emacs-overlay/commit/d30068dd0433250991335f12f75882f1688ac465) | `` Updated nongnu ``                   |
| [`5682e635`](https://github.com/nix-community/emacs-overlay/commit/5682e6355a915c1a529a663da6c27b76fb4a1a37) | `` repos/emacs: Fix update unstable `` |
| [`10d666ad`](https://github.com/nix-community/emacs-overlay/commit/10d666ad8ae003661063ac31ec97bf8412365e00) | `` Updated emacs ``                    |
| [`2e5c8290`](https://github.com/nix-community/emacs-overlay/commit/2e5c829031eff28f624f6aa4bf5c228918e50589) | `` Updated melpa ``                    |