### PR TITLE
chore(flake/nix-index-database): `46579253` -> `26a0f969`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -453,11 +453,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740281615,
-        "narHash": "sha256-dZWcbAQ1sF8oVv+zjSKkPVY0ebwENQEkz5vc6muXbKY=",
+        "lastModified": 1740886574,
+        "narHash": "sha256-jN6kJ41B6jUVDTebIWeebTvrKP6YiLd1/wMej4uq4Sk=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "465792533d03e6bb9dc849d58ab9d5e31fac9023",
+        "rev": "26a0f969549cf4d56f6e9046b9e0418b3f3b94a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`26a0f969`](https://github.com/nix-community/nix-index-database/commit/26a0f969549cf4d56f6e9046b9e0418b3f3b94a5) | `` update generated.nix to release 2025-03-02-031754 `` |
| [`a316a3dd`](https://github.com/nix-community/nix-index-database/commit/a316a3ddddd6e61ba8f06cd6f32113422c5a9b1d) | `` flake.lock: Update ``                                |