### PR TITLE
chore(flake/emacs-overlay): `be151c9c` -> `1f5b2624`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1740414197,
-        "narHash": "sha256-6yz+f0yB7PNA6bbZ9v2xfiLu22Fpyi+v/8Pq6vqQY5Y=",
+        "lastModified": 1740475513,
+        "narHash": "sha256-3I91L2+qV3DZ0dnCPTdehX82le93OLMYVoZk6KoJHBE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "be151c9c85940398b90492db97d84a2a43e66fa6",
+        "rev": "1f5b2624c2ee0491b1767be073765d6b9a3c67f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`1f5b2624`](https://github.com/nix-community/emacs-overlay/commit/1f5b2624c2ee0491b1767be073765d6b9a3c67f4) | `` Updated emacs ``  |
| [`328acd88`](https://github.com/nix-community/emacs-overlay/commit/328acd88b3ae28d4045d19ff57352ccc716292ac) | `` Updated melpa ``  |
| [`252ff563`](https://github.com/nix-community/emacs-overlay/commit/252ff563400439aceaba651d3e53a620da882cf6) | `` Updated emacs ``  |
| [`a102af41`](https://github.com/nix-community/emacs-overlay/commit/a102af41f3208c038f38a78329cf158f60efe82f) | `` Updated melpa ``  |
| [`e344b295`](https://github.com/nix-community/emacs-overlay/commit/e344b295cd95068a7a8a152b1e0e2c7b2840fae3) | `` Updated elpa ``   |
| [`8e1487c5`](https://github.com/nix-community/emacs-overlay/commit/8e1487c5b4754b564c9a67549513365c31045c60) | `` Updated nongnu `` |