### PR TITLE
chore(flake/nur): `5479646b` -> `20ff961c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1741693509,
-        "narHash": "sha256-emkxnsZstiJWmGACimyAYqIKz2Qz5We5h1oBVDyQjLw=",
+        "lastModified": 1741723036,
+        "narHash": "sha256-L9tVnZpa6Cb0DgSStIbV5QPRAQ8F94UvKcfiQ1ZZSAA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5479646b2574837f1899da78bdf9a48b75a9fb27",
+        "rev": "20ff961c7fbaf9ecb7a808c0e27bb0984d93f74f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`20ff961c`](https://github.com/nix-community/NUR/commit/20ff961c7fbaf9ecb7a808c0e27bb0984d93f74f) | `` automatic update `` |
| [`6815862f`](https://github.com/nix-community/NUR/commit/6815862fd9f8ff0d9d86eaf129e7eb5035523672) | `` automatic update `` |
| [`8b11b9a4`](https://github.com/nix-community/NUR/commit/8b11b9a4659beffac7c339bf10065c094015a82a) | `` automatic update `` |
| [`585fafac`](https://github.com/nix-community/NUR/commit/585fafac07c32136039918d7ce45022dbed171f5) | `` automatic update `` |
| [`2154142f`](https://github.com/nix-community/NUR/commit/2154142facaa23e5e4e5bfc865eef42c66886eec) | `` automatic update `` |
| [`ca3f17f8`](https://github.com/nix-community/NUR/commit/ca3f17f88592090d829aca17f6e30f7f5d07fb35) | `` automatic update `` |
| [`c40eaab1`](https://github.com/nix-community/NUR/commit/c40eaab12dfd5b7144abac933166d4aac4322102) | `` automatic update `` |