### PR TITLE
chore(flake/sops-nix): `e653d71e` -> `d016ce03`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -867,11 +867,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741644481,
-        "narHash": "sha256-E0RrMykMtEv15V3QhpsFutgoSKhL1JBhidn+iZajOyg=",
+        "lastModified": 1741861888,
+        "narHash": "sha256-ynOgXAyToeE1UdLNfrUn/hL7MN0OpIS2BtNdLjpjPf0=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "e653d71e82575a43fe9d228def8eddb73887b866",
+        "rev": "d016ce0365b87d848a57c12ffcfdc71da7a2b55f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                   |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`e0f3d6e7`](https://github.com/Mic92/sops-nix/commit/e0f3d6e7ec3c248f6f1fd46f4d51648bad3ff3ce) | `` update vendorHash ``                                                   |
| [`7f175df5`](https://github.com/Mic92/sops-nix/commit/7f175df5508d01edfd540180340c8e3e0aa27edd) | `` build(deps): bump github.com/go-jose/go-jose/v4 from 4.0.4 to 4.0.5 `` |
| [`c3640e8b`](https://github.com/Mic92/sops-nix/commit/c3640e8b1c529593c104555c47f1a0ad8ea1c9b0) | `` update vendorHash ``                                                   |
| [`76a1a68e`](https://github.com/Mic92/sops-nix/commit/76a1a68e41157b9f6aa92ad4bd67c60542196a73) | `` build(deps): bump github.com/getsops/sops/v3 from 3.8.1 to 3.9.4 ``    |
| [`33c99f6c`](https://github.com/Mic92/sops-nix/commit/33c99f6cc9268eea2aad72deef1955a0f0317027) | `` ci/update-vendor-hash: use github app token ``                         |
| [`ec6368b3`](https://github.com/Mic92/sops-nix/commit/ec6368b3fb872462b78848f6fd8bac65ed1ce7af) | `` dependabot: limit open pull request for go ``                          |
| [`2f9b8fff`](https://github.com/Mic92/sops-nix/commit/2f9b8fff01d5a1ca0690e6dbfeba12cc38a20688) | `` upgrade-flakes: use github app ``                                      |
| [`d202efd6`](https://github.com/Mic92/sops-nix/commit/d202efd6b8f956c3558206ef926d1aa3945c1f6d) | `` add auto-merge ``                                                      |
| [`5bdbe5d6`](https://github.com/Mic92/sops-nix/commit/5bdbe5d68765daeaf50ec4fe9fd36054f223eb16) | `` replace mergify with merge queues ``                                   |
| [`d4381259`](https://github.com/Mic92/sops-nix/commit/d438125960f6d6ec61f33a9230f9ab3bd6264333) | `` bump nixpkgs ``                                                        |
| [`ff242449`](https://github.com/Mic92/sops-nix/commit/ff242449204e3381c05998b26d70476ff901abe7) | `` update vendorHash ``                                                   |
| [`d9fb8607`](https://github.com/Mic92/sops-nix/commit/d9fb8607a9bea73300758af16f7b3a3a2a37a326) | `` build(deps): bump golang.org/x/net from 0.33.0 to 0.36.0 ``            |
| [`c2769e75`](https://github.com/Mic92/sops-nix/commit/c2769e75cb1003029b6fcac96cf2b9aabf5550ab) | `` build(deps): bump golang.org/x/crypto from 0.33.0 to 0.36.0 ``         |
| [`d47dc04f`](https://github.com/Mic92/sops-nix/commit/d47dc04fb1eb4cc9460991e940a6f55914fed04a) | `` build(deps): bump golang.org/x/sys from 0.30.0 to 0.31.0 ``            |
| [`490ce28c`](https://github.com/Mic92/sops-nix/commit/490ce28c2974e5cbda9da2e4a4c591d05fee60a6) | `` scripts/update-vendor-hash.sh: run go mod tidy ``                      |
| [`432671f1`](https://github.com/Mic92/sops-nix/commit/432671f1900b3e200edf33f7503512efe017dfe9) | `` Fix After example ``                                                   |
| [`cbad8dc5`](https://github.com/Mic92/sops-nix/commit/cbad8dc5ef5aa80544e069ade52e79ff46539978) | `` Add default home-manager module ``                                     |