### PR TITLE
chore(flake/emacs-overlay): `920cd4e8` -> `5e5da9a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1740302110,
-        "narHash": "sha256-rQY2wY+KTGIH2oZFyqdsODjqmOJqyn+0BNURADQHi/s=",
+        "lastModified": 1740388545,
+        "narHash": "sha256-r5FUH8Y9DbLVywlrxRgTPP6ktaTticek4UvY/X5gzKo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "920cd4e86af18bd67a60013d80a79ff2cd7a176b",
+        "rev": "5e5da9a8fc5088aa96d20acc8c39c7a0c0cc8a76",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`5e5da9a8`](https://github.com/nix-community/emacs-overlay/commit/5e5da9a8fc5088aa96d20acc8c39c7a0c0cc8a76) | `` Updated emacs ``        |
| [`3122bebc`](https://github.com/nix-community/emacs-overlay/commit/3122bebca19dcd9e65afdae12b65e9350880eb8b) | `` Updated melpa ``        |
| [`7499231e`](https://github.com/nix-community/emacs-overlay/commit/7499231e05179138025dc0475e71f7e9de367ee1) | `` Updated emacs ``        |
| [`283ec87e`](https://github.com/nix-community/emacs-overlay/commit/283ec87e72aee66efba226dab834898427205455) | `` Updated melpa ``        |
| [`65f79051`](https://github.com/nix-community/emacs-overlay/commit/65f79051adf6b396295b66774d098035756643af) | `` Updated elpa ``         |
| [`83cacf2e`](https://github.com/nix-community/emacs-overlay/commit/83cacf2eec19d4ec4b2da24f6d15160ee6d7f17c) | `` Updated nongnu ``       |
| [`84420d19`](https://github.com/nix-community/emacs-overlay/commit/84420d1963cada13bc63be2e118082586690728a) | `` Updated emacs ``        |
| [`63383c89`](https://github.com/nix-community/emacs-overlay/commit/63383c897a48902d9db34a4f0119c446138e7ed8) | `` Updated melpa ``        |
| [`1efaf5b1`](https://github.com/nix-community/emacs-overlay/commit/1efaf5b1996a2664dd131dbbaa1b21d2e7aa6134) | `` Updated elpa ``         |
| [`ce2bb956`](https://github.com/nix-community/emacs-overlay/commit/ce2bb956486001473be5067243c688df2232c085) | `` Updated nongnu ``       |
| [`6f753dda`](https://github.com/nix-community/emacs-overlay/commit/6f753ddacb4828a6c27b02c00e8066266517324e) | `` Updated flake inputs `` |