### PR TITLE
chore(flake/catppuccin): `b1ff2a63` -> `2884670e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1739934729,
-        "narHash": "sha256-PcrLk10meIJICzUJqtCMOJxoITzbH52fZg2XAB7SSsM=",
+        "lastModified": 1741287139,
+        "narHash": "sha256-lpSXdmXj6fEo3DwImX6+R/cSakuIHWJ+gLGw1ZcVOXs=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "b1ff2a638afa827f1473498190a2c1cae1cf41cf",
+        "rev": "2884670e4deddc862988ba25548211ff13a5a742",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`2884670e`](https://github.com/catppuccin/nix/commit/2884670e4deddc862988ba25548211ff13a5a742) | `` feat(home-manager/neovim): add option for custom settings (#457) `` |
| [`868ac543`](https://github.com/catppuccin/nix/commit/868ac543b1434e973a5b20cba70263fdc3d2ceef) | `` style: format 9d4f9bf ``                                            |
| [`9d4f9bf2`](https://github.com/catppuccin/nix/commit/9d4f9bf252068432f833e828c5d7637f27792e77) | `` feat(home-manager/zed-editor): icon support (#467) ``               |
| [`2e2cd909`](https://github.com/catppuccin/nix/commit/2e2cd909e1645bb5c5f7824326ec7b7abe4c6cbe) | `` feat(home-manager): add support for thunderbird (#480) ``           |
| [`7f8e5398`](https://github.com/catppuccin/nix/commit/7f8e53985c655625af9aeb10ac09ed88d1cc53cf) | `` ci: disable nix in renovate (#483) ``                               |
| [`2cfcd2be`](https://github.com/catppuccin/nix/commit/2cfcd2bec1619664ee0fb0c0f8db58259ad0eece) | `` ci: add update-locks (#476) ``                                      |