### PR TITLE
chore(flake/nur): `7af4e0d1` -> `b8e55bb8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1740955512,
-        "narHash": "sha256-Vi3KjG8Inu74SBraIy8ynon2deiq6Qb9vxqPNZR44WU=",
+        "lastModified": 1740973901,
+        "narHash": "sha256-jclguxm6ttmdIy/y+OpRJO/Rv+tcQbe3PQpNRuSjffY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7af4e0d15a2948fd5226456cf030492575c31174",
+        "rev": "b8e55bb8625d0c9c5c780d3046635915aa99a5fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b8e55bb8`](https://github.com/nix-community/NUR/commit/b8e55bb8625d0c9c5c780d3046635915aa99a5fe) | `` automatic update `` |
| [`27c215df`](https://github.com/nix-community/NUR/commit/27c215df50e54f048a03616eb9fc20190e5d71f5) | `` automatic update `` |