### PR TITLE
chore(flake/catppuccin): `1e3fe44b` -> `f833a338`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1741914590,
-        "narHash": "sha256-R8Bxh/AMD6nvmQrC43DkUkuwDmTWlyvNAzJ0Riq5w5U=",
+        "lastModified": 1741985801,
+        "narHash": "sha256-EnjiCpEi8p1kFgNUCVPuDUYoOSYBlr7ByMEF8qMGZws=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "1e3fe44bc13809f62c2ef0aa864a304a6c8ebea4",
+        "rev": "f833a338ff6c091c84e041ee77ce88f8b242ca79",
         "type": "github"
       },
       "original": {
@@ -543,11 +543,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741246872,
-        "narHash": "sha256-Q6pMP4a9ed636qilcYX8XUguvKl/0/LGXhHcRI91p0U=",
+        "lastModified": 1741851582,
+        "narHash": "sha256-cPfs8qMccim2RBgtKGF+x9IBCduRvd/N5F4nYpU0TVE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "10069ef4cf863633f57238f179a0297de84bd8d3",
+        "rev": "6607cf789e541e7873d40d3a8f7815ea92204f32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                  |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`f833a338`](https://github.com/catppuccin/nix/commit/f833a338ff6c091c84e041ee77ce88f8b242ca79) | `` fix(tests): disable forgejo (#505) `` |
| [`c25c3798`](https://github.com/catppuccin/nix/commit/c25c37989eadcc90c99c6893f0076e3c4b2a8714) | `` chore: update flakes (#502) ``        |
| [`da127abf`](https://github.com/catppuccin/nix/commit/da127abff7b72f371f4e347514dd110bee93b142) | `` chore: update port sources (#501) ``  |