### PR TITLE
chore(flake/emacs-overlay): `eb9ed82a` -> `610d71db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1742547910,
-        "narHash": "sha256-213i0ePMSf/IsCuRyXGHE4an10uhXUEQ/4phZxT9CO8=",
+        "lastModified": 1742576675,
+        "narHash": "sha256-2JbkmTzqfb5c/zk2xM6JKHZzgN1YsxblgqucbI0P4bU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "eb9ed82ad09dd90999157ae430a3bd4f760fe9a9",
+        "rev": "610d71db8074a369a0498572ff75b444d284409d",
         "type": "github"
       },
       "original": {
@@ -622,11 +622,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1742388435,
-        "narHash": "sha256-GheQGRNYAhHsvPxWVOhAmg9lZKkis22UPbEHlmZMthg=",
+        "lastModified": 1742512142,
+        "narHash": "sha256-8XfURTDxOm6+33swQJu/hx6xw1Tznl8vJJN5HwVqckg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b75693fb46bfaf09e662d09ec076c5a162efa9f6",
+        "rev": "7105ae3957700a9646cc4b766f5815b23ed0c682",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`610d71db`](https://github.com/nix-community/emacs-overlay/commit/610d71db8074a369a0498572ff75b444d284409d) | `` Updated melpa ``        |
| [`1c9ef4a0`](https://github.com/nix-community/emacs-overlay/commit/1c9ef4a01434e2704dd0dfe4f7cf7c6c3152a1a8) | `` Updated emacs ``        |
| [`d569e8e8`](https://github.com/nix-community/emacs-overlay/commit/d569e8e880441dee471e379fb6bf670ddce8205c) | `` Updated elpa ``         |
| [`5b2a716c`](https://github.com/nix-community/emacs-overlay/commit/5b2a716c2380d7d1c1b0a914f2dcf5c977d7f79f) | `` Updated nongnu ``       |
| [`3afcb9aa`](https://github.com/nix-community/emacs-overlay/commit/3afcb9aa51c5e6ac42c643c035729c695bd15a60) | `` Updated flake inputs `` |