### PR TITLE
chore(flake/nur): `b9ac27d1` -> `0ff6d47c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -809,11 +809,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1743047474,
-        "narHash": "sha256-eqW3Ps+e+3KH3dru+NjLxtn4scbjJU6wkc3C7LDSMZo=",
+        "lastModified": 1743089166,
+        "narHash": "sha256-rsEDTOyaf4ilSsjWzssMJDS+x9f8HKFxlFNWuvnpmTo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b9ac27d1c1b1567c52c965bdc5a09007a95f8f91",
+        "rev": "0ff6d47ceb7bd1b4aae97bf5ed50138c3c0ec8a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0ff6d47c`](https://github.com/nix-community/NUR/commit/0ff6d47ceb7bd1b4aae97bf5ed50138c3c0ec8a2) | `` automatic update `` |
| [`cdcd4bde`](https://github.com/nix-community/NUR/commit/cdcd4bde90a21ad8badca122f4f8957c6855a58c) | `` automatic update `` |
| [`63ba8703`](https://github.com/nix-community/NUR/commit/63ba8703fdc2bc7a5bfeb0732b6027361414aee2) | `` automatic update `` |
| [`6472c9cf`](https://github.com/nix-community/NUR/commit/6472c9cf462524ab126c3585528f008c1f912293) | `` automatic update `` |
| [`4f5d839c`](https://github.com/nix-community/NUR/commit/4f5d839c6843133fcfdb1ebd02167568dfccb1be) | `` automatic update `` |
| [`8ef917c1`](https://github.com/nix-community/NUR/commit/8ef917c1d2d775ac7b8e0b46af464b691fc2ac5b) | `` automatic update `` |
| [`83c6dda9`](https://github.com/nix-community/NUR/commit/83c6dda92511c8f158c82071d9e50053200806c9) | `` automatic update `` |
| [`28d3daa9`](https://github.com/nix-community/NUR/commit/28d3daa92d92a61134fba2cddcd85e80d83fc0ad) | `` automatic update `` |
| [`c8dc3e94`](https://github.com/nix-community/NUR/commit/c8dc3e94a8b2ce71a2d5539158220a7bfa405839) | `` automatic update `` |
| [`e74550f2`](https://github.com/nix-community/NUR/commit/e74550f29777d72344aac03e6d376e955d7e307d) | `` automatic update `` |