### PR TITLE
chore(flake/nur): `8d885f0b` -> `5ed09e4b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1742575552,
-        "narHash": "sha256-2mwGsKymKgpWb62vZWTV642f6FXrxIwdPuevv5L3U0I=",
+        "lastModified": 1742586297,
+        "narHash": "sha256-ZK06qhlLEHrecgS4ctgmVgEiPr2rf/RJsOHfVC5Aju4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8d885f0b2f3e6e725195fbf018b01aa1583857a4",
+        "rev": "5ed09e4bd4eaa50884f9d823674c146bfc11312a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5ed09e4b`](https://github.com/nix-community/NUR/commit/5ed09e4bd4eaa50884f9d823674c146bfc11312a) | `` automatic update `` |
| [`76b7eeaa`](https://github.com/nix-community/NUR/commit/76b7eeaa58c6e0dddc487716f6f19619be127ed7) | `` automatic update `` |
| [`74ee3e11`](https://github.com/nix-community/NUR/commit/74ee3e11517253c50dfdf78b00f458325fb1e393) | `` automatic update `` |