### PR TITLE
chore(flake/emacs-overlay): `0d92783c` -> `e55eb3c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1743474120,
-        "narHash": "sha256-F7wKIx2WEuzfRN//Qho7axdFtIsnGsxkCRWJwzL2KgE=",
+        "lastModified": 1743560066,
+        "narHash": "sha256-TEOXLYzb7to6ilgZxrw2qYbPDZgTXjceC42IzOQZagw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0d92783cc1d0ec68d631f6e93204b21282505806",
+        "rev": "e55eb3c7e5b57cbf8de23e1f720e42ccad09fcee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`e55eb3c7`](https://github.com/nix-community/emacs-overlay/commit/e55eb3c7e5b57cbf8de23e1f720e42ccad09fcee) | `` Updated emacs ``  |
| [`544c96b7`](https://github.com/nix-community/emacs-overlay/commit/544c96b704ea59fe3e1bd76a536758633ee96148) | `` Updated melpa ``  |
| [`db8a2610`](https://github.com/nix-community/emacs-overlay/commit/db8a2610df1f0e87a0278991689672fa05dcd465) | `` Updated elpa ``   |
| [`751252c3`](https://github.com/nix-community/emacs-overlay/commit/751252c3406c870b80a958bfab637d4e47b856d1) | `` Updated nongnu `` |
| [`546597a4`](https://github.com/nix-community/emacs-overlay/commit/546597a40c0f033b319ea9b64ff40e1aaaee2faf) | `` Updated emacs ``  |
| [`cdfc6459`](https://github.com/nix-community/emacs-overlay/commit/cdfc64596e5100a1028bd877cb10ed2e35a06782) | `` Updated melpa ``  |
| [`0116ef85`](https://github.com/nix-community/emacs-overlay/commit/0116ef85eea312a054e686d50e81f849e30ab368) | `` Updated elpa ``   |
| [`de76e72a`](https://github.com/nix-community/emacs-overlay/commit/de76e72ac45f352e52135d433e25b759e6f0908c) | `` Updated nongnu `` |
| [`3fe8f6c0`](https://github.com/nix-community/emacs-overlay/commit/3fe8f6c091e799d7a932f9447b762df7c8812619) | `` Updated melpa ``  |