### PR TITLE
chore(flake/nur): `9532ba62` -> `6c577edf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1742369565,
-        "narHash": "sha256-TnjneWnElM9o9BcuLmdCk5NlfQBCGatzu1CIiZY3e9k=",
+        "lastModified": 1742457422,
+        "narHash": "sha256-5oD9QOGLDua8HV7cFepbuIbTeFO4CPaJm8AAgrZa8pg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9532ba6290a4859a73af67bd7d957b0796a568da",
+        "rev": "6c577edfa37bf0f6cd7f26d6a9d4910bffcf43fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6c577edf`](https://github.com/nix-community/NUR/commit/6c577edfa37bf0f6cd7f26d6a9d4910bffcf43fe) | `` automatic update `` |
| [`46d0b1e9`](https://github.com/nix-community/NUR/commit/46d0b1e91f070ebf9489cc34937196d2e8a55f58) | `` automatic update `` |
| [`5169fe85`](https://github.com/nix-community/NUR/commit/5169fe85ebfb706ba81da187616c1a85c443b3f9) | `` automatic update `` |
| [`873ef711`](https://github.com/nix-community/NUR/commit/873ef7114a909019b204a232cf29c7e4e10c6e99) | `` automatic update `` |
| [`fbbbeec5`](https://github.com/nix-community/NUR/commit/fbbbeec581b26a85adc2e8048533f9944fb96ae9) | `` automatic update `` |
| [`d6970c62`](https://github.com/nix-community/NUR/commit/d6970c62e0a57898211038b93b95371c7997de18) | `` automatic update `` |
| [`b753f2f4`](https://github.com/nix-community/NUR/commit/b753f2f4e43b4be88af28afe6f3495b51115aba2) | `` automatic update `` |
| [`5a2496ea`](https://github.com/nix-community/NUR/commit/5a2496ea92cf508535de81edffc9ea3b2adc12d6) | `` automatic update `` |
| [`6c801409`](https://github.com/nix-community/NUR/commit/6c801409aba92a1b854789b48a69d844217f7f7d) | `` automatic update `` |
| [`a8df1007`](https://github.com/nix-community/NUR/commit/a8df1007d3929bff87ab0ee2bbd99b864ac5715a) | `` automatic update `` |
| [`e35ce996`](https://github.com/nix-community/NUR/commit/e35ce99602bd7c8de77eaf9c8aef04bb7b5b024c) | `` automatic update `` |
| [`050321a4`](https://github.com/nix-community/NUR/commit/050321a44512de76ef1a8845ab35cfe177a72fda) | `` automatic update `` |
| [`94772757`](https://github.com/nix-community/NUR/commit/94772757a94ca1af8900550c7e75ea73d9c13c78) | `` automatic update `` |
| [`f4bc5100`](https://github.com/nix-community/NUR/commit/f4bc510066ba6b49696000ea55ac683cfaeb51d1) | `` automatic update `` |
| [`109239a2`](https://github.com/nix-community/NUR/commit/109239a2416cf433816d582f9cd21a02286b967d) | `` automatic update `` |
| [`9d388fe4`](https://github.com/nix-community/NUR/commit/9d388fe46c1d9e5bc49647395fec4880b57e21ff) | `` automatic update `` |
| [`6a11a1bf`](https://github.com/nix-community/NUR/commit/6a11a1bff1e4a174c4fee42e525fd188260e3593) | `` automatic update `` |
| [`fe1a7798`](https://github.com/nix-community/NUR/commit/fe1a779825b896bdcf5b78488a004e521dd88423) | `` automatic update `` |
| [`4b54d2af`](https://github.com/nix-community/NUR/commit/4b54d2afde226b410f0fa7c685a862c2893ddce1) | `` automatic update `` |
| [`6e54bc26`](https://github.com/nix-community/NUR/commit/6e54bc26b9498189655e0e0f9c80d07ac0ae5137) | `` automatic update `` |
| [`339f1d2f`](https://github.com/nix-community/NUR/commit/339f1d2fd68fc1e33ece1f94ee2ab4b4badecbf7) | `` automatic update `` |
| [`4ddff3eb`](https://github.com/nix-community/NUR/commit/4ddff3ebb2955c862626116f773c5529d223bb2c) | `` automatic update `` |
| [`1ad28216`](https://github.com/nix-community/NUR/commit/1ad28216d9a988e1e786d2d818db7cab20ca59ae) | `` automatic update `` |
| [`f9d4d88c`](https://github.com/nix-community/NUR/commit/f9d4d88c9077ea28373084aa2cbae262993255b2) | `` automatic update `` |
| [`cdfdee95`](https://github.com/nix-community/NUR/commit/cdfdee95d3c671d0f0aefe1d88d7b220a7156a5a) | `` automatic update `` |