### PR TITLE
chore(flake/emacs-overlay): `30ca4323` -> `db37ae9c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1741335646,
-        "narHash": "sha256-0b5l4LoRko19pQI16+xXi7yzUeVKwzLKLOagywQULPg=",
+        "lastModified": 1741485571,
+        "narHash": "sha256-fpm1ZTfGfMG36c4G3HSwmbd09zU3egmM0dfgDxkT3h4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "30ca43239c2b58a25fb73c7ed972d8e87e04d845",
+        "rev": "db37ae9cd947031ad83288dec514233ffd262ffd",
         "type": "github"
       },
       "original": {
@@ -606,11 +606,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1741196730,
-        "narHash": "sha256-0Sj6ZKjCpQMfWnN0NURqRCQn2ob7YtXTAOTwCuz7fkA=",
+        "lastModified": 1741332913,
+        "narHash": "sha256-ri1e8ZliWS3Jnp9yqpKApHaOo7KBN33W8ECAKA4teAQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "48913d8f9127ea6530a2a2f1bd4daa1b8685d8a3",
+        "rev": "20755fa05115c84be00b04690630cb38f0a203ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
| [`db37ae9c`](https://github.com/nix-community/emacs-overlay/commit/db37ae9cd947031ad83288dec514233ffd262ffd) | `` Updated emacs ``                                                       |
| [`0e7d88c3`](https://github.com/nix-community/emacs-overlay/commit/0e7d88c313f7eab70ebac6897b427df026e47e98) | `` Updated melpa ``                                                       |
| [`a231ca83`](https://github.com/nix-community/emacs-overlay/commit/a231ca8318ad9e18cd71383b6e6252c104318696) | `` .github: pin Nix 2.24.12 for CI ``                                     |
| [`d47cbc64`](https://github.com/nix-community/emacs-overlay/commit/d47cbc6420041baf1f8185b859d92bff8d8cf4df) | `` Updated elpa ``                                                        |
| [`1558e250`](https://github.com/nix-community/emacs-overlay/commit/1558e2501940c87434e4cba90babc1517c1ccacd) | `` Updated nongnu ``                                                      |
| [`df8a3133`](https://github.com/nix-community/emacs-overlay/commit/df8a3133fae8a6c98ae23b249b57d902f03eff84) | `` Updated flake inputs ``                                                |
| [`6e4d92e5`](https://github.com/nix-community/emacs-overlay/commit/6e4d92e5c26dc81241d4c800531ad1f8ee68f213) | `` Revert "Temporarily make `packages` correspond to emacs-unstable" ``   |
| [`4944e1c6`](https://github.com/nix-community/emacs-overlay/commit/4944e1c699d13c014df2882dffc981069c36dca2) | `` Temporarily make `packages` correspond to emacs-unstable ``            |
| [`be12ed91`](https://github.com/nix-community/emacs-overlay/commit/be12ed914c415a330efb69600b6732add76b0a87) | `` Revert "Temporarily make `packages` correspond to emacs-unstable" ``   |
| [`e129cea3`](https://github.com/nix-community/emacs-overlay/commit/e129cea3d6d3ea152429f5d0926cec2d148d2ec6) | `` Temporarily make `packages` correspond to emacs-unstable ``            |
| [`c34d2288`](https://github.com/nix-community/emacs-overlay/commit/c34d22888cd6fcb565cbb6a05fcd45e6099ce5f4) | `` overlay/emacs: update patch for #318 (upstream bug#63288 bug#76523) `` |
| [`87d5e2bb`](https://github.com/nix-community/emacs-overlay/commit/87d5e2bbc04a8d2ddff9e1f9e266bf81c3bd45b2) | `` Updated flake inputs ``                                                |
| [`5f5a48f8`](https://github.com/nix-community/emacs-overlay/commit/5f5a48f87c3f0e35dbb34f50d4d13595038901d2) | `` .github: Unpin Nix 2.18 for CI ``                                      |