### PR TITLE
chore(flake/emacs-overlay): `0f095d48` -> `4a462936`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1740678710,
-        "narHash": "sha256-VP3pDWBT1SKTl0x8kRR5y09GTkkTc79VThpeadUQL94=",
+        "lastModified": 1740763725,
+        "narHash": "sha256-KumD2s9L4YjSQu92w42dM0ZXNwen6lKykmjrfL7GS0o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0f095d48c2018d23ba5d7c4ff59ddd7e65364532",
+        "rev": "4a462936ca22eae70fd47fa3c9bef7f00153d2a1",
         "type": "github"
       },
       "original": {
@@ -603,11 +603,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1740463929,
-        "narHash": "sha256-4Xhu/3aUdCKeLfdteEHMegx5ooKQvwPHNkOgNCXQrvc=",
+        "lastModified": 1740603184,
+        "narHash": "sha256-t+VaahjQAWyA+Ctn2idyo1yxRIYpaDxMgHkgCNiMJa4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5d7db4668d7a0c6cc5fc8cf6ef33b008b2b1ed8b",
+        "rev": "f44bd8ca21e026135061a0a57dcf3d0775b67a49",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`4a462936`](https://github.com/nix-community/emacs-overlay/commit/4a462936ca22eae70fd47fa3c9bef7f00153d2a1) | `` Updated emacs ``        |
| [`beeab7d7`](https://github.com/nix-community/emacs-overlay/commit/beeab7d70df6af0b89a5a72fc15e14ee8bc7e802) | `` Updated melpa ``        |
| [`8caa640e`](https://github.com/nix-community/emacs-overlay/commit/8caa640eefce63e1eb794764c72eb310b81a2f6b) | `` Updated elpa ``         |
| [`4e5ec287`](https://github.com/nix-community/emacs-overlay/commit/4e5ec287045fb5606fb2c803c786bff45d67635e) | `` Updated nongnu ``       |
| [`502293ae`](https://github.com/nix-community/emacs-overlay/commit/502293ae094f7ecd604500ffb19ad35bd429311b) | `` Updated emacs ``        |
| [`e1a4ad6a`](https://github.com/nix-community/emacs-overlay/commit/e1a4ad6a8f4d5f59f8e60c204f36b4fcf44a020d) | `` Updated melpa ``        |
| [`729ae31c`](https://github.com/nix-community/emacs-overlay/commit/729ae31cfa6a051b9585f9f4076e3df082bacfa2) | `` Updated emacs ``        |
| [`4d07ad50`](https://github.com/nix-community/emacs-overlay/commit/4d07ad503083e74d8f1452d89b0aadda7d84d88c) | `` Updated melpa ``        |
| [`cf54a476`](https://github.com/nix-community/emacs-overlay/commit/cf54a476c3668c857790fdab45f6d57c0b75d8a2) | `` Updated elpa ``         |
| [`d4a74627`](https://github.com/nix-community/emacs-overlay/commit/d4a7462796499731f35090dc6a9d5723d1d68798) | `` Updated nongnu ``       |
| [`b926ba80`](https://github.com/nix-community/emacs-overlay/commit/b926ba80f7c96487d5117f53003e3f9a6ae55759) | `` Updated flake inputs `` |