### PR TITLE
chore(flake/sops-nix): `3f241253` -> `e653d71e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -867,11 +867,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741043164,
-        "narHash": "sha256-9lfmSZLz6eq9Ygr6cCmvQiiBEaPb54pUBcjvbEMPORc=",
+        "lastModified": 1741644481,
+        "narHash": "sha256-E0RrMykMtEv15V3QhpsFutgoSKhL1JBhidn+iZajOyg=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "3f2412536eeece783f0d0ad3861417f347219f4d",
+        "rev": "e653d71e82575a43fe9d228def8eddb73887b866",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                         |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`e653d71e`](https://github.com/Mic92/sops-nix/commit/e653d71e82575a43fe9d228def8eddb73887b866) | `` build(deps): bump cachix/install-nix-action from 30 to 31 `` |