### PR TITLE
chore(flake/gptel): `4d0689a9` -> `10e16c39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -315,11 +315,11 @@
     "gptel": {
       "flake": false,
       "locked": {
-        "lastModified": 1740812546,
-        "narHash": "sha256-bAiyrUjiqiVBxVkkZb3VHZm0P1FsUvQ0A4tANn/l5SM=",
+        "lastModified": 1741235273,
+        "narHash": "sha256-7ARfPC9bj7UNbkSCCnnBP8+HUriGp2ufRc960m0CKlE=",
         "owner": "karthink",
         "repo": "gptel",
-        "rev": "4d0689a9ba83ffb59c58d5c8e18f3b0c5c4f2940",
+        "rev": "10e16c39f61a7387b07b081a8bbefc69caebd24b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                         |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`10e16c39`](https://github.com/karthink/gptel/commit/10e16c39f61a7387b07b081a8bbefc69caebd24b) | `` gptel: Add message-marker for fine-tuning spacing ``         |
| [`ed937183`](https://github.com/karthink/gptel/commit/ed937183e84600bc3f1c215064e7d6d554ab9ded) | `` very rough first pass gemini support ``                      |
| [`2d9f03cf`](https://github.com/karthink/gptel/commit/2d9f03cf49a8db3fad5c811d06a2f4f39e82f2ab) | `` all-model vanishing message support ``                       |
| [`1fda164b`](https://github.com/karthink/gptel/commit/1fda164b99a552a1815abbb97ca55b5ff84a407e) | `` bounds overhaul to support more text property types ``       |
| [`a78497f5`](https://github.com/karthink/gptel/commit/a78497f52871a80f15e956449ccca904190da699) | `` gptel-openai: Parse tool results from buffer ``              |
| [`dd8a1e6d`](https://github.com/karthink/gptel/commit/dd8a1e6d115f2d42c1ce4cc6f486fbad8f5c7ff4) | `` gptel-org: Tool result handling for Org ``                   |
| [`2d44edae`](https://github.com/karthink/gptel/commit/2d44edae73b924f47660dc452b18133e1c58b34f) | `` gptel-org: Always create prompt in a temp buffer ``          |
| [`6f5b28d8`](https://github.com/karthink/gptel/commit/6f5b28d847434032ffe8ee94f97757ba3f109db0) | `` gptel: Propertize tool results for persistence ``            |
| [`cb420b69`](https://github.com/karthink/gptel/commit/cb420b69287c0df69672ea916e318685b4a312ce) | `` gptel: Breaking change to gptel-request API ``               |
| [`08014b56`](https://github.com/karthink/gptel/commit/08014b56671b58f8ed0d6b7a0eedb830406750c2) | `` gptel: Separate tool confirmation and result insertion ``    |
| [`98d43605`](https://github.com/karthink/gptel/commit/98d4360592bb7c9cc392d5fcda7dc6c23b26572f) | `` gptel: Switch to pcase in insert callbacks ``                |
| [`2bcf06d7`](https://github.com/karthink/gptel/commit/2bcf06d7d4719598af8a2bbd11fc34cec4b3d7ed) | `` gptel: rename gptel--get-bounds ``                           |
| [`53be24e1`](https://github.com/karthink/gptel/commit/53be24e1c9b02d8eabd0ef24d3e72759328b2f65) | `` gptel-kagi: Use gptel--trim-prefixes ``                      |
| [`52f19025`](https://github.com/karthink/gptel/commit/52f19025ebfe59072be299ee255796a229a2dbc4) | `` gptel-org: combine conditions in gptel-org--create-prompt `` |
| [`dc16ec58`](https://github.com/karthink/gptel/commit/dc16ec580e9bbee527c89f14a54f080096a6267b) | `` gptel: Use gptel-response-separator in post-insert ``        |