### PR TITLE
chore(flake/home-manager): `70fbbf05` -> `def0dbbc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741056285,
-        "narHash": "sha256-/JKDMVqq8PIqcGonBVKbKq1SooV3kzGmv+cp3rKAgPA=",
+        "lastModified": 1741174782,
+        "narHash": "sha256-dYRebJk58/d5Ej1G6xTOadTfG6tU5zFgXYrLsRJlrgw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "70fbbf05a5594b0a72124ab211bff1d502c89e3f",
+        "rev": "def0dbbcea715d4514ca343ab4d6d7f3a1742da0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`def0dbbc`](https://github.com/nix-community/home-manager/commit/def0dbbcea715d4514ca343ab4d6d7f3a1742da0) | `` vscode: Support Cursor AI (#6417) ``                    |
| [`b1b964ea`](https://github.com/nix-community/home-manager/commit/b1b964ea9348aef08cab514fa88e9c99def6fd63) | `` mbsync: support maildir paths containing spaces ``      |
| [`6f71acf7`](https://github.com/nix-community/home-manager/commit/6f71acf71bd6a8a6f3152769737a53af6da6ae63) | `` git: apply sendmailCmd instead of smtpServer (#6399) `` |
| [`3f08cd8e`](https://github.com/nix-community/home-manager/commit/3f08cd8ef77dcd7586075a460a61c8432baf25a9) | `` ci: add labels for firefox (#6520) ``                   |