### PR TITLE
chore(flake/nur): `cb79e7a9` -> `c54e9eec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -685,11 +685,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1741246872,
-        "narHash": "sha256-Q6pMP4a9ed636qilcYX8XUguvKl/0/LGXhHcRI91p0U=",
+        "lastModified": 1741379970,
+        "narHash": "sha256-Wh7esNh7G24qYleLvgOSY/7HlDUzWaL/n4qzlBePpiw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "10069ef4cf863633f57238f179a0297de84bd8d3",
+        "rev": "36fd87baa9083f34f7f5027900b62ee6d09b1f2f",
         "type": "github"
       },
       "original": {
@@ -776,11 +776,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1741362345,
-        "narHash": "sha256-SzmW7n6N9wOKdTMPkKE0y1gt3544Qcqm4kWUl7iOelM=",
+        "lastModified": 1741607119,
+        "narHash": "sha256-liLX43CyPSaqkNpUXwWknzLl2SAI6l42kJEKefZTFfo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cb79e7a9c3f50ad60872f2fa8f81977a8f387871",
+        "rev": "c54e9eec7b949e50a24cd387feb3df9b06800c95",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                       |
| -------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`c54e9eec`](https://github.com/nix-community/NUR/commit/c54e9eec7b949e50a24cd387feb3df9b06800c95) | `` automatic update ``        |
| [`23e427f8`](https://github.com/nix-community/NUR/commit/23e427f82e4224c478100ac74629ac0ef9d7c511) | `` automatic update ``        |
| [`16c4d3d1`](https://github.com/nix-community/NUR/commit/16c4d3d19048e88b72ad59a57129bd436378a92a) | `` automatic update ``        |
| [`48604b22`](https://github.com/nix-community/NUR/commit/48604b22468378d07b7437bff16540413d4eccb9) | `` automatic update ``        |
| [`05607425`](https://github.com/nix-community/NUR/commit/05607425540ace50b41392637ea33b23bff0d2c7) | `` automatic update ``        |
| [`bbde911f`](https://github.com/nix-community/NUR/commit/bbde911fa67d0d399cbcfc44324d29c850ca17e6) | `` automatic update ``        |
| [`863babe4`](https://github.com/nix-community/NUR/commit/863babe488dc1c4e67b29513a70b2742873d4fab) | `` automatic update ``        |
| [`5dd6c62f`](https://github.com/nix-community/NUR/commit/5dd6c62f5d82c0df91d931adca209d7b4597abc3) | `` automatic update ``        |
| [`083e3a9b`](https://github.com/nix-community/NUR/commit/083e3a9b90014308dd21c2132fd61978592e752d) | `` automatic update ``        |
| [`4857af6f`](https://github.com/nix-community/NUR/commit/4857af6fe36d572ff76b940bb2d0656ca72c3318) | `` automatic update ``        |
| [`c143e90d`](https://github.com/nix-community/NUR/commit/c143e90d9b29db3c50c41b655e42b24cb0b01570) | `` automatic update ``        |
| [`cfbc69ce`](https://github.com/nix-community/NUR/commit/cfbc69cec15a5b967c6ebc7e6bce284ddec64ea5) | `` automatic update ``        |
| [`4f93eff0`](https://github.com/nix-community/NUR/commit/4f93eff06c29359a0acab7bc7171723d6204e2dc) | `` automatic update ``        |
| [`4ae43b04`](https://github.com/nix-community/NUR/commit/4ae43b04c54350575c1e0fd6ee1547629b2e06ff) | `` automatic update ``        |
| [`38c57681`](https://github.com/nix-community/NUR/commit/38c5768166682ff0805919f88f51c6f3cda39286) | `` automatic update ``        |
| [`455ebb27`](https://github.com/nix-community/NUR/commit/455ebb271ed913d9884438c1ec2dd30fbaeff8c6) | `` automatic update ``        |
| [`6afa16cf`](https://github.com/nix-community/NUR/commit/6afa16cf6d8d9c8319c8d09f2468dd6ab96f6b5b) | `` automatic update ``        |
| [`6d138c69`](https://github.com/nix-community/NUR/commit/6d138c6932518413171db9dad473b03cd28529d6) | `` automatic update ``        |
| [`fa523663`](https://github.com/nix-community/NUR/commit/fa523663def23e8ea77569e8dd1888bab089f48c) | `` automatic update ``        |
| [`4ef4b74f`](https://github.com/nix-community/NUR/commit/4ef4b74f680164335c8b4ec6b9af62f958b4862d) | `` automatic update ``        |
| [`91c6573e`](https://github.com/nix-community/NUR/commit/91c6573e442b73d8bdffde40f40baacf42cf42a0) | `` automatic update ``        |
| [`55fd8b94`](https://github.com/nix-community/NUR/commit/55fd8b947ee109c7bc8ed6713a1e2e09d3e83c56) | `` automatic update ``        |
| [`1e9030fd`](https://github.com/nix-community/NUR/commit/1e9030fd2f14504327331b24cd1fe4c35a7bf77b) | `` automatic update ``        |
| [`3bd99868`](https://github.com/nix-community/NUR/commit/3bd99868267234f5412bf239aa9444b14748e871) | `` automatic update ``        |
| [`732a8689`](https://github.com/nix-community/NUR/commit/732a8689fe2920f02cd39d6e65175ff157ae1610) | `` automatic update ``        |
| [`578639a5`](https://github.com/nix-community/NUR/commit/578639a51829bdae39b513d77298fd0c1409c258) | `` automatic update ``        |
| [`ba902eb1`](https://github.com/nix-community/NUR/commit/ba902eb190eb80ad4a02cf06da88a64323b4277d) | `` automatic update ``        |
| [`233d3db0`](https://github.com/nix-community/NUR/commit/233d3db032651458ce1b7632196cfe7d630e163d) | `` automatic update ``        |
| [`6e7426d5`](https://github.com/nix-community/NUR/commit/6e7426d53e54208c250a06e9a6855cef3cb8d4b7) | `` automatic update ``        |
| [`7fa9a32d`](https://github.com/nix-community/NUR/commit/7fa9a32d8696367679321696291a7eec278d128c) | `` automatic update ``        |
| [`3ce84aa6`](https://github.com/nix-community/NUR/commit/3ce84aa694da48341364b976645eed16546d1989) | `` automatic update ``        |
| [`0d419807`](https://github.com/nix-community/NUR/commit/0d4198078cdf5ba81e429db4409ae2ad78b3d747) | `` automatic update ``        |
| [`48b066a9`](https://github.com/nix-community/NUR/commit/48b066a9ce31aaaa5b95f5e4de8e92afba055736) | `` automatic update ``        |
| [`024c29f5`](https://github.com/nix-community/NUR/commit/024c29f568433b7740dfa4b9a23edec3a152f0f6) | `` automatic update ``        |
| [`cd11d35e`](https://github.com/nix-community/NUR/commit/cd11d35e9a3686d484546df595c44695f22849b9) | `` automatic update ``        |
| [`597f6777`](https://github.com/nix-community/NUR/commit/597f67772a2f3acb6ade6a076c0fb9404065a578) | `` automatic update ``        |
| [`fc6bcda7`](https://github.com/nix-community/NUR/commit/fc6bcda73a1b088b6a324bdb725c41d2bd76730a) | `` automatic update ``        |
| [`309e2ee7`](https://github.com/nix-community/NUR/commit/309e2ee7ded1bc21cb3641cfd693fbc5899622e7) | `` automatic update ``        |
| [`f3ecd675`](https://github.com/nix-community/NUR/commit/f3ecd675a74a347a47d2edc2266d5bbb2ec1f1c0) | `` automatic update ``        |
| [`f334b8ab`](https://github.com/nix-community/NUR/commit/f334b8ab164396fe8e78204bd4f5c406596f13be) | `` automatic update ``        |
| [`1d6c8d84`](https://github.com/nix-community/NUR/commit/1d6c8d84756af4333a42bd743a56d87d2f83e784) | `` automatic update ``        |
| [`8db96b86`](https://github.com/nix-community/NUR/commit/8db96b86c54c84ba04c07381856250150ba121cc) | `` add colorman repository `` |
| [`3c1d7745`](https://github.com/nix-community/NUR/commit/3c1d774501d2300c51ce37ea6d1405d5ea12e740) | `` automatic update ``        |
| [`cc096e52`](https://github.com/nix-community/NUR/commit/cc096e52e88ec35f3cdadd5fa8e580949aed8057) | `` automatic update ``        |
| [`74e3cd81`](https://github.com/nix-community/NUR/commit/74e3cd81b164d51ee984acf765f46d21d9db21c4) | `` automatic update ``        |
| [`4b18c409`](https://github.com/nix-community/NUR/commit/4b18c409d6eec35758ae8de62fdbcf286b96774e) | `` automatic update ``        |
| [`092e0387`](https://github.com/nix-community/NUR/commit/092e038744c6c05b2014e59a9c816b4d2225f887) | `` automatic update ``        |
| [`38afa55e`](https://github.com/nix-community/NUR/commit/38afa55e2389ac0a5e958e47c64a27d57f6378b8) | `` automatic update ``        |
| [`cce0d2dc`](https://github.com/nix-community/NUR/commit/cce0d2dc897c6a4fde930f6b3776338570a11c7f) | `` automatic update ``        |
| [`8eb112d4`](https://github.com/nix-community/NUR/commit/8eb112d4b39d22307831bea487ac0c5d6378aaaf) | `` automatic update ``        |
| [`f5119f30`](https://github.com/nix-community/NUR/commit/f5119f305b98837525820c8d6fa92446945c5084) | `` automatic update ``        |
| [`39dfc86c`](https://github.com/nix-community/NUR/commit/39dfc86c8bb0d24590b34f898a1866d79778bacb) | `` automatic update ``        |
| [`4c41cecc`](https://github.com/nix-community/NUR/commit/4c41cecc8400938ce5bc93a57b1eefcb77998ddf) | `` automatic update ``        |
| [`bd344428`](https://github.com/nix-community/NUR/commit/bd344428bf59a78e21d8476e81c018e94ed1c6b0) | `` automatic update ``        |
| [`84c34746`](https://github.com/nix-community/NUR/commit/84c34746969c63f8edbe5c76bd3fa0b015fd9a0f) | `` automatic update ``        |
| [`c37ef3bb`](https://github.com/nix-community/NUR/commit/c37ef3bb44a4ff3c0648117b83e3dac16169f43f) | `` automatic update ``        |
| [`ac6817d1`](https://github.com/nix-community/NUR/commit/ac6817d1b19982281407a3eed6d758304aab0aeb) | `` automatic update ``        |
| [`90a5202e`](https://github.com/nix-community/NUR/commit/90a5202e29458cf9b00932ad497722e48cb2e8e7) | `` automatic update ``        |
| [`bb39fa1c`](https://github.com/nix-community/NUR/commit/bb39fa1c47c243178ca5601ddcb6097b968adf08) | `` automatic update ``        |
| [`7bac0ff1`](https://github.com/nix-community/NUR/commit/7bac0ff1547a0d2e85efbc71780735d35a343b1f) | `` automatic update ``        |
| [`65dae65b`](https://github.com/nix-community/NUR/commit/65dae65b9c1e6dde97314e917f5551abdf3d0097) | `` automatic update ``        |
| [`d3e16e2f`](https://github.com/nix-community/NUR/commit/d3e16e2f828366614acd8f775e72388f16caa8a6) | `` automatic update ``        |
| [`45c9f6f8`](https://github.com/nix-community/NUR/commit/45c9f6f809fdd8c7cffe11904bc5b296a3550d3c) | `` automatic update ``        |
| [`a29fb2d6`](https://github.com/nix-community/NUR/commit/a29fb2d6455220eea452cc65cb567180ddd16547) | `` automatic update ``        |
| [`32f63788`](https://github.com/nix-community/NUR/commit/32f63788e2ea8b4afc290ab0e2b71cdf4fa1cca8) | `` automatic update ``        |
| [`54352c3c`](https://github.com/nix-community/NUR/commit/54352c3c3110f34e71a2ae9a0210aa6955555760) | `` automatic update ``        |
| [`69036f07`](https://github.com/nix-community/NUR/commit/69036f0739abb33baea3d19e8d592d4266ca1a01) | `` automatic update ``        |
| [`5dffbc3e`](https://github.com/nix-community/NUR/commit/5dffbc3e49964e20aefe8b4619a3708bde95ee9a) | `` automatic update ``        |
| [`c966bd68`](https://github.com/nix-community/NUR/commit/c966bd6835f63dbb24857bd820a55e43427cca94) | `` automatic update ``        |
| [`4463e638`](https://github.com/nix-community/NUR/commit/4463e6382eca077dbd3c74ae336aef516221b4fc) | `` automatic update ``        |
| [`ed0d685a`](https://github.com/nix-community/NUR/commit/ed0d685aa5d2360c662893cdc1fa07e5c623f72a) | `` automatic update ``        |
| [`b1da1da7`](https://github.com/nix-community/NUR/commit/b1da1da74b062575f080ca75d2d09e6364c1483f) | `` automatic update ``        |
| [`f785e553`](https://github.com/nix-community/NUR/commit/f785e5536d285a4c8d2af2d86436b756b88f3f38) | `` automatic update ``        |