### PR TITLE
chore(flake/emacs-overlay): `70dcaaf2` -> `6a25d3f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1741540370,
-        "narHash": "sha256-TNXVcJY1A3tr4hclP/p4OtNAsMqTP+LEE8J4rYvKPfY=",
+        "lastModified": 1741623701,
+        "narHash": "sha256-fN1LYtj3hWyOhJ11r/u47CWLIxGwC8q5qevwSHRU2kw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "70dcaaf21a78253742d3caae56dadc5447d85c15",
+        "rev": "6a25d3f956603e1f18499f33951ad6f2a9fa2f6e",
         "type": "github"
       },
       "original": {
@@ -606,11 +606,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1741332913,
-        "narHash": "sha256-ri1e8ZliWS3Jnp9yqpKApHaOo7KBN33W8ECAKA4teAQ=",
+        "lastModified": 1741445498,
+        "narHash": "sha256-F5Em0iv/CxkN5mZ9hRn3vPknpoWdcdCyR0e4WklHwiE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "20755fa05115c84be00b04690630cb38f0a203ad",
+        "rev": "52e3095f6d812b91b22fb7ad0bfc1ab416453634",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`6a25d3f9`](https://github.com/nix-community/emacs-overlay/commit/6a25d3f956603e1f18499f33951ad6f2a9fa2f6e) | `` Updated elpa ``         |
| [`fb5010aa`](https://github.com/nix-community/emacs-overlay/commit/fb5010aa3179e77f595cd3be1760817b86b6dbda) | `` Updated nongnu ``       |
| [`7a25a145`](https://github.com/nix-community/emacs-overlay/commit/7a25a145b8a7f455e62185af431001d70471b199) | `` Updated emacs ``        |
| [`4b3be58e`](https://github.com/nix-community/emacs-overlay/commit/4b3be58e33b2075d0a1abb82d45fcf35b498624c) | `` Updated melpa ``        |
| [`7236e0ba`](https://github.com/nix-community/emacs-overlay/commit/7236e0baef0a94fa7826f034ea96433224bcea89) | `` Updated emacs ``        |
| [`9f323fca`](https://github.com/nix-community/emacs-overlay/commit/9f323fcaa64ee12653b9d67d49e791a9d21113d2) | `` Updated melpa ``        |
| [`abda9338`](https://github.com/nix-community/emacs-overlay/commit/abda9338130e71108be0447c364a94c1a9d1d050) | `` Updated elpa ``         |
| [`0ff5e038`](https://github.com/nix-community/emacs-overlay/commit/0ff5e0381a8023bd456be3cbbda62d396cbed0f9) | `` Updated nongnu ``       |
| [`6f2afe90`](https://github.com/nix-community/emacs-overlay/commit/6f2afe90ca842c346e5ec4ddc9a7e2a5a6be0cec) | `` Updated flake inputs `` |