### PR TITLE
chore(flake/nur): `ecd94252` -> `b8651f88`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1742615538,
-        "narHash": "sha256-BYkXyaO9NFWro/yg7rgpTl9ad8bwp41gHJ7RugSvEm8=",
+        "lastModified": 1742672714,
+        "narHash": "sha256-tChligBHNdtr1klJdQQBiuu0qerZ/i/iVEo3K3r0PGg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ecd9425244a8d8f0ddb64e3ff58b02957dcac805",
+        "rev": "b8651f88d8f880613d2f0bf70daf9ecea509a5c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b8651f88`](https://github.com/nix-community/NUR/commit/b8651f88d8f880613d2f0bf70daf9ecea509a5c2) | `` automatic update `` |
| [`19b12d87`](https://github.com/nix-community/NUR/commit/19b12d8700e5af4cda13bc0b7b62d52a1af97e2a) | `` automatic update `` |
| [`dc12c6cc`](https://github.com/nix-community/NUR/commit/dc12c6cc1e679f70ed72027bae93b86c41309943) | `` automatic update `` |
| [`af69c990`](https://github.com/nix-community/NUR/commit/af69c990800493c42fac30d3f646c72fd9ce0654) | `` automatic update `` |
| [`1a669c2f`](https://github.com/nix-community/NUR/commit/1a669c2f4654481c4fb804fd1ed435b34d46bf21) | `` automatic update `` |
| [`df2bc2d2`](https://github.com/nix-community/NUR/commit/df2bc2d23993e95a992d92ba325414d5ebb57f5d) | `` automatic update `` |
| [`e616f9cd`](https://github.com/nix-community/NUR/commit/e616f9cd10a31ae4a76e6e2424b2f57de291c7c9) | `` automatic update `` |
| [`0eadb44f`](https://github.com/nix-community/NUR/commit/0eadb44f48ae149536423ebf1c976a328e585a0d) | `` automatic update `` |
| [`1d93c884`](https://github.com/nix-community/NUR/commit/1d93c884f94993958d5f7da1a851ce10a324c539) | `` automatic update `` |
| [`b0afff18`](https://github.com/nix-community/NUR/commit/b0afff183e005482ed9670a90ae3ff59830a2ffd) | `` automatic update `` |
| [`c72c4acc`](https://github.com/nix-community/NUR/commit/c72c4acc9a04d2d242c9dadfee75d358d75a9e38) | `` automatic update `` |
| [`27b2e90a`](https://github.com/nix-community/NUR/commit/27b2e90a348260991fadb7f667782a9615b10600) | `` automatic update `` |