### PR TITLE
chore(flake/nur): `34d8ed39` -> `0f2b9c7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -809,11 +809,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1742799072,
-        "narHash": "sha256-GpvnDOLF0dmT2FfsehSU8Yzqb3Ko9gz6bOT73OHmDSI=",
+        "lastModified": 1742886062,
+        "narHash": "sha256-WDRV3sDF72Y+Ztbw5/ZiwVhU28ivQ+D6xuEgLWWZhm8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "34d8ed39ae963aa627212204df4ddc8389312aa0",
+        "rev": "0f2b9c7d62d229664ef162da461789eba8ae1feb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0f2b9c7d`](https://github.com/nix-community/NUR/commit/0f2b9c7d62d229664ef162da461789eba8ae1feb) | `` automatic update `` |
| [`dcb3ba70`](https://github.com/nix-community/NUR/commit/dcb3ba703bf384fc7294caa683eded6242460712) | `` automatic update `` |
| [`559de88c`](https://github.com/nix-community/NUR/commit/559de88c4d92b37f60a7b2b7373bee4b48aabc40) | `` automatic update `` |
| [`2b101784`](https://github.com/nix-community/NUR/commit/2b1017841ab33c2458682b2108dd0b95c57352df) | `` automatic update `` |
| [`7582de0e`](https://github.com/nix-community/NUR/commit/7582de0e1fb252f78d619f3336d0e0b9987e06ce) | `` automatic update `` |
| [`626c1c19`](https://github.com/nix-community/NUR/commit/626c1c19e80dea0cedec210f307c01b691353ff5) | `` automatic update `` |
| [`cf76d27b`](https://github.com/nix-community/NUR/commit/cf76d27bf28c1976f6957f96a49c95a35763777e) | `` automatic update `` |
| [`d24c83d8`](https://github.com/nix-community/NUR/commit/d24c83d856648940490da12e06dfe6dbd4df7944) | `` automatic update `` |
| [`bd3e0bbb`](https://github.com/nix-community/NUR/commit/bd3e0bbb0ded9f5c2909443f352bda957234c6f5) | `` automatic update `` |
| [`17e8bf3f`](https://github.com/nix-community/NUR/commit/17e8bf3f786d44411ec15e348d9fe8ac741489d2) | `` automatic update `` |
| [`797067d7`](https://github.com/nix-community/NUR/commit/797067d7e3601713a3b43f823248a6232486376c) | `` automatic update `` |
| [`40f6fc3b`](https://github.com/nix-community/NUR/commit/40f6fc3bf0314f6f1b982143e6aa1aded4a1b450) | `` automatic update `` |
| [`eb607159`](https://github.com/nix-community/NUR/commit/eb6071597126086590c507463014c62ccb20d7f4) | `` automatic update `` |
| [`38778027`](https://github.com/nix-community/NUR/commit/387780271700a8fa6daff0d8c9acdf49876e258b) | `` automatic update `` |
| [`7b9cadfb`](https://github.com/nix-community/NUR/commit/7b9cadfb356324c950d7fbff17f3185b412864ad) | `` automatic update `` |
| [`4126c7bf`](https://github.com/nix-community/NUR/commit/4126c7bf5768f61342702ccba2ef595651675233) | `` automatic update `` |
| [`4eb50d03`](https://github.com/nix-community/NUR/commit/4eb50d0351d392dde86c8e089752240dfac1e298) | `` automatic update `` |
| [`f456e76e`](https://github.com/nix-community/NUR/commit/f456e76e79d10cf6cbf5611da903fb334570d38c) | `` automatic update `` |
| [`ea0193fe`](https://github.com/nix-community/NUR/commit/ea0193fe45d4c749fba336fd34b7d63214a12e28) | `` automatic update `` |
| [`220e5f36`](https://github.com/nix-community/NUR/commit/220e5f36c7c5d9df1dcec81348dc7b122ae7ec0c) | `` automatic update `` |
| [`13b396f4`](https://github.com/nix-community/NUR/commit/13b396f44f4f0895c4fcf0d2bd7cb95ff2d7cfe9) | `` automatic update `` |
| [`eb04da40`](https://github.com/nix-community/NUR/commit/eb04da40fd6ae6c24041c12c6ce47daffdae909f) | `` automatic update `` |
| [`ec93b668`](https://github.com/nix-community/NUR/commit/ec93b66841b9ae269ffce936975b96d4951b65b9) | `` automatic update `` |
| [`42b7b4b8`](https://github.com/nix-community/NUR/commit/42b7b4b8b2c53d3b1ed2301a5761ac63653a5e1b) | `` automatic update `` |
| [`3452b41d`](https://github.com/nix-community/NUR/commit/3452b41dbbb1cf4efd873258942910337aa5322d) | `` automatic update `` |