### PR TITLE
chore(flake/sops-nix): `787afce4` -> `1770be8a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -867,11 +867,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742239755,
-        "narHash": "sha256-ptn8dR4Uat3UUadGYNnB7CIH9SQm8mK69D2A/twBUXQ=",
+        "lastModified": 1742406979,
+        "narHash": "sha256-r0aq70/3bmfjTP+JZs4+XV5SgmCtk1BLU4CQPWGtA7o=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "787afce414bcce803b605c510b60bf43c11f4b55",
+        "rev": "1770be8ad89e41f1ed5a60ce628dd10877cb3609",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                   |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`1770be8a`](https://github.com/Mic92/sops-nix/commit/1770be8ad89e41f1ed5a60ce628dd10877cb3609) | `` nix-darwin: remove lib.traceVal from sops.templates `` |