### PR TITLE
chore(flake/nix-index-database): `66537fb1` -> `5c77c6d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -453,11 +453,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741619381,
-        "narHash": "sha256-koZtlJRqi0/MD/AKd0KrXLA2NuBOVzlIyAJprjzpxZE=",
+        "lastModified": 1742096597,
+        "narHash": "sha256-CUy00dj513aIvtN2NGiDKLCVEQSz4xHWSDf229EiJdU=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "66537fb185462ba9b07f4e6f2d54894a1b2d04ab",
+        "rev": "5c77c6d6f2e8cc6007c2b1a4df1a507834404a67",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`5c77c6d6`](https://github.com/nix-community/nix-index-database/commit/5c77c6d6f2e8cc6007c2b1a4df1a507834404a67) | `` update generated.nix to release 2025-03-16-032233 `` |
| [`71ff3929`](https://github.com/nix-community/nix-index-database/commit/71ff39291a195291890ca25b8b20e62db442fcbe) | `` flake.lock: Update ``                                |