### PR TITLE
chore(flake/nur): `e4939177` -> `227e307d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1740667465,
-        "narHash": "sha256-y48/nmlieyShkQw/afAwaoQ/uCuRjhiNd7XlcdeQoHI=",
+        "lastModified": 1740685799,
+        "narHash": "sha256-eTmR1itpKw4X8nJAFtHpTbfLcJwU0NSv3sVeFyqKIbs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e493917781e06efb25b6b4722f429069c4457841",
+        "rev": "227e307d94e61acd8c7b98fcab0c1f35f4849f3f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`227e307d`](https://github.com/nix-community/NUR/commit/227e307d94e61acd8c7b98fcab0c1f35f4849f3f) | `` automatic update `` |
| [`f6e4e7bf`](https://github.com/nix-community/NUR/commit/f6e4e7bf8821f41c37eba36bca23c96791817b75) | `` automatic update `` |
| [`6a6c59f1`](https://github.com/nix-community/NUR/commit/6a6c59f1914fd2d0614f9b61dd21c5b90b342361) | `` automatic update `` |
| [`f13dfae0`](https://github.com/nix-community/NUR/commit/f13dfae0d68d6b20ba40b403e9d78ab61abcf2a2) | `` automatic update `` |