### PR TITLE
chore(flake/emacs-overlay): `257cf838` -> `70dcaaf2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1741511575,
-        "narHash": "sha256-UX9XCbxV5fbZdMoYEqbD3ldtYtWuoXe8A1qKTYIh0DY=",
+        "lastModified": 1741540370,
+        "narHash": "sha256-TNXVcJY1A3tr4hclP/p4OtNAsMqTP+LEE8J4rYvKPfY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "257cf8385441733ba3594e1e9f8edcf10adfbc31",
+        "rev": "70dcaaf21a78253742d3caae56dadc5447d85c15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`70dcaaf2`](https://github.com/nix-community/emacs-overlay/commit/70dcaaf21a78253742d3caae56dadc5447d85c15) | `` Updated emacs ``  |
| [`a08f98d5`](https://github.com/nix-community/emacs-overlay/commit/a08f98d5802594b910424fd61287af654a4ef6fe) | `` Updated melpa ``  |
| [`a554bd33`](https://github.com/nix-community/emacs-overlay/commit/a554bd3376a0f58d221c43377c50f4a92b139860) | `` Updated elpa ``   |
| [`409ef878`](https://github.com/nix-community/emacs-overlay/commit/409ef8787b0fed67147af9124ef15562a1187d88) | `` Updated nongnu `` |