### PR TITLE
chore(flake/catppuccin): `2884670e` -> `5aa5fa69`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1741287139,
-        "narHash": "sha256-lpSXdmXj6fEo3DwImX6+R/cSakuIHWJ+gLGw1ZcVOXs=",
+        "lastModified": 1741386593,
+        "narHash": "sha256-N/HQkFkFyGgeXPZygwCAQ7xwZhPVkHXpfQR0Qh4zh0k=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "2884670e4deddc862988ba25548211ff13a5a742",
+        "rev": "5aa5fa6921b486fc466ca634325485118872bede",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                   |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`5aa5fa69`](https://github.com/catppuccin/nix/commit/5aa5fa6921b486fc466ca634325485118872bede) | `` ci: fix token perms in update-locks (#488) ``                          |
| [`6aa4bdaa`](https://github.com/catppuccin/nix/commit/6aa4bdaae1811b4a498036edcb21c26ac5677f65) | `` ci: use workflow_dispatch over workflow_call in update-locks (#487) `` |
| [`182a2433`](https://github.com/catppuccin/nix/commit/182a2433e96463086c5bf3dc0ed7f7a5550c20a9) | `` ci: fix update locks workflow (#484) ``                                |