### PR TITLE
chore(flake/nur): `d773f491` -> `0da9e382`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1741665021,
-        "narHash": "sha256-9dA0dL29jf9xcNarQaIgrVWqWS+FCmmGlpQktGgT7xE=",
+        "lastModified": 1741670434,
+        "narHash": "sha256-/HwQwLHJVGHSnxiQJTu6c5m8YwS1tl3KVt3fBVrNkGk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d773f491f5017f7c7d617db22f5ee15a7371009e",
+        "rev": "0da9e38262198c1a7b674c8fefdff5184dacaae6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0da9e382`](https://github.com/nix-community/NUR/commit/0da9e38262198c1a7b674c8fefdff5184dacaae6) | `` automatic update `` |
| [`51aadf1e`](https://github.com/nix-community/NUR/commit/51aadf1e1dfb8bd3f30c59f6097ad4ea67d64fa3) | `` automatic update `` |