### PR TITLE
chore(flake/nur): `2f760664` -> `d773f491`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1741649763,
-        "narHash": "sha256-436Es6IDqrUukz5VLjRP41F/znZPFZEz274s6phBR5o=",
+        "lastModified": 1741665021,
+        "narHash": "sha256-9dA0dL29jf9xcNarQaIgrVWqWS+FCmmGlpQktGgT7xE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2f76066428491220b7bd46388ac1e8e9d1ead805",
+        "rev": "d773f491f5017f7c7d617db22f5ee15a7371009e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d773f491`](https://github.com/nix-community/NUR/commit/d773f491f5017f7c7d617db22f5ee15a7371009e) | `` automatic update `` |
| [`2cae3f91`](https://github.com/nix-community/NUR/commit/2cae3f9192726e8f69f9ed49687799c6b2235358) | `` automatic update `` |
| [`1f7a8029`](https://github.com/nix-community/NUR/commit/1f7a8029468c23a2e0ec0f65f259f37c56d17cae) | `` automatic update `` |
| [`a8b04150`](https://github.com/nix-community/NUR/commit/a8b0415080654d0ce22aa0914c41195886ce6e29) | `` automatic update `` |
| [`6af72914`](https://github.com/nix-community/NUR/commit/6af7291432ebfd85e4a0ba269b7875af625cbef6) | `` automatic update `` |
| [`ab6a12d9`](https://github.com/nix-community/NUR/commit/ab6a12d9298c5c7cae81207f7d0bf258b6e3d253) | `` automatic update `` |
| [`113c5364`](https://github.com/nix-community/NUR/commit/113c5364a110ef7340bb50536b457240ad453b64) | `` automatic update `` |