### PR TITLE
chore(flake/nur): `55621830` -> `4552766b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1740412333,
-        "narHash": "sha256-MUXzOKzNKBbAHIX9kXyXdfM/65qTG5zF8cg5Ga2mjbQ=",
+        "lastModified": 1740483293,
+        "narHash": "sha256-URiMosktrbEm/dPPGcYTLzCV8EA+9/ZVO3KEyum6Ntg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "55621830db3fd2c56874e018cdcf160674672762",
+        "rev": "4552766bd3b205a1c6750e073a7e98d8b4808f46",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4552766b`](https://github.com/nix-community/NUR/commit/4552766bd3b205a1c6750e073a7e98d8b4808f46) | `` automatic update `` |
| [`af497c21`](https://github.com/nix-community/NUR/commit/af497c21de74d91724a72838f5ff3916f0cefc6b) | `` automatic update `` |
| [`e9baa733`](https://github.com/nix-community/NUR/commit/e9baa7332bec91731e3b791919bbf53f65b300ef) | `` automatic update `` |
| [`b8e94474`](https://github.com/nix-community/NUR/commit/b8e944745e7f5a2bc150388c72cd9ff86fef8f49) | `` automatic update `` |
| [`989090fe`](https://github.com/nix-community/NUR/commit/989090fefa740c671ee960d3c70f998bc0d96e9c) | `` automatic update `` |
| [`81668bb7`](https://github.com/nix-community/NUR/commit/81668bb777f55e9bc3f9ce0416145ef371ced0aa) | `` automatic update `` |
| [`cdbf6b98`](https://github.com/nix-community/NUR/commit/cdbf6b98e62155a02934d3d1f4edf43fc25632cd) | `` automatic update `` |
| [`84c2efb6`](https://github.com/nix-community/NUR/commit/84c2efb627e07576dc27bb2723f65e54c868a0ad) | `` automatic update `` |
| [`3081d15d`](https://github.com/nix-community/NUR/commit/3081d15da91a3e7daf2eecb146fb1be78198c085) | `` automatic update `` |
| [`3adf3d3a`](https://github.com/nix-community/NUR/commit/3adf3d3a2c0a4fd2e13f2c11d2718e01c795a10b) | `` automatic update `` |
| [`c50eb02c`](https://github.com/nix-community/NUR/commit/c50eb02cfb2d7f951356635835af62d2e311ee09) | `` automatic update `` |
| [`0a1eb5a2`](https://github.com/nix-community/NUR/commit/0a1eb5a285183802319eb273fca5d7ec3dc78f19) | `` automatic update `` |
| [`7999d738`](https://github.com/nix-community/NUR/commit/7999d7381698fece0be81b2b931c9f0bb7c1036e) | `` automatic update `` |
| [`bfb0ab7c`](https://github.com/nix-community/NUR/commit/bfb0ab7c3a567dcd75f8dbf4bf652bb0acb94383) | `` automatic update `` |
| [`eeacb15e`](https://github.com/nix-community/NUR/commit/eeacb15e75f1d78f273bbcfd4e1093001dc098b8) | `` automatic update `` |
| [`aaaeec79`](https://github.com/nix-community/NUR/commit/aaaeec79025068414c1623780313f13eb416458f) | `` automatic update `` |
| [`e68f9268`](https://github.com/nix-community/NUR/commit/e68f9268c9e1f0574649609261385ffd031d0d86) | `` automatic update `` |
| [`669af3c1`](https://github.com/nix-community/NUR/commit/669af3c1c36887eb78bc94e79decfdc68d64e1a6) | `` automatic update `` |
| [`2c29dd6e`](https://github.com/nix-community/NUR/commit/2c29dd6e145765636f56c69b9b45f06feda96d40) | `` automatic update `` |
| [`b5fb4c19`](https://github.com/nix-community/NUR/commit/b5fb4c19c2f213702ee0eb9aa11c99af065f2dda) | `` automatic update `` |
| [`de9d548f`](https://github.com/nix-community/NUR/commit/de9d548f9c3eb0e8d30ebf087bfb61e41fe80b06) | `` automatic update `` |
| [`e3467aa8`](https://github.com/nix-community/NUR/commit/e3467aa89846c91ee9e7033ff3a94a0231d1de07) | `` automatic update `` |
| [`f44d2a80`](https://github.com/nix-community/NUR/commit/f44d2a80e73615d5dfec70e25d1a00120c1a1c04) | `` automatic update `` |
| [`67cf1efa`](https://github.com/nix-community/NUR/commit/67cf1efa9b136f5d8e42e0e13fe9c489edacfd49) | `` automatic update `` |
| [`98448aee`](https://github.com/nix-community/NUR/commit/98448aeeaf621d7c4ad8bee07cf79983a5928f29) | `` automatic update `` |