### PR TITLE
chore(flake/emacs-overlay): `4a462936` -> `317e9986`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1740763725,
-        "narHash": "sha256-KumD2s9L4YjSQu92w42dM0ZXNwen6lKykmjrfL7GS0o=",
+        "lastModified": 1740850895,
+        "narHash": "sha256-hAP2ruVUWv38yy1eGd7yrcEuqlRtIMzA6ZcheN9n7qM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4a462936ca22eae70fd47fa3c9bef7f00153d2a1",
+        "rev": "317e9986ebfbcdccfe2c105557c8d724c394843a",
         "type": "github"
       },
       "original": {
@@ -603,11 +603,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1740603184,
-        "narHash": "sha256-t+VaahjQAWyA+Ctn2idyo1yxRIYpaDxMgHkgCNiMJa4=",
+        "lastModified": 1740743217,
+        "narHash": "sha256-brsCRzLqimpyhORma84c3W2xPbIidZlIc3JGIuQVSNI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f44bd8ca21e026135061a0a57dcf3d0775b67a49",
+        "rev": "b27ba4eb322d9d2bf2dc9ada9fd59442f50c8d7c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`317e9986`](https://github.com/nix-community/emacs-overlay/commit/317e9986ebfbcdccfe2c105557c8d724c394843a) | `` Updated emacs ``        |
| [`1d7cd9ca`](https://github.com/nix-community/emacs-overlay/commit/1d7cd9ca0f25ecaba43b5ab862d070e52759d1d5) | `` Updated melpa ``        |
| [`853677de`](https://github.com/nix-community/emacs-overlay/commit/853677de00453b36ad157c49ff281223f768a7fe) | `` Updated elpa ``         |
| [`6734cac0`](https://github.com/nix-community/emacs-overlay/commit/6734cac0dff7a8f28bbdbe13f43985efa230c191) | `` Updated nongnu ``       |
| [`25b732c2`](https://github.com/nix-community/emacs-overlay/commit/25b732c255ccb41258d70d775afb9f16e25fa3d5) | `` Updated emacs ``        |
| [`def3611a`](https://github.com/nix-community/emacs-overlay/commit/def3611a88dbb462a14ee2ca708041dfd49986ab) | `` Updated melpa ``        |
| [`08c393b5`](https://github.com/nix-community/emacs-overlay/commit/08c393b5550213be99daf14795a257ea300864a6) | `` Updated flake inputs `` |
| [`b330e15b`](https://github.com/nix-community/emacs-overlay/commit/b330e15b67dd5dfb413455dd10f161c2d87dfe34) | `` Updated emacs ``        |
| [`64a6c0a5`](https://github.com/nix-community/emacs-overlay/commit/64a6c0a53debb7df15510df9b59ac7786b33f59c) | `` Updated melpa ``        |
| [`125a3649`](https://github.com/nix-community/emacs-overlay/commit/125a36498b1468c259acfbfb641ef68b4fcef8a8) | `` Updated elpa ``         |
| [`5a69438d`](https://github.com/nix-community/emacs-overlay/commit/5a69438d395151fc8c8f54d7b76186a51bdaa2ea) | `` Updated nongnu ``       |