### PR TITLE
chore(flake/home-manager): `2d057cd9` -> `1efd2503`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742842119,
-        "narHash": "sha256-YnJ1MHMLMDcWW4sRQya7IfXdJQAqW5y+lkL/WIvefc8=",
+        "lastModified": 1743136572,
+        "narHash": "sha256-uwaVrKgi6g1TUq56247j6QvvFtYHloCkjCrEpGBvV54=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2d057cd9d4f767737498e0aae75b07353c75bdee",
+        "rev": "1efd2503172016a6742c87b47b43ca2c8145607d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                          |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`1efd2503`](https://github.com/nix-community/home-manager/commit/1efd2503172016a6742c87b47b43ca2c8145607d) | `` flake.lock: Update (#6708) ``                                                                 |
| [`26ccff08`](https://github.com/nix-community/home-manager/commit/26ccff08df360afd888b08633a5dddbb99f04d8f) | `` thunderbird: set additional gmail smtpserver settings (#6713) ``                              |
| [`13d68e9a`](https://github.com/nix-community/home-manager/commit/13d68e9ac05caccc1f81ce40612a8086421e1706) | `` helix: avoid IFD (#6714) ``                                                                   |
| [`b14a70c4`](https://github.com/nix-community/home-manager/commit/b14a70c40f4fd0b73d095ab04a7c6e31fbc18e52) | `` fzf: update zsh integration to be after plugins (#6716) ``                                    |
| [`171915bf`](https://github.com/nix-community/home-manager/commit/171915bfce41018528fda9960211e81946d999b7) | `` fzf: fix zsh integration (keybinds rewritten by omz) (#6712) ``                               |
| [`693840c0`](https://github.com/nix-community/home-manager/commit/693840c01b9bef9e54100239cef937e53d4661bf) | `` vscode: Fix version checks when using Cursor (#6680) ``                                       |
| [`ce287a5c`](https://github.com/nix-community/home-manager/commit/ce287a5cd3ef78203bc78021447f937a988d9f6f) | `` mpdscribble: add module (#6259) ``                                                            |
| [`0ff53f6d`](https://github.com/nix-community/home-manager/commit/0ff53f6d336edb3ad81647dc931ad1c9c7f890ca) | `` helix: add extraConfig option (#6575) ``                                                      |
| [`2321c688`](https://github.com/nix-community/home-manager/commit/2321c6889bd473d384b687c7d536d88fec3b3256) | `` ripgrep-all: Add module (#5459) ``                                                            |
| [`338b2eab`](https://github.com/nix-community/home-manager/commit/338b2eabdfde14a79755341ea472e2c55d1064c4) | `` waybar: integrate with tray.target (#6675) ``                                                 |
| [`b9da58d5`](https://github.com/nix-community/home-manager/commit/b9da58d50551ebd74226fb8487b248a5a36c988f) | `` carapace: conditionally disable unnecessary fish completion workaround on fish 4.0 (#6694) `` |
| [`f565da89`](https://github.com/nix-community/home-manager/commit/f565da89e759ebf57b236510aa955b8a2d41c779) | `` davmail: add package option (#6705) ``                                                        |
| [`d8b4ba07`](https://github.com/nix-community/home-manager/commit/d8b4ba070f5dfcb6c051c74fb31eafb58127580b) | `` mergiraf: init module (#6633) ``                                                              |
| [`8bef8b7a`](https://github.com/nix-community/home-manager/commit/8bef8b7a0a95d347018f09b291e2fa0a77abd23f) | `` direnv: fix typo ``                                                                           |
| [`529906d6`](https://github.com/nix-community/home-manager/commit/529906d6a2ef020130110f4f8214a4513aa7996f) | `` podman: fix typo ``                                                                           |
| [`5abb21dc`](https://github.com/nix-community/home-manager/commit/5abb21dc10e4a9aaee5874c36e800a2609eceaef) | `` distrobox: fix typo ``                                                                        |
| [`e3dded7a`](https://github.com/nix-community/home-manager/commit/e3dded7a85c68f8445a735d70920fc00a808621b) | `` fish: Fix manpage completion generation with paths containing spaces (#6703) ``               |
| [`29806065`](https://github.com/nix-community/home-manager/commit/298060655681ec239491252da9b295d854ff51fe) | `` distrobox: replace hardcoded path with config package's path (#6701) ``                       |
| [`869f2ec2`](https://github.com/nix-community/home-manager/commit/869f2ec2add75ce2a70a6dbbf585b8399abec625) | `` zsh: fix concatenation of aliases and global aliases (#6698) ``                               |
| [`c4d5d728`](https://github.com/nix-community/home-manager/commit/c4d5d72805d14ea43c140eeb70401bf84c0f11b4) | `` neomutt: remove empty lines (#6523) ``                                                        |