### PR TITLE
chore(flake/home-manager): `b6fd653e` -> `c21383b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743360001,
-        "narHash": "sha256-HtpS/ZdgWXw0y+aFdORcX5RuBGTyz3WskThspNR70SM=",
+        "lastModified": 1743482579,
+        "narHash": "sha256-u81nqA4UuRatKDkzUuIfVYdLMw8birEy+99oXpdyXhY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b6fd653ef8fbeccfd4958650757e91767a65506d",
+        "rev": "c21383b556609ce1ad901aa08b4c6fbd9e0c7af0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                        |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| [`c21383b5`](https://github.com/nix-community/home-manager/commit/c21383b556609ce1ad901aa08b4c6fbd9e0c7af0) | `` streamlink: init module (#6031) ``                                                          |
| [`5e193cdc`](https://github.com/nix-community/home-manager/commit/5e193cdcab61b5e7096ef3c132fdc0149e14f2d9) | `` msmtp: fix missing inherits (#6741) ``                                                      |
| [`0b491b46`](https://github.com/nix-community/home-manager/commit/0b491b460f52e87e23eb17bbf59c6ae64b7664c1) | `` treewide: remove with lib (#6735) ``                                                        |
| [`ccd7df83`](https://github.com/nix-community/home-manager/commit/ccd7df836e1f42ea84806760f25b77b586370259) | `` mcfly: Fix fzf overriding mcfly's Ctrl+R bind on fish(#6736) ``                             |
| [`21669077`](https://github.com/nix-community/home-manager/commit/216690777e47aa0fb1475e4dbe2510554ce0bc4b) | `` nixos-module: Fix potential recursion between users.users and home-manager.users (#6622) `` |