### PR TITLE
chore(flake/emacs-overlay): `93e148ba` -> `e6361983`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1743268410,
-        "narHash": "sha256-JT3B9nidF+0PRVgHB4Vy/3pShCrU6lUK1Kjn8yoiSZM=",
+        "lastModified": 1743301145,
+        "narHash": "sha256-53mZ7NyIScw688WmsgRJZxKbsy3D0rgVVSb0CGHQknk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "93e148ba6bdd5db1a40878ab04f5901e263553f6",
+        "rev": "e6361983cfc586fc16d27aba29cc799818f2051b",
         "type": "github"
       },
       "original": {
@@ -623,11 +623,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1742937945,
-        "narHash": "sha256-lWc+79eZRyvHp/SqMhHTMzZVhpxkRvthsP1Qx6UCq0E=",
+        "lastModified": 1743231893,
+        "narHash": "sha256-tpJsHMUPEhEnzySoQxx7+kA+KUtgWqvlcUBqROYNNt0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d02d88f8de5b882ccdde0465d8fa2db3aa1169f7",
+        "rev": "c570c1f5304493cafe133b8d843c7c1c4a10d3a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`e6361983`](https://github.com/nix-community/emacs-overlay/commit/e6361983cfc586fc16d27aba29cc799818f2051b) | `` Updated emacs ``        |
| [`a9743da3`](https://github.com/nix-community/emacs-overlay/commit/a9743da37057722611286077ea01fc55efc0099e) | `` Updated melpa ``        |
| [`266302f8`](https://github.com/nix-community/emacs-overlay/commit/266302f8e5781ba8b4597d4da4e471b2c81a42b4) | `` Updated elpa ``         |
| [`eb4887de`](https://github.com/nix-community/emacs-overlay/commit/eb4887de64a5fd0e12654b6e1256ca210b55f52f) | `` Updated nongnu ``       |
| [`e4d0afb6`](https://github.com/nix-community/emacs-overlay/commit/e4d0afb69413c4e051817da3a025073bde388a30) | `` Updated flake inputs `` |