### PR TITLE
chore(flake/home-manager): `f4d9d1e2` -> `938e802b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743527271,
-        "narHash": "sha256-EuanEW1qqXZ2h0zJnq7uz8BoHbsgHgUrqWkCZHwZ9FA=",
+        "lastModified": 1743553103,
+        "narHash": "sha256-mfqG5NEa1APkqiGT2arkBDHUeDm+1afFpTcwyE+Szbo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f4d9d1e2ad19d544a0a0cf3f8f371c6139c762e9",
+        "rev": "938e802b70ee7700141b18ef8dca05ad89917a37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`938e802b`](https://github.com/nix-community/home-manager/commit/938e802b70ee7700141b18ef8dca05ad89917a37) | `` alacritty: add `theme` option (#5238) ``          |
| [`e355ae93`](https://github.com/nix-community/home-manager/commit/e355ae93a3cdaff64a3152c78b944ef36a85e8ce) | `` docs: add docs for mkOutOfStoreSymlink (#6660) `` |
| [`89279a66`](https://github.com/nix-community/home-manager/commit/89279a66f4c6c32ea39940a6af63171dae75aafd) | `` fcitx5: set SDL_IM_MODULE (#6742) ``              |