### PR TITLE
chore(flake/emacs-overlay): `317e9986` -> `07b94b74`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1740850895,
-        "narHash": "sha256-hAP2ruVUWv38yy1eGd7yrcEuqlRtIMzA6ZcheN9n7qM=",
+        "lastModified": 1740881632,
+        "narHash": "sha256-N7Po9ryonMtni70Z+ElcWZA0r+wP6oCHqXbv+QsLxsg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "317e9986ebfbcdccfe2c105557c8d724c394843a",
+        "rev": "07b94b745e7c9f7be4e50309a85770cf97c8b9e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`07b94b74`](https://github.com/nix-community/emacs-overlay/commit/07b94b745e7c9f7be4e50309a85770cf97c8b9e9) | `` Updated emacs ``  |
| [`964db202`](https://github.com/nix-community/emacs-overlay/commit/964db2028a2c75f290218026d86536ecbda8cc17) | `` Updated melpa ``  |
| [`25a6cbcf`](https://github.com/nix-community/emacs-overlay/commit/25a6cbcfc86cf2485269062126d11c7b85b8fe01) | `` Updated elpa ``   |
| [`962bfba0`](https://github.com/nix-community/emacs-overlay/commit/962bfba0e234812c75a9e8152eda902fc9eea3af) | `` Updated nongnu `` |