### PR TITLE
chore(flake/nur): `4552766b` -> `19be56b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1740483293,
-        "narHash": "sha256-URiMosktrbEm/dPPGcYTLzCV8EA+9/ZVO3KEyum6Ntg=",
+        "lastModified": 1740513008,
+        "narHash": "sha256-HIyaQOay9oEcjoWvUzyR4LrHaThGWaghj6d45uFo4XY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4552766bd3b205a1c6750e073a7e98d8b4808f46",
+        "rev": "19be56b8788c58eb2c10dcac51c508a5e2505d27",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                     |
| -------------------------------------------------------------------------------------------------- | --------------------------- |
| [`19be56b8`](https://github.com/nix-community/NUR/commit/19be56b8788c58eb2c10dcac51c508a5e2505d27) | `` bot-wxt1221/nur: init `` |
| [`2125f607`](https://github.com/nix-community/NUR/commit/2125f607c8da8affb1fce57a422ee078ba399954) | `` automatic update ``      |
| [`6648bde8`](https://github.com/nix-community/NUR/commit/6648bde8f040a73d3bbc1a27870201c930ce8fc3) | `` automatic update ``      |
| [`ecc4b75c`](https://github.com/nix-community/NUR/commit/ecc4b75ce31086a70ea52104edff2523fb630f5d) | `` automatic update ``      |
| [`2f870320`](https://github.com/nix-community/NUR/commit/2f870320a423b88592fc6f4dffa6ece86eb06dc4) | `` automatic update ``      |
| [`c6611a3e`](https://github.com/nix-community/NUR/commit/c6611a3e6bf7682aadefc235edabee60fc9b2123) | `` automatic update ``      |
| [`4c916182`](https://github.com/nix-community/NUR/commit/4c91618210486145251ecabacfcb5fb473bb175d) | `` automatic update ``      |