### PR TITLE
chore(flake/gptel): `b2e54046` -> `4d0689a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -315,11 +315,11 @@
     "gptel": {
       "flake": false,
       "locked": {
-        "lastModified": 1739718451,
-        "narHash": "sha256-8cggTJtWr79ILWttiKWJH5iVcbt8U9vITwV9joNOTgE=",
+        "lastModified": 1740812546,
+        "narHash": "sha256-bAiyrUjiqiVBxVkkZb3VHZm0P1FsUvQ0A4tANn/l5SM=",
         "owner": "karthink",
         "repo": "gptel",
-        "rev": "b2e54046fef11566a087587f37d7ea5b194c2074",
+        "rev": "4d0689a9ba83ffb59c58d5c8e18f3b0c5c4f2940",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`4d0689a9`](https://github.com/karthink/gptel/commit/4d0689a9ba83ffb59c58d5c8e18f3b0c5c4f2940) | `` very rough first pass gemini support ``                             |
| [`5fe062ba`](https://github.com/karthink/gptel/commit/5fe062ba4bdcd1cefc4fa28f8d5f76ebd368b296) | `` drive-by kagi string trimming update ``                             |
| [`cc18cc44`](https://github.com/karthink/gptel/commit/cc18cc44cdf57af87f22e953d15b99ea8f29fb45) | `` all-model vanishing message support ``                              |
| [`3c74df1d`](https://github.com/karthink/gptel/commit/3c74df1d5b6a662c27de200c308c4bac79a7c593) | `` bounds overhaul to support more text property types ``              |
| [`6cf0b0b1`](https://github.com/karthink/gptel/commit/6cf0b0b13dfb51e6f20e23e29beaeca265f5f133) | `` format and de-format tool call ids ``                               |
| [`2440b8cc`](https://github.com/karthink/gptel/commit/2440b8ccbbbc96f7847c251e52f76105a068a07e) | `` Explicit tool calls ``                                              |
| [`ad6be580`](https://github.com/karthink/gptel/commit/ad6be5806fb12085af61d7d877b0c25fd76f9411) | `` combine conditions in gptel-org--create-prompt ``                   |
| [`3727a956`](https://github.com/karthink/gptel/commit/3727a95646813b4ebb6844bd27b47a94aaefe3c4) | `` Separate gptel-display-tool-calls and gptel-display-tool-results `` |
| [`7eea99c3`](https://github.com/karthink/gptel/commit/7eea99c3681da6506088e0cdc1f543efdc2b5eb4) | `` cond -> pcase ``                                                    |
| [`7ad479f5`](https://github.com/karthink/gptel/commit/7ad479f5903cb8d6067852a9ae4a25365bfb089e) | `` gptel--get-bounds -> gptel--get-response-bounds ``                  |
| [`45dd2f03`](https://github.com/karthink/gptel/commit/45dd2f03d93aad8edb33799b8db46bd54da6d345) | `` Drive-by fixup of a missed separator ``                             |
| [`73133590`](https://github.com/karthink/gptel/commit/73133590fa34c51bf2c528862be103a97c6463f0) | `` gptel-openai: Add support for gpt-4.5-preview (#673) ``             |
| [`ce042d69`](https://github.com/karthink/gptel/commit/ce042d692a5d31bb1aadcf5ad96817547b1b3045) | `` gptel: Use "model" instead of "GPT model" (#635) ``                 |
| [`e9d7903d`](https://github.com/karthink/gptel/commit/e9d7903d556cfda304fb990869bc914847ab7ed3) | `` gptel-perplexity: reasoning and deep-research models (#664) ``      |
| [`6ad2afa7`](https://github.com/karthink/gptel/commit/6ad2afa7e249de12416b746f1e961c55d2f58722) | `` README: Add configuration for Anthropic thinking LLMs ``            |
| [`2bb081e5`](https://github.com/karthink/gptel/commit/2bb081e55e33b3df2b60d51d988713d9470e7d6c) | `` gptel-anthropic: Add support for claude-3-7-sonnet-20250219 ``      |
| [`aa62573e`](https://github.com/karthink/gptel/commit/aa62573ee7b14830ffa1cdb3709e588b8fa64f2e) | `` README: Restructure FAQ (fix typo) ``                               |
| [`3fdcb225`](https://github.com/karthink/gptel/commit/3fdcb2256a0365f4608be0c1bf8406619c53938e) | `` README: Restructure FAQ ``                                          |
| [`5d5610df`](https://github.com/karthink/gptel/commit/5d5610dfb62d218447b210ec8c8f833c6aca262e) | `` gptel-rewrite: Appease byte-compiler ``                             |