### PR TITLE
chore(flake/emacs-overlay): `1dbdb57a` -> `8566c4f4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1742955228,
-        "narHash": "sha256-YEypEIGUjupPKA4FLTcvWmA7L5fW7tb9FBKgvTD5FB0=",
+        "lastModified": 1743006152,
+        "narHash": "sha256-1mkjVaVLaQVJSnW0/ziFpqevuU9p74niwF4tkS3wHMo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1dbdb57a8759ac9f32ad5ce8effa188bf43c70da",
+        "rev": "8566c4f4dea1698078dc003a7c55ba7f59ac3b27",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`8566c4f4`](https://github.com/nix-community/emacs-overlay/commit/8566c4f4dea1698078dc003a7c55ba7f59ac3b27) | `` Updated flake inputs `` |
| [`6a171492`](https://github.com/nix-community/emacs-overlay/commit/6a1714928534fd6e2c0c68f42507f05d9dba6820) | `` Updated emacs ``        |
| [`4cdd23dd`](https://github.com/nix-community/emacs-overlay/commit/4cdd23dd293850c2df56732e7272c8fd1be98b64) | `` Updated melpa ``        |