### PR TITLE
chore(flake/emacs-overlay): `2ac7be36` -> `93e148ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1743239789,
-        "narHash": "sha256-WvJj6PCAdBmWx69OYvAUVtLG9gFdChMteHZTaYrADqQ=",
+        "lastModified": 1743268410,
+        "narHash": "sha256-JT3B9nidF+0PRVgHB4Vy/3pShCrU6lUK1Kjn8yoiSZM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2ac7be36de0ef1e6936c7ba89fbf8d2ae87f4ddd",
+        "rev": "93e148ba6bdd5db1a40878ab04f5901e263553f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`93e148ba`](https://github.com/nix-community/emacs-overlay/commit/93e148ba6bdd5db1a40878ab04f5901e263553f6) | `` Updated emacs ``  |
| [`fea7b861`](https://github.com/nix-community/emacs-overlay/commit/fea7b861199eab24c45c1cccae4063e09822e247) | `` Updated melpa ``  |
| [`ea0e0d32`](https://github.com/nix-community/emacs-overlay/commit/ea0e0d323d7a6da70589a290ff5eb8c15d3777c0) | `` Updated elpa ``   |
| [`aef3d84c`](https://github.com/nix-community/emacs-overlay/commit/aef3d84c6134082f056e27fb538606ca6237c786) | `` Updated nongnu `` |