### PR TITLE
chore(flake/nur): `37d4dcca` -> `96d9df0d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -701,11 +701,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1742422364,
-        "narHash": "sha256-mNqIplmEohk5jRkqYqG19GA8MbQ/D4gQSK0Mu4LvfRQ=",
+        "lastModified": 1742669843,
+        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a84ebe20c6bc2ecbcfb000a50776219f48d134cc",
+        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
         "type": "github"
       },
       "original": {
@@ -776,11 +776,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1742698203,
-        "narHash": "sha256-aDZYU8w7mRTCeK+6s7HOJw3V/LHkIfj2me169ZtpVIQ=",
+        "lastModified": 1742789076,
+        "narHash": "sha256-vlNcrzo7IfKdV3ME47O4NVk2o5qmirWyFGJNbHNOb5Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "37d4dccaebc470005f1a414994a967bdfc94c0f8",
+        "rev": "96d9df0d8235ee88c1a18f43f116475c2b9cdfe8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                               |
| -------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`96d9df0d`](https://github.com/nix-community/NUR/commit/96d9df0d8235ee88c1a18f43f116475c2b9cdfe8) | `` flake: Add darwin module output `` |
| [`4b941f79`](https://github.com/nix-community/NUR/commit/4b941f790233331e6fd66d21c1a0b743a4d2d635) | `` automatic update ``                |
| [`f5fee7d4`](https://github.com/nix-community/NUR/commit/f5fee7d416db88da3f75679e731abcba6becd0ef) | `` automatic update ``                |
| [`43f4e71c`](https://github.com/nix-community/NUR/commit/43f4e71cc7cc8e9167b604bc2507be334d54fe61) | `` automatic update ``                |
| [`fc918aba`](https://github.com/nix-community/NUR/commit/fc918aba9398033103c519c81aa89135621bbd3d) | `` automatic update ``                |
| [`917514fd`](https://github.com/nix-community/NUR/commit/917514fdd4956898c4220c8141fe079ce38e326a) | `` automatic update ``                |
| [`bcee91d9`](https://github.com/nix-community/NUR/commit/bcee91d98b699c352ab6ed29de11a1689de53f55) | `` automatic update ``                |
| [`2941113f`](https://github.com/nix-community/NUR/commit/2941113f90447eb357d3994c876221f8c7ea2423) | `` automatic update ``                |
| [`50c3bab8`](https://github.com/nix-community/NUR/commit/50c3bab816cc4ef881aa18dc85f893d5964fa99c) | `` automatic update ``                |
| [`371448da`](https://github.com/nix-community/NUR/commit/371448da3ce11464151d079210da53762c54cb2e) | `` automatic update ``                |
| [`57e0d726`](https://github.com/nix-community/NUR/commit/57e0d726d3d7b3543ab743eadd09aad608e1aa6e) | `` automatic update ``                |
| [`e1122e9d`](https://github.com/nix-community/NUR/commit/e1122e9df149e70316ed8c27e43d4a528bf96667) | `` automatic update ``                |
| [`d5e510e8`](https://github.com/nix-community/NUR/commit/d5e510e8b40bc20a1082a1f419161310bead3238) | `` automatic update ``                |
| [`974fe069`](https://github.com/nix-community/NUR/commit/974fe069b84c49e6133099f24e4f9ccd95877f11) | `` automatic update ``                |
| [`ddb77c54`](https://github.com/nix-community/NUR/commit/ddb77c54f257566ff34a0ba8c758a7b3cc0d76bf) | `` automatic update ``                |
| [`c52011ab`](https://github.com/nix-community/NUR/commit/c52011abd7fda6d05aa84e9e0110d56f06cac071) | `` automatic update ``                |
| [`380e726b`](https://github.com/nix-community/NUR/commit/380e726bcb864d495cee8b9263d407e9bec07dbb) | `` automatic update ``                |
| [`20a8870f`](https://github.com/nix-community/NUR/commit/20a8870fbc19fda438ddfe18cc7727ebc5bf6d8a) | `` automatic update ``                |
| [`20589456`](https://github.com/nix-community/NUR/commit/20589456dcc5142c9fd22b8790487b6249fd9ca1) | `` automatic update ``                |
| [`24f32131`](https://github.com/nix-community/NUR/commit/24f32131f5602eb6d1467c17fa1b947bf7d54be8) | `` automatic update ``                |