### PR TITLE
chore(flake/nur): `cfc7df80` -> `1cf77528`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -685,11 +685,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1741513245,
-        "narHash": "sha256-7rTAMNTY1xoBwz0h7ZMtEcd8LELk9R5TzBPoHuhNSCk=",
+        "lastModified": 1741851582,
+        "narHash": "sha256-cPfs8qMccim2RBgtKGF+x9IBCduRvd/N5F4nYpU0TVE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e3e32b642a31e6714ec1b712de8c91a3352ce7e1",
+        "rev": "6607cf789e541e7873d40d3a8f7815ea92204f32",
         "type": "github"
       },
       "original": {
@@ -776,11 +776,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1741793676,
-        "narHash": "sha256-WUs3G667A+j0ZX835XFh/W761w00l4Y3iwOVgkLMX98=",
+        "lastModified": 1741895983,
+        "narHash": "sha256-7CqlVqSsc/H4dy0P034L0IrWzueShNR3fvN6GQQE2E0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cfc7df80bd722fad88b5ca248ae56252987b8650",
+        "rev": "1cf775289a4bd43ebeae46cc351d200aa4ed1c04",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1cf77528`](https://github.com/nix-community/NUR/commit/1cf775289a4bd43ebeae46cc351d200aa4ed1c04) | `` automatic update `` |
| [`f4a8aa6a`](https://github.com/nix-community/NUR/commit/f4a8aa6a770e06de61e20f2c067f5271b309e49e) | `` automatic update `` |
| [`bdfd1a6d`](https://github.com/nix-community/NUR/commit/bdfd1a6dd2b5c8295de741a151062c2a3fb13830) | `` automatic update `` |
| [`2ac2be6a`](https://github.com/nix-community/NUR/commit/2ac2be6a5936459018f10608b723487468a13f56) | `` automatic update `` |
| [`e4c83877`](https://github.com/nix-community/NUR/commit/e4c83877ba34196738717c257f9937eeabcc7dc7) | `` automatic update `` |
| [`977a54a6`](https://github.com/nix-community/NUR/commit/977a54a6e8847c5b84d4de77b16bcb866083c6e0) | `` automatic update `` |
| [`f4fccef7`](https://github.com/nix-community/NUR/commit/f4fccef789ea96ba0f3d894c4129ba4e587dd7e7) | `` automatic update `` |
| [`b795c62e`](https://github.com/nix-community/NUR/commit/b795c62ea2169d66f07ccca387b2b504ba152726) | `` automatic update `` |
| [`bf5fd1f0`](https://github.com/nix-community/NUR/commit/bf5fd1f0d255150dab7a4733dc491a26fff06e62) | `` automatic update `` |
| [`1b8a790d`](https://github.com/nix-community/NUR/commit/1b8a790d56c967332f735b8212602b95916fe251) | `` automatic update `` |
| [`127448d0`](https://github.com/nix-community/NUR/commit/127448d05a0d15a884c56d2a3ee4a4934fb491ff) | `` automatic update `` |
| [`47ff3c65`](https://github.com/nix-community/NUR/commit/47ff3c651973e2c6bd032e76a39d8c5e35bae606) | `` automatic update `` |
| [`614d1be9`](https://github.com/nix-community/NUR/commit/614d1be9e5d14cef04bf41fbff1582f0af84a6f8) | `` automatic update `` |
| [`c2cc26ba`](https://github.com/nix-community/NUR/commit/c2cc26baf582a31d857a683b2d8630125b82eb58) | `` automatic update `` |
| [`1f6284e6`](https://github.com/nix-community/NUR/commit/1f6284e68b2c833739803a42047e70e54e3c13f9) | `` automatic update `` |
| [`2c751123`](https://github.com/nix-community/NUR/commit/2c75112374dbe0f3f54f32aeb434f1eb0010f44c) | `` automatic update `` |
| [`06cb2447`](https://github.com/nix-community/NUR/commit/06cb244758948fe93dda13e6e0e55a5840b4cee0) | `` automatic update `` |
| [`dfbd07b6`](https://github.com/nix-community/NUR/commit/dfbd07b60849d0933964fb59d54265d71ff2a9a9) | `` automatic update `` |
| [`a7b60a3f`](https://github.com/nix-community/NUR/commit/a7b60a3f55f441b43501f831279bf27b810e95b1) | `` automatic update `` |
| [`344e64c2`](https://github.com/nix-community/NUR/commit/344e64c21d194c4ce7e215c0de2e292c032494df) | `` automatic update `` |
| [`abfbfa17`](https://github.com/nix-community/NUR/commit/abfbfa1720a4f70135d54d2f935104eaff184b25) | `` automatic update `` |
| [`dd94f95c`](https://github.com/nix-community/NUR/commit/dd94f95c9666a8bd70e0ee4f376152ad5a568676) | `` automatic update `` |
| [`231e0cbf`](https://github.com/nix-community/NUR/commit/231e0cbf9316bad58e12f8efe3c904a6dcc771b9) | `` automatic update `` |
| [`d546b266`](https://github.com/nix-community/NUR/commit/d546b26605c072ac5907e060696cff3176e8f652) | `` automatic update `` |
| [`33bbd4d1`](https://github.com/nix-community/NUR/commit/33bbd4d164ae43114c8fab141a0b1e7e356061bd) | `` automatic update `` |
| [`0ebe8705`](https://github.com/nix-community/NUR/commit/0ebe870599022881b924860a7c9cd930df899474) | `` automatic update `` |
| [`36029b62`](https://github.com/nix-community/NUR/commit/36029b628f984761489d94e2fde942a9c0c375bf) | `` automatic update `` |
| [`8a38b29f`](https://github.com/nix-community/NUR/commit/8a38b29f38afb374c33123fd0d0128cab36a1ea4) | `` automatic update `` |
| [`66c039b0`](https://github.com/nix-community/NUR/commit/66c039b079bb6f30a4df398fc3b89059f45a86a4) | `` automatic update `` |
| [`3664b6ac`](https://github.com/nix-community/NUR/commit/3664b6acb64e66f8412f7fb3e4a18148e5c39fdd) | `` automatic update `` |
| [`1c477154`](https://github.com/nix-community/NUR/commit/1c47715436da3942b8e33031658701259dc92a22) | `` automatic update `` |
| [`cc8a747d`](https://github.com/nix-community/NUR/commit/cc8a747d5bf8dc0d9ec24fde5bb2ce8d9c00a23c) | `` automatic update `` |
| [`bef2349a`](https://github.com/nix-community/NUR/commit/bef2349ace6ed06c9a021d479e30f42925b50da9) | `` automatic update `` |
| [`d3ceec8b`](https://github.com/nix-community/NUR/commit/d3ceec8ba01e8982846f7a1f2ac1cd3f04fc84c3) | `` automatic update `` |
| [`9322e4e6`](https://github.com/nix-community/NUR/commit/9322e4e649aea20192d98c035dbc47a8556ca306) | `` automatic update `` |
| [`06135b1b`](https://github.com/nix-community/NUR/commit/06135b1b2ab920078528dad67e0a210edf890c7a) | `` automatic update `` |
| [`0b3c59f8`](https://github.com/nix-community/NUR/commit/0b3c59f8fdf55e33f119328f0d91efcc0e22675d) | `` automatic update `` |
| [`aaf66ba0`](https://github.com/nix-community/NUR/commit/aaf66ba0016cd5789d5b7ac0fdd0a80fe65a5380) | `` automatic update `` |