### PR TITLE
chore(flake/nur): `840a27e7` -> `bdfb9056`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1742327107,
-        "narHash": "sha256-oVUFdOWCJIZJBHVp2EGoUvL2PxOUctG8PQLG5ZwcUp0=",
+        "lastModified": 1742341522,
+        "narHash": "sha256-+NyCn2Av7Y7IwPZ+Ryxw0GEwAMovc+KAE4lXBA4MpBs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "840a27e7ab2f2f26fb5cc58c403dbf4edcf1f213",
+        "rev": "bdfb905677c951eb738740e0ab514fe1aea1c230",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bdfb9056`](https://github.com/nix-community/NUR/commit/bdfb905677c951eb738740e0ab514fe1aea1c230) | `` automatic update `` |
| [`2b1f72cc`](https://github.com/nix-community/NUR/commit/2b1f72cc8d6a00d32311c4f4b4f3888ec8932d25) | `` automatic update `` |
| [`bb3b26ea`](https://github.com/nix-community/NUR/commit/bb3b26eaf155f4cbec4cfbfc9022708fe2113273) | `` automatic update `` |
| [`51106768`](https://github.com/nix-community/NUR/commit/51106768b9a5f5407c593c1e1e3586b63b43a447) | `` automatic update `` |
| [`d7ba3ec7`](https://github.com/nix-community/NUR/commit/d7ba3ec7a15a2e5eef5eda2a16564e7a2bd6b06e) | `` automatic update `` |
| [`16d430eb`](https://github.com/nix-community/NUR/commit/16d430ebb4bd5e627d531010408943fe0a4bc61c) | `` automatic update `` |