### PR TITLE
chore(flake/nur): `0da9e382` -> `5479646b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1741670434,
-        "narHash": "sha256-/HwQwLHJVGHSnxiQJTu6c5m8YwS1tl3KVt3fBVrNkGk=",
+        "lastModified": 1741693509,
+        "narHash": "sha256-emkxnsZstiJWmGACimyAYqIKz2Qz5We5h1oBVDyQjLw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0da9e38262198c1a7b674c8fefdff5184dacaae6",
+        "rev": "5479646b2574837f1899da78bdf9a48b75a9fb27",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5479646b`](https://github.com/nix-community/NUR/commit/5479646b2574837f1899da78bdf9a48b75a9fb27) | `` automatic update `` |
| [`f1b3ba0c`](https://github.com/nix-community/NUR/commit/f1b3ba0c23233b402b4df174d9e7cc5933e2a53b) | `` automatic update `` |
| [`2f70b3b5`](https://github.com/nix-community/NUR/commit/2f70b3b55e84c938f3b54c1fb9b8400d18371de6) | `` automatic update `` |
| [`0e25def7`](https://github.com/nix-community/NUR/commit/0e25def7d13e0c2579b8f148e2fc338ae5fcfd3a) | `` automatic update `` |
| [`4afac9fd`](https://github.com/nix-community/NUR/commit/4afac9fd5f7f0860eedf75b3101d1149593b8dc0) | `` automatic update `` |
| [`bc6ad74f`](https://github.com/nix-community/NUR/commit/bc6ad74f6fba9f8a80752af4ccf26a50594e57c9) | `` automatic update `` |