### PR TITLE
chore(flake/catppuccin): `dc7e553e` -> `62424ccd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1741424456,
-        "narHash": "sha256-46m7KqjSoabM5JdqP8Om9+PWioRy0uU746MZuLyw/6o=",
+        "lastModified": 1741521711,
+        "narHash": "sha256-uV+olxh2H8GrB676m8lHpDujYVJ1K5rie6Y0GEFSMhI=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "dc7e553e91c37cec5083ac5cfaff6a28565d1334",
+        "rev": "62424ccd65e280f3739754e0f30b85c901f6bcd9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                              |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`62424ccd`](https://github.com/catppuccin/nix/commit/62424ccd65e280f3739754e0f30b85c901f6bcd9) | `` fix: assert home-manager version for thunderbird module (#489) `` |