### PR TITLE
chore(flake/srvos): `f6ddf92b` -> `b3065811`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -884,11 +884,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740012831,
-        "narHash": "sha256-u6Y5ttXBuQ+tyyCei07QnbNL6Gydv55OpoGh4fXzTqg=",
+        "lastModified": 1740358604,
+        "narHash": "sha256-Wi87Dx5j8JH+ETlU0zrPSAe7zD2wQkEY6DtITCeyOdI=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "f6ddf92bc61e021ea05c971a055624509ffac429",
+        "rev": "b3065811ae1c822b856af8a254e07703172a0e76",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`b3065811`](https://github.com/nix-community/srvos/commit/b3065811ae1c822b856af8a254e07703172a0e76) | `` dev/private/flake.lock: Update `` |
| [`8ecabb59`](https://github.com/nix-community/srvos/commit/8ecabb59c4c0393e8a71836096c4cdaf600e0898) | `` flake.lock: Update ``             |