### PR TITLE
chore(flake/nur): `8e4cfd0f` -> `5dc38ad5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1741736710,
-        "narHash": "sha256-d8KB6FWkS/MbvLPwErBLu/rYeEqMr5ol9NR4IvTyft8=",
+        "lastModified": 1741751159,
+        "narHash": "sha256-7TR5dtgSS8Hcp9aQsOSWXqrIjwUzItEkDMCwUYUx9eU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8e4cfd0f0393746e75cee200fce2307e66f59d2e",
+        "rev": "5dc38ad58a0233151ebb76386ee6ca36d1b5874f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5dc38ad5`](https://github.com/nix-community/NUR/commit/5dc38ad58a0233151ebb76386ee6ca36d1b5874f) | `` automatic update `` |
| [`2187d4db`](https://github.com/nix-community/NUR/commit/2187d4db355cd7867bad622ecdcc1d46a7ff36e2) | `` automatic update `` |
| [`2c449a11`](https://github.com/nix-community/NUR/commit/2c449a114bfdbe8760dd5352dc01f541a682d4c0) | `` automatic update `` |