### PR TITLE
chore(flake/nur): `41711da5` -> `cfc7df80`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1741773644,
-        "narHash": "sha256-H4aGuVAtHoth6K7vEA+G6r4pgxjgzxxO8fbOJguAquc=",
+        "lastModified": 1741793676,
+        "narHash": "sha256-WUs3G667A+j0ZX835XFh/W761w00l4Y3iwOVgkLMX98=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "41711da5b46e12b73d59cba152a3a50a50184fe2",
+        "rev": "cfc7df80bd722fad88b5ca248ae56252987b8650",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cfc7df80`](https://github.com/nix-community/NUR/commit/cfc7df80bd722fad88b5ca248ae56252987b8650) | `` automatic update `` |
| [`099284ae`](https://github.com/nix-community/NUR/commit/099284ae486850bcaf8e5481a83644d33b7da03c) | `` automatic update `` |
| [`e5191b50`](https://github.com/nix-community/NUR/commit/e5191b50528b586d65ae4f0ac5634a9fb9478175) | `` automatic update `` |
| [`f0f50544`](https://github.com/nix-community/NUR/commit/f0f5054482a333a56d17f5f1ff8e9c2022c4f6fa) | `` automatic update `` |