### PR TITLE
chore(flake/nur): `69fcdee0` -> `6966ac74`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -809,11 +809,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1743157624,
-        "narHash": "sha256-AY2iDjR8hggtcSIVE3w90uAYKdt23v5tGU1J9sk1iw4=",
+        "lastModified": 1743176855,
+        "narHash": "sha256-qcH/GarOlyZ6SXqW+xxGAgJH2xBrJ8/E9jiVKZlsdbY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "69fcdee0ebc6c6469693b167453e0ccdf3b91412",
+        "rev": "6966ac7457bf3e4152663f4df90886742242da9b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6966ac74`](https://github.com/nix-community/NUR/commit/6966ac7457bf3e4152663f4df90886742242da9b) | `` automatic update `` |
| [`03311b92`](https://github.com/nix-community/NUR/commit/03311b9203f417372cf5018348aa016854bd903a) | `` automatic update `` |