### PR TITLE
chore(flake/emacs-overlay): `7ea1ac24` -> `1dbdb57a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1742750000,
-        "narHash": "sha256-03p4sJr5edbuXd5AkoUTr46co5+/B4APV/Sbv/hoDHk=",
+        "lastModified": 1742955228,
+        "narHash": "sha256-YEypEIGUjupPKA4FLTcvWmA7L5fW7tb9FBKgvTD5FB0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7ea1ac244572b6186965d15ef05ec5d466aac1ea",
+        "rev": "1dbdb57a8759ac9f32ad5ce8effa188bf43c70da",
         "type": "github"
       },
       "original": {
@@ -623,11 +623,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1742512142,
-        "narHash": "sha256-8XfURTDxOm6+33swQJu/hx6xw1Tznl8vJJN5HwVqckg=",
+        "lastModified": 1742751704,
+        "narHash": "sha256-rBfc+H1dDBUQ2mgVITMGBPI1PGuCznf9rcWX/XIULyE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7105ae3957700a9646cc4b766f5815b23ed0c682",
+        "rev": "f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`1dbdb57a`](https://github.com/nix-community/emacs-overlay/commit/1dbdb57a8759ac9f32ad5ce8effa188bf43c70da) | `` Updated emacs ``        |
| [`3e99d755`](https://github.com/nix-community/emacs-overlay/commit/3e99d7551b584e6bea226e3584a9a1badb1dc0be) | `` Updated melpa ``        |
| [`823311cf`](https://github.com/nix-community/emacs-overlay/commit/823311cf70d42ac9a47d739f03f32caaee1afb22) | `` Updated elpa ``         |
| [`7bcb7f0f`](https://github.com/nix-community/emacs-overlay/commit/7bcb7f0f34a5c1619290c5f4b965485931d88f32) | `` Updated nongnu ``       |
| [`6d55b448`](https://github.com/nix-community/emacs-overlay/commit/6d55b448e61097a6efdd8ee2aa5c48b8bbbf9c8c) | `` Updated emacs ``        |
| [`9160b7d6`](https://github.com/nix-community/emacs-overlay/commit/9160b7d694548b35eb19e75e566fd981306deb58) | `` Updated melpa ``        |
| [`db9a65f3`](https://github.com/nix-community/emacs-overlay/commit/db9a65f3237a2c62880c7b6a3c42df46033fd9db) | `` Updated elpa ``         |
| [`1682b0cf`](https://github.com/nix-community/emacs-overlay/commit/1682b0cff38bb84874d4b025f67b0cd09c3b9209) | `` Updated nongnu ``       |
| [`703bcc93`](https://github.com/nix-community/emacs-overlay/commit/703bcc932b2865780db8a6dff16f01f1646f8012) | `` Updated emacs ``        |
| [`7a2638b7`](https://github.com/nix-community/emacs-overlay/commit/7a2638b739c4442c081ebe9d9c1afbf6f788e5f4) | `` Updated melpa ``        |
| [`19e1382e`](https://github.com/nix-community/emacs-overlay/commit/19e1382e83aff8a36649951d1b31d7894f34d9b6) | `` Updated emacs ``        |
| [`e5cebb96`](https://github.com/nix-community/emacs-overlay/commit/e5cebb964c2cc690268a9b473d68f6cafe50ac23) | `` Updated melpa ``        |
| [`bae62204`](https://github.com/nix-community/emacs-overlay/commit/bae622049a9a44675ed9bcc786110a8764e40109) | `` Updated elpa ``         |
| [`346d78c7`](https://github.com/nix-community/emacs-overlay/commit/346d78c7e60dd9c70ff21e8868ba5cd29d8c44cc) | `` Updated nongnu ``       |
| [`cb257a1d`](https://github.com/nix-community/emacs-overlay/commit/cb257a1d672f75f2f3e375fe1080216131dd1fb0) | `` Updated emacs ``        |
| [`d86a74c6`](https://github.com/nix-community/emacs-overlay/commit/d86a74c6f6a4331686551423190b9d9d906acc36) | `` Updated melpa ``        |
| [`e47075c2`](https://github.com/nix-community/emacs-overlay/commit/e47075c2d6dbf9ac28b3a1666e27f82b5c31e112) | `` Updated elpa ``         |
| [`d4b1161f`](https://github.com/nix-community/emacs-overlay/commit/d4b1161f3dcdfc3791ca12c78f2b9e8a30b2a806) | `` Updated nongnu ``       |
| [`1fce7ecc`](https://github.com/nix-community/emacs-overlay/commit/1fce7ecc2e2f9ed0687443a752b7c90528fff383) | `` Updated emacs ``        |
| [`b43f60c8`](https://github.com/nix-community/emacs-overlay/commit/b43f60c83346eb87f0026f8f8b9fe1ea46e02b14) | `` Updated melpa ``        |
| [`aa264941`](https://github.com/nix-community/emacs-overlay/commit/aa264941dac4e2f66f8cf516cd59563a394473c4) | `` Updated flake inputs `` |
| [`27ba6c50`](https://github.com/nix-community/emacs-overlay/commit/27ba6c5075c4b1b53db6a1c7795b16ba4047dde7) | `` Updated emacs ``        |
| [`b682a3e4`](https://github.com/nix-community/emacs-overlay/commit/b682a3e473d4fd927a29f27a5a9c476804b1b13c) | `` Updated melpa ``        |
| [`07687120`](https://github.com/nix-community/emacs-overlay/commit/07687120e3ad939356003cbceaecf8ec70b2652e) | `` Updated elpa ``         |
| [`1a68860f`](https://github.com/nix-community/emacs-overlay/commit/1a68860fdb98eed4af06df26aebfca5a2de6e4ef) | `` Updated nongnu ``       |
| [`3e3eebc9`](https://github.com/nix-community/emacs-overlay/commit/3e3eebc9023bd4d9f12492a122ffedaad8e3503e) | `` Updated flake inputs `` |