### PR TITLE
chore(flake/nur): `227e307d` -> `906d0e30`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1740685799,
-        "narHash": "sha256-eTmR1itpKw4X8nJAFtHpTbfLcJwU0NSv3sVeFyqKIbs=",
+        "lastModified": 1740724935,
+        "narHash": "sha256-RUW5rJQIGIYV+VnC+ySmangGn1eRcSLNJAA+jzeygHo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "227e307d94e61acd8c7b98fcab0c1f35f4849f3f",
+        "rev": "906d0e30b6d9c63b7df13e05b310368cd97372e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                      |
| -------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`906d0e30`](https://github.com/nix-community/NUR/commit/906d0e30b6d9c63b7df13e05b310368cd97372e8) | `` Try to auth for push using HTTP header `` |
| [`0ed1a467`](https://github.com/nix-community/NUR/commit/0ed1a467447a04a60cdc6444de0dedd9adc55952) | `` automatic update ``                       |
| [`e59dec62`](https://github.com/nix-community/NUR/commit/e59dec620fca179fcbed5204ff877ad398a7f281) | `` automatic update ``                       |
| [`9f8b4b1b`](https://github.com/nix-community/NUR/commit/9f8b4b1b2a29ae6dc0395b81e9d457a14b8016c4) | `` automatic update ``                       |
| [`d2b7592e`](https://github.com/nix-community/NUR/commit/d2b7592e32da8b821b0c5bc1ef4b2d7aaa219a4d) | `` automatic update ``                       |
| [`6fa38b80`](https://github.com/nix-community/NUR/commit/6fa38b808fa0ad1f137cc2a3b99ad7388ecfca64) | `` automatic update ``                       |
| [`4955211b`](https://github.com/nix-community/NUR/commit/4955211b864792ebf0e29f362ade41ac2cecde3c) | `` automatic update ``                       |