### PR TITLE
chore(flake/nur): `dec087a2` -> `9532ba62`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1742356336,
-        "narHash": "sha256-8E6vUUgtHjreazzNskGrH8W+LNbdYCtavKkjSS136HA=",
+        "lastModified": 1742369565,
+        "narHash": "sha256-TnjneWnElM9o9BcuLmdCk5NlfQBCGatzu1CIiZY3e9k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dec087a23272d7e06f238db9b6b6d890b309d3d5",
+        "rev": "9532ba6290a4859a73af67bd7d957b0796a568da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9532ba62`](https://github.com/nix-community/NUR/commit/9532ba6290a4859a73af67bd7d957b0796a568da) | `` automatic update `` |
| [`3a6ef810`](https://github.com/nix-community/NUR/commit/3a6ef810edf314abde497ddd406ce25e524a118d) | `` automatic update `` |
| [`15a5e7b0`](https://github.com/nix-community/NUR/commit/15a5e7b0a4919a3823a1100059fee959018d512b) | `` automatic update `` |
| [`c0c1c963`](https://github.com/nix-community/NUR/commit/c0c1c963109570232baddcd7f452e1257797e6d9) | `` automatic update `` |
| [`659898c4`](https://github.com/nix-community/NUR/commit/659898c4ba3ae3bd4c2faea11bb763b1c79d9db3) | `` automatic update `` |
| [`e7ba1c1d`](https://github.com/nix-community/NUR/commit/e7ba1c1df59326c321c2167148b6cde2753fe225) | `` automatic update `` |
| [`f5ada523`](https://github.com/nix-community/NUR/commit/f5ada523d9f9f295d15a601997f2ec41e0b85028) | `` automatic update `` |
| [`a44eb6d3`](https://github.com/nix-community/NUR/commit/a44eb6d369b1a68e4e993400f83b9a8b35759141) | `` automatic update `` |