### PR TITLE
chore(flake/emacs-overlay): `b32134c9` -> `c6be3549`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1743354910,
-        "narHash": "sha256-sIwcZ2HXq8yyBpfmUaRqI9v8pjKUiIpDvg162v8p634=",
+        "lastModified": 1743386826,
+        "narHash": "sha256-tu1Cq5RWW6LYxiYubWrlunz2X2dZqqq5DP7J4FLih9s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b32134c9ab10f44aec6dfc3e76d4e51383130cd8",
+        "rev": "c6be354945805ac0015725b7b9b49e9ecad85c8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`c6be3549`](https://github.com/nix-community/emacs-overlay/commit/c6be354945805ac0015725b7b9b49e9ecad85c8f) | `` Updated melpa ``        |
| [`cef67817`](https://github.com/nix-community/emacs-overlay/commit/cef6781712f39fe74f09cdcfc109799ffe81aba6) | `` Updated elpa ``         |
| [`4fbe4254`](https://github.com/nix-community/emacs-overlay/commit/4fbe4254fdf5223b5b66a222e801030f70944885) | `` Updated nongnu ``       |
| [`fdd12f9f`](https://github.com/nix-community/emacs-overlay/commit/fdd12f9f1011c6bf22aad083aadbeea2a4396388) | `` Updated flake inputs `` |