### PR TITLE
chore(flake/nur): `fb1df366` -> `0b2a3fad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1742003741,
-        "narHash": "sha256-yzy5mgVyQJMJ8kZEM4i9/wBPSjrk6Cq6XdVLUO1phak=",
+        "lastModified": 1742053504,
+        "narHash": "sha256-3cdNXi+o6syNwJ+ktZLXeuMTnwOOk4HSrNIJtfx0+3U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fb1df3665509831508e54356182e7ac24f99a5b3",
+        "rev": "0b2a3fadd7505123e37158bd702f618a2c8f011b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0b2a3fad`](https://github.com/nix-community/NUR/commit/0b2a3fadd7505123e37158bd702f618a2c8f011b) | `` automatic update `` |
| [`7887073e`](https://github.com/nix-community/NUR/commit/7887073e8a73588c4450a190af4c648aa2ec3cd1) | `` automatic update `` |
| [`754da210`](https://github.com/nix-community/NUR/commit/754da210f1b82105543e814576e8a0763d253e36) | `` automatic update `` |
| [`86d0c71b`](https://github.com/nix-community/NUR/commit/86d0c71bfdbb6764d42cb56c44b97dea63837741) | `` automatic update `` |
| [`16673433`](https://github.com/nix-community/NUR/commit/16673433ddf98926db2982582a3a34858cea6fce) | `` automatic update `` |
| [`ac44f812`](https://github.com/nix-community/NUR/commit/ac44f81220a373c823ad72b57eb1371fe65c9ce4) | `` automatic update `` |