### PR TITLE
chore(flake/nur): `87a83ecc` -> `7154bccf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1741981449,
-        "narHash": "sha256-NyWfdVwiProOhZDglFD0yJrgHKkz9G7c9ypwFEoLgyE=",
+        "lastModified": 1741995902,
+        "narHash": "sha256-aUNK4tk+Lj+mLlS/VA1E6lsUmuJK21zWskXT76lEnYo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "87a83ecc5f37ac79abe1cd21a0b941fb55de8caa",
+        "rev": "7154bccf4578389edf83aae893522d94ee2c9dc7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7154bccf`](https://github.com/nix-community/NUR/commit/7154bccf4578389edf83aae893522d94ee2c9dc7) | `` automatic update `` |
| [`054e174c`](https://github.com/nix-community/NUR/commit/054e174cdc40bd1f56c91591a95f35fc3472299e) | `` automatic update `` |
| [`23fb3cc2`](https://github.com/nix-community/NUR/commit/23fb3cc211add382809379c2d652a7a807f88fb1) | `` automatic update `` |