### PR TITLE
chore(flake/sops-nix): `07af005b` -> `3f241253`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -864,11 +864,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739262228,
-        "narHash": "sha256-7JAGezJ0Dn5qIyA2+T4Dt/xQgAbhCglh6lzCekTVMeU=",
+        "lastModified": 1741043164,
+        "narHash": "sha256-9lfmSZLz6eq9Ygr6cCmvQiiBEaPb54pUBcjvbEMPORc=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "07af005bb7d60c7f118d9d9f5530485da5d1e975",
+        "rev": "3f2412536eeece783f0d0ad3861417f347219f4d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                     |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`3f241253`](https://github.com/Mic92/sops-nix/commit/3f2412536eeece783f0d0ad3861417f347219f4d) | `` update vendorHash ``                                                     |
| [`06a3691b`](https://github.com/Mic92/sops-nix/commit/06a3691bdb7e0dcc3c0f21248c7423ddbe7a0e29) | `` build(deps): bump github.com/go-jose/go-jose/v3 from 3.0.3 to 3.0.4 ``   |
| [`9c7171fc`](https://github.com/Mic92/sops-nix/commit/9c7171fc60b41ae9304430522ef847f33407ef01) | `` update vendorHash ``                                                     |
| [`fd19d9fe`](https://github.com/Mic92/sops-nix/commit/fd19d9fecbc3ee83d1a6cbfebd6e035bb59a36e5) | `` build(deps): bump github.com/ProtonMail/go-crypto from 1.1.5 to 1.1.6 `` |