### PR TITLE
chore(flake/home-manager): `eae06a96` -> `22a36aa7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742241223,
-        "narHash": "sha256-GyFiAxF1ou3lxdCFlLQJh2JdPpj7B+9mXQzieKSYo7g=",
+        "lastModified": 1742326330,
+        "narHash": "sha256-Tumt3tcMXJniSh7tw2gW+WAnVLeB3WWm+E+yYFnLBXo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "eae06a96af1903655f06cb401907555ea4048357",
+        "rev": "22a36aa709de7dd42b562a433b9cefecf104a6ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                        |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`22a36aa7`](https://github.com/nix-community/home-manager/commit/22a36aa709de7dd42b562a433b9cefecf104a6ee) | `` swww: add swww service module for swww-daemon (#6543) ``                    |
| [`fb74bb76`](https://github.com/nix-community/home-manager/commit/fb74bb76d94a6c55632376c931fc108131260ee9) | `` vscode: fix creation of storage.json file (#6650) ``                        |
| [`c657142e`](https://github.com/nix-community/home-manager/commit/c657142e24a43ea1035889f0b0a7c24598e0e18a) | `` thunderbird: add message filters option  (#6652) ``                         |
| [`b870fb2d`](https://github.com/nix-community/home-manager/commit/b870fb2d62ee0deb657951f83e8689143dce98c8) | `` zsh: update zsh initContent example to use lib.literalExpression (#6637) `` |
| [`18e7d548`](https://github.com/nix-community/home-manager/commit/18e7d548992eb1900fdaad5f1a3eb8fd849b0cdd) | `` ci: bump cachix/cachix-action from 15 to 16 (#6644) ``                      |