### PR TITLE
chore(flake/nur): `20ff961c` -> `8e4cfd0f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1741723036,
-        "narHash": "sha256-L9tVnZpa6Cb0DgSStIbV5QPRAQ8F94UvKcfiQ1ZZSAA=",
+        "lastModified": 1741736710,
+        "narHash": "sha256-d8KB6FWkS/MbvLPwErBLu/rYeEqMr5ol9NR4IvTyft8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "20ff961c7fbaf9ecb7a808c0e27bb0984d93f74f",
+        "rev": "8e4cfd0f0393746e75cee200fce2307e66f59d2e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8e4cfd0f`](https://github.com/nix-community/NUR/commit/8e4cfd0f0393746e75cee200fce2307e66f59d2e) | `` automatic update `` |
| [`125409ce`](https://github.com/nix-community/NUR/commit/125409ce15661c24a936950668c93bbebe9026b7) | `` automatic update `` |
| [`b88b728a`](https://github.com/nix-community/NUR/commit/b88b728a7ab8626af4e89920a6133d3b4f0ecc29) | `` automatic update `` |
| [`122e9d68`](https://github.com/nix-community/NUR/commit/122e9d68505de4d1ee2db7544bd3dbf2dd08338b) | `` automatic update `` |