### PR TITLE
chore(flake/emacs-overlay): `a2f3f627` -> `055dec4a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1740993510,
-        "narHash": "sha256-RTcoEoqRAUFzS9fmmEHSo96KQvUbMw6+M3i10rXm7KU=",
+        "lastModified": 1741057546,
+        "narHash": "sha256-s2XHX2Mj7hUcIcafcBSGFPjtGYotu4pr60Bbb17Jh98=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a2f3f627209efaac4b41810e1d3464ea59c5e9ef",
+        "rev": "055dec4a21185c6024f35f36398c395193e86491",
         "type": "github"
       },
       "original": {
@@ -603,11 +603,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1740865531,
-        "narHash": "sha256-h00vGIh/jxcGl8aWdfnVRD74KuLpyY3mZgMFMy7iKIc=",
+        "lastModified": 1740932899,
+        "narHash": "sha256-F0qDu2egq18M3edJwEOAE+D+VQ+yESK6YWPRQBfOqq8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5ef6c425980847c78a80d759abc476e941a9bf42",
+        "rev": "1546c45c538633ae40b93e2d14e0bb6fd8f13347",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`055dec4a`](https://github.com/nix-community/emacs-overlay/commit/055dec4a21185c6024f35f36398c395193e86491) | `` Updated emacs ``        |
| [`ca678124`](https://github.com/nix-community/emacs-overlay/commit/ca6781247e2693f5aa7de347398d5ec8dba78fe2) | `` Updated melpa ``        |
| [`fcedbc41`](https://github.com/nix-community/emacs-overlay/commit/fcedbc416147a78eb1c1a86c514f6e3a2356b8af) | `` Updated elpa ``         |
| [`e78ff1a3`](https://github.com/nix-community/emacs-overlay/commit/e78ff1a3628c122ccd2d5b2881455abd50c2e9a7) | `` Updated nongnu ``       |
| [`a9e823f2`](https://github.com/nix-community/emacs-overlay/commit/a9e823f2647f26b99aaacaf3bf6a5112ba40907c) | `` Updated flake inputs `` |
| [`a3bf2052`](https://github.com/nix-community/emacs-overlay/commit/a3bf20522b1fa7295ca05ea4a8d37546915e598e) | `` Updated emacs ``        |
| [`07db8ce6`](https://github.com/nix-community/emacs-overlay/commit/07db8ce61e871ee3d09794051711b2bbfbd01073) | `` Updated melpa ``        |
| [`89a692ea`](https://github.com/nix-community/emacs-overlay/commit/89a692ea4dd03aecfb3d00e9d61199f0a5085b04) | `` Updated elpa ``         |
| [`1a01699a`](https://github.com/nix-community/emacs-overlay/commit/1a01699a722bb2ad99c91c55af38fd9768edbacd) | `` Updated nongnu ``       |