### PR TITLE
chore(flake/sops-nix): `d016ce03` -> `787afce4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -867,11 +867,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741861888,
-        "narHash": "sha256-ynOgXAyToeE1UdLNfrUn/hL7MN0OpIS2BtNdLjpjPf0=",
+        "lastModified": 1742239755,
+        "narHash": "sha256-ptn8dR4Uat3UUadGYNnB7CIH9SQm8mK69D2A/twBUXQ=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "d016ce0365b87d848a57c12ffcfdc71da7a2b55f",
+        "rev": "787afce414bcce803b605c510b60bf43c11f4b55",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                            |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`787afce4`](https://github.com/Mic92/sops-nix/commit/787afce414bcce803b605c510b60bf43c11f4b55) | `` add uid and gid to templates ``                                 |
| [`b33837ae`](https://github.com/Mic92/sops-nix/commit/b33837ae3cfa012b65810891bebbee71fa4c0658) | `` Fix symlink ownership change on Darwin systems. ``              |
| [`9520344f`](https://github.com/Mic92/sops-nix/commit/9520344f1f788c49591df03de2e25fe48364e0bd) | `` use nixpkgs-unstable for home-manager/darwin-nix/treefmt-nix `` |
| [`c125ee77`](https://github.com/Mic92/sops-nix/commit/c125ee77365a9b9520bbbfc6129cf800f0a6fc5a) | `` [create-pull-request] automated change ``                       |
| [`dfa41105`](https://github.com/Mic92/sops-nix/commit/dfa411056f48a716dc2ab011294348e86d0d04f2) | `` uprade-flakes: write permissions are no longer needed ``        |
| [`1f8e8fcf`](https://github.com/Mic92/sops-nix/commit/1f8e8fcf3f7e89b863258fa2e330606eee8a4f3d) | `` fix home-manager module ``                                      |
| [`7eb64563`](https://github.com/Mic92/sops-nix/commit/7eb645636c5dbb7373bf512081cbe5041262f154) | `` Make assertions lazy ``                                         |