### PR TITLE
chore(flake/emacs-ultra-scroll): `2c517bf9` -> `34a9f0df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
     "emacs-ultra-scroll": {
       "flake": false,
       "locked": {
-        "lastModified": 1737932205,
-        "narHash": "sha256-U2QTbxkch/oGdXXnzf2EPX3Ga3VYmQlnjC/JKBq5DEI=",
+        "lastModified": 1741646217,
+        "narHash": "sha256-i/0WUHjAyN0Ysq8+aDbqvX1mOEZn0e8JlO1XdXetQBE=",
         "owner": "jdtsmith",
         "repo": "ultra-scroll",
-        "rev": "2c517bf9b61bf432f706ff8a585ba453c7476be2",
+        "rev": "34a9f0dfba0fefeafd634ad4c4d1a6ed78ddd612",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                  |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
| [`34a9f0df`](https://github.com/jdtsmith/ultra-scroll/commit/34a9f0dfba0fefeafd634ad4c4d1a6ed78ddd612) | `` Correctly avoid point-min/max move at buffer begin/end ``             |
| [`b2ea02fa`](https://github.com/jdtsmith/ultra-scroll/commit/b2ea02fafe4d8ca3b444517268088f5f4a088277) | `` only move to point-min/max at beg/end of buffer when cursor hidden `` |