### PR TITLE
chore(flake/emacs-overlay): `6a25d3f9` -> `267b2c6c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1741623701,
-        "narHash": "sha256-fN1LYtj3hWyOhJ11r/u47CWLIxGwC8q5qevwSHRU2kw=",
+        "lastModified": 1742493347,
+        "narHash": "sha256-n/VMvni7SScVE54XCzKZ7dWbn5yqKFXef6n0KILhJk0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6a25d3f956603e1f18499f33951ad6f2a9fa2f6e",
+        "rev": "267b2c6c63a6bd881b2b0df3b320e480d16b2cc6",
         "type": "github"
       },
       "original": {
@@ -622,11 +622,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1741445498,
-        "narHash": "sha256-F5Em0iv/CxkN5mZ9hRn3vPknpoWdcdCyR0e4WklHwiE=",
+        "lastModified": 1742388435,
+        "narHash": "sha256-GheQGRNYAhHsvPxWVOhAmg9lZKkis22UPbEHlmZMthg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "52e3095f6d812b91b22fb7ad0bfc1ab416453634",
+        "rev": "b75693fb46bfaf09e662d09ec076c5a162efa9f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                            |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
| [`267b2c6c`](https://github.com/nix-community/emacs-overlay/commit/267b2c6c63a6bd881b2b0df3b320e480d16b2cc6) | `` Updated emacs ``                                |
| [`dbb1f4a7`](https://github.com/nix-community/emacs-overlay/commit/dbb1f4a704ad22f6ce85c6e9f2ddb17eb5d8f043) | `` Updated melpa ``                                |
| [`579f9ad9`](https://github.com/nix-community/emacs-overlay/commit/579f9ad90b9cfe0fea9c6e127558993dcb3a8a92) | `` Updated elpa ``                                 |
| [`9da82e6c`](https://github.com/nix-community/emacs-overlay/commit/9da82e6c25030b8e4d3e77b8998f5001d6ff4db7) | `` Updated nongnu ``                               |
| [`cea26be4`](https://github.com/nix-community/emacs-overlay/commit/cea26be44236b6fbcdf6a59683447297dd1d266e) | `` Updated flake inputs ``                         |
| [`2600d932`](https://github.com/nix-community/emacs-overlay/commit/2600d9324f1235740233313b9a8cec81d8f2db4b) | `` org-re-reveal: fix src hash ``                  |
| [`d8b5b164`](https://github.com/nix-community/emacs-overlay/commit/d8b5b1643d15bca3308b687918461f5f370f8c6d) | `` Updated emacs ``                                |
| [`4e90e203`](https://github.com/nix-community/emacs-overlay/commit/4e90e203bc51f2453e0b2cbe4a453fcc65d7c85f) | `` Updated melpa ``                                |
| [`2fa195d9`](https://github.com/nix-community/emacs-overlay/commit/2fa195d926963ec26b34fa463412081f93d91747) | `` Updated emacs ``                                |
| [`47ae9445`](https://github.com/nix-community/emacs-overlay/commit/47ae944500aabb8102c9588899a3b3445326bc3a) | `` Updated melpa ``                                |
| [`b95dbb1a`](https://github.com/nix-community/emacs-overlay/commit/b95dbb1a831e484036eac624fa9bb8b0e74bc8cb) | `` Updated elpa ``                                 |
| [`4e632e99`](https://github.com/nix-community/emacs-overlay/commit/4e632e99aa1352521f583b43f777c4b68111159c) | `` Updated nongnu ``                               |
| [`26e784b3`](https://github.com/nix-community/emacs-overlay/commit/26e784b36d9619a9857b6412c89969e4b83eb2a8) | `` Updated emacs ``                                |
| [`8a580131`](https://github.com/nix-community/emacs-overlay/commit/8a580131660c6c6999ddadc8bd55b487a6cce02e) | `` Updated melpa ``                                |
| [`2261955a`](https://github.com/nix-community/emacs-overlay/commit/2261955a6935c9619746629fbc2cf30078686474) | `` Updated elpa ``                                 |
| [`e1dda3fb`](https://github.com/nix-community/emacs-overlay/commit/e1dda3fbcee95d17233b6648b6c2dacabc052744) | `` Updated nongnu ``                               |
| [`f3fe04dd`](https://github.com/nix-community/emacs-overlay/commit/f3fe04dd81fa25496e9b27e3fda96d08ccbfc275) | `` Updated melpa ``                                |
| [`88e5af73`](https://github.com/nix-community/emacs-overlay/commit/88e5af734af21da9d12eeab0a59c11b8dc921599) | `` Updated flake inputs ``                         |
| [`9503dff9`](https://github.com/nix-community/emacs-overlay/commit/9503dff9b07e6980bce78c7c4c0ed2c070064cc5) | `` Updated emacs ``                                |
| [`450130c7`](https://github.com/nix-community/emacs-overlay/commit/450130c769dd6de54354c4db0409d41d0f9d2de6) | `` Updated melpa ``                                |
| [`545fa06e`](https://github.com/nix-community/emacs-overlay/commit/545fa06e94538b5ee8705199d86debb1710e73c4) | `` Updated elpa ``                                 |
| [`23c39b79`](https://github.com/nix-community/emacs-overlay/commit/23c39b791e1add67525fe83bd0b1d0f92ee75d80) | `` Updated nongnu ``                               |
| [`ad79b25b`](https://github.com/nix-community/emacs-overlay/commit/ad79b25bb65446895c811ccf348b961583649a16) | `` Updated melpa ``                                |
| [`91c89f41`](https://github.com/nix-community/emacs-overlay/commit/91c89f41cb7c5a8804a7970cdfdaf9c401db6164) | `` Updated emacs ``                                |
| [`3c75f0f3`](https://github.com/nix-community/emacs-overlay/commit/3c75f0f339d9e23c5c71ea26d67eb0ed2d5b498d) | `` Updated melpa ``                                |
| [`ecaf1d4d`](https://github.com/nix-community/emacs-overlay/commit/ecaf1d4d12cd4a6007bc73674d3398aa806c3993) | `` Updated elpa ``                                 |
| [`af4abc35`](https://github.com/nix-community/emacs-overlay/commit/af4abc353d2dc12aa0971ccfb10c2db76a692529) | `` Updated nongnu ``                               |
| [`006123de`](https://github.com/nix-community/emacs-overlay/commit/006123de77fdafa8748b365ea7abdb514421f223) | `` Updated flake inputs ``                         |
| [`b856b055`](https://github.com/nix-community/emacs-overlay/commit/b856b055ef825bb78a4b0a488f693ac78b1301ce) | `` Revert ".github: pin Nix 2.24.12 for CI" ``     |
| [`3d30a184`](https://github.com/nix-community/emacs-overlay/commit/3d30a184b68deddb95990a24c95f821f82c5abbe) | `` Bump cachix/install-nix-action from 30 to 31 `` |
| [`8b2e6a35`](https://github.com/nix-community/emacs-overlay/commit/8b2e6a35c25a495311acd41f4115daa543a50709) | `` Updated emacs ``                                |
| [`3e29088f`](https://github.com/nix-community/emacs-overlay/commit/3e29088fe999648dca4a09293367626c4000cedd) | `` Updated melpa ``                                |
| [`771324e4`](https://github.com/nix-community/emacs-overlay/commit/771324e439b2e58fdac19801f311fb04ba780fd9) | `` Updated elpa ``                                 |
| [`406d2a3d`](https://github.com/nix-community/emacs-overlay/commit/406d2a3d0cfdc4dc5c0476b19773927e477229ab) | `` Updated nongnu ``                               |
| [`d706c55c`](https://github.com/nix-community/emacs-overlay/commit/d706c55c58c012dc917be46b9f973b048ea4cb53) | `` Updated nongnu ``                               |
| [`dc8481f1`](https://github.com/nix-community/emacs-overlay/commit/dc8481f18cdb6d7b3b02b95419059f60b982f12b) | `` Bump cachix/cachix-action from 15 to 16 ``      |
| [`7a9a2538`](https://github.com/nix-community/emacs-overlay/commit/7a9a25389a6ad9402f9aa5087ccb36f8383045a8) | `` Updated emacs ``                                |
| [`5d5c1f6f`](https://github.com/nix-community/emacs-overlay/commit/5d5c1f6fdce7fab42ee84bc94eb3e39f112fc42f) | `` Updated melpa ``                                |
| [`a06c25da`](https://github.com/nix-community/emacs-overlay/commit/a06c25dabe2db425e5c0e9a6a56371bc9886337c) | `` Updated emacs ``                                |
| [`7f3451c7`](https://github.com/nix-community/emacs-overlay/commit/7f3451c7f055d88e4df22b19620885022cbb3c7e) | `` Updated melpa ``                                |
| [`961e2380`](https://github.com/nix-community/emacs-overlay/commit/961e23802247c5580ef4a2106dbcf187d88622a6) | `` Updated elpa ``                                 |
| [`fe7f0c0f`](https://github.com/nix-community/emacs-overlay/commit/fe7f0c0f04123a4a9f2eed3276fa9d23a7e50f58) | `` Updated nongnu ``                               |
| [`a9700718`](https://github.com/nix-community/emacs-overlay/commit/a9700718d9e66273b3600a5313d6cf745fdcc069) | `` Updated flake inputs ``                         |
| [`1f50951e`](https://github.com/nix-community/emacs-overlay/commit/1f50951e95b896fb6fbe9388914d4838909e91b1) | `` Updated fromElisp ``                            |
| [`e2e02bea`](https://github.com/nix-community/emacs-overlay/commit/e2e02bea39ae8e7e48a40e476ffec438e181d930) | `` Updated flake inputs ``                         |
| [`c799d9c6`](https://github.com/nix-community/emacs-overlay/commit/c799d9c6c955de5a698373b0ebb96daa7c8063ce) | `` Updated emacs ``                                |
| [`d1e4a12b`](https://github.com/nix-community/emacs-overlay/commit/d1e4a12b288c9402139ab409460620d11d1b88ae) | `` Updated melpa ``                                |
| [`7e13aa50`](https://github.com/nix-community/emacs-overlay/commit/7e13aa507d714371e6ff70a91d76dcb339311773) | `` Updated fromElisp ``                            |
| [`e138db11`](https://github.com/nix-community/emacs-overlay/commit/e138db11982437a66216ac559de564728e42c4a2) | `` Updated elpa ``                                 |
| [`bcadbffd`](https://github.com/nix-community/emacs-overlay/commit/bcadbffd57a2160d2cf5089adcfa47d50594d36f) | `` Updated emacs ``                                |
| [`a5846781`](https://github.com/nix-community/emacs-overlay/commit/a5846781f6570a46af25337bddadfc4b50b59af8) | `` Updated melpa ``                                |
| [`7c8613e3`](https://github.com/nix-community/emacs-overlay/commit/7c8613e351a14fb3a5f4c61c365e067530a72217) | `` Updated elpa ``                                 |
| [`9a878feb`](https://github.com/nix-community/emacs-overlay/commit/9a878febfcb31d35a4b33a6b30a8c9d276f8a84c) | `` Updated nongnu ``                               |
| [`5ca8419d`](https://github.com/nix-community/emacs-overlay/commit/5ca8419dfc9f6c451aa9bfee0f37ff28c9582774) | `` Updated emacs ``                                |
| [`4ecca5ba`](https://github.com/nix-community/emacs-overlay/commit/4ecca5ba1a749e52e1f5f927d89e620f9a14f9d7) | `` Updated melpa ``                                |
| [`d72523e2`](https://github.com/nix-community/emacs-overlay/commit/d72523e2f7238ebce18f06c018e954d5131de6c3) | `` Updated elpa ``                                 |
| [`5d6c4842`](https://github.com/nix-community/emacs-overlay/commit/5d6c484290f0754ce745ea6f7e2b7d037bdc7b76) | `` Updated emacs ``                                |
| [`b43e58ca`](https://github.com/nix-community/emacs-overlay/commit/b43e58ca70f2b494e1b91d82893a36bc2b7ff9b3) | `` Updated melpa ``                                |
| [`efab8094`](https://github.com/nix-community/emacs-overlay/commit/efab809432104b6f93d3903aa47e6fbbe2939038) | `` Updated emacs ``                                |
| [`3fb47ca2`](https://github.com/nix-community/emacs-overlay/commit/3fb47ca23e2fa45d30eedcf2219552385f91b596) | `` Updated melpa ``                                |
| [`dbc622fe`](https://github.com/nix-community/emacs-overlay/commit/dbc622fee56f7de989ed34c8603e4be3a72133bf) | `` Updated elpa ``                                 |
| [`e4dd6105`](https://github.com/nix-community/emacs-overlay/commit/e4dd610561afe502e72918f6bc1e4070e3443d8d) | `` Updated nongnu ``                               |
| [`4d008ab4`](https://github.com/nix-community/emacs-overlay/commit/4d008ab4feb8d398819ae2a23565b81f395e86f6) | `` Updated flake inputs ``                         |
| [`7066864e`](https://github.com/nix-community/emacs-overlay/commit/7066864e5344c117e53320bfa798e9131b0eb5db) | `` Updated emacs ``                                |
| [`da88eada`](https://github.com/nix-community/emacs-overlay/commit/da88eadabf11bf42cbc5dd35dc8a572635c04d7f) | `` Updated melpa ``                                |
| [`755cb642`](https://github.com/nix-community/emacs-overlay/commit/755cb6420c7bc3b9c55aaf54568e090c1b2903a5) | `` Updated elpa ``                                 |
| [`1b0330de`](https://github.com/nix-community/emacs-overlay/commit/1b0330deb5dcd993d934c4380e1ecd96e87bd162) | `` Updated nongnu ``                               |
| [`ae149842`](https://github.com/nix-community/emacs-overlay/commit/ae149842faeb725ee444f0eed5ec8eb0861b8d0d) | `` Updated flake inputs ``                         |
| [`3ec299dc`](https://github.com/nix-community/emacs-overlay/commit/3ec299dc7f35c1c6164859777321d1b1f0305ad3) | `` Updated emacs ``                                |
| [`80ae1125`](https://github.com/nix-community/emacs-overlay/commit/80ae11251c3bb81474e9e14a4cd77fecb726ef17) | `` Updated melpa ``                                |
| [`34c2a5d9`](https://github.com/nix-community/emacs-overlay/commit/34c2a5d93606f6f952c34a85e5346029869bd8f0) | `` Updated emacs ``                                |
| [`e2499376`](https://github.com/nix-community/emacs-overlay/commit/e2499376503d31b4a263a9820bcd64b8f3430f83) | `` Updated melpa ``                                |
| [`1c31da84`](https://github.com/nix-community/emacs-overlay/commit/1c31da84e07ab95cb1bb5c26c4e9ddbe94725584) | `` Updated elpa ``                                 |
| [`d35b8422`](https://github.com/nix-community/emacs-overlay/commit/d35b8422e591b87bef34382a01258eb4f32b2f23) | `` Updated nongnu ``                               |
| [`e69c9add`](https://github.com/nix-community/emacs-overlay/commit/e69c9add9acc10220d9679f4f3ca34ea01a4c7be) | `` Updated emacs ``                                |
| [`db5b856b`](https://github.com/nix-community/emacs-overlay/commit/db5b856bb02ebb6abd621aa00e7664ff357c6d68) | `` Updated melpa ``                                |
| [`cfe450e7`](https://github.com/nix-community/emacs-overlay/commit/cfe450e7c41c66aa5b87c855b72d8e2969907fae) | `` Updated elpa ``                                 |
| [`1000f664`](https://github.com/nix-community/emacs-overlay/commit/1000f6646f2167d50c6493d920a16e75c27dd926) | `` Updated nongnu ``                               |
| [`04d8748d`](https://github.com/nix-community/emacs-overlay/commit/04d8748de599621ca0ae7f9766c489adf45d63de) | `` Updated emacs ``                                |
| [`92655efb`](https://github.com/nix-community/emacs-overlay/commit/92655efb6a543af855d9ee117a4836139d4fe0ea) | `` Updated melpa ``                                |
| [`dd4b8102`](https://github.com/nix-community/emacs-overlay/commit/dd4b810268262c2790475a7bb4f2583c292f1ee4) | `` Updated emacs ``                                |
| [`14a84d58`](https://github.com/nix-community/emacs-overlay/commit/14a84d587dc86a10542329f6f15df8db8d56d52b) | `` Updated melpa ``                                |
| [`c46bbc0d`](https://github.com/nix-community/emacs-overlay/commit/c46bbc0d6dd03af88ae94f62cf74fc7a309d0a11) | `` Updated elpa ``                                 |
| [`e4e75569`](https://github.com/nix-community/emacs-overlay/commit/e4e7556964ff3cffd494fb1015f6655129011e59) | `` Updated nongnu ``                               |
| [`2695d538`](https://github.com/nix-community/emacs-overlay/commit/2695d53827b4200a195f932a5beb47fe5f9e3213) | `` Updated elpa ``                                 |
| [`eda1672f`](https://github.com/nix-community/emacs-overlay/commit/eda1672f7c1062ffa7bd9392c3796a45ee5f7b63) | `` Updated nongnu ``                               |
| [`04892169`](https://github.com/nix-community/emacs-overlay/commit/04892169ec614a3ddeb1ca4a8e6a86e9d410d30c) | `` starhugger: fix src hash ``                     |
| [`5fdeee5c`](https://github.com/nix-community/emacs-overlay/commit/5fdeee5cee62b5f5b09f9d0c7a103f1c5c426d2b) | `` Updated emacs ``                                |
| [`2886bb1f`](https://github.com/nix-community/emacs-overlay/commit/2886bb1fa37af55db9eed88505917930fc82bcd4) | `` Updated melpa ``                                |
| [`84fbb394`](https://github.com/nix-community/emacs-overlay/commit/84fbb394e473b356dab59820a185d13feffb7203) | `` Updated flake inputs ``                         |
| [`e6acc432`](https://github.com/nix-community/emacs-overlay/commit/e6acc4327ba98ade994a6b804b01ab5087726ce2) | `` Updated emacs ``                                |
| [`b8093212`](https://github.com/nix-community/emacs-overlay/commit/b8093212f99e5d41e077a65bd4d21fd81f5cb092) | `` Updated melpa ``                                |
| [`6cdcd31f`](https://github.com/nix-community/emacs-overlay/commit/6cdcd31f6f9d252a2c94eac01e6e23696bc3d0ff) | `` Updated elpa ``                                 |
| [`37428a43`](https://github.com/nix-community/emacs-overlay/commit/37428a4344c0ce40b09431787190fdb4cbb5c296) | `` Updated nongnu ``                               |
| [`706c0b0f`](https://github.com/nix-community/emacs-overlay/commit/706c0b0f6f2abe59c8e3071366e9fcedeb2bb641) | `` Updated flake inputs ``                         |