### PR TITLE
chore(flake/nur): `6c577edf` -> `a609adcf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1742457422,
-        "narHash": "sha256-5oD9QOGLDua8HV7cFepbuIbTeFO4CPaJm8AAgrZa8pg=",
+        "lastModified": 1742499911,
+        "narHash": "sha256-93QYtDeMar+Pqehly80Gc/OzQPbLHrmpaBgjn8/bMVk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6c577edfa37bf0f6cd7f26d6a9d4910bffcf43fe",
+        "rev": "a609adcf1407d124b810955ed1be2a8ed57107fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a609adcf`](https://github.com/nix-community/NUR/commit/a609adcf1407d124b810955ed1be2a8ed57107fb) | `` automatic update `` |
| [`c7edffc3`](https://github.com/nix-community/NUR/commit/c7edffc3256b6b204803c8fa6342095f82ca1a0a) | `` automatic update `` |
| [`018d499c`](https://github.com/nix-community/NUR/commit/018d499c90b2a9fb4d457de12c8fbda258c9347f) | `` automatic update `` |
| [`bc9eee46`](https://github.com/nix-community/NUR/commit/bc9eee467383ec5cd58bf0b9ca969f5f09236f89) | `` automatic update `` |
| [`d9d8b4a0`](https://github.com/nix-community/NUR/commit/d9d8b4a05f5dd729135e4d885e7f209c4a635fd2) | `` automatic update `` |
| [`09c092ee`](https://github.com/nix-community/NUR/commit/09c092eef9358a6d35774c06bdd6aa9ff9191898) | `` automatic update `` |
| [`7c62470d`](https://github.com/nix-community/NUR/commit/7c62470ddf4d8a9b45d78f31d182baf5980493be) | `` automatic update `` |