### PR TITLE
chore(flake/nur): `b8651f88` -> `37d4dcca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1742672714,
-        "narHash": "sha256-tChligBHNdtr1klJdQQBiuu0qerZ/i/iVEo3K3r0PGg=",
+        "lastModified": 1742698203,
+        "narHash": "sha256-aDZYU8w7mRTCeK+6s7HOJw3V/LHkIfj2me169ZtpVIQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b8651f88d8f880613d2f0bf70daf9ecea509a5c2",
+        "rev": "37d4dccaebc470005f1a414994a967bdfc94c0f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`37d4dcca`](https://github.com/nix-community/NUR/commit/37d4dccaebc470005f1a414994a967bdfc94c0f8) | `` automatic update `` |
| [`3d476a6a`](https://github.com/nix-community/NUR/commit/3d476a6a7afaf8e6d1ce0c0b09538a12dd5a5678) | `` automatic update `` |
| [`635036ec`](https://github.com/nix-community/NUR/commit/635036ec7ec1fce48d678acfbc84b83c4d44ec41) | `` automatic update `` |