### PR TITLE
chore(flake/nur): `803af1de` -> `f1660106`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1740801919,
-        "narHash": "sha256-ropUCFjTBDFYt5oEWjZaxM0CaINTUcVc7BGNtf0K0TE=",
+        "lastModified": 1740829874,
+        "narHash": "sha256-Ak3ap99aFmp/c2wYd1OTfPIHIN4nEwh7L2OSiaybPLk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "803af1dede2d5da2d5d8b9216eadc2d9c286541d",
+        "rev": "f16601060b86870c5eb024901f4ac1cbf86ca607",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f1660106`](https://github.com/nix-community/NUR/commit/f16601060b86870c5eb024901f4ac1cbf86ca607) | `` automatic update `` |
| [`df3489b0`](https://github.com/nix-community/NUR/commit/df3489b09ed508b936612d1d1bcea3fc451136eb) | `` automatic update `` |
| [`ac26ab61`](https://github.com/nix-community/NUR/commit/ac26ab615f76424a021e50cc8e4f792cd3d6a125) | `` automatic update `` |
| [`4080002e`](https://github.com/nix-community/NUR/commit/4080002eb21bf7d8c7f8841b7c8f5233a28fe95d) | `` automatic update `` |
| [`f527ad38`](https://github.com/nix-community/NUR/commit/f527ad38a26529f240b4f07985f7f23f6cc01336) | `` automatic update `` |
| [`d9e7e302`](https://github.com/nix-community/NUR/commit/d9e7e302501bf6b23900bfb59495b7e1f9875818) | `` automatic update `` |
| [`fdee33d2`](https://github.com/nix-community/NUR/commit/fdee33d2417f116e0230d6091d485e2c58b58e55) | `` automatic update `` |