### PR TITLE
chore(flake/nur): `01f6711f` -> `803af1de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -682,11 +682,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1740560979,
-        "narHash": "sha256-Vr3Qi346M+8CjedtbyUevIGDZW8LcA1fTG0ugPY/Hic=",
+        "lastModified": 1740695751,
+        "narHash": "sha256-D+R+kFxy1KsheiIzkkx/6L63wEHBYX21OIwlFV8JvDs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5135c59491985879812717f4c9fea69604e7f26f",
+        "rev": "6313551cd05425cd5b3e63fe47dbc324eabb15e4",
         "type": "github"
       },
       "original": {
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1740772057,
-        "narHash": "sha256-sA1oMMHcEgUzgAhPYJUbkPVPV0NmSBghPO0Xs+VzaMI=",
+        "lastModified": 1740801919,
+        "narHash": "sha256-ropUCFjTBDFYt5oEWjZaxM0CaINTUcVc7BGNtf0K0TE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "01f6711f0ea4091cc0e13d540ff0b7ea1c7db8ff",
+        "rev": "803af1dede2d5da2d5d8b9216eadc2d9c286541d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`803af1de`](https://github.com/nix-community/NUR/commit/803af1dede2d5da2d5d8b9216eadc2d9c286541d) | `` automatic update `` |
| [`3f2d5061`](https://github.com/nix-community/NUR/commit/3f2d50612cb011c2096a61f3bde331c66d3212b2) | `` automatic update `` |
| [`cec74042`](https://github.com/nix-community/NUR/commit/cec74042228d5bd5e1e9f017bf0a64ea8a5975f4) | `` automatic update `` |
| [`2efd0873`](https://github.com/nix-community/NUR/commit/2efd087395c3c3a0778af4bfb79ea8955a5dbb17) | `` automatic update `` |