### PR TITLE
chore(flake/nur): `bca836cd` -> `d5806468`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1740255824,
-        "narHash": "sha256-2JqThJ+VgT2xPhVKCsIuWMEAEskXDZc++JQqiR6Pfk4=",
+        "lastModified": 1740297309,
+        "narHash": "sha256-z3xbS9emRqB9rxAbkjwef2Ry85HHxKEf7XljEsP93uY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bca836cda440d41eb616125da37d881f1e4d94e8",
+        "rev": "d5806468192d3838d117f9cf222602ca144b4e5b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d5806468`](https://github.com/nix-community/NUR/commit/d5806468192d3838d117f9cf222602ca144b4e5b) | `` automatic update `` |
| [`29c88c4d`](https://github.com/nix-community/NUR/commit/29c88c4d03be768817e71327b9e4cf11c8048fa0) | `` automatic update `` |
| [`53b1679a`](https://github.com/nix-community/NUR/commit/53b1679a1587c0f0014165edebd71c75debe142a) | `` automatic update `` |
| [`63174e42`](https://github.com/nix-community/NUR/commit/63174e42cae5526a0643f28d9ad44f7f68429174) | `` automatic update `` |
| [`7907a45a`](https://github.com/nix-community/NUR/commit/7907a45adedf8c09f208c75acfe28127f2d2acfe) | `` automatic update `` |
| [`3575b8d7`](https://github.com/nix-community/NUR/commit/3575b8d74be596e22d1b05941ddab79715aa638c) | `` automatic update `` |