### PR TITLE
chore(flake/emacs-overlay): `213d27a8` -> `1d3a6e22`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1740561392,
-        "narHash": "sha256-UKbTtTv+OBB/kgV3wgCRor57fxShWAsvVqqF2X69KSY=",
+        "lastModified": 1740648034,
+        "narHash": "sha256-pDAnvLZOIGjf0A92m+uxZxbIvcbT4wo4LmMCemA0Zi8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "213d27a8b579113ffe399ee672d84519464b11e8",
+        "rev": "1d3a6e22ae1e938a2fd284b67ea9eb4d0ce044af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`1d3a6e22`](https://github.com/nix-community/emacs-overlay/commit/1d3a6e22ae1e938a2fd284b67ea9eb4d0ce044af) | `` Updated emacs ``  |
| [`a0b1fd87`](https://github.com/nix-community/emacs-overlay/commit/a0b1fd87b709569b28ba3c5ef53c15ad32eea39d) | `` Updated melpa ``  |
| [`ee8442ab`](https://github.com/nix-community/emacs-overlay/commit/ee8442abce734e9a1d0e5824818062bcbf358e73) | `` Updated emacs ``  |
| [`ebb0d1f1`](https://github.com/nix-community/emacs-overlay/commit/ebb0d1f10ad7cdc1f6fb32b705b3fd9af1f4ba79) | `` Updated melpa ``  |
| [`bc2df4c6`](https://github.com/nix-community/emacs-overlay/commit/bc2df4c6d209c0bc469156d972af4fa4625577f9) | `` Updated elpa ``   |
| [`d86a911d`](https://github.com/nix-community/emacs-overlay/commit/d86a911dd1bccb6b3359c3103cf54da7213e7b8c) | `` Updated nongnu `` |
| [`27928cb2`](https://github.com/nix-community/emacs-overlay/commit/27928cb214eda2ce3663f739bc26c7414164abee) | `` Updated emacs ``  |
| [`376ea070`](https://github.com/nix-community/emacs-overlay/commit/376ea0703f24e172d2dbf2ef9ff2cca50d45dcc5) | `` Updated melpa ``  |
| [`3ef72281`](https://github.com/nix-community/emacs-overlay/commit/3ef722812a5a439b44b3efcb4c6625207e14e84c) | `` Updated elpa ``   |
| [`f14ef843`](https://github.com/nix-community/emacs-overlay/commit/f14ef8436bed7233832bb746c46cf1fa54e50c6b) | `` Updated nongnu `` |