### PR TITLE
chore(flake/srvos): `b3065811` -> `168d4bff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -884,11 +884,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740358604,
-        "narHash": "sha256-Wi87Dx5j8JH+ETlU0zrPSAe7zD2wQkEY6DtITCeyOdI=",
+        "lastModified": 1740963569,
+        "narHash": "sha256-LR4DTYEj4MfkG0++UfHK3JOoKS1ljvBWOf6gHCeLhFA=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "b3065811ae1c822b856af8a254e07703172a0e76",
+        "rev": "168d4bff4d49a431e030056c83592c3a683db44f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`168d4bff`](https://github.com/nix-community/srvos/commit/168d4bff4d49a431e030056c83592c3a683db44f) | `` dev/private/flake.lock: Update `` |
| [`5ddde7e4`](https://github.com/nix-community/srvos/commit/5ddde7e4b5cc69014242adc955707a710a9c5919) | `` flake.lock: Update ``             |