### PR TITLE
chore(flake/home-manager): `94605dca` -> `da018181`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742447757,
-        "narHash": "sha256-Q0KXcHQmum8L6IzGhhkVhjFMKY6BvYa/rhmLP26Ws8o=",
+        "lastModified": 1742508854,
+        "narHash": "sha256-vQQTIl4+slrcu7ftVKNBql9ngBdY0dcYGujdT7zIVp0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "94605dcadefeaff6b35c8931c9f38e4f4dc7ad0a",
+        "rev": "da0181819479ddc034a3db9a77ed21ea3bcc0668",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`da018181`](https://github.com/nix-community/home-manager/commit/da0181819479ddc034a3db9a77ed21ea3bcc0668) | `` tests: scrub lazy{docker,git} on darwin ``                          |
| [`2e9981ca`](https://github.com/nix-community/home-manager/commit/2e9981ca0d6cee56f54a5e265b5edcd4dfc1b554) | `` lazydocker: null package support ``                                 |
| [`65413f29`](https://github.com/nix-community/home-manager/commit/65413f297f8c4c42a99270c15bce7bda1bfea724) | `` lazydocker: remove with lib ``                                      |
| [`46efc3b2`](https://github.com/nix-community/home-manager/commit/46efc3b2e14783d39f595cb0e5954a3a1edb0217) | `` lazydocker: add module ``                                           |
| [`20ec3c10`](https://github.com/nix-community/home-manager/commit/20ec3c10498938c3ff78075b5fae94fe1cd4a715) | `` mcfly: Fix swapped shell names ``                                   |
| [`d725df5a`](https://github.com/nix-community/home-manager/commit/d725df5ad8cee60e61ee6fe3afb735e4fbc1ff41) | `` mcfly: fix mcfly-fzf in non-interactive shells (#6669) ``           |
| [`fc189507`](https://github.com/nix-community/home-manager/commit/fc189507bc0bc74b3794ee6912a5b80de8dfcc0c) | `` docs: nixos module declarative installation instructions (#6208) `` |
| [`c36cc49e`](https://github.com/nix-community/home-manager/commit/c36cc49e55aff5562b0ca924f34285de6d6273be) | `` onlyoffice: add module (#6667) ``                                   |