### PR TITLE
chore(flake/catppuccin): `62424ccd` -> `4f56f4da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1741521711,
-        "narHash": "sha256-uV+olxh2H8GrB676m8lHpDujYVJ1K5rie6Y0GEFSMhI=",
+        "lastModified": 1741641627,
+        "narHash": "sha256-AkMboWm5a666QLh8ioLJaZlaee7oBOvkbjZZSVTU17Q=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "62424ccd65e280f3739754e0f30b85c901f6bcd9",
+        "rev": "4f56f4da1d6927eca769b78b1e22fcefd5ffaa73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                              |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`4f56f4da`](https://github.com/catppuccin/nix/commit/4f56f4da1d6927eca769b78b1e22fcefd5ffaa73) | `` fix(home-manager/rofi): update to use upstream overhaul (#494) `` |