### PR TITLE
chore(flake/sops-nix): `67566fe6` -> `e7f4d7ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -923,11 +923,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742700801,
-        "narHash": "sha256-ZGlpUDsuBdeZeTNgoMv+aw0ByXT2J3wkYw9kJwkAS4M=",
+        "lastModified": 1743502316,
+        "narHash": "sha256-zI2WSkU+ei4zCxT+IVSQjNM9i0ST++T2qSFXTsAND7s=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "67566fe68a8bed2a7b1175fdfb0697ed22ae8852",
+        "rev": "e7f4d7ed8bce8dfa7d2f2fe6f8b8f523e54646f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                      |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`e7f4d7ed`](https://github.com/Mic92/sops-nix/commit/e7f4d7ed8bce8dfa7d2f2fe6f8b8f523e54646f8) | `` make writing templates more atomic ``     |
| [`01fc2068`](https://github.com/Mic92/sops-nix/commit/01fc2068e653767c06aa91b3720fb3355e8e4335) | `` [create-pull-request] automated change `` |
| [`9d9bfbb1`](https://github.com/Mic92/sops-nix/commit/9d9bfbb13bdff51dfc649d4c103096d789dc8dc0) | `` [create-pull-request] automated change `` |