### PR TITLE
chore(flake/emacs-overlay): `e6361983` -> `b32134c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1743301145,
-        "narHash": "sha256-53mZ7NyIScw688WmsgRJZxKbsy3D0rgVVSb0CGHQknk=",
+        "lastModified": 1743354910,
+        "narHash": "sha256-sIwcZ2HXq8yyBpfmUaRqI9v8pjKUiIpDvg162v8p634=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e6361983cfc586fc16d27aba29cc799818f2051b",
+        "rev": "b32134c9ab10f44aec6dfc3e76d4e51383130cd8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`b32134c9`](https://github.com/nix-community/emacs-overlay/commit/b32134c9ab10f44aec6dfc3e76d4e51383130cd8) | `` Updated emacs ``  |
| [`29040dae`](https://github.com/nix-community/emacs-overlay/commit/29040daea41a538090d3d9c5fe88db73a7058b24) | `` Updated melpa ``  |
| [`ac743c4c`](https://github.com/nix-community/emacs-overlay/commit/ac743c4c14382f4ec05c2f8c54598ef6a5cdf0f3) | `` Updated elpa ``   |
| [`c4ac49fb`](https://github.com/nix-community/emacs-overlay/commit/c4ac49fb4b212fcf52867f2fe28bf3f29bd25b80) | `` Updated nongnu `` |
| [`d9008b26`](https://github.com/nix-community/emacs-overlay/commit/d9008b26a6827690c44d65d6c92ba90176c0dede) | `` Updated emacs ``  |
| [`dd4c7375`](https://github.com/nix-community/emacs-overlay/commit/dd4c7375201c434741edf42ce560cf2aa56daa8d) | `` Updated melpa ``  |