### PR TITLE
chore(flake/nur): `6cec53b3` -> `70ee0165`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1740219286,
-        "narHash": "sha256-IvYKRrx24/yDQvQk/1pJhm2ngxjSTBqi2g5Ly8pgkxA=",
+        "lastModified": 1740239278,
+        "narHash": "sha256-GlUE97PyIjetONiFU3Pyif/6AGLtg+mG0+W4GuA7XEI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6cec53b34684074b57e92c4a017160a8ae7b7b37",
+        "rev": "70ee01650bed9f1c9fc28897dc993e76f32566a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`70ee0165`](https://github.com/nix-community/NUR/commit/70ee01650bed9f1c9fc28897dc993e76f32566a5) | `` automatic update `` |
| [`788e0c8a`](https://github.com/nix-community/NUR/commit/788e0c8a12d07651b27cfaa5079b97e77331ab57) | `` automatic update `` |
| [`ddd04f01`](https://github.com/nix-community/NUR/commit/ddd04f01f4eb9e985b03f06d2fc409172c8ee87f) | `` automatic update `` |
| [`ddd21083`](https://github.com/nix-community/NUR/commit/ddd2108324f7698caca0c853ad8168cce9e686bf) | `` automatic update `` |
| [`e0e6e20e`](https://github.com/nix-community/NUR/commit/e0e6e20e8c3232c853079d1f510a09833de94c4c) | `` automatic update `` |
| [`84bd76af`](https://github.com/nix-community/NUR/commit/84bd76afc922a80e8fa0b774e8be2ab9c851682e) | `` automatic update `` |
| [`040a3465`](https://github.com/nix-community/NUR/commit/040a346548181bc19e24dfbe559d8b0e9187bafa) | `` automatic update `` |