### PR TITLE
chore(flake/home-manager): `b8869e4e` -> `b71edac7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740624780,
-        "narHash": "sha256-8TP61AI3QBQsjzVUQFIV8NoB5nbYfJB3iHczhBikDkU=",
+        "lastModified": 1740699498,
+        "narHash": "sha256-r9hkKzX99CGiP1ZqH0e+SWKK4CMsRNRLyotuwrUjhTI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b8869e4ead721bbd4f0d6b927e8395705d4f16e6",
+        "rev": "b71edac7a3167026aabea82a54d08b1794088c21",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`b71edac7`](https://github.com/nix-community/home-manager/commit/b71edac7a3167026aabea82a54d08b1794088c21) | `` launchd: sync up with changes from nix-darwin (#6508) `` |
| [`343646e0`](https://github.com/nix-community/home-manager/commit/343646e092696d94b6f22b6875ae685756fd4cf0) | `` kitty: add action aliases config (#6538) ``              |
| [`0208592b`](https://github.com/nix-community/home-manager/commit/0208592b59424449de69619d37f93f735de0fc33) | `` idlehook: fix service.restart merge (#6544) ``           |
| [`cf3bf4f1`](https://github.com/nix-community/home-manager/commit/cf3bf4f1b72077e287c36152b9fcead0cfa672d5) | `` mpd: refactor implementation (#6537) ``                  |
| [`11e6d208`](https://github.com/nix-community/home-manager/commit/11e6d20803cb660094a7657b8f1653d96d61b527) | `` ghostty: fix typo (#6541) ``                             |