### PR TITLE
chore(flake/home-manager): `1d2ed9c5` -> `b6fd653e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743346616,
-        "narHash": "sha256-AB/ve2el1TB7k4iyogHGCVlWVkrhp3+4FKKMr1W5iKQ=",
+        "lastModified": 1743360001,
+        "narHash": "sha256-HtpS/ZdgWXw0y+aFdORcX5RuBGTyz3WskThspNR70SM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1d2ed9c503cf41ca7f3db091edc8519dcdcd8b41",
+        "rev": "b6fd653ef8fbeccfd4958650757e91767a65506d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`b6fd653e`](https://github.com/nix-community/home-manager/commit/b6fd653ef8fbeccfd4958650757e91767a65506d) | `` newsboat: add a package option to the module (#6717) `` |
| [`09280e17`](https://github.com/nix-community/home-manager/commit/09280e17bbd29536efd1549751038fa155489bd4) | `` xdg-autostart: Add readOnly option (#6629) ``           |