### PR TITLE
chore(flake/srvos): `0e15f4ee` -> `60a187c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -887,11 +887,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742307357,
-        "narHash": "sha256-N3rtpv2ehTHQB+yX6aGkav1fqNCOgh1EfeA47Zk2hAc=",
+        "lastModified": 1742432134,
+        "narHash": "sha256-J9BMk5uEXGZqe3ksA+TNjpuWx67r6qwa6MCS+ayDTqw=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "0e15f4ee9117c0c47bf8e644f5a6a8759d8392ae",
+        "rev": "60a187c45762fcc5ed0f3c97e1da890d0ed3f695",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`60a187c4`](https://github.com/nix-community/srvos/commit/60a187c45762fcc5ed0f3c97e1da890d0ed3f695) | `` dev/private/flake.lock: Update `` |
| [`4b7b1a69`](https://github.com/nix-community/srvos/commit/4b7b1a690318d7c740a8dad2f29aa8a8e02e1211) | `` flake.lock: Update ``             |