### PR TITLE
chore(flake/emacs-overlay): `40466220` -> `6429ee53`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1741109012,
-        "narHash": "sha256-th96gqh+H7HoIgSLn3PpazxFTO8WjuN8IqdYtFrwzDw=",
+        "lastModified": 1741149197,
+        "narHash": "sha256-ctL0hvG9EMNW60Uz/EOX7QpmbDHBji4WtAgKl83E7t4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "40466220218949e1f8b36d6ba44e27644dd6bc14",
+        "rev": "6429ee53a1c1199637602275c00aca475d8e8057",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                  |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
| [`6429ee53`](https://github.com/nix-community/emacs-overlay/commit/6429ee53a1c1199637602275c00aca475d8e8057) | `` repos/emacs: Rewrite unstable updater using Python `` |
| [`abeede51`](https://github.com/nix-community/emacs-overlay/commit/abeede518295bf29ce648cbf016c025a6b0e8c09) | `` Updated emacs ``                                      |
| [`b914784d`](https://github.com/nix-community/emacs-overlay/commit/b914784db149a0fffc64b35be7027b54457084b7) | `` Updated melpa ``                                      |
| [`9e9da591`](https://github.com/nix-community/emacs-overlay/commit/9e9da5913711176f19fd3650e5d97fe02bc10da0) | `` Updated elpa ``                                       |
| [`d78a4467`](https://github.com/nix-community/emacs-overlay/commit/d78a44674c43943b751fd664fcbbe905a990a90d) | `` Updated nongnu ``                                     |