### PR TITLE
chore(flake/emacs-overlay): `d4c8403d` -> `2ac7be36`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1743214408,
-        "narHash": "sha256-crIPBiBneJR7RJkASKmBZ1fHTLI9BOdjqEbqiE1m1Jc=",
+        "lastModified": 1743239789,
+        "narHash": "sha256-WvJj6PCAdBmWx69OYvAUVtLG9gFdChMteHZTaYrADqQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d4c8403d372379595c2e608f36312157e0fc0938",
+        "rev": "2ac7be36de0ef1e6936c7ba89fbf8d2ae87f4ddd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`2ac7be36`](https://github.com/nix-community/emacs-overlay/commit/2ac7be36de0ef1e6936c7ba89fbf8d2ae87f4ddd) | `` Updated emacs `` |
| [`092a831b`](https://github.com/nix-community/emacs-overlay/commit/092a831b09bce1c328efeacd99fc1dcb2f825655) | `` Updated melpa `` |