### PR TITLE
chore(flake/nur): `f658044e` -> `dcc6f70a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -702,11 +702,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1742669843,
-        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
+        "lastModified": 1742889210,
+        "narHash": "sha256-hw63HnwnqU3ZQfsMclLhMvOezpM7RSB0dMAtD5/sOiw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
+        "rev": "698214a32beb4f4c8e3942372c694f40848b360d",
         "type": "github"
       },
       "original": {
@@ -809,11 +809,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1742898418,
-        "narHash": "sha256-h+EATNfCOfU+RnvkcE69RunFWSxSlIodxULf8GUF3DM=",
+        "lastModified": 1743025561,
+        "narHash": "sha256-wbszHA2bJaA9TSLkiU1Gqby4noRNhhWi9CNoFqxSPj0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f658044ee4c3e2ebee93366b0d2ea0099c01e889",
+        "rev": "dcc6f70a7f8c69b50a266de40ca6228f01a50c88",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dcc6f70a`](https://github.com/nix-community/NUR/commit/dcc6f70a7f8c69b50a266de40ca6228f01a50c88) | `` automatic update `` |
| [`3f67c6a7`](https://github.com/nix-community/NUR/commit/3f67c6a7653307e42ca9beccdf7f63ce27864740) | `` automatic update `` |
| [`6c75b8c6`](https://github.com/nix-community/NUR/commit/6c75b8c6f152d908aed10a97c9cfd518222bc38b) | `` automatic update `` |
| [`76ca80f4`](https://github.com/nix-community/NUR/commit/76ca80f4cc791d21048533c39a293730f3f2b5b8) | `` automatic update `` |
| [`ec18f2ee`](https://github.com/nix-community/NUR/commit/ec18f2eeb761f8687a99f98d848d5257cf331df1) | `` automatic update `` |
| [`d180d873`](https://github.com/nix-community/NUR/commit/d180d873b53eb80c6efc15b59af5cf03d878aef2) | `` automatic update `` |
| [`7a6d1dbb`](https://github.com/nix-community/NUR/commit/7a6d1dbb909d5a4a9d7f3e2c5579c74dfef34e83) | `` automatic update `` |
| [`54987a4f`](https://github.com/nix-community/NUR/commit/54987a4f986cea1f0548c7cbe3503df62e823ba0) | `` automatic update `` |
| [`db13ba58`](https://github.com/nix-community/NUR/commit/db13ba582bb11db59045628569b5cf8807da63aa) | `` automatic update `` |
| [`1936b1d6`](https://github.com/nix-community/NUR/commit/1936b1d639a231a38accbc99d59e0fdfff4e998c) | `` automatic update `` |
| [`88fa68c0`](https://github.com/nix-community/NUR/commit/88fa68c0ed1af322f15684b6cf7914e6d8918933) | `` automatic update `` |
| [`e43eceb3`](https://github.com/nix-community/NUR/commit/e43eceb3e638ad6822ef3b6449f0ec72f5a4c70c) | `` automatic update `` |
| [`028c4f0c`](https://github.com/nix-community/NUR/commit/028c4f0ccf35ede826a3eff910cb4fe6b8e6cfb5) | `` automatic update `` |
| [`888410d1`](https://github.com/nix-community/NUR/commit/888410d18e228aa445678c9d9bdad16741922565) | `` automatic update `` |
| [`5a6a8760`](https://github.com/nix-community/NUR/commit/5a6a8760fa15b2f64884373e1e18d70255ceb5b5) | `` automatic update `` |
| [`fba11b41`](https://github.com/nix-community/NUR/commit/fba11b41940b3cd2fa38ed045d3f929950547ba5) | `` automatic update `` |
| [`d28bb594`](https://github.com/nix-community/NUR/commit/d28bb594bc3f7ab466f89806cfd0f940d7764b1c) | `` automatic update `` |
| [`d4542672`](https://github.com/nix-community/NUR/commit/d4542672fa52f22a4c089020bf823917590947fa) | `` automatic update `` |
| [`2322de33`](https://github.com/nix-community/NUR/commit/2322de3398c46948554ed96bcb5662352b2a2568) | `` automatic update `` |
| [`da1f8703`](https://github.com/nix-community/NUR/commit/da1f8703b7e179487742515aa7abc843f25a2a50) | `` automatic update `` |
| [`e877eb56`](https://github.com/nix-community/NUR/commit/e877eb56f46722fca894e4b162998ef83054b02a) | `` automatic update `` |
| [`4877fcde`](https://github.com/nix-community/NUR/commit/4877fcde84e6e243d786adebc51d3fcd6fa77c98) | `` automatic update `` |
| [`f5067402`](https://github.com/nix-community/NUR/commit/f50674023ee219063b42a11f369c11792dceca51) | `` automatic update `` |
| [`6602c070`](https://github.com/nix-community/NUR/commit/6602c070a47cec20c1e2e0d30077f88a20b6e074) | `` automatic update `` |
| [`1efba0ed`](https://github.com/nix-community/NUR/commit/1efba0ed2b99e6cb2ba2b1309d47a6b9888e530f) | `` automatic update `` |
| [`833e7932`](https://github.com/nix-community/NUR/commit/833e7932aa33baa1da033fc4b194c3316d7ec7ac) | `` automatic update `` |
| [`3bcafefc`](https://github.com/nix-community/NUR/commit/3bcafefc2ba8acb9e026dbbea4e25ae6a16565d3) | `` automatic update `` |
| [`865ceec6`](https://github.com/nix-community/NUR/commit/865ceec61c4e4fcff93e287b2349f39f25b162d4) | `` automatic update `` |
| [`dd197fbd`](https://github.com/nix-community/NUR/commit/dd197fbd421ef34161d25f7a0e0c1940983fd536) | `` automatic update `` |