### PR TITLE
chore(flake/home-manager): `486b0660` -> `7f4c60a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741217763,
-        "narHash": "sha256-g/TrltIjFHIjtzKY5CJpoPANfHQWDD43G5U1a/v5oVg=",
+        "lastModified": 1741461731,
+        "narHash": "sha256-BBQfGvO3GWOV+5tmqH14gNcZrRaQ7Q3tQx31Frzoip8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "486b066025dccd8af7fbe5dd2cc79e46b88c80da",
+        "rev": "7f4c60a3d6e548dbc13666565c22cb3f8dcdad44",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                  |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`7f4c60a3`](https://github.com/nix-community/home-manager/commit/7f4c60a3d6e548dbc13666565c22cb3f8dcdad44) | `` podman: fix podman-user-wait-network-online (#6586) ``                |
| [`65d6043d`](https://github.com/nix-community/home-manager/commit/65d6043d32db2bf7fa22abd274443485cecef053) | `` flake.lock: Update (#6588) ``                                         |
| [`20a6b363`](https://github.com/nix-community/home-manager/commit/20a6b3631bb9b9308a3ed2348e261c9029b5f7eb) | `` navi: handle xdg directory on darwin (#6589) ``                       |
| [`b2314312`](https://github.com/nix-community/home-manager/commit/b2314312f2ee6893c83d0b5af74d949bc8530409) | `` zsh: correct syntax option to syntax-highlighting (#5792) ``          |
| [`2c87a647`](https://github.com/nix-community/home-manager/commit/2c87a6475fba12c9eb04ccb7375da0e32da48dc1) | `` flake-module: rename `homeManagerModules` to `homeModules` (#6406) `` |
| [`c040d1c5`](https://github.com/nix-community/home-manager/commit/c040d1c556476d9b82c7f3f1a0ce0906fcdf7108) | `` xembed-sni-proxy: change default package (#6587) ``                   |
| [`26f6b862`](https://github.com/nix-community/home-manager/commit/26f6b862645ff281f3bada5d406e8c20de8d837c) | `` tests/gh-dash: enable gh to test extension adding ``                  |
| [`5ab4305f`](https://github.com/nix-community/home-manager/commit/5ab4305f345ccf628fbcaa7a2dfd3696accd907b) | `` gh-dash: fix ``                                                       |
| [`1347b0b4`](https://github.com/nix-community/home-manager/commit/1347b0b468ddf355657d58e50811238cfff517cb) | `` tests: move vinegar to linux only ``                                  |
| [`3ade6542`](https://github.com/nix-community/home-manager/commit/3ade65425772e5ee25989726b41074fcb4a9a372) | `` tests/neovide: fix deprecation ``                                     |
| [`d2c014e1`](https://github.com/nix-community/home-manager/commit/d2c014e1c73195d1958abec0c5ca6112b07b79da) | `` treewide: null package support (#6582) ``                             |
| [`6c2b7940`](https://github.com/nix-community/home-manager/commit/6c2b79403e9ae852fbf1d55b29f2ea4d2aa43255) | `` treewide: use graphical-session.target for GUI services (#5785) ``    |
| [`95711f92`](https://github.com/nix-community/home-manager/commit/95711f926676018d279ba09fe7530d03b5d5b3e2) | `` treewide: remove with lib (#6512) ``                                  |
| [`83f46293`](https://github.com/nix-community/home-manager/commit/83f4629364b6e627ce25d7d246058e48ffa4b111) | `` granted: support fish shell (#6549) ``                                |
| [`04c915bc`](https://github.com/nix-community/home-manager/commit/04c915bcf1a1eac3519372ff3185beef053fba7c) | `` firefox: Support paths for userChrome & userContent (#3856) ``        |