### PR TITLE
chore(flake/emacs-overlay): `1d3a6e22` -> `0f095d48`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1740648034,
-        "narHash": "sha256-pDAnvLZOIGjf0A92m+uxZxbIvcbT4wo4LmMCemA0Zi8=",
+        "lastModified": 1740678710,
+        "narHash": "sha256-VP3pDWBT1SKTl0x8kRR5y09GTkkTc79VThpeadUQL94=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1d3a6e22ae1e938a2fd284b67ea9eb4d0ce044af",
+        "rev": "0f095d48c2018d23ba5d7c4ff59ddd7e65364532",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`0f095d48`](https://github.com/nix-community/emacs-overlay/commit/0f095d48c2018d23ba5d7c4ff59ddd7e65364532) | `` Updated emacs ``        |
| [`6c0990dd`](https://github.com/nix-community/emacs-overlay/commit/6c0990dd521678094ccb1e75773916e1c849e40d) | `` Updated melpa ``        |
| [`b8e573e0`](https://github.com/nix-community/emacs-overlay/commit/b8e573e04f5511292aa55ade043aff99fe064aff) | `` Updated elpa ``         |
| [`9574465e`](https://github.com/nix-community/emacs-overlay/commit/9574465ed1622fdd07f04ace51a50518eb135896) | `` Updated nongnu ``       |
| [`2d746a0d`](https://github.com/nix-community/emacs-overlay/commit/2d746a0d7869f210bda1c5f234b56e25886ddf2b) | `` Updated flake inputs `` |