### PR TITLE
chore(flake/catppuccin): `a3f70463` -> `50abeb97`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1741732420,
-        "narHash": "sha256-szO/TCc+UrjEtxi4K3GyoAv5/DKDkUeRtpTZTJY+zI4=",
+        "lastModified": 1741860468,
+        "narHash": "sha256-ArG3mnjHmcal5ny72VZvCqHchz9RsWiUBCRSGS0FXlA=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "a3f70463fb5e3df32d2d52a2705606db03843de2",
+        "rev": "50abeb976eb85fe6695a2888ec4c274675563c15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                             |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`50abeb97`](https://github.com/catppuccin/nix/commit/50abeb976eb85fe6695a2888ec4c274675563c15) | `` fix(docs): theming  (#498) ``                    |
| [`da6d4151`](https://github.com/catppuccin/nix/commit/da6d41516d7b70799b3c1d9b2d9e7731c5f8cb04) | `` fix(pkgs/rofi): remove import at build (#497) `` |