### PR TITLE
chore(flake/srvos): `7d337b5a` -> `73e2a272`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -887,11 +887,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741906120,
-        "narHash": "sha256-li20Fq8t7IPlQJI/NRcLXa2Us1Dmoo+11lKGvZs+t3E=",
+        "lastModified": 1742173155,
+        "narHash": "sha256-O+p7U0fepbze8lPKbGA5zjF+13ds0o7CdZJTj0j3FSU=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "7d337b5a3735ec7702fc30ebcb34c116bb8a3784",
+        "rev": "73e2a272b180ff659777c7a7f369f5565a677473",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`73e2a272`](https://github.com/nix-community/srvos/commit/73e2a272b180ff659777c7a7f369f5565a677473) | `` dev/private/flake.lock: Update `` |
| [`831ca601`](https://github.com/nix-community/srvos/commit/831ca601e04793c6bb2c3a4c2605624b1d0a956f) | `` flake.lock: Update ``             |