### PR TITLE
chore(flake/catppuccin): `d84df59c` -> `4cb9c621`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1742098205,
-        "narHash": "sha256-gCkVTohFTyq/Pi3dlUhv1uA5Kqbalf45nLmUDRluULE=",
+        "lastModified": 1742254251,
+        "narHash": "sha256-3wGCx5UR86pgurSYB//LsBMKAsw6qpiOpnzgShPQKkM=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "d84df59c7aa29cebaff9f190d19c24e7ddacd773",
+        "rev": "4cb9c621072312fb45c6e86b57e5fabd97f1b95d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                  |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`4cb9c621`](https://github.com/catppuccin/nix/commit/4cb9c621072312fb45c6e86b57e5fabd97f1b95d) | `` ci: pass nix files to `nix fmt` (#510) ``                             |
| [`fe8a7a19`](https://github.com/catppuccin/nix/commit/fe8a7a1992a7d248a40ffa5d5ff9efe02b388b4c) | `` ci: actually update cachix/install-nix-action action to v31 (#508) `` |
| [`3b76dadd`](https://github.com/catppuccin/nix/commit/3b76dadd337df17d377d46a84da41f1cd6c4ddfb) | `` ci: update cachix/cachix-action action to v16 (#506) ``               |
| [`a5a138b7`](https://github.com/catppuccin/nix/commit/a5a138b702cde64332d10637cbe9b45d1403b24b) | `` ci: update cachix/install-nix-action action to v31 (#507) ``          |