### PR TITLE
chore(flake/darwin): `6ab392f6` -> `42be12b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739933872,
-        "narHash": "sha256-UhuvTR4OrWR+WBaRCZm4YMkvjJhZ1KZo/jRjE41m+Ek=",
+        "lastModified": 1740452771,
+        "narHash": "sha256-/tI1vFJ7/dXJqUmI+s0EV1F0DPe6dZvT444mrLUkrlU=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "6ab392f626a19f1122d1955c401286e1b7cf6b53",
+        "rev": "42be12b510253d750138ec90c66decc282298b44",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                              |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
| [`11ea44f3`](https://github.com/LnL7/nix-darwin/commit/11ea44f3e20737004f7c0f1d27354b9d7a79c2f5) | `` pam: add `pam_reattach` support ``                |
| [`47f26307`](https://github.com/LnL7/nix-darwin/commit/47f263077ee53de95a1c35eb6892665d77ce6165) | `` pam: switch to using `sudo_local` file ``         |
| [`bde9fa6f`](https://github.com/LnL7/nix-darwin/commit/bde9fa6f64211dc8bc9717fb37463e65de238b08) | `` add networking.hosts and .hostFiles from nixos `` |
| [`c9c2d40f`](https://github.com/LnL7/nix-darwin/commit/c9c2d40f7172747823dc9c5ab16b9bb541cf3c0d) | `` pam: remove `with lib;` ``                        |