### PR TITLE
chore(flake/nur): `c54e9eec` -> `2f760664`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -685,11 +685,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1741379970,
-        "narHash": "sha256-Wh7esNh7G24qYleLvgOSY/7HlDUzWaL/n4qzlBePpiw=",
+        "lastModified": 1741513245,
+        "narHash": "sha256-7rTAMNTY1xoBwz0h7ZMtEcd8LELk9R5TzBPoHuhNSCk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "36fd87baa9083f34f7f5027900b62ee6d09b1f2f",
+        "rev": "e3e32b642a31e6714ec1b712de8c91a3352ce7e1",
         "type": "github"
       },
       "original": {
@@ -776,11 +776,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1741607119,
-        "narHash": "sha256-liLX43CyPSaqkNpUXwWknzLl2SAI6l42kJEKefZTFfo=",
+        "lastModified": 1741649763,
+        "narHash": "sha256-436Es6IDqrUukz5VLjRP41F/znZPFZEz274s6phBR5o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c54e9eec7b949e50a24cd387feb3df9b06800c95",
+        "rev": "2f76066428491220b7bd46388ac1e8e9d1ead805",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2f760664`](https://github.com/nix-community/NUR/commit/2f76066428491220b7bd46388ac1e8e9d1ead805) | `` automatic update `` |
| [`b75e6eba`](https://github.com/nix-community/NUR/commit/b75e6eba839de21b10fe23e008883d4a708ef0ff) | `` automatic update `` |
| [`31f7ab82`](https://github.com/nix-community/NUR/commit/31f7ab827d9e337fee99a019435fea26be0e3e33) | `` automatic update `` |
| [`b4a0e8b5`](https://github.com/nix-community/NUR/commit/b4a0e8b582386f8f5c279e5be02a35738d4c595e) | `` automatic update `` |
| [`b3f51483`](https://github.com/nix-community/NUR/commit/b3f51483701a1bab9d7f648c492c53de51f6ee16) | `` automatic update `` |
| [`1e56eba2`](https://github.com/nix-community/NUR/commit/1e56eba22ff0f652028b3e8ff593dfa345a88716) | `` automatic update `` |
| [`2429032c`](https://github.com/nix-community/NUR/commit/2429032c8e3e9ab425766c5245586cc5bf01705c) | `` automatic update `` |
| [`94c59313`](https://github.com/nix-community/NUR/commit/94c593132a446ddebd864b35949134810ae3e705) | `` automatic update `` |
| [`c7acd5a8`](https://github.com/nix-community/NUR/commit/c7acd5a8358884334d2064086e6237eaac3b593d) | `` automatic update `` |
| [`d088b00e`](https://github.com/nix-community/NUR/commit/d088b00ec78e528ecabf81600e800637c5e8bd02) | `` automatic update `` |
| [`52bbc51b`](https://github.com/nix-community/NUR/commit/52bbc51b3783f64701c70b72b7c72b490274eb25) | `` automatic update `` |
| [`4049d4e6`](https://github.com/nix-community/NUR/commit/4049d4e6fab8863ca77c1acc6565ee25800e517f) | `` automatic update `` |
| [`fa05c69b`](https://github.com/nix-community/NUR/commit/fa05c69ba51285df96be19fefb49ff053f888ce9) | `` automatic update `` |
| [`8a02a777`](https://github.com/nix-community/NUR/commit/8a02a777b2aa7ff471dfb6e124f9ebae3405c6b5) | `` automatic update `` |
| [`e2e76a37`](https://github.com/nix-community/NUR/commit/e2e76a3772fc9968e0c4b0a55253f598b0921b13) | `` automatic update `` |
| [`94dcb7c6`](https://github.com/nix-community/NUR/commit/94dcb7c6d3a6f93ec26cbf8fbb090921576282e0) | `` automatic update `` |
| [`0bc0cdd2`](https://github.com/nix-community/NUR/commit/0bc0cdd2a29a2983872893ea910884b3f46d13a3) | `` automatic update `` |
| [`d8f9d7df`](https://github.com/nix-community/NUR/commit/d8f9d7dff14ecf8cd1697431ae948e7c32519c2c) | `` automatic update `` |
| [`e16e94d5`](https://github.com/nix-community/NUR/commit/e16e94d5185dfe2664c11c5c50ed21ce26f5ead3) | `` automatic update `` |