### PR TITLE
chore(flake/minimal-emacs-d): `39fde920` -> `9952dc2b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -398,11 +398,11 @@
     "minimal-emacs-d": {
       "flake": false,
       "locked": {
-        "lastModified": 1742597056,
-        "narHash": "sha256-oVF8nvKHp/jZ/8LTiyt5CNyVgTR5dUz2zEWbFlBgZk4=",
+        "lastModified": 1742914344,
+        "narHash": "sha256-f2hD3yfe/+Emt+3hN54vOadRvPaWDo2qoC1koTHp3nQ=",
         "owner": "jamescherti",
         "repo": "minimal-emacs.d",
-        "rev": "39fde9204d35f5ef36609cf2ab14265843e01ad9",
+        "rev": "9952dc2bbbd5f3e74923b774fa730f72dc5ecc4b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                             |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------- |
| [`9952dc2b`](https://github.com/jamescherti/minimal-emacs.d/commit/9952dc2bbbd5f3e74923b774fa730f72dc5ecc4b) | `` Update README.md ``              |
| [`d6eac7d7`](https://github.com/jamescherti/minimal-emacs.d/commit/d6eac7d7055325655cd2dfae73a40c56d8946395) | `` Update README.md ``              |
| [`052a7199`](https://github.com/jamescherti/minimal-emacs.d/commit/052a7199f27ebb86b67bf2e3b27f258cef529bde) | `` Update README.md ``              |
| [`0caaeb61`](https://github.com/jamescherti/minimal-emacs.d/commit/0caaeb6110e738eeefdd28f1bc16c3f67b7dc667) | `` Update README.md ``              |
| [`616bea30`](https://github.com/jamescherti/minimal-emacs.d/commit/616bea30c74ac213d891c0934a5904f01a7bcfe3) | `` Closes #53: Update docstrings `` |