### PR TITLE
chore(flake/emacs-overlay): `7d03e8ca` -> `30ca4323`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1741192029,
-        "narHash": "sha256-Pl3tiqVoOEddjRNklFWPuXNSSsXw1kmuvSw3bdKw988=",
+        "lastModified": 1741335646,
+        "narHash": "sha256-0b5l4LoRko19pQI16+xXi7yzUeVKwzLKLOagywQULPg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7d03e8ca90e6b438820dee99144a0d03d556f530",
+        "rev": "30ca43239c2b58a25fb73c7ed972d8e87e04d845",
         "type": "github"
       },
       "original": {
@@ -603,11 +603,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1741048562,
-        "narHash": "sha256-W4YZ3fvWZiFYYyd900kh8P8wU6DHSiwaH0j4+fai1Sk=",
+        "lastModified": 1741196730,
+        "narHash": "sha256-0Sj6ZKjCpQMfWnN0NURqRCQn2ob7YtXTAOTwCuz7fkA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6af28b834daca767a7ef99f8a7defa957d0ade6f",
+        "rev": "48913d8f9127ea6530a2a2f1bd4daa1b8685d8a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                   |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
| [`30ca4323`](https://github.com/nix-community/emacs-overlay/commit/30ca43239c2b58a25fb73c7ed972d8e87e04d845) | `` Updated flake inputs ``                                |
| [`cb747e4b`](https://github.com/nix-community/emacs-overlay/commit/cb747e4bc76c308d2ece3721bf07f534d10cb196) | `` Updated flake inputs ``                                |
| [`d6871ef5`](https://github.com/nix-community/emacs-overlay/commit/d6871ef57d1e1e520d64e40c01b1f0f171d0c3f7) | `` overlays/emacs: rename emacs-pgtk to emacs-git-pgtk `` |
| [`ffcf0dae`](https://github.com/nix-community/emacs-overlay/commit/ffcf0dae804167e97b5ccb25ab1366f523384f76) | `` Updated flake inputs ``                                |