### PR TITLE
chore(flake/nixos-cosmic): `216557e6` -> `c62c1915`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -514,11 +514,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1742641703,
-        "narHash": "sha256-hoN8blvJco8OSZmPj8izwQaQUdydVi+5FO4/nWd1MNU=",
+        "lastModified": 1742847293,
+        "narHash": "sha256-2TJhcc0oczRl6ngiv42gkHB0HFMGaA50tiuDs7Ivl5A=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "216557e6cd229dbe7d73a497c227824a3c579cd7",
+        "rev": "c62c19158e4841550b8ebf614bb8b7147ef19e30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                                 |
| ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`c62c1915`](https://github.com/lilyinstarlight/nixos-cosmic/commit/c62c19158e4841550b8ebf614bb8b7147ef19e30) | `` nixos/cosmic-greeter: add package option (#726) ``                   |
| [`2c9c267f`](https://github.com/lilyinstarlight/nixos-cosmic/commit/2c9c267ff122161a637d611b13066fd577886fba) | `` cosmic-session: override `cargo-target-dir` with just flag (#727) `` |
| [`98a0228c`](https://github.com/lilyinstarlight/nixos-cosmic/commit/98a0228c8324b8094423640939586daf14109c25) | `` cosmic-ext-applet-caffeine: init (#694) ``                           |