### PR TITLE
chore(flake/emacs-overlay): `267b2c6c` -> `808ae038`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1742493347,
-        "narHash": "sha256-n/VMvni7SScVE54XCzKZ7dWbn5yqKFXef6n0KILhJk0=",
+        "lastModified": 1742523104,
+        "narHash": "sha256-xszUn7/EjXpq43LO9Qgn7je+2Z8qOfpYDGLoEjo25No=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "267b2c6c63a6bd881b2b0df3b320e480d16b2cc6",
+        "rev": "808ae0382b035600bc8829918bfe5ea1fa63dab4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`808ae038`](https://github.com/nix-community/emacs-overlay/commit/808ae0382b035600bc8829918bfe5ea1fa63dab4) | `` Updated emacs ``        |
| [`a61682fe`](https://github.com/nix-community/emacs-overlay/commit/a61682fe03208c4c7dd03df1168cc649e9b53a2e) | `` Updated melpa ``        |
| [`b4eb6f51`](https://github.com/nix-community/emacs-overlay/commit/b4eb6f516044b9cd684688db5b76929719fe75aa) | `` Updated elpa ``         |
| [`51492f08`](https://github.com/nix-community/emacs-overlay/commit/51492f085b00e7841e588ec543f126e3d9499c4d) | `` Updated nongnu ``       |
| [`019e8f27`](https://github.com/nix-community/emacs-overlay/commit/019e8f27127bd6df233c445b6abbfcc90b1420e4) | `` Updated flake inputs `` |