### PR TITLE
chore(flake/srvos): `535b036e` -> `fa814c65`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -884,11 +884,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741102373,
-        "narHash": "sha256-1RuqSXBLG8tjoLWuYpfzhFxIAlJfwROshjxFsgWLiQQ=",
+        "lastModified": 1741275113,
+        "narHash": "sha256-1vZe724XGlH+hKo8mgwhC9iQdaX2Ntcosl3Gk5UOzPA=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "535b036ed25cd1dd1a9a11a686941dd4fd677431",
+        "rev": "fa814c65868d32f7bd4d13a87b191ace02feb7d8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`fa814c65`](https://github.com/nix-community/srvos/commit/fa814c65868d32f7bd4d13a87b191ace02feb7d8) | `` dev/private/flake.lock: Update `` |
| [`3bff600d`](https://github.com/nix-community/srvos/commit/3bff600def9f64a205f9ff3c5fe6c7597e7f1d84) | `` flake.lock: Update ``             |