### PR TITLE
chore(flake/git-hooks): `1293270f` -> `b5a62751`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -278,11 +278,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741373960,
-        "narHash": "sha256-7/JbMIY/QhdCFdpZ6bCRshClUdZK/LJw+e7OLJhU1iQ=",
+        "lastModified": 1741379162,
+        "narHash": "sha256-srpAbmJapkaqGRE3ytf3bj4XshspVR5964OX5LfjDWc=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "1293270f9d650ed794958dc97dcf497b425b465c",
+        "rev": "b5a62751225b2f62ff3147d0a334055ebadcd5cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                          |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`f4cdd2cc`](https://github.com/cachix/git-hooks.nix/commit/f4cdd2cc618f1ad3d8e4e43da36a120d55ee2b72) | `` Improve `configPath` docs ``                                  |
| [`e2fcecd7`](https://github.com/cachix/git-hooks.nix/commit/e2fcecd7db11ee277dc9fd8c285ddfd2ae7840af) | `` Improve the error message when an existing config is found `` |
| [`d952b5be`](https://github.com/cachix/git-hooks.nix/commit/d952b5be9c76833413cd8e4dab74a6e89b3e3719) | `` Pass through all options in `run` ``                          |
| [`5af65eba`](https://github.com/cachix/git-hooks.nix/commit/5af65eba2b5d1a27111a3605dc06d59bed07aa86) | `` Use the correct path when unlinking the exising config ``     |