### PR TITLE
chore(flake/home-manager): `c21383b5` -> `f4d9d1e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743482579,
-        "narHash": "sha256-u81nqA4UuRatKDkzUuIfVYdLMw8birEy+99oXpdyXhY=",
+        "lastModified": 1743527271,
+        "narHash": "sha256-EuanEW1qqXZ2h0zJnq7uz8BoHbsgHgUrqWkCZHwZ9FA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c21383b556609ce1ad901aa08b4c6fbd9e0c7af0",
+        "rev": "f4d9d1e2ad19d544a0a0cf3f8f371c6139c762e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                       |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`f4d9d1e2`](https://github.com/nix-community/home-manager/commit/f4d9d1e2ad19d544a0a0cf3f8f371c6139c762e9) | `` broot: get rid of IFDs (#6723) ``                                                          |
| [`0afad8f0`](https://github.com/nix-community/home-manager/commit/0afad8f08014c992c832466c1d46a0aa96ca2563) | `` Revert "nixos-module: Fix potential recursion between users.users and home-ma…" (#6745) `` |
| [`55cf1f16`](https://github.com/nix-community/home-manager/commit/55cf1f16324e694c991e846ad5fc897f0f75ac64) | `` firefox: fix missing lib (#6744) ``                                                        |