### PR TITLE
chore(flake/home-manager): `18780912` -> `30cce684`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741791118,
-        "narHash": "sha256-4Y427uj0eql4yRU5rely3EcOlB9q457UDbG9omPtXiA=",
+        "lastModified": 1741914680,
+        "narHash": "sha256-Vu4DIZvgfWMzhUyxbHUrJaQb5232S5vuwxQ2sBcBVHk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "18780912345970e5b546b1b085385789b6935a83",
+        "rev": "30cce6848a5aa41ceb5fb33185b84868cc3e9bef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                              |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`30cce684`](https://github.com/nix-community/home-manager/commit/30cce6848a5aa41ceb5fb33185b84868cc3e9bef) | `` synthing: fix synthing config being deleted on rebuild (#6621) ``                 |
| [`6914c15c`](https://github.com/nix-community/home-manager/commit/6914c15c09e3e635ce678eb72f5781e5a85a6b24) | `` tests/default: scrub zsh ``                                                       |
| [`8f8f5432`](https://github.com/nix-community/home-manager/commit/8f8f5432d152d64dfde0e77c61530c3754dce660) | `` tests/zsh: fix zshrc content priority test ``                                     |
| [`0b0baed7`](https://github.com/nix-community/home-manager/commit/0b0baed7b2bf6a5e365d4cba042b580a2bc32e34) | `` tests/default: blacklist sapling ``                                               |
| [`0e46e842`](https://github.com/nix-community/home-manager/commit/0e46e84279d3d8eb7dcb044cb8aa9baa93298e66) | `` zsh: cleanup empty / wrong generated lines ``                                     |
| [`5d511628`](https://github.com/nix-community/home-manager/commit/5d5116286269c4e11976f6450afde1b30c3834c0) | `` syncthing: have tray wait in submodule (#6617) ``                                 |
| [`1b0efe3d`](https://github.com/nix-community/home-manager/commit/1b0efe3d335f452595512c7b275e5dddfbfb28a5) | `` zsh: move option variables closer to usage ``                                     |
| [`ad487d38`](https://github.com/nix-community/home-manager/commit/ad487d3863e94ac839b2e1e451197ab5a4aafd1b) | `` zsh: move config variables closer to usage ``                                     |
| [`b5142d46`](https://github.com/nix-community/home-manager/commit/b5142d46a3f912ef99e9cec3e51d757fbeaf14ea) | `` zsh: remove with lib ``                                                           |
| [`56374cc6`](https://github.com/nix-community/home-manager/commit/56374cc64d58451b359bb4e8502387d3a96e7c7b) | `` zoxide: remove with lib ``                                                        |
| [`d30c1d30`](https://github.com/nix-community/home-manager/commit/d30c1d30bfbc287883c3d9e2ee811e2ac22ff879) | `` zoxide: move to bottom of zsh content ``                                          |
| [`6576167e`](https://github.com/nix-community/home-manager/commit/6576167e6b3f2b5c60e48b62f792410bd3b4824c) | `` macos-remap-keys: add (#6605) ``                                                  |
| [`ef257da5`](https://github.com/nix-community/home-manager/commit/ef257da52a299a47cc7235da270ab3b427a4ea5b) | `` docs: enhance comment for home.stateVersion option (#6116) ``                     |
| [`7832b5aa`](https://github.com/nix-community/home-manager/commit/7832b5aa95f68a421dc9b4b3c17dcf942ac6145b) | `` zsh: refactor zsh configuration for better order control over `.zshrc` (#6479) `` |