### PR TITLE
chore(flake/srvos): `168d4bff` -> `535b036e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -884,11 +884,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740963569,
-        "narHash": "sha256-LR4DTYEj4MfkG0++UfHK3JOoKS1ljvBWOf6gHCeLhFA=",
+        "lastModified": 1741102373,
+        "narHash": "sha256-1RuqSXBLG8tjoLWuYpfzhFxIAlJfwROshjxFsgWLiQQ=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "168d4bff4d49a431e030056c83592c3a683db44f",
+        "rev": "535b036ed25cd1dd1a9a11a686941dd4fd677431",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                  |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`cfb3e1ed`](https://github.com/nix-community/srvos/commit/cfb3e1ed44509f38c818f7fc8e2b9836c9fcb901) | `` nix-experimental: don't override `system-features` `` |