### PR TITLE
chore(flake/emacs-overlay): `9d534b57` -> `849cd492`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1743092657,
-        "narHash": "sha256-ow7/uhFsONGV8y7YwokqRU1SFrkN1op73MvzuE8dynU=",
+        "lastModified": 1743184222,
+        "narHash": "sha256-B2R43Vsz7NgcaMZQRLQkklosgW1Uo1Z5AS+8R6f1s/A=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9d534b5749cd539145580f0ad588a912990841dc",
+        "rev": "849cd4920ec9a1976dc916b192f7f2401ec13c5b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`849cd492`](https://github.com/nix-community/emacs-overlay/commit/849cd4920ec9a1976dc916b192f7f2401ec13c5b) | `` Updated emacs ``  |
| [`313b7a77`](https://github.com/nix-community/emacs-overlay/commit/313b7a777f7f9755ea8a7c3c284f0d0ab6f9520b) | `` Updated melpa ``  |
| [`c553e898`](https://github.com/nix-community/emacs-overlay/commit/c553e898a9639c65ee1ace89580edf48147530cf) | `` Updated elpa ``   |
| [`a8c83905`](https://github.com/nix-community/emacs-overlay/commit/a8c8390564a2189d14eace17a02e65e19e17f766) | `` Updated nongnu `` |
| [`40a9308b`](https://github.com/nix-community/emacs-overlay/commit/40a9308b06ee2061c5871038024ffcfd992a9ce8) | `` Updated emacs ``  |
| [`76ed1d1b`](https://github.com/nix-community/emacs-overlay/commit/76ed1d1b6c3ae80cc12dfc464e3efa743cccd720) | `` Updated melpa ``  |
| [`16b1c42e`](https://github.com/nix-community/emacs-overlay/commit/16b1c42e9567cb7fc145674e169d1d724a221a8d) | `` Updated emacs ``  |
| [`a6b2ff5a`](https://github.com/nix-community/emacs-overlay/commit/a6b2ff5a6122cca749ad9686f1ef5f70dfba667a) | `` Updated melpa ``  |
| [`45285809`](https://github.com/nix-community/emacs-overlay/commit/45285809053bff315187b2c915554f19608dc0b6) | `` Updated elpa ``   |
| [`b33e5b1c`](https://github.com/nix-community/emacs-overlay/commit/b33e5b1ce7e2bdb6e8532d259928c89f2bb3c973) | `` Updated nongnu `` |