### PR TITLE
chore(flake/srvos): `60a187c4` -> `7a4dc5c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -943,11 +943,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742432134,
-        "narHash": "sha256-J9BMk5uEXGZqe3ksA+TNjpuWx67r6qwa6MCS+ayDTqw=",
+        "lastModified": 1743041209,
+        "narHash": "sha256-ANo3g355dNIF0Rtv3eLrJPu1h58Pn6O6mK0oBrcBq8A=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "60a187c45762fcc5ed0f3c97e1da890d0ed3f695",
+        "rev": "7a4dc5c1112b2cde72ab05f70f522cfecb9c48d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                       |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`7a4dc5c1`](https://github.com/nix-community/srvos/commit/7a4dc5c1112b2cde72ab05f70f522cfecb9c48d1) | `` darwin/server: includeUninstaller -> darwin-uninstaller `` |