### PR TITLE
chore(flake/home-manager): `7f4c60a3` -> `744f749d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741461731,
-        "narHash": "sha256-BBQfGvO3GWOV+5tmqH14gNcZrRaQ7Q3tQx31Frzoip8=",
+        "lastModified": 1741579508,
+        "narHash": "sha256-skRbH+UF2ES+msEa+KWi7AQFX73S+QsGlPsyCU6XyE0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7f4c60a3d6e548dbc13666565c22cb3f8dcdad44",
+        "rev": "744f749dd6fbc1489591ea370b95156858629cb9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                           |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`744f749d`](https://github.com/nix-community/home-manager/commit/744f749dd6fbc1489591ea370b95156858629cb9) | `` mods: add a mods module (#6339) ``                                             |
| [`ce9cb249`](https://github.com/nix-community/home-manager/commit/ce9cb2496c48ebb33e42ee0ab82267f67b82f71e) | `` podman: added volume, image, and build quadlets (#6137) ``                     |
| [`f8bb0ba6`](https://github.com/nix-community/home-manager/commit/f8bb0ba6de361c43c1c1e9756375f23ffadac1f9) | `` zoxide: update mkOrder to place bash configuration at end of bashrc (#6572) `` |
| [`597f9c2f`](https://github.com/nix-community/home-manager/commit/597f9c2f06af8791b31c48ad05471ac5afbd0f0a) | `` thunderbird: set additional gmail server settings (#6579) ``                   |
| [`db4386d6`](https://github.com/nix-community/home-manager/commit/db4386d686fb0b2788e7422e6a2299deace9c4b1) | `` home-environment: add line-break after sessionSearchVariables (#6596) ``       |
| [`2967de4d`](https://github.com/nix-community/home-manager/commit/2967de4d1146f1b6aa820eed85b823ea2ebfd0fa) | `` debug: make NIX_DEBUG_INFO_DIRS a list of strings (#6595) ``                   |
| [`cf47e7ea`](https://github.com/nix-community/home-manager/commit/cf47e7ea2182c5638fdd1b42de329cc7d185cf8b) | `` qt: use home.sessionSearchVariables ``                                         |
| [`ab56fd8d`](https://github.com/nix-community/home-manager/commit/ab56fd8db811581323bb7aecd9c47c5956b3b17c) | `` targets/generic-linux: use home.sessionSearchVariables for XCURSOR_PATH ``     |
| [`5094e32c`](https://github.com/nix-community/home-manager/commit/5094e32ccea3168a5cb9ee6e3b7e74aaf4d866a9) | `` home-cursor: use home.sessionSearchVariables for XCURSOR_PATH ``               |
| [`daab3230`](https://github.com/nix-community/home-manager/commit/daab32302b0bdd9bfff9e75d32375353d95b9c4f) | `` debug: use home.sessionSearchVariables for NIX_DEBUG_INFO_DIRS ``              |
| [`601f8d07`](https://github.com/nix-community/home-manager/commit/601f8d073c0b2f1fb4601b4727fb43ba6412685b) | `` im/fcitx5: use home.sessionSearchVariables for QT_PLUGIN_PATH ``               |
| [`277eea1c`](https://github.com/nix-community/home-manager/commit/277eea1cc7a5c37ea0b9aa8198cd1f2db3d6715c) | `` home-environment: add home.sessionSearchVariables ``                           |
| [`07f505f9`](https://github.com/nix-community/home-manager/commit/07f505f91e0c7112550845425222f41865c4260a) | `` qt: add "kde6" to qt.platformTheme (#6493) ``                                  |
| [`1fd39a10`](https://github.com/nix-community/home-manager/commit/1fd39a105575ea997b32a043a0dd2c49294add5b) | `` tests/vscode: fix darwin snippets test ``                                      |
| [`8d2a0581`](https://github.com/nix-community/home-manager/commit/8d2a05810834119b96531745de7943cc8ba5bb79) | `` tests/thunderbird: fix darwin test ``                                          |
| [`4f2c4612`](https://github.com/nix-community/home-manager/commit/4f2c4612861405d40bc81fa8a8575d15bee6e8d2) | `` tests/yubikey-agent-darwin: fix test ``                                        |
| [`4c964336`](https://github.com/nix-community/home-manager/commit/4c9643363a0f218a3d473149f6a024c8a66d0f62) | `` tests/ollama: fix darwin test ``                                               |
| [`68540fb7`](https://github.com/nix-community/home-manager/commit/68540fb7755d3be96c71cfc5a6f43a3d615d9de7) | `` tests/syncthing: syncthing wrapper stubbing for darwin ``                      |
| [`15498b94`](https://github.com/nix-community/home-manager/commit/15498b94ec2c7aa857864af105b72cb41def0b00) | `` tests/syncthing: fix extra-options on darwin ``                                |
| [`1909541f`](https://github.com/nix-community/home-manager/commit/1909541fc7e844266df393a25c386cb4ca14f6e3) | `` tests/targets-darwin: fix user-defaults test ``                                |
| [`91f88408`](https://github.com/nix-community/home-manager/commit/91f88408ccb7649dc6feec5ba565aee4e2097510) | `` .github/workflows/test.yml: enable darwin tests ``                             |
| [`b3e11ed4`](https://github.com/nix-community/home-manager/commit/b3e11ed4a99bca48e47d7d7df6535c80dc73c79e) | `` tests: central darwin stubbing ``                                              |
| [`b74402e4`](https://github.com/nix-community/home-manager/commit/b74402e4e8f8cebbec860f0ba8fef2f703ad79f0) | `` tests: expose scrubDerivation ``                                               |
| [`72580374`](https://github.com/nix-community/home-manager/commit/72580374c81ad8803675ee0dc829a60773d24401) | `` Translate using Weblate (Chinese (Traditional Han script)) (#6581) ``          |
| [`b23c4d4c`](https://github.com/nix-community/home-manager/commit/b23c4d4cbe931240fad25bba01509edc03c3aac6) | `` flake.lock: Update (#6591) ``                                                  |