### PR TITLE
chore(flake/emacs-overlay): `1f5b2624` -> `443bea7e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1740475513,
-        "narHash": "sha256-3I91L2+qV3DZ0dnCPTdehX82le93OLMYVoZk6KoJHBE=",
+        "lastModified": 1740535805,
+        "narHash": "sha256-mbEBB/lrNjEEis8/3bgQfPWfWvGHYLwmyDm60QCIOnE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1f5b2624c2ee0491b1767be073765d6b9a3c67f4",
+        "rev": "443bea7e42fe696fd7696eb70e70b6b4cd52e478",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`443bea7e`](https://github.com/nix-community/emacs-overlay/commit/443bea7e42fe696fd7696eb70e70b6b4cd52e478) | `` Updated emacs ``  |
| [`9fa26d5e`](https://github.com/nix-community/emacs-overlay/commit/9fa26d5e4f4589fe75e44ba45ed6f0a0e9b0c64c) | `` Updated melpa ``  |
| [`f76e0708`](https://github.com/nix-community/emacs-overlay/commit/f76e0708c040298b5e2d5ebffe121dea6c03ad98) | `` Updated elpa ``   |
| [`35d679a9`](https://github.com/nix-community/emacs-overlay/commit/35d679a967cdd6b19619505d3e8ae6f2a57acb4a) | `` Updated nongnu `` |
| [`e61547b1`](https://github.com/nix-community/emacs-overlay/commit/e61547b1c4cdf6e6ed72862748397e49df9129ca) | `` Updated emacs ``  |
| [`c8e5624d`](https://github.com/nix-community/emacs-overlay/commit/c8e5624dfce7df62b2c7f60a8af697fb1350af69) | `` Updated melpa ``  |
| [`d82d304b`](https://github.com/nix-community/emacs-overlay/commit/d82d304bcd1398e223dee8de927db024dced5128) | `` Updated elpa ``   |
| [`fc3c4c71`](https://github.com/nix-community/emacs-overlay/commit/fc3c4c71024415bc186fa3155df6ec87a5caf91b) | `` Updated nongnu `` |