### PR TITLE
chore(flake/srvos): `fa814c65` -> `037690b0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -887,11 +887,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741275113,
-        "narHash": "sha256-1vZe724XGlH+hKo8mgwhC9iQdaX2Ntcosl3Gk5UOzPA=",
+        "lastModified": 1741636056,
+        "narHash": "sha256-YYqTwGHpbeHs3m9jfqJJv6qO6fV6vXyB2cOVefINRTg=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "fa814c65868d32f7bd4d13a87b191ace02feb7d8",
+        "rev": "037690b00101fe635e83963dd965f04d5dad0a68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                         |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`037690b0`](https://github.com/nix-community/srvos/commit/037690b00101fe635e83963dd965f04d5dad0a68) | `` build(deps): bump cachix/install-nix-action from 30 to 31 `` |
| [`4b726f14`](https://github.com/nix-community/srvos/commit/4b726f14b80473a05302cdcd70d3043a183c5276) | `` dev/private/flake.lock: Update ``                            |
| [`5254eb1b`](https://github.com/nix-community/srvos/commit/5254eb1bfbb129f5f30538d9bd773b57aaddbff9) | `` flake.lock: Update ``                                        |