### PR TITLE
chore(flake/emacs-overlay): `55019a35` -> `40466220`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1741079649,
-        "narHash": "sha256-eaJaCxvqKklKAPfxsRzjpNcMTxCMt8bz3BfYBn+gukw=",
+        "lastModified": 1741109012,
+        "narHash": "sha256-th96gqh+H7HoIgSLn3PpazxFTO8WjuN8IqdYtFrwzDw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "55019a35f027fca211caff7ef7a7a870e82ceec8",
+        "rev": "40466220218949e1f8b36d6ba44e27644dd6bc14",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`40466220`](https://github.com/nix-community/emacs-overlay/commit/40466220218949e1f8b36d6ba44e27644dd6bc14) | `` Updated emacs ``  |
| [`7ba25893`](https://github.com/nix-community/emacs-overlay/commit/7ba25893e77211cf52374858ad40e192814f039b) | `` Updated melpa ``  |
| [`4a09d090`](https://github.com/nix-community/emacs-overlay/commit/4a09d090c2c67640cc22fb5cd75342d10a419a53) | `` Updated elpa ``   |
| [`a0fe5d5a`](https://github.com/nix-community/emacs-overlay/commit/a0fe5d5ac55d9c20e51c040984cbdef48d69e306) | `` Updated nongnu `` |