### PR TITLE
chore(flake/nur): `b8c3f80b` -> `a216f207`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1740540021,
-        "narHash": "sha256-uxu8YpBaGK1ko4h/xno+xSYz0N8+nLlZ6QrzamvJtbk=",
+        "lastModified": 1740565672,
+        "narHash": "sha256-Rp9CWIhgR3f6QmnYXtCtAhuROUjAhSIRxjqRV06kZz0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b8c3f80bbd0516a9ff06d0cad14627e2496e07bf",
+        "rev": "a216f20701538d3392f128c16aff8c7ed67a4c6e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a216f207`](https://github.com/nix-community/NUR/commit/a216f20701538d3392f128c16aff8c7ed67a4c6e) | `` automatic update `` |
| [`2fd33c46`](https://github.com/nix-community/NUR/commit/2fd33c46b60c6f671d8cf1fd203d864caa567798) | `` automatic update `` |
| [`321e390f`](https://github.com/nix-community/NUR/commit/321e390f15b6f22558c243ca27331b9dcaa5d00b) | `` automatic update `` |
| [`6ba313d7`](https://github.com/nix-community/NUR/commit/6ba313d7584eaae1c83c42bca869e0fa71110e3a) | `` automatic update `` |
| [`2539ba08`](https://github.com/nix-community/NUR/commit/2539ba081520c58721f2f2482b9a805cd8317b91) | `` automatic update `` |
| [`1cf51f05`](https://github.com/nix-community/NUR/commit/1cf51f05eb37d1411ad14ae12ce09582dde4d7ee) | `` automatic update `` |