### PR TITLE
chore(flake/darwin): `95eac71b` -> `2d9b6331`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742165923,
-        "narHash": "sha256-WKzuVsHXjuxYjS9KxKdpoPWpT37LofyS5llSssEw058=",
+        "lastModified": 1742373336,
+        "narHash": "sha256-oEF5dBlq8wGD3mkJ5PmFS1PGb28uYmvuy1IH6roIGkQ=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "95eac71bf52b271523d0ca81dbbeb3182990fc24",
+        "rev": "2d9b63316926aa130a5a51136d93b9be28808f26",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                      |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
| [`9951b44d`](https://github.com/LnL7/nix-darwin/commit/9951b44d5bdebd062dab70701d7b21350cbbc6ab) | `` nix-darwin: system tools can be configured indvidually `` |