### PR TITLE
chore(flake/home-manager): `da018181` -> `8a68f18e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742508854,
-        "narHash": "sha256-vQQTIl4+slrcu7ftVKNBql9ngBdY0dcYGujdT7zIVp0=",
+        "lastModified": 1742569620,
+        "narHash": "sha256-igC2cu+cPRB3E4QwKR+vGagyAtoyB+DrmWwDKm8jkaw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "da0181819479ddc034a3db9a77ed21ea3bcc0668",
+        "rev": "8a68f18e96bcab13e4f97bece61e6602298a3141",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                           |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`8a68f18e`](https://github.com/nix-community/home-manager/commit/8a68f18e96bcab13e4f97bece61e6602298a3141) | `` distrobox: add module (#6528) ``               |
| [`d6171149`](https://github.com/nix-community/home-manager/commit/d61711497be9ad6a6633aaf203b038b5a970621f) | `` iamb: nullable package support ``              |
| [`e5ab1811`](https://github.com/nix-community/home-manager/commit/e5ab18116c4dae69be789aaf33d70e901b5a9ba6) | `` iamb: new module ``                            |
| [`71cbeb3a`](https://github.com/nix-community/home-manager/commit/71cbeb3afd1ea8fa95af9dd6c0567d763ba44bee) | `` hyprpolkitagent: add khaneliman maintainer ``  |
| [`c1ca8974`](https://github.com/nix-community/home-manager/commit/c1ca8974b3330301c8b6939277db3beedb5c3ca1) | `` hyprpolkitagent: use wayland.systemd.target `` |
| [`29c6f2b0`](https://github.com/nix-community/home-manager/commit/29c6f2b0cb2a028ae27ad7c51c0f516ac3d5e4f8) | `` polkit-gnome: init module ``                   |
| [`5503a758`](https://github.com/nix-community/home-manager/commit/5503a758f9e2f9580dac416d342a113f4c7e7370) | `` lxqt-policykit-agent: init module ``           |
| [`cc538c37`](https://github.com/nix-community/home-manager/commit/cc538c3793322ec773f75631065ad9acfe04678a) | `` hyprpolkitagent: init module ``                |