### PR TITLE
chore(flake/nur): `0315d575` -> `87a83ecc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1741967242,
-        "narHash": "sha256-jIUgXueaXBrzwk53e3gn6ZYHGnovOBweGDXY6wOT5ho=",
+        "lastModified": 1741981449,
+        "narHash": "sha256-NyWfdVwiProOhZDglFD0yJrgHKkz9G7c9ypwFEoLgyE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0315d575038b428a92589185f6318ff49504b711",
+        "rev": "87a83ecc5f37ac79abe1cd21a0b941fb55de8caa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`87a83ecc`](https://github.com/nix-community/NUR/commit/87a83ecc5f37ac79abe1cd21a0b941fb55de8caa) | `` automatic update `` |
| [`1ebb46ef`](https://github.com/nix-community/NUR/commit/1ebb46ef6ac07fe695984eec8b4f936e92f4dce5) | `` automatic update `` |
| [`d4074ef9`](https://github.com/nix-community/NUR/commit/d4074ef95ee8cd851489cec37bcae3fcb9096940) | `` automatic update `` |