### PR TITLE
chore(flake/emacs-overlay): `c6be3549` -> `0d92783c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1743386826,
-        "narHash": "sha256-tu1Cq5RWW6LYxiYubWrlunz2X2dZqqq5DP7J4FLih9s=",
+        "lastModified": 1743474120,
+        "narHash": "sha256-F7wKIx2WEuzfRN//Qho7axdFtIsnGsxkCRWJwzL2KgE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c6be354945805ac0015725b7b9b49e9ecad85c8f",
+        "rev": "0d92783cc1d0ec68d631f6e93204b21282505806",
         "type": "github"
       },
       "original": {
@@ -623,11 +623,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1743231893,
-        "narHash": "sha256-tpJsHMUPEhEnzySoQxx7+kA+KUtgWqvlcUBqROYNNt0=",
+        "lastModified": 1743367904,
+        "narHash": "sha256-sOos1jZGKmT6xxPvxGQyPTApOunXvScV4lNjBCXd/CI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c570c1f5304493cafe133b8d843c7c1c4a10d3a6",
+        "rev": "7ffe0edc685f14b8c635e3d6591b0bbb97365e6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`0d92783c`](https://github.com/nix-community/emacs-overlay/commit/0d92783cc1d0ec68d631f6e93204b21282505806) | `` Updated emacs ``        |
| [`38a249fd`](https://github.com/nix-community/emacs-overlay/commit/38a249fda284859c84a52b4cf01eb4ce228123ee) | `` Updated melpa ``        |
| [`d799dd63`](https://github.com/nix-community/emacs-overlay/commit/d799dd6335a6fa6492e35d3ef8fe162e733b13c5) | `` Updated elpa ``         |
| [`f0c5236b`](https://github.com/nix-community/emacs-overlay/commit/f0c5236b15d6db5a3a57306fc88819420660fbed) | `` Updated nongnu ``       |
| [`6da4875e`](https://github.com/nix-community/emacs-overlay/commit/6da4875ee60564cb6941f9365494252d24061d1e) | `` Updated emacs ``        |
| [`5fa8029c`](https://github.com/nix-community/emacs-overlay/commit/5fa8029c3c950a8fbf68335a13158e64dcc27106) | `` Updated melpa ``        |
| [`081e845f`](https://github.com/nix-community/emacs-overlay/commit/081e845fa004616a620ccde84fea9ddeedfdc43b) | `` Updated elpa ``         |
| [`fd96db82`](https://github.com/nix-community/emacs-overlay/commit/fd96db82c19e763bd22b7e92299e387814caee7f) | `` Updated nongnu ``       |
| [`115c507f`](https://github.com/nix-community/emacs-overlay/commit/115c507f3298f60579d8ae37b948cc2fbd6955b4) | `` Updated flake inputs `` |
| [`6164f832`](https://github.com/nix-community/emacs-overlay/commit/6164f832e3e21a8c5df6f3ccaa82facf3cef21c0) | `` Updated emacs ``        |
| [`d39448af`](https://github.com/nix-community/emacs-overlay/commit/d39448af6c3224f349aba1fd8923e1833d8f4460) | `` Updated melpa ``        |