### PR TITLE
chore(flake/nur): `dcc6f70a` -> `b9ac27d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -809,11 +809,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1743025561,
-        "narHash": "sha256-wbszHA2bJaA9TSLkiU1Gqby4noRNhhWi9CNoFqxSPj0=",
+        "lastModified": 1743047474,
+        "narHash": "sha256-eqW3Ps+e+3KH3dru+NjLxtn4scbjJU6wkc3C7LDSMZo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dcc6f70a7f8c69b50a266de40ca6228f01a50c88",
+        "rev": "b9ac27d1c1b1567c52c965bdc5a09007a95f8f91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b9ac27d1`](https://github.com/nix-community/NUR/commit/b9ac27d1c1b1567c52c965bdc5a09007a95f8f91) | `` automatic update `` |