### PR TITLE
chore(flake/catppuccin): `4cb9c621` -> `5e303e8d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1742254251,
-        "narHash": "sha256-3wGCx5UR86pgurSYB//LsBMKAsw6qpiOpnzgShPQKkM=",
+        "lastModified": 1742599566,
+        "narHash": "sha256-xr6ntmiUPXSh9o9mJ7og9vxALMQs1EQhIhWUAO2D1M0=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "4cb9c621072312fb45c6e86b57e5fabd97f1b95d",
+        "rev": "5e303e8d7e251868fa79f83bbda69da90aa62402",
         "type": "github"
       },
       "original": {
@@ -559,11 +559,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741851582,
-        "narHash": "sha256-cPfs8qMccim2RBgtKGF+x9IBCduRvd/N5F4nYpU0TVE=",
+        "lastModified": 1742288794,
+        "narHash": "sha256-Txwa5uO+qpQXrNG4eumPSD+hHzzYi/CdaM80M9XRLCo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6607cf789e541e7873d40d3a8f7815ea92204f32",
+        "rev": "b6eaf97c6960d97350c584de1b6dcff03c9daf42",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                       |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`5e303e8d`](https://github.com/catppuccin/nix/commit/5e303e8d7e251868fa79f83bbda69da90aa62402) | `` feat(home-manager): add support for qutebrowser (#479) ``                  |
| [`df9d3c93`](https://github.com/catppuccin/nix/commit/df9d3c9393fdfecbbe2678e5834a2e5467bf501c) | `` feat(home-manager): add support for swaync (#149) ``                       |
| [`d632e0a8`](https://github.com/catppuccin/nix/commit/d632e0a8e3e5534e681f75a63b2b08d00ff7e91d) | `` feat(home-manager): add support for wezterm (#433) ``                      |
| [`7831ef09`](https://github.com/catppuccin/nix/commit/7831ef095d051948fee65f58bfca45d0b8712579) | `` feat(home-manager/hyprlock): allow using default config for port (#514) `` |
| [`4aa3a5ce`](https://github.com/catppuccin/nix/commit/4aa3a5ce09f7c9fde9db9973b9e63fd1d584bcbc) | `` Revert "fix(tests): disable forgejo (#505)" (#516) ``                      |
| [`e1cf7f94`](https://github.com/catppuccin/nix/commit/e1cf7f9422e94c5f71d604e41c3948dd5fd32652) | `` revert: "fix(home-manager/lazygit): avoid IFD" (#515) ``                   |
| [`536b426a`](https://github.com/catppuccin/nix/commit/536b426a2dbee018bdcb1579e2c026965f747f20) | `` chore: update flakes (#512) ``                                             |
| [`798e4db8`](https://github.com/catppuccin/nix/commit/798e4db802035c735de1a04798a582c56a21b9a3) | `` chore: update port sources (#511) ``                                       |
| [`215a7b69`](https://github.com/catppuccin/nix/commit/215a7b69548251697e2e4f461433e0e8ddce8f23) | `` docs(README): link to IFD tracking issue (#513) ``                         |
| [`7a1df680`](https://github.com/catppuccin/nix/commit/7a1df6805635dd61321d618cce87fad514f17e91) | `` feat(home-manager): add support for vscode (#509) ``                       |