### PR TITLE
chore(flake/minimal-emacs-d): `24b7946f` -> `e00753f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -398,11 +398,11 @@
     "minimal-emacs-d": {
       "flake": false,
       "locked": {
-        "lastModified": 1742927533,
-        "narHash": "sha256-E3+c11zSCl98afoibfcE9cHwEgoiHLMvc7Y2gIayX4w=",
+        "lastModified": 1742946233,
+        "narHash": "sha256-PMdinv3uhnxKns4nca/4FAPvnYe88LC2YNm36kabxU4=",
         "owner": "jamescherti",
         "repo": "minimal-emacs.d",
-        "rev": "24b7946fcb57e3cc5e532bc4a3378e2116a2e264",
+        "rev": "e00753f2c6ef8a6890370f2056281cb259fddb78",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`e00753f2`](https://github.com/jamescherti/minimal-emacs.d/commit/e00753f2c6ef8a6890370f2056281cb259fddb78) | `` Update README.md `` |
| [`c2ef0f6e`](https://github.com/jamescherti/minimal-emacs.d/commit/c2ef0f6ebc3c0487851d5530e40f7af50e07d58b) | `` Update README.md `` |
| [`33b06a45`](https://github.com/jamescherti/minimal-emacs.d/commit/33b06a454b5a98e854512dafff1dec1806cf2679) | `` Update README.md `` |
| [`c30a9cc4`](https://github.com/jamescherti/minimal-emacs.d/commit/c30a9cc4ffcd07aacd0689f1b5df45d076165c2f) | `` Update README.md `` |