### PR TITLE
chore(flake/emacs-overlay): `d9492638` -> `a2f3f627`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1740932314,
-        "narHash": "sha256-htNmp0ZAoijeKWbIqTFCEYlz+i2db6g28IVg9AjyKHM=",
+        "lastModified": 1740993510,
+        "narHash": "sha256-RTcoEoqRAUFzS9fmmEHSo96KQvUbMw6+M3i10rXm7KU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d9492638daa77fca7bf84e5b218cd95598ac3f72",
+        "rev": "a2f3f627209efaac4b41810e1d3464ea59c5e9ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`a2f3f627`](https://github.com/nix-community/emacs-overlay/commit/a2f3f627209efaac4b41810e1d3464ea59c5e9ef) | `` Updated emacs ``  |
| [`1380335c`](https://github.com/nix-community/emacs-overlay/commit/1380335c04290c350fc6c9c68aad5b1042db7f45) | `` Updated melpa ``  |
| [`72ba1ab1`](https://github.com/nix-community/emacs-overlay/commit/72ba1ab1718cb98af75b6ad499d1c21d3ded5909) | `` Updated emacs ``  |
| [`631115ae`](https://github.com/nix-community/emacs-overlay/commit/631115aefc00f857fb8e4e85f432b9c9da06cd51) | `` Updated melpa ``  |
| [`d52bccd0`](https://github.com/nix-community/emacs-overlay/commit/d52bccd00912d307acb90aac7b587b4ff8f9347f) | `` Updated elpa ``   |
| [`14359af6`](https://github.com/nix-community/emacs-overlay/commit/14359af6615294b759e0231a1da2ef7c79d7e3a9) | `` Updated nongnu `` |