### PR TITLE
chore(flake/nur): `7154bccf` -> `fb1df366`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1741995902,
-        "narHash": "sha256-aUNK4tk+Lj+mLlS/VA1E6lsUmuJK21zWskXT76lEnYo=",
+        "lastModified": 1742003741,
+        "narHash": "sha256-yzy5mgVyQJMJ8kZEM4i9/wBPSjrk6Cq6XdVLUO1phak=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7154bccf4578389edf83aae893522d94ee2c9dc7",
+        "rev": "fb1df3665509831508e54356182e7ac24f99a5b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fb1df366`](https://github.com/nix-community/NUR/commit/fb1df3665509831508e54356182e7ac24f99a5b3) | `` automatic update `` |
| [`23d8e2e0`](https://github.com/nix-community/NUR/commit/23d8e2e03b38a4a08b1a7e2f1e08ef3e40a82298) | `` automatic update `` |