### PR TITLE
chore(flake/nixos-hardware): `b48cc4da` -> `e1f12151`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -528,11 +528,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1741325094,
-        "narHash": "sha256-RUAdT8dZ6k/486vnu3tiNRrNW6+Q8uSD2Mq7gTX4jlo=",
+        "lastModified": 1741792691,
+        "narHash": "sha256-f0BVt1/cvA0DQ/q3rB+HY4g4tKksd03ZkzI4xehC2Ew=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "b48cc4dab0f9711af296fc367b6108cf7b8ccb16",
+        "rev": "e1f12151258b12c567f456d8248e4694e9390613",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`e1f12151`](https://github.com/NixOS/nixos-hardware/commit/e1f12151258b12c567f456d8248e4694e9390613) | `` refactor: add model to outputs ``                   |
| [`09e97074`](https://github.com/NixOS/nixos-hardware/commit/09e97074ad78706156e8c8d380b8196a602ef719) | `` refactor: add generic laptop spec ``                |
| [`1b1acdc3`](https://github.com/NixOS/nixos-hardware/commit/1b1acdc3e7e4b2e4b5f07430392939e19a90fb8a) | `` init ``                                             |
| [`de70a293`](https://github.com/NixOS/nixos-hardware/commit/de70a293ae40aebe74545017d1dd76c3c81353a3) | `` Adjust README after suspend fix reimplementation `` |
| [`b416c1d5`](https://github.com/NixOS/nixos-hardware/commit/b416c1d56f33bf902625b2cd0ee43dbc59fc64dd) | `` Simplify implementation of B550 suspend fix ``      |
| [`59314eb9`](https://github.com/NixOS/nixos-hardware/commit/59314eb9f5f542af1866ae8706ac9816542fc104) | `` surface: linux 6.12.17 -> 6.12.18 ``                |
| [`14f45c1a`](https://github.com/NixOS/nixos-hardware/commit/14f45c1a639118ec3e08ebd18285895fb5dc8ad9) | `` gpd-win-max-2-2023/bmi260: 1.0.0 -> 1.1.0 ``        |
| [`d25dac1b`](https://github.com/NixOS/nixos-hardware/commit/d25dac1bd5eed6fbf67eb79d1f15d624e5a2c032) | `` dell/xps/13-9350: use lunar-lake cpu config ``      |