### PR TITLE
chore(flake/nur): `a609adcf` -> `8bf15ff9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1742499911,
-        "narHash": "sha256-93QYtDeMar+Pqehly80Gc/OzQPbLHrmpaBgjn8/bMVk=",
+        "lastModified": 1742514337,
+        "narHash": "sha256-pnmBhtLZr3+v1rHrfYDTgPaANBQvafc6awpHvXkS0Xk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a609adcf1407d124b810955ed1be2a8ed57107fb",
+        "rev": "8bf15ff943e51b2685388947476f3f5fcc2101a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8bf15ff9`](https://github.com/nix-community/NUR/commit/8bf15ff943e51b2685388947476f3f5fcc2101a7) | `` automatic update `` |
| [`6c8e8056`](https://github.com/nix-community/NUR/commit/6c8e80564974e42a1be302b6c64168d7d8a6572d) | `` automatic update `` |
| [`1c4e253c`](https://github.com/nix-community/NUR/commit/1c4e253c93e976f9b238c34eb534feaeb67ee7b2) | `` automatic update `` |