### PR TITLE
chore(flake/nur): `0f2b9c7d` -> `f658044e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -809,11 +809,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1742886062,
-        "narHash": "sha256-WDRV3sDF72Y+Ztbw5/ZiwVhU28ivQ+D6xuEgLWWZhm8=",
+        "lastModified": 1742898418,
+        "narHash": "sha256-h+EATNfCOfU+RnvkcE69RunFWSxSlIodxULf8GUF3DM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0f2b9c7d62d229664ef162da461789eba8ae1feb",
+        "rev": "f658044ee4c3e2ebee93366b0d2ea0099c01e889",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f658044e`](https://github.com/nix-community/NUR/commit/f658044ee4c3e2ebee93366b0d2ea0099c01e889) | `` automatic update `` |