### PR TITLE
chore(flake/emacs-overlay): `610d71db` -> `19f9488c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1742576675,
-        "narHash": "sha256-2JbkmTzqfb5c/zk2xM6JKHZzgN1YsxblgqucbI0P4bU=",
+        "lastModified": 1742663916,
+        "narHash": "sha256-aLpOsp8iyuHFO6fZfCn0xkssHCYyrPqANVJWx86yb1g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "610d71db8074a369a0498572ff75b444d284409d",
+        "rev": "19f9488c8af0a0572e610d1bbf9d9b833df57524",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`19f9488c`](https://github.com/nix-community/emacs-overlay/commit/19f9488c8af0a0572e610d1bbf9d9b833df57524) | `` Updated emacs ``  |
| [`4d18179d`](https://github.com/nix-community/emacs-overlay/commit/4d18179df3bdc525d47b305a9c2bfd3777d5daa4) | `` Updated melpa ``  |
| [`9d9fd66b`](https://github.com/nix-community/emacs-overlay/commit/9d9fd66b04458c37431f5d24f3931cd842bdb936) | `` Updated elpa ``   |
| [`b994d654`](https://github.com/nix-community/emacs-overlay/commit/b994d654c0125ba00b4e71807b8b136165f22f6c) | `` Updated nongnu `` |
| [`31ee8006`](https://github.com/nix-community/emacs-overlay/commit/31ee8006935d8c3ce678854d8e46d74915a16960) | `` Updated emacs ``  |
| [`60fccc42`](https://github.com/nix-community/emacs-overlay/commit/60fccc4236b6045b8d66e3bd4e5996dd6f3f55e6) | `` Updated melpa ``  |
| [`724499d6`](https://github.com/nix-community/emacs-overlay/commit/724499d6305658949e21e01f5624ac429d9ab48a) | `` Updated emacs ``  |
| [`bd42aa36`](https://github.com/nix-community/emacs-overlay/commit/bd42aa36e2ebb59a4f7d3ad09c424cb40542eb83) | `` Updated melpa ``  |
| [`23410425`](https://github.com/nix-community/emacs-overlay/commit/23410425af373451cf1bc19de6d3cc02a8704d2f) | `` Updated elpa ``   |
| [`1b606ebe`](https://github.com/nix-community/emacs-overlay/commit/1b606ebe8ca90d7f0d43c661b7b0225facf5c08e) | `` Updated nongnu `` |