### PR TITLE
chore(flake/srvos): `037690b0` -> `7d337b5a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -887,11 +887,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741636056,
-        "narHash": "sha256-YYqTwGHpbeHs3m9jfqJJv6qO6fV6vXyB2cOVefINRTg=",
+        "lastModified": 1741906120,
+        "narHash": "sha256-li20Fq8t7IPlQJI/NRcLXa2Us1Dmoo+11lKGvZs+t3E=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "037690b00101fe635e83963dd965f04d5dad0a68",
+        "rev": "7d337b5a3735ec7702fc30ebcb34c116bb8a3784",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`7d337b5a`](https://github.com/nix-community/srvos/commit/7d337b5a3735ec7702fc30ebcb34c116bb8a3784) | `` dev/private/flake.lock: Update `` |
| [`435224a3`](https://github.com/nix-community/srvos/commit/435224a301354382a344a7b35123ba9e7098f881) | `` flake.lock: Update ``             |