### PR TITLE
chore(flake/nur): `a216f207` -> `e4939177`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -682,11 +682,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1740367490,
-        "narHash": "sha256-WGaHVAjcrv+Cun7zPlI41SerRtfknGQap281+AakSAw=",
+        "lastModified": 1740560979,
+        "narHash": "sha256-Vr3Qi346M+8CjedtbyUevIGDZW8LcA1fTG0ugPY/Hic=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0196c0175e9191c474c26ab5548db27ef5d34b05",
+        "rev": "5135c59491985879812717f4c9fea69604e7f26f",
         "type": "github"
       },
       "original": {
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1740565672,
-        "narHash": "sha256-Rp9CWIhgR3f6QmnYXtCtAhuROUjAhSIRxjqRV06kZz0=",
+        "lastModified": 1740667465,
+        "narHash": "sha256-y48/nmlieyShkQw/afAwaoQ/uCuRjhiNd7XlcdeQoHI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a216f20701538d3392f128c16aff8c7ed67a4c6e",
+        "rev": "e493917781e06efb25b6b4722f429069c4457841",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e4939177`](https://github.com/nix-community/NUR/commit/e493917781e06efb25b6b4722f429069c4457841) | `` automatic update `` |
| [`aba36e5a`](https://github.com/nix-community/NUR/commit/aba36e5a043589355cb7a7df368571f8c327fe63) | `` automatic update `` |
| [`d48c7529`](https://github.com/nix-community/NUR/commit/d48c75298b49667ae57ab17bf5fe7e691695a111) | `` automatic update `` |
| [`5953647f`](https://github.com/nix-community/NUR/commit/5953647f5b7d0eb928d188dd507fe63f34465418) | `` automatic update `` |
| [`32eb8668`](https://github.com/nix-community/NUR/commit/32eb8668e5b3de02c6d5891ee1736c2ab35148f8) | `` automatic update `` |
| [`ef34655f`](https://github.com/nix-community/NUR/commit/ef34655f7f6972b52bcec7692d9a0ae7d9c3fb38) | `` automatic update `` |
| [`1ca8ff37`](https://github.com/nix-community/NUR/commit/1ca8ff37f33a560c4a292ed83774434854f0b39a) | `` automatic update `` |
| [`747cae6b`](https://github.com/nix-community/NUR/commit/747cae6b2d0094c436f84895f0b6bd70a49aebe8) | `` automatic update `` |
| [`7e6d6c86`](https://github.com/nix-community/NUR/commit/7e6d6c86944aeea7fa4b88cc9ee3671b25de55b1) | `` automatic update `` |
| [`3a837f04`](https://github.com/nix-community/NUR/commit/3a837f04cf508ed3e0d4f7d3069cdcefd7a722de) | `` automatic update `` |
| [`2e80b737`](https://github.com/nix-community/NUR/commit/2e80b737688496c5a3b0557009c8aa0bb5d0f98c) | `` automatic update `` |
| [`3ac90af1`](https://github.com/nix-community/NUR/commit/3ac90af14fb26c7ae3498d40e72fa8f3036dd148) | `` automatic update `` |
| [`45fdeec6`](https://github.com/nix-community/NUR/commit/45fdeec61694b88fee67cb94c19b4f4a6576816d) | `` automatic update `` |
| [`3c777541`](https://github.com/nix-community/NUR/commit/3c77754174701483def1f06cc3b92d06994952b7) | `` automatic update `` |
| [`a3d7ee95`](https://github.com/nix-community/NUR/commit/a3d7ee95fea0a969cecde010bd8f40b1ade5f68d) | `` automatic update `` |
| [`0d52a464`](https://github.com/nix-community/NUR/commit/0d52a4640df0a1c00b366c0d47ab21187218c7cb) | `` automatic update `` |
| [`ab4dcea9`](https://github.com/nix-community/NUR/commit/ab4dcea9acd4ce723a5db2c02db8770acae8c629) | `` automatic update `` |
| [`c3cb609a`](https://github.com/nix-community/NUR/commit/c3cb609a6c3d2f435acdeaae202f49580ed89f7a) | `` automatic update `` |
| [`f4425e17`](https://github.com/nix-community/NUR/commit/f4425e1735b56f9758263410e95277cbf31e6768) | `` automatic update `` |
| [`df75386e`](https://github.com/nix-community/NUR/commit/df75386ee540563c5dff6f9c307ec53ab4e02812) | `` automatic update `` |
| [`320cb997`](https://github.com/nix-community/NUR/commit/320cb99796f3ff9851d5c7334aebf1139d142307) | `` automatic update `` |
| [`441cdab4`](https://github.com/nix-community/NUR/commit/441cdab4c5a5b63ecb1ffff3d4c9f9c7a2d27179) | `` automatic update `` |
| [`8a316dc4`](https://github.com/nix-community/NUR/commit/8a316dc4468a7c98e594c1ce5d5807b5eb1bd8c2) | `` automatic update `` |
| [`11a0c72c`](https://github.com/nix-community/NUR/commit/11a0c72cc96ad44f401cd57ddaefd4355c0f3dd9) | `` automatic update `` |
| [`fed913ba`](https://github.com/nix-community/NUR/commit/fed913ba38a0189de802b3ad3db99450460f9d14) | `` automatic update `` |
| [`3f055871`](https://github.com/nix-community/NUR/commit/3f0558711894ae01806feed2fc1034f0537023ac) | `` automatic update `` |
| [`07854295`](https://github.com/nix-community/NUR/commit/0785429511818e208af790141bf7d328335ce2f2) | `` automatic update `` |