### PR TITLE
chore(flake/emacs-overlay): `8566c4f4` -> `9d534b57`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1743006152,
-        "narHash": "sha256-1mkjVaVLaQVJSnW0/ziFpqevuU9p74niwF4tkS3wHMo=",
+        "lastModified": 1743092657,
+        "narHash": "sha256-ow7/uhFsONGV8y7YwokqRU1SFrkN1op73MvzuE8dynU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8566c4f4dea1698078dc003a7c55ba7f59ac3b27",
+        "rev": "9d534b5749cd539145580f0ad588a912990841dc",
         "type": "github"
       },
       "original": {
@@ -623,11 +623,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1742751704,
-        "narHash": "sha256-rBfc+H1dDBUQ2mgVITMGBPI1PGuCznf9rcWX/XIULyE=",
+        "lastModified": 1742937945,
+        "narHash": "sha256-lWc+79eZRyvHp/SqMhHTMzZVhpxkRvthsP1Qx6UCq0E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092",
+        "rev": "d02d88f8de5b882ccdde0465d8fa2db3aa1169f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                         |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------- |
| [`9d534b57`](https://github.com/nix-community/emacs-overlay/commit/9d534b5749cd539145580f0ad588a912990841dc) | `` Updated elpa ``              |
| [`5c22a238`](https://github.com/nix-community/emacs-overlay/commit/5c22a2387d4ac1e1d64d66489e7d3ecb0a30cbcd) | `` Updated emacs ``             |
| [`93fbd5a8`](https://github.com/nix-community/emacs-overlay/commit/93fbd5a873d74bb035f249a65c20cb0dfdc0c2e5) | `` Updated melpa ``             |
| [`616ec6ce`](https://github.com/nix-community/emacs-overlay/commit/616ec6ce6e0df878a95ad6884452fd728e8e9386) | `` Updated flake inputs ``      |
| [`3c71542f`](https://github.com/nix-community/emacs-overlay/commit/3c71542fc0dd16002a5336767c1a9e0d10a3a746) | `` python-mode: fix src hash `` |
| [`b9d19638`](https://github.com/nix-community/emacs-overlay/commit/b9d19638352bd5a7b601ac47f3f20d8fb9b82028) | `` Updated emacs ``             |
| [`db7e1fa7`](https://github.com/nix-community/emacs-overlay/commit/db7e1fa7a20e0815263063f7cea8b7883f1f08dc) | `` Updated melpa ``             |
| [`290c10bc`](https://github.com/nix-community/emacs-overlay/commit/290c10bc7a3c4a66410e2f25aed40998a884c511) | `` Updated elpa ``              |
| [`864e85fe`](https://github.com/nix-community/emacs-overlay/commit/864e85fe4ddf014da3dd5d296e987ba3fa69c7d4) | `` Updated nongnu ``            |