### PR TITLE
chore(flake/nixos-hardware): `009b764a` -> `b48cc4da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -528,11 +528,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1740646007,
-        "narHash": "sha256-dMReDQobS3kqoiUCQIYI9c0imPXRZnBubX20yX/G5LE=",
+        "lastModified": 1741325094,
+        "narHash": "sha256-RUAdT8dZ6k/486vnu3tiNRrNW6+Q8uSD2Mq7gTX4jlo=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "009b764ac98a3602d41fc68072eeec5d24fc0e49",
+        "rev": "b48cc4dab0f9711af296fc367b6108cf7b8ccb16",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                           |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`b48cc4da`](https://github.com/NixOS/nixos-hardware/commit/b48cc4dab0f9711af296fc367b6108cf7b8ccb16) | `` pine64/rockpro64: HDMI output and Network in initrd ``                         |
| [`ae546d01`](https://github.com/NixOS/nixos-hardware/commit/ae546d018a7f23e3ca35fdcaf31be4ff8d148d80) | `` Add support for TUXEDO InfinityBook Pro Intel Gen9 ``                          |
| [`71ab5581`](https://github.com/NixOS/nixos-hardware/commit/71ab5581a0f646e30482a3c39d7bd23f21425f12) | `` apple/t2: update patches ``                                                    |
| [`5335d430`](https://github.com/NixOS/nixos-hardware/commit/5335d4303bb020eb43acdcd16a872468091aa649) | `` README: fix typos in the examples and make formatting more consistent ``       |
| [`52cfc084`](https://github.com/NixOS/nixos-hardware/commit/52cfc084ef508ec25ea960afc2995032b679b45e) | `` dell/inspiron/7559: add + corresponding Skylake architecture configuration. `` |
| [`d23a3bc3`](https://github.com/NixOS/nixos-hardware/commit/d23a3bc3c600a064c72c7fb02862edfab11a46cf) | `` surface: linux 6.12.16 -> 6.12.17 ``                                           |