### PR TITLE
chore(flake/emacs-overlay): `849cd492` -> `d4c8403d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1743184222,
-        "narHash": "sha256-B2R43Vsz7NgcaMZQRLQkklosgW1Uo1Z5AS+8R6f1s/A=",
+        "lastModified": 1743214408,
+        "narHash": "sha256-crIPBiBneJR7RJkASKmBZ1fHTLI9BOdjqEbqiE1m1Jc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "849cd4920ec9a1976dc916b192f7f2401ec13c5b",
+        "rev": "d4c8403d372379595c2e608f36312157e0fc0938",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`d4c8403d`](https://github.com/nix-community/emacs-overlay/commit/d4c8403d372379595c2e608f36312157e0fc0938) | `` Updated emacs ``        |
| [`03bc4aa1`](https://github.com/nix-community/emacs-overlay/commit/03bc4aa163546aa0d3c5909c8047fcd2992e0cd3) | `` Updated melpa ``        |
| [`bc789ba9`](https://github.com/nix-community/emacs-overlay/commit/bc789ba9f1147999c213d625f635a155f043151c) | `` Updated elpa ``         |
| [`cbb037af`](https://github.com/nix-community/emacs-overlay/commit/cbb037aff028f1ead04d0364dafa37488c00e3ed) | `` Updated nongnu ``       |
| [`580c98c4`](https://github.com/nix-community/emacs-overlay/commit/580c98c4c9a140f2f6f01d9c87bb0f7130420f82) | `` Updated flake inputs `` |