### PR TITLE
chore(flake/home-manager): `1f679ed2` -> `b4314965`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743259333,
-        "narHash": "sha256-2Fi3K++co4IGbeOLGXdRA6VEfbzQzMgcuBaPTyjfj0s=",
+        "lastModified": 1743267068,
+        "narHash": "sha256-G7866vbO5jgqMcYJzgbxej40O6mBGQMGt6gM0himjoA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1f679ed2a2ebe3894bad9f89fb0bd9f141c28a68",
+        "rev": "b431496538b0e294fbe44a1441b24ae8195c63f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                     |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`b4314965`](https://github.com/nix-community/home-manager/commit/b431496538b0e294fbe44a1441b24ae8195c63f0) | `` launchd: refactor setupLaunchAgents ``   |
| [`86d2e3b0`](https://github.com/nix-community/home-manager/commit/86d2e3b00561a166f8c31ff9ec6a947ca0992ec5) | `` launchd: remove checkLaunchAgents ``     |
| [`ef8f8987`](https://github.com/nix-community/home-manager/commit/ef8f898727d174b16a154b29e8c0f82d39cbac21) | `` launchd: add khaneliman maintainer ``    |
| [`a710f337`](https://github.com/nix-community/home-manager/commit/a710f337d6f541f5ba50bc2d5daa6c34e9ee5834) | `` launchd: remove with lib ``              |
| [`f1d4acaa`](https://github.com/nix-community/home-manager/commit/f1d4acaa1085930f76165e99db356db9f9f9fda6) | `` treewide: use mkPackageOption (#6727) `` |