### PR TITLE
chore(flake/home-manager): `c12dcc9b` -> `74f0a854`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740432748,
-        "narHash": "sha256-BCeFtoJ/+LrZc03viRJWHfzAqqG8gPu/ikZeurv05xs=",
+        "lastModified": 1740494361,
+        "narHash": "sha256-Dd/GhJ9qKmUwuhgt/PAROG8J6YdU2ZjtJI9SQX5sVQI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c12dcc9b61429b2ad437a7d4974399ad8f910319",
+        "rev": "74f0a8546e3f2458c870cf90fc4b38ac1f498b17",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                      |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`74f0a854`](https://github.com/nix-community/home-manager/commit/74f0a8546e3f2458c870cf90fc4b38ac1f498b17) | `` clipse: add additional options (#6525) `` |