### PR TITLE
chore(flake/nur): `54f52988` -> `01f6711f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1740742280,
-        "narHash": "sha256-eNjtuIv4lhXXE1ZeGLE73WcGHJ91sCDs62tJyhJFrwE=",
+        "lastModified": 1740772057,
+        "narHash": "sha256-sA1oMMHcEgUzgAhPYJUbkPVPV0NmSBghPO0Xs+VzaMI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "54f52988f6310779304432a3159bf7754d251c23",
+        "rev": "01f6711f0ea4091cc0e13d540ff0b7ea1c7db8ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`01f6711f`](https://github.com/nix-community/NUR/commit/01f6711f0ea4091cc0e13d540ff0b7ea1c7db8ff) | `` automatic update `` |
| [`8822fdd2`](https://github.com/nix-community/NUR/commit/8822fdd2d474a2fa4e900edde0097121c6e23b4a) | `` automatic update `` |
| [`cd313338`](https://github.com/nix-community/NUR/commit/cd313338b42e3572ad9dbfee3475d75291a1317e) | `` automatic update `` |
| [`efae8e00`](https://github.com/nix-community/NUR/commit/efae8e0003bace2a0634b98d6909eb4b5bbbf67f) | `` automatic update `` |
| [`602ad15b`](https://github.com/nix-community/NUR/commit/602ad15b538463340c12fa303aeb99758231f95f) | `` automatic update `` |
| [`3b265947`](https://github.com/nix-community/NUR/commit/3b265947efc7c05a5a31618e166edd632b45e699) | `` automatic update `` |
| [`4c72d645`](https://github.com/nix-community/NUR/commit/4c72d645ddda6bdbed73070b35ba0c60d79afd16) | `` automatic update `` |
| [`c131fd8f`](https://github.com/nix-community/NUR/commit/c131fd8f8b71efad8105bb016b40e48905d2b307) | `` automatic update `` |
| [`73e816d5`](https://github.com/nix-community/NUR/commit/73e816d56548c0e23443f1d016a9e2572ad46087) | `` automatic update `` |