### PR TITLE
chore(flake/nur): `b8e55bb8` -> `2d682d3e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -773,11 +773,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1740973901,
-        "narHash": "sha256-jclguxm6ttmdIy/y+OpRJO/Rv+tcQbe3PQpNRuSjffY=",
+        "lastModified": 1741031108,
+        "narHash": "sha256-tLTHpyeyBWq3N9xJAPNopl382p9Xh9gUfjjedZVnWUA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b8e55bb8625d0c9c5c780d3046635915aa99a5fe",
+        "rev": "2d682d3e41d24f64342d0024efd4eef7d0422895",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2d682d3e`](https://github.com/nix-community/NUR/commit/2d682d3e41d24f64342d0024efd4eef7d0422895) | `` automatic update `` |
| [`ead8ecbe`](https://github.com/nix-community/NUR/commit/ead8ecbe5be1312af49859f269764421132de223) | `` automatic update `` |
| [`e5b6c67a`](https://github.com/nix-community/NUR/commit/e5b6c67aaac0b58a91fe25b0497f9377f5945f34) | `` automatic update `` |
| [`ad500bcc`](https://github.com/nix-community/NUR/commit/ad500bcca20e1749278e396b70dc682f8807ac21) | `` automatic update `` |
| [`1f003d9d`](https://github.com/nix-community/NUR/commit/1f003d9d6130bbd631d42db0bde6d7ac7a0fe41d) | `` automatic update `` |
| [`da86fa56`](https://github.com/nix-community/NUR/commit/da86fa561754b82db9b91dc9440d288e5c167009) | `` automatic update `` |
| [`18f50056`](https://github.com/nix-community/NUR/commit/18f50056ce251613ac628cf8f36313fcb661e622) | `` automatic update `` |
| [`21fdc547`](https://github.com/nix-community/NUR/commit/21fdc5474c036ad9b19cf1b31e0b8b888879c98b) | `` automatic update `` |
| [`7575d230`](https://github.com/nix-community/NUR/commit/7575d230df5ed77246347233d0b8eae0860f861e) | `` automatic update `` |
| [`71166675`](https://github.com/nix-community/NUR/commit/71166675fa4f5ab0c8e60f061d40f97bcec0a0c6) | `` automatic update `` |
| [`747de3a5`](https://github.com/nix-community/NUR/commit/747de3a5080747c28d10ed3bf1982d1c5e4d7c5a) | `` automatic update `` |
| [`837c0a06`](https://github.com/nix-community/NUR/commit/837c0a06e25b0ca7150ebc6fe049652e8bbbf059) | `` automatic update `` |
| [`cb1cdd6b`](https://github.com/nix-community/NUR/commit/cb1cdd6bb2f4c7c64c4802ad27de18f8aee208f2) | `` automatic update `` |
| [`fbaf37e0`](https://github.com/nix-community/NUR/commit/fbaf37e080f2e35777126cce3c578375514bd38a) | `` automatic update `` |
| [`5b8e7900`](https://github.com/nix-community/NUR/commit/5b8e7900c70359ae66bfcbd21dbfb0cf6fae21fc) | `` automatic update `` |
| [`ac0094a5`](https://github.com/nix-community/NUR/commit/ac0094a52e15cfec11dfb694c4a0f662c0c4d273) | `` automatic update `` |