### PR TITLE
chore(flake/minimal-emacs-d): `e00753f2` -> `4276b3a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -398,11 +398,11 @@
     "minimal-emacs-d": {
       "flake": false,
       "locked": {
-        "lastModified": 1742946233,
-        "narHash": "sha256-PMdinv3uhnxKns4nca/4FAPvnYe88LC2YNm36kabxU4=",
+        "lastModified": 1743088199,
+        "narHash": "sha256-KiZSlmeT/BeDHY1VLNigI0ZyBRaI94ZFETU8nzLVOWI=",
         "owner": "jamescherti",
         "repo": "minimal-emacs.d",
-        "rev": "e00753f2c6ef8a6890370f2056281cb259fddb78",
+        "rev": "4276b3a53a9aa258f2941ab0350316cbad1a35bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`4276b3a5`](https://github.com/jamescherti/minimal-emacs.d/commit/4276b3a53a9aa258f2941ab0350316cbad1a35bc) | `` Update README.md `` |
| [`68cd7346`](https://github.com/jamescherti/minimal-emacs.d/commit/68cd734633c36453434d9938a461ac399ce3b197) | `` Update README.md `` |
| [`fb39be1c`](https://github.com/jamescherti/minimal-emacs.d/commit/fb39be1cdeae1d2bed964c63e2005a950b5ca6a2) | `` Update README.md `` |
| [`907ee513`](https://github.com/jamescherti/minimal-emacs.d/commit/907ee513e816a5629cfdf47ded04799f6b901af7) | `` Update README.md `` |