### PR TITLE
chore(flake/sops-nix): `1770be8a` -> `67566fe6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -901,11 +901,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742406979,
-        "narHash": "sha256-r0aq70/3bmfjTP+JZs4+XV5SgmCtk1BLU4CQPWGtA7o=",
+        "lastModified": 1742700801,
+        "narHash": "sha256-ZGlpUDsuBdeZeTNgoMv+aw0ByXT2J3wkYw9kJwkAS4M=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "1770be8ad89e41f1ed5a60ce628dd10877cb3609",
+        "rev": "67566fe68a8bed2a7b1175fdfb0697ed22ae8852",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                     |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`e1c75fc5`](https://github.com/Mic92/sops-nix/commit/e1c75fc565294a4ad69ae912ea9bed9578da1869) | `` [create-pull-request] automated change ``                |
| [`f721b63e`](https://github.com/Mic92/sops-nix/commit/f721b63e0ed88abcb48f938c6721601d52377a9a) | `` update vendorHash ``                                     |
| [`a71db947`](https://github.com/Mic92/sops-nix/commit/a71db9472ba1eb280e636630b8469e0a3ae89a1c) | `` Bump github.com/golang-jwt/jwt/v5 from 5.2.1 to 5.2.2 `` |