### PR TITLE
chore(flake/home-manager): `4e12151c` -> `eae06a96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741955947,
-        "narHash": "sha256-2lbURKclgKqBNm7hVRtWh0A7NrdsibD0EaWhahUVhhY=",
+        "lastModified": 1742241223,
+        "narHash": "sha256-GyFiAxF1ou3lxdCFlLQJh2JdPpj7B+9mXQzieKSYo7g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4e12151c9e014e2449e0beca2c0e9534b96a26b4",
+        "rev": "eae06a96af1903655f06cb401907555ea4048357",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`eae06a96`](https://github.com/nix-community/home-manager/commit/eae06a96af1903655f06cb401907555ea4048357) | `` ci: bump cachix/install-nix-action from 30 to 31 (#6643) ``  |
| [`f55c5f65`](https://github.com/nix-community/home-manager/commit/f55c5f6569c98f36969def802f84bde44f254f41) | `` kubecolor: create oc alias conditionally ``                  |
| [`f9f766c6`](https://github.com/nix-community/home-manager/commit/f9f766c6009410f4523f28cfc0ec7d194b2676fa) | `` kubecolor: add oc alias ``                                   |
| [`e94ec0a6`](https://github.com/nix-community/home-manager/commit/e94ec0a6cd4cabca56b9bc2d5e2c05374132f34a) | `` kubecolor: add enableZshIntegration option for completion `` |
| [`5a6e5a59`](https://github.com/nix-community/home-manager/commit/5a6e5a59a4d332edaa7d5d1604eb58ead27af851) | `` tests: stub more expected packages darwin (#6649) ``         |