### PR TITLE
chore(flake/nur): `f1660106` -> `7af4e0d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -682,11 +682,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1740695751,
-        "narHash": "sha256-D+R+kFxy1KsheiIzkkx/6L63wEHBYX21OIwlFV8JvDs=",
+        "lastModified": 1740828860,
+        "narHash": "sha256-cjbHI+zUzK5CPsQZqMhE3npTyYFt9tJ3+ohcfaOF/WM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6313551cd05425cd5b3e63fe47dbc324eabb15e4",
+        "rev": "303bd8071377433a2d8f76e684ec773d70c5b642",
         "type": "github"
       },
       "original": {
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1740829874,
-        "narHash": "sha256-Ak3ap99aFmp/c2wYd1OTfPIHIN4nEwh7L2OSiaybPLk=",
+        "lastModified": 1740955512,
+        "narHash": "sha256-Vi3KjG8Inu74SBraIy8ynon2deiq6Qb9vxqPNZR44WU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f16601060b86870c5eb024901f4ac1cbf86ca607",
+        "rev": "7af4e0d15a2948fd5226456cf030492575c31174",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                           |
| -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`7af4e0d1`](https://github.com/nix-community/NUR/commit/7af4e0d15a2948fd5226456cf030492575c31174) | `` automatic update ``                                            |
| [`34d59df5`](https://github.com/nix-community/NUR/commit/34d59df59f6468e3646550dd512bda7903442136) | `` automatic update ``                                            |
| [`6def4742`](https://github.com/nix-community/NUR/commit/6def47427ce83f56c6a07a5651536e26f227f386) | `` automatic update ``                                            |
| [`fa058870`](https://github.com/nix-community/NUR/commit/fa0588702380d66e0b91ac789b62626e8f3ea3c6) | `` automatic update ``                                            |
| [`2e391c4f`](https://github.com/nix-community/NUR/commit/2e391c4fe65f5b5d19015bbd8cfd19837cf90779) | `` automatic update ``                                            |
| [`eb2e9317`](https://github.com/nix-community/NUR/commit/eb2e9317b9e301ed5cbe2b07cb57b33558b79670) | `` automatic update ``                                            |
| [`c7df1e7d`](https://github.com/nix-community/NUR/commit/c7df1e7d91b56322d5327118be64ef0c0a916c04) | `` automatic update ``                                            |
| [`1e3ed66f`](https://github.com/nix-community/NUR/commit/1e3ed66f42330c2a81dff559411a9da87aba0ff2) | `` automatic update ``                                            |
| [`1788063f`](https://github.com/nix-community/NUR/commit/1788063f2dfe4bc8ed0d643abb1df2771446b7af) | `` automatic update ``                                            |
| [`82a3630c`](https://github.com/nix-community/NUR/commit/82a3630ccf72a8f58172df8f63b104170f55bfa2) | `` automatic update ``                                            |
| [`e79eda30`](https://github.com/nix-community/NUR/commit/e79eda30591e5f9fb16aca4dd3669851c1ef8bc1) | `` automatic update ``                                            |
| [`24505e02`](https://github.com/nix-community/NUR/commit/24505e0253c0ea54d50355c53bfd7a8d55c9cf4b) | `` automatic update ``                                            |
| [`3d55715d`](https://github.com/nix-community/NUR/commit/3d55715d114aa7a63e5c1b243c7df94abe1abdbf) | `` automatic update ``                                            |
| [`2c063c63`](https://github.com/nix-community/NUR/commit/2c063c634741b2c58c41f1f67e25076c9117c4d0) | `` automatic update ``                                            |
| [`e48029b6`](https://github.com/nix-community/NUR/commit/e48029b67f41c929589353ee08b84c02906f5756) | `` automatic update ``                                            |
| [`1e0113bf`](https://github.com/nix-community/NUR/commit/1e0113bf56a2b7f7127e2136390e76cb7cb455eb) | `` automatic update ``                                            |
| [`adf98dd2`](https://github.com/nix-community/NUR/commit/adf98dd2ff8da6d8e373d31d206044ebfa655004) | `` automatic update ``                                            |
| [`529cd4b9`](https://github.com/nix-community/NUR/commit/529cd4b947ff59cbd46c6f56905d9e36aa5bda15) | `` automatic update ``                                            |
| [`a62ba464`](https://github.com/nix-community/NUR/commit/a62ba4646a9ad85f5756bfc0f935839fdfd602f2) | `` automatic update ``                                            |
| [`ba8ad4bd`](https://github.com/nix-community/NUR/commit/ba8ad4bd86e3764a8525ece8117a85f332b4f158) | `` Remove erroneous fetch-depth: 0 ``                             |
| [`0c6545c2`](https://github.com/nix-community/NUR/commit/0c6545c22443e67b68b1f948c410618f15b09129) | `` automatic update ``                                            |
| [`b2a42a2a`](https://github.com/nix-community/NUR/commit/b2a42a2adf325836884573963593e781e380cae8) | `` Revert nixpkgs branch change ``                                |
| [`8d8ad6ad`](https://github.com/nix-community/NUR/commit/8d8ad6ad9fbac4539f11eb8511266dc66ae80b3a) | `` NUR-combined default branch now main ``                        |
| [`608457d6`](https://github.com/nix-community/NUR/commit/608457d63463fab76e4657075fc01d639bc15019) | `` automatic update ``                                            |
| [`7f0fc17d`](https://github.com/nix-community/NUR/commit/7f0fc17d79ff34c4b2a03e61002d255ddccbef0a) | `` nur-packages-template default branch has been moved to main `` |
| [`395c8bbf`](https://github.com/nix-community/NUR/commit/395c8bbfc7a8ee0a436b771935d141b679173e9b) | `` automatic update ``                                            |
| [`a37f0bb6`](https://github.com/nix-community/NUR/commit/a37f0bb606742f5c13d32447a1be2c1a30fe6336) | `` Get rid of mergify ``                                          |
| [`708a538c`](https://github.com/nix-community/NUR/commit/708a538c1bb644acc762927445fc562e83252d18) | `` Update README to point to new NUR default branch ``            |
| [`74b044b2`](https://github.com/nix-community/NUR/commit/74b044b24ea1e0889317b9067711741590dcd5d0) | `` Update index.py reference to point to new default branch ``    |
| [`8f3a04ee`](https://github.com/nix-community/NUR/commit/8f3a04eeff1eea2b7515ee0be5efee61f10d2c64) | `` Update branch name to main in workflows ``                     |
| [`11471aa0`](https://github.com/nix-community/NUR/commit/11471aa095d11efd42fae5840460b3dc6f4409b8) | `` automatic update ``                                            |
| [`4535bc4d`](https://github.com/nix-community/NUR/commit/4535bc4d7e29333092cbed60894fa85cd0669255) | `` Update peter-evans/repository-dispatch action to v3 ``         |
| [`cb81fad7`](https://github.com/nix-community/NUR/commit/cb81fad75b39d0f4e1b3f4732cddb7aa51836165) | `` Externally dispatch NUR-adjacent repository updates ``         |
| [`d87c4c36`](https://github.com/nix-community/NUR/commit/d87c4c3607d23e6e298f2277a8dbcef818cecb26) | `` add in ianmurphy1 nur repo ``                                  |
| [`b92dec71`](https://github.com/nix-community/NUR/commit/b92dec71e76702d2208c6f6d9f758a8e9649f061) | `` automatic update ``                                            |
| [`14e5b771`](https://github.com/nix-community/NUR/commit/14e5b771eafa7933e2c189a082c7b53db07c827b) | `` automatic update ``                                            |
| [`efadff3f`](https://github.com/nix-community/NUR/commit/efadff3f90fb07193808c0eff037addae42cfaa7) | `` automatic update ``                                            |
| [`e732503d`](https://github.com/nix-community/NUR/commit/e732503d07b547eb8790bb2893c91c1f162b770c) | `` automatic update ``                                            |
| [`13665caa`](https://github.com/nix-community/NUR/commit/13665caaa8faa8484d388c97cd5ccfeb5e07aaef) | `` automatic update ``                                            |
| [`a5a6e69e`](https://github.com/nix-community/NUR/commit/a5a6e69ea90b026cd28f43263c2d6622869a4d44) | `` automatic update ``                                            |
| [`34e4f58a`](https://github.com/nix-community/NUR/commit/34e4f58a29a6ee9401cf15a664b6ed34d2425d5e) | `` automatic update ``                                            |