### PR TITLE
chore(flake/catppuccin): `4f56f4da` -> `a3f70463`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1741641627,
-        "narHash": "sha256-AkMboWm5a666QLh8ioLJaZlaee7oBOvkbjZZSVTU17Q=",
+        "lastModified": 1741732420,
+        "narHash": "sha256-szO/TCc+UrjEtxi4K3GyoAv5/DKDkUeRtpTZTJY+zI4=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "4f56f4da1d6927eca769b78b1e22fcefd5ffaa73",
+        "rev": "a3f70463fb5e3df32d2d52a2705606db03843de2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                         |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`a3f70463`](https://github.com/catppuccin/nix/commit/a3f70463fb5e3df32d2d52a2705606db03843de2) | `` refactor: add `catppuccin-` prefix to `buildCatppuccinPort` pnames (#492) `` |