### PR TITLE
chore(flake/srvos): `73e2a272` -> `0e15f4ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -887,11 +887,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742173155,
-        "narHash": "sha256-O+p7U0fepbze8lPKbGA5zjF+13ds0o7CdZJTj0j3FSU=",
+        "lastModified": 1742307357,
+        "narHash": "sha256-N3rtpv2ehTHQB+yX6aGkav1fqNCOgh1EfeA47Zk2hAc=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "73e2a272b180ff659777c7a7f369f5565a677473",
+        "rev": "0e15f4ee9117c0c47bf8e644f5a6a8759d8392ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                                                   |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
| [`e78e019c`](https://github.com/nix-community/srvos/commit/e78e019c9d25fbeafd4a85c2507bcb890b09cff6) | `` nix-experimental: make nix.settings.system-features compatible with both 24.11 and nixpkgs-unstable `` |
| [`7f531af0`](https://github.com/nix-community/srvos/commit/7f531af024b0e2829be4aa6f095eb1ae1be4ea1b) | `` add better homebrew defaults ``                                                                        |