### PR TITLE
chore(flake/emacs-overlay): `19f9488c` -> `7ea1ac24`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1742663916,
-        "narHash": "sha256-aLpOsp8iyuHFO6fZfCn0xkssHCYyrPqANVJWx86yb1g=",
+        "lastModified": 1742750000,
+        "narHash": "sha256-03p4sJr5edbuXd5AkoUTr46co5+/B4APV/Sbv/hoDHk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "19f9488c8af0a0572e610d1bbf9d9b833df57524",
+        "rev": "7ea1ac244572b6186965d15ef05ec5d466aac1ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`7ea1ac24`](https://github.com/nix-community/emacs-overlay/commit/7ea1ac244572b6186965d15ef05ec5d466aac1ea) | `` Updated emacs ``  |
| [`b97a3361`](https://github.com/nix-community/emacs-overlay/commit/b97a3361d70afa1c7445a5f2a1de7bd0ee4b0962) | `` Updated melpa ``  |
| [`9452615e`](https://github.com/nix-community/emacs-overlay/commit/9452615e48e59a0230689d652fbd4577f8196439) | `` Updated elpa ``   |
| [`60c7e153`](https://github.com/nix-community/emacs-overlay/commit/60c7e153c4427fda98f8a3f529af964bae90f722) | `` Updated nongnu `` |
| [`f42d70c2`](https://github.com/nix-community/emacs-overlay/commit/f42d70c2f52e2e1da8e6cdd0fb1a5a1485e51a5e) | `` Updated emacs ``  |
| [`ce25fe74`](https://github.com/nix-community/emacs-overlay/commit/ce25fe74afb1cdcaaea2f9bad45af6ade508cba0) | `` Updated melpa ``  |
| [`bcc49aba`](https://github.com/nix-community/emacs-overlay/commit/bcc49aba7034c9ec53a9a2cb84f738b6e0096031) | `` Updated emacs ``  |
| [`aeb802f1`](https://github.com/nix-community/emacs-overlay/commit/aeb802f1435767a5b004dfeb551461b59b66ae38) | `` Updated melpa ``  |
| [`6165241a`](https://github.com/nix-community/emacs-overlay/commit/6165241a57f8a03b1442f2d8206a049d71c1f224) | `` Updated elpa ``   |
| [`b2d9aed4`](https://github.com/nix-community/emacs-overlay/commit/b2d9aed459819478d03016c728fdfdc797801ff3) | `` Updated nongnu `` |