### PR TITLE
chore(flake/nur): `1cf77528` -> `0315d575`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1741895983,
-        "narHash": "sha256-7CqlVqSsc/H4dy0P034L0IrWzueShNR3fvN6GQQE2E0=",
+        "lastModified": 1741967242,
+        "narHash": "sha256-jIUgXueaXBrzwk53e3gn6ZYHGnovOBweGDXY6wOT5ho=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1cf775289a4bd43ebeae46cc351d200aa4ed1c04",
+        "rev": "0315d575038b428a92589185f6318ff49504b711",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0315d575`](https://github.com/nix-community/NUR/commit/0315d575038b428a92589185f6318ff49504b711) | `` automatic update `` |
| [`fc4860b6`](https://github.com/nix-community/NUR/commit/fc4860b6b689a8b96faafb157d390f26878590be) | `` automatic update `` |
| [`a791613d`](https://github.com/nix-community/NUR/commit/a791613d6b24f6514fc56bd715364b9e12423fb1) | `` automatic update `` |
| [`433b1a30`](https://github.com/nix-community/NUR/commit/433b1a302be3ce4b7d8abc5734f29a2699dab954) | `` automatic update `` |
| [`ab2805a3`](https://github.com/nix-community/NUR/commit/ab2805a39f35fb09a0980368eb0202796c3c2120) | `` automatic update `` |
| [`c44dd787`](https://github.com/nix-community/NUR/commit/c44dd7872789632ba263b98b0217e14374282c1d) | `` automatic update `` |
| [`9faefc39`](https://github.com/nix-community/NUR/commit/9faefc394d02f6fd03755ebaf95c61d0e9b8df6c) | `` automatic update `` |
| [`e786b392`](https://github.com/nix-community/NUR/commit/e786b39208062c0643361b0cc8c8f1aec1d28f3a) | `` automatic update `` |
| [`f9584610`](https://github.com/nix-community/NUR/commit/f95846104ae4d3178494fdccaff94796eb856e83) | `` automatic update `` |
| [`1996d32c`](https://github.com/nix-community/NUR/commit/1996d32c7141cabe581b4c27baf4a105da136ccb) | `` automatic update `` |
| [`0291c5af`](https://github.com/nix-community/NUR/commit/0291c5af04f485b9da466615db1511442870bbd5) | `` automatic update `` |
| [`9ec063aa`](https://github.com/nix-community/NUR/commit/9ec063aa0dc0c12433705221947e3316a8991ba3) | `` automatic update `` |
| [`9e550781`](https://github.com/nix-community/NUR/commit/9e55078118bb935c1b26e9e3c27ca6caa327a058) | `` automatic update `` |
| [`f71aba2f`](https://github.com/nix-community/NUR/commit/f71aba2f5afb8e6ea0c6dfa2a3e9aa53dc660679) | `` automatic update `` |
| [`517f8986`](https://github.com/nix-community/NUR/commit/517f8986ad8cb683214bc06688259d0de76027c1) | `` automatic update `` |
| [`761e844c`](https://github.com/nix-community/NUR/commit/761e844cf01fcfc27173370d2775b4871693e52f) | `` automatic update `` |
| [`6ff758ea`](https://github.com/nix-community/NUR/commit/6ff758ea32876dc9185ca8654ba1ab95a8a29935) | `` automatic update `` |
| [`7d1e9ef8`](https://github.com/nix-community/NUR/commit/7d1e9ef8d038a412a36db05db865abdf5ce2e0b7) | `` automatic update `` |
| [`0f2caaeb`](https://github.com/nix-community/NUR/commit/0f2caaeb7fb0b25f218a855fb7cc2fd6e58914fe) | `` automatic update `` |