### PR TITLE
chore(flake/darwin): `4d8a4516` -> `9175b4bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741906019,
-        "narHash": "sha256-c9L0yCdpBzPVTcExcqTti6vP6GuPVaCaVCDf0M8eu+I=",
+        "lastModified": 1742013980,
+        "narHash": "sha256-34YbfwABU5nb0F5eaaJE3ujldaNDhmyxw7CWqhXJV08=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "4d8a451649b6de429ea7e169378488305d0d9399",
+        "rev": "9175b4bb5f127fb7b5784b14f7e01abff24c378f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                    |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
| [`814b5038`](https://github.com/LnL7/nix-darwin/commit/814b50389980a257f4e2fe675e909633ccf88d8f) | `` Fix merging of system.defaults.CustomUserPreferences `` |