### PR TITLE
chore(flake/home-manager): `7fb86787` -> `c630dfa8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741635347,
-        "narHash": "sha256-2aYfV44h18alHXopyfL4D9GsnpE5XlSVkp4MGe586VU=",
+        "lastModified": 1741701235,
+        "narHash": "sha256-gBlb8R9gnjUAT5XabJeel3C2iEUiBHx3+91651y3Sqo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7fb8678716c158642ac42f9ff7a18c0800fea551",
+        "rev": "c630dfa8abcc65984cc1e47fb25d4552c81dd37e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`c630dfa8`](https://github.com/nix-community/home-manager/commit/c630dfa8abcc65984cc1e47fb25d4552c81dd37e) | `` nix-darwin: respect username setting of home-manager in activation script (#5881) `` |
| [`7fd6dc2b`](https://github.com/nix-community/home-manager/commit/7fd6dc2b94f10b0229f5e6b8fd5ed49636f895e1) | `` granted: fix fish shell integration (#6602) ``                                       |