### PR TITLE
chore(flake/gptel): `10e16c39` -> `4f4894f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -315,11 +315,11 @@
     "gptel": {
       "flake": false,
       "locked": {
-        "lastModified": 1741235273,
-        "narHash": "sha256-7ARfPC9bj7UNbkSCCnnBP8+HUriGp2ufRc960m0CKlE=",
+        "lastModified": 1741334638,
+        "narHash": "sha256-TdTm9VYi1KCrW0B4jTVuVDizJTtlPjm28W/Ef5XJaAE=",
         "owner": "karthink",
         "repo": "gptel",
-        "rev": "10e16c39f61a7387b07b081a8bbefc69caebd24b",
+        "rev": "4f4894f8c70da2de8ca58f6da7e66e0ac849d51b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                        |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`4f4894f8`](https://github.com/karthink/gptel/commit/4f4894f8c70da2de8ca58f6da7e66e0ac849d51b) | `` gptel: Add message-marker for fine-tuned spacing ``         |
| [`8e0de5dd`](https://github.com/karthink/gptel/commit/8e0de5dd25b85122e35da9e2e3a7d09e2e46ece8) | `` gptel: overhaul bounds, support more text property types `` |
| [`e53076f4`](https://github.com/karthink/gptel/commit/e53076f43e9a8865e951383037b5f1ba520f9470) | `` test: Update submodule ``                                   |
| [`1d0b3d11`](https://github.com/karthink/gptel/commit/1d0b3d112bd74ecd9f0789b5ce2526d0e9992fb6) | `` gptel-ollama: Parse tool results from buffer ``             |
| [`1a3b393a`](https://github.com/karthink/gptel/commit/1a3b393a4b676c89e7d675c7d1b395c73d238755) | `` gptel-anthropic: Parse tool results from buffer ``          |
| [`13757388`](https://github.com/karthink/gptel/commit/13757388ca1f41bf5556201f96ab18b97ad63872) | `` gptel-gemini: Parse tool results from buffer ``             |
| [`00f39ea1`](https://github.com/karthink/gptel/commit/00f39ea179630cd9a15430d0edc2d584a139ed31) | `` gptel: Ignore blank/whitespace messages ``                  |
| [`e96ca2aa`](https://github.com/karthink/gptel/commit/e96ca2aa46978e8165c110f0264d5113ac64154b) | `` gptel-openai: Parse tool results from buffer ``             |
| [`56623b98`](https://github.com/karthink/gptel/commit/56623b9889e5b8849ea648110fd5fe0d6db726ac) | `` gptel-org: Tool result handling for Org ``                  |
| [`d222ed82`](https://github.com/karthink/gptel/commit/d222ed823afe2648a37fef4368e4414b90205b72) | `` gptel-org: Always create prompt in a temp buffer ``         |
| [`aded7787`](https://github.com/karthink/gptel/commit/aded7787d623f663623493382bfa97d1040a3bc8) | `` gptel: Make tool call records in buffer recoverable ``      |