### PR TITLE
chore(flake/nur): `70ee0165` -> `730b7875`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1740239278,
-        "narHash": "sha256-GlUE97PyIjetONiFU3Pyif/6AGLtg+mG0+W4GuA7XEI=",
+        "lastModified": 1740253674,
+        "narHash": "sha256-5uORHfjmbFBOcPLdpqk5sRUoeg1Hl2lSs1qDUlQ1P0Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "70ee01650bed9f1c9fc28897dc993e76f32566a5",
+        "rev": "730b78756948a6fffbdc6045fd71c47f87ff340f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`730b7875`](https://github.com/nix-community/NUR/commit/730b78756948a6fffbdc6045fd71c47f87ff340f) | `` automatic update `` |
| [`611e62ce`](https://github.com/nix-community/NUR/commit/611e62ce40d323cb779b4bba61d8b0e0d80a573c) | `` automatic update `` |
| [`73d3915c`](https://github.com/nix-community/NUR/commit/73d3915c66bb6e7e2736def2d78005c106ca8d5b) | `` automatic update `` |
| [`98e0db39`](https://github.com/nix-community/NUR/commit/98e0db390aa7bea4790458bbb1187fa497e2f0d5) | `` automatic update `` |