### PR TITLE
chore(flake/darwin): `75f8e4db` -> `73d59580`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743125241,
-        "narHash": "sha256-TA/xYqZbBwCCprXf8ABORDsjJy0Idw6OdQNqYQhgKCM=",
+        "lastModified": 1743496612,
+        "narHash": "sha256-emPWa5lmKbnyuj8c1mSJUkzJNT+iJoU9GMcXwjp2oVM=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "75f8e4dbc553d3052f917e66ee874f69d49c9981",
+        "rev": "73d59580d01e9b9f957ba749f336a272869c42dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                 |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
| [`1b8d7118`](https://github.com/nix-darwin/nix-darwin/commit/1b8d71182676c7820b4cac0067ac0432860edb63) | `` linux-builder: format ``                                             |
| [`b8939c4f`](https://github.com/nix-darwin/nix-darwin/commit/b8939c4fe41adbcb619b8ee477a309c8baca0dcf) | `` linux-builder: remove /nix/store external directory when disabled `` |
| [`a175c68f`](https://github.com/nix-darwin/nix-darwin/commit/a175c68f3fa3d072b935518d0dd3d20c71048458) | `` linux-builder: upgrade working directory ``                          |
| [`e7bd2f8f`](https://github.com/nix-darwin/nix-darwin/commit/e7bd2f8f2f0829149ce99142e2ad1cdce9dff155) | `` nix-tools: re‐add `nixPackage` ``                                    |
| [`75a7fb88`](https://github.com/nix-darwin/nix-darwin/commit/75a7fb885d0afcaa77e6c930be991aab6a6755ab) | `` website: try to fix redirect ``                                      |
| [`516590cf`](https://github.com/nix-darwin/nix-darwin/commit/516590cf1299aceb7f987d433e14f406f9089973) | `` website: fix manual path ``                                          |
| [`2c77fdbf`](https://github.com/nix-darwin/nix-darwin/commit/2c77fdbfba643fbd201837c1dcff5fcdf340da39) | `` ci: deploy the website from GitHub Actions ``                        |
| [`a5af2a5b`](https://github.com/nix-darwin/nix-darwin/commit/a5af2a5b22f991987a19cee673ac9f9c09587f1f) | `` readme: use logo from GitHub attachments ``                          |