### PR TITLE
chore(flake/nixpkgs): `52faf482` -> `77b584d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -686,11 +686,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1743315132,
-        "narHash": "sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om+D4UnDhlDW9BE=",
+        "lastModified": 1743448293,
+        "narHash": "sha256-bmEPmSjJakAp/JojZRrUvNcDX2R5/nuX6bm+seVaGhs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "52faf482a3889b7619003c0daec593a1912fddc1",
+        "rev": "77b584d61ff80b4cef9245829a6f1dfad5afdfa3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`bdb1b016`](https://github.com/NixOS/nixpkgs/commit/bdb1b01672d5eefe6e7b3566ccfe2d811c4e458c) | `` xmoto: 0.6.2 -> 0.6.3 ``                                                   |
| [`e5e665ba`](https://github.com/NixOS/nixpkgs/commit/e5e665bae251e25cf4768b6e63fce697f33888e4) | `` treefmt: 2.1.1 -> 2.2.0 (#394906) ``                                       |
| [`6e2688ad`](https://github.com/NixOS/nixpkgs/commit/6e2688ad175ede1b936c8680743f529d493f0cbd) | `` urh: pin numpy_1 to fix #371164 (#391888) ``                               |
| [`7ad16070`](https://github.com/NixOS/nixpkgs/commit/7ad16070bbf6ee4c6b141bf275593542db3cf0e3) | `` tailwindcss_4: 4.0.15 -> 4.0.17 ``                                         |
| [`7595aa9d`](https://github.com/NixOS/nixpkgs/commit/7595aa9df94f13761d05a79824e2d62734c184d1) | `` luaPackages.lualine-nvim: update on 2025-03-31 ``                          |
| [`fa97e9e3`](https://github.com/NixOS/nixpkgs/commit/fa97e9e3e8f99a7dc15c1cc404b3efad8c65d2da) | `` linuxPackages.rtl8821ce: 0-unstable-2025-03-12 -> 0-unstable-2025-03-31 `` |
| [`61440cf1`](https://github.com/NixOS/nixpkgs/commit/61440cf18e9f1a21b4a1363e5d0996e023a11705) | `` humility: unstable-2023-11-08-> 0-unstable-2025-02-25 (#394104) ``         |
| [`14367cc8`](https://github.com/NixOS/nixpkgs/commit/14367cc8edf84641a49467ecf614ab31b155ce1c) | `` python3Packages.clickhouse-connect: fix build (#394385) ``                 |
| [`3ceea612`](https://github.com/NixOS/nixpkgs/commit/3ceea61224a46a5b9f109d6ad75e860c896bfe6a) | `` mpv: add libdisplay-info to fix dmabuf-wayland ``                          |
| [`a8fe508e`](https://github.com/NixOS/nixpkgs/commit/a8fe508e275705a05ce70245bd9969522a7f7364) | `` vimPlugins.bitbake-vim: 2025-03-24 -> 2.8.8 ``                             |
| [`5664f191`](https://github.com/NixOS/nixpkgs/commit/5664f19152f68c3948b78f1cd9b7063e2b9ddb3c) | `` vimPlugins.parrot-nvim: init at 2025-03-30 ``                              |
| [`b69c99b3`](https://github.com/NixOS/nixpkgs/commit/b69c99b36da80f579cec7e3090545fbdb2bed974) | `` glamoroustoolkit: 1.1.14 -> 1.1.16 ``                                      |
| [`e0186c6d`](https://github.com/NixOS/nixpkgs/commit/e0186c6d5813690a6474ecf2ca57022ec8164c2d) | `` vimPlugins.nvim-tinygit: init at 2025-03-30 ``                             |
| [`fedcd912`](https://github.com/NixOS/nixpkgs/commit/fedcd912c6f3b9b5f599bafea063d93ac902103a) | `` luaPackages: update on 2025-03-31 ``                                       |
| [`87c04e7e`](https://github.com/NixOS/nixpkgs/commit/87c04e7ef977c16b07f94eda7e9c331654a1b2f2) | `` crowdin-cli: 4.6.1 -> 4.7.0 ``                                             |
| [`4683fd1e`](https://github.com/NixOS/nixpkgs/commit/4683fd1edbea3bf0ea4164a594572cd205ff5131) | `` python312Packages.ttkbootstrap: 1.10.1 -> 1.12.0 ``                        |
| [`7489803a`](https://github.com/NixOS/nixpkgs/commit/7489803a69af827da0b40be7f7ebc4246cde320b) | `` vimPlugins.whichpy-nvim: init at 2025-03-14 ``                             |
| [`016a24e4`](https://github.com/NixOS/nixpkgs/commit/016a24e4dc5c587259c2bf76f4451241c08fa727) | `` apptainer, singularity: deprecate workarounds for vendorHash overriding `` |
| [`76ba3d47`](https://github.com/NixOS/nixpkgs/commit/76ba3d47e52c003a00934c5b56d9b2b0ad0f0d52) | `` yggstack: 1.0.1 -> 1.0.4 ``                                                |
| [`2107f032`](https://github.com/NixOS/nixpkgs/commit/2107f032ab4befe851cd1035d88db9dd3474689d) | `` nixos/startx: remove graphical-session assertions ``                       |
| [`e12690d5`](https://github.com/NixOS/nixpkgs/commit/e12690d530ed0116a54598e8ea7fcb31870d63ee) | `` nixos/movim: Fix accidental append to module system property ``            |
| [`09879a45`](https://github.com/NixOS/nixpkgs/commit/09879a452b37bb07d02599a247cd22aa87b8e864) | `` nixos/hyprland: fix call to wayland-session.nix ``                         |
| [`2a7180b3`](https://github.com/NixOS/nixpkgs/commit/2a7180b3db2d9b98683941e8f1d14c444ce93a7a) | `` nixos/release-notes: add release notes for COSMIC modules ``               |
| [`cd795fd3`](https://github.com/NixOS/nixpkgs/commit/cd795fd3f0a910b60cf9823284f3e99ba367301e) | `` nixos/modules: cosmic: init ``                                             |
| [`cd85a8a8`](https://github.com/NixOS/nixpkgs/commit/cd85a8a82762745e86e8d1f7a34bd3989ee2748e) | `` nixos/modules: cosmic-greeter: init ``                                     |
| [`44718e84`](https://github.com/NixOS/nixpkgs/commit/44718e84d9a1cc3afbf767907006f2b99b210b00) | `` glab: use finalAttrs pattern and writableTmpDirAsHomeHook ``               |
| [`71a4b4bf`](https://github.com/NixOS/nixpkgs/commit/71a4b4bf223d8e448c5208b11043b37cb8c400fd) | `` cloud-hypervisor: 44.0 -> 45.0 ``                                          |
| [`9adf6e59`](https://github.com/NixOS/nixpkgs/commit/9adf6e599ce353a3171a6466d75d779048ab2be2) | `` gnat-bootstrap12: restrict platforms ``                                    |
| [`66917f1c`](https://github.com/NixOS/nixpkgs/commit/66917f1c8da3d34dc10e8c33e07da5cc47ae331d) | `` yabridge: revert workaround for wine 9.5 (#394378) ``                      |
| [`67277b7d`](https://github.com/NixOS/nixpkgs/commit/67277b7de8cb0fbf9274eb3420a76daf9845915f) | `` typos-lsp: 0.1.35 -> 0.1.36 ``                                             |
| [`79417864`](https://github.com/NixOS/nixpkgs/commit/79417864ec0ef7461d8beb016c1fedc799021afa) | `` vimPlugins.nvim-origami: init at 2025-03-31 ``                             |
| [`3ad75749`](https://github.com/NixOS/nixpkgs/commit/3ad757495a14c036769a1c1e6fd1caeb07191726) | `` appium-inspector: restrict platforms to linux ``                           |
| [`d5d9044f`](https://github.com/NixOS/nixpkgs/commit/d5d9044f0aec43813a892df93b4f6621c182596f) | `` meld: 3.22.3 → 3.23.0 ``                                                   |
| [`4117dcee`](https://github.com/NixOS/nixpkgs/commit/4117dceede40303acfc8171e88c39b63dd5a073c) | `` Revert "tiledb: 2.18.2 -> 2.27.2" ``                                       |
| [`2a981da0`](https://github.com/NixOS/nixpkgs/commit/2a981da0449038a2159411c67137cfcd1f69fbfa) | `` libblake3: 1.7.0 -> 1.8.0 ``                                               |
| [`1237682d`](https://github.com/NixOS/nixpkgs/commit/1237682d298e430ad1730561f12e4876cb2b6781) | `` python313Packages.tencentcloud-sdk-python: 3.0.1350 -> 3.0.1351 ``         |
| [`524f7212`](https://github.com/NixOS/nixpkgs/commit/524f7212895650431bad1cb7e650f05106d3e184) | `` obs-studio: enable browser support ``                                      |
| [`6d11b756`](https://github.com/NixOS/nixpkgs/commit/6d11b756a43adb43bc4be31a42e6ab45d7bd7697) | `` xorg.xf86videovmware: restore Mesa/XA dependency ``                        |
| [`a9df43c4`](https://github.com/NixOS/nixpkgs/commit/a9df43c4293b355e07998bf0f24cc2b325a54883) | `` mesa: reenable XA for now ``                                               |
| [`1ce315b7`](https://github.com/NixOS/nixpkgs/commit/1ce315b7dfeb8db2a41df9ebea9a488a18a58171) | `` edl: 3.52.1-unstable-2024-10-12 -> 3.52.1-unstable-2025-03-23 ``           |
| [`a6af279b`](https://github.com/NixOS/nixpkgs/commit/a6af279b61f0c77e397b57eb57fffffb48121c03) | `` vimPlugins.hurl-nvim: init at 2025-03-04 ``                                |
| [`6f6d4aa9`](https://github.com/NixOS/nixpkgs/commit/6f6d4aa9e94380232823d77ec2380d57c035433e) | `` b3sum: 1.7.0 -> 1.8.0 ``                                                   |
| [`a83347b1`](https://github.com/NixOS/nixpkgs/commit/a83347b14b0bc885d945cb979f5bae6222ed5aa0) | `` omake: 0.10.6 → 0.10.7 ``                                                  |
| [`087872a1`](https://github.com/NixOS/nixpkgs/commit/087872a16e04536b55ca2edbca0a239d0b7a8f11) | `` afflib: 3.7.20 -> 3.7.21 ``                                                |
| [`49ca8bcb`](https://github.com/NixOS/nixpkgs/commit/49ca8bcb4d7637abc0318918a7f461fb7415c7b5) | `` dsview: unbreak on GCC 14, modernize ``                                    |
| [`b8300894`](https://github.com/NixOS/nixpkgs/commit/b8300894a946993506d56a9b2ecbfc2af2d5f2ec) | `` ecs-agent: 1.91.1 -> 1.91.2 ``                                             |
| [`86c7364c`](https://github.com/NixOS/nixpkgs/commit/86c7364c4cd03c632a30298dace64c898a081d54) | `` rke: 1.8.0 -> 1.8.1 ``                                                     |
| [`9980ac66`](https://github.com/NixOS/nixpkgs/commit/9980ac66beb46cd51a2d7e12ee90b843e7757c8d) | `` lazysql: 0.3.6 -> 0.3.7 ``                                                 |
| [`9547dfd9`](https://github.com/NixOS/nixpkgs/commit/9547dfd9310f28537804fa53e33555e29ed4f408) | `` golangci-lint: 2.0.0 -> 2.0.2 ``                                           |
| [`eb74e7f1`](https://github.com/NixOS/nixpkgs/commit/eb74e7f1a6eb4ac8dfc80cdee52448dbed8d3a94) | `` obs-studio: 31.0.2 -> 31.0.3 ``                                            |
| [`cd6f6791`](https://github.com/NixOS/nixpkgs/commit/cd6f6791e94d08b983fe6d127ec6942176737f6a) | `` nixosTests.fail2ban: extend test coverage ``                               |
| [`0dbddf81`](https://github.com/NixOS/nixpkgs/commit/0dbddf816a6959442a5314f8654edac721761545) | `` nixosTests.fail2ban: migrate to runTest ``                                 |
| [`c3edb5c0`](https://github.com/NixOS/nixpkgs/commit/c3edb5c06574df697088b8bbc7f3d6bc36ba10b8) | `` python312Packages.scancode-toolkit: 32.3.1 -> 32.3.3 ``                    |
| [`58889e17`](https://github.com/NixOS/nixpkgs/commit/58889e17f519ba789e1096eac8afcf73085c1265) | `` mame: 0.275 -> 0.276 ``                                                    |
| [`ed2073bf`](https://github.com/NixOS/nixpkgs/commit/ed2073bf6a7b5355f41d31e23e4c92be9a72aec0) | `` python312Packages.mplhep: 0.3.58 -> 0.3.59 (#394370) ``                    |
| [`c7da4e2b`](https://github.com/NixOS/nixpkgs/commit/c7da4e2b54a4d789a11af397604ad73fea8a986d) | `` pgroll: 0.8.0 -> 0.10.0 ``                                                 |
| [`b6420c7b`](https://github.com/NixOS/nixpkgs/commit/b6420c7bca86997ad66218dcf4fb902efc7ac4f6) | `` gitignore: ignore worktrees ``                                             |
| [`c5efe798`](https://github.com/NixOS/nixpkgs/commit/c5efe798bc669169236f248e095ee2f91cafa1ed) | `` python313Packages.pyisy: 3.1.14 -> 3.4.0 ``                                |
| [`06725c14`](https://github.com/NixOS/nixpkgs/commit/06725c1404def10e827196d1429c45d48bbd5f93) | `` python313Packages.ical: 9.0.2 -> 9.0.3 ``                                  |
| [`16cce3c3`](https://github.com/NixOS/nixpkgs/commit/16cce3c39c0151682a246b2773a4ee78bc10d357) | `` python313Packages.nhc: 0.4.11 -> 0.4.12 ``                                 |
| [`21af19fa`](https://github.com/NixOS/nixpkgs/commit/21af19fa5cbf04784303c65a688ce665c9a39e6f) | `` pplite: fix build with flint 3.2 ``                                        |
| [`efa1f973`](https://github.com/NixOS/nixpkgs/commit/efa1f9731768dc5488f415b183e323cb151980ce) | `` rs: modernize ``                                                           |
| [`d27c6262`](https://github.com/NixOS/nixpkgs/commit/d27c6262e6d8d81ce10f9eb5e42912406a3897d5) | `` rs: fix build with gcc14 ``                                                |
| [`21ec8478`](https://github.com/NixOS/nixpkgs/commit/21ec8478ed588617612ad2d5c935499df42655cb) | `` ns-3: 39 -> 44, fix build with gcc14 ``                                    |
| [`0d509da6`](https://github.com/NixOS/nixpkgs/commit/0d509da698769ba2e7038a8a3fe2e3dcc16c044d) | `` dnscontrol: 4.17.0 -> 4.18.0 ``                                            |
| [`6154ce8b`](https://github.com/NixOS/nixpkgs/commit/6154ce8bddd30621744ed8bbbd4ae32afb859cc8) | `` qpwgraph: 0.8.2 -> 0.8.3 ``                                                |
| [`e92837b0`](https://github.com/NixOS/nixpkgs/commit/e92837b03d26c3d661b97825d296c5ca86489c99) | `` feather: 2.7.0 -> 2.8.0 ``                                                 |
| [`7b7629e5`](https://github.com/NixOS/nixpkgs/commit/7b7629e5a67d886b8c3c382542e20ee69a3bc7ec) | `` triforce-lv2: 0.2.0 -> 0.2.1 ``                                            |
| [`2e07c7e2`](https://github.com/NixOS/nixpkgs/commit/2e07c7e2f64047feccce7f3625f31e52092a0b0d) | `` vscode-extensions.anweber.vscode-httpyac: 6.16.6 -> 6.16.7 ``              |
| [`da3e9fb5`](https://github.com/NixOS/nixpkgs/commit/da3e9fb55566e203877a5616292b5bb197a140f9) | `` lsd: re-enable tests ``                                                    |
| [`fbb72fba`](https://github.com/NixOS/nixpkgs/commit/fbb72fba9868c57232e5fd65fcbf08e3260e297c) | `` vscode-extensions.charliermarsh.ruff: 2025.14.0 -> 2025.22.0 ``            |
| [`593aaf96`](https://github.com/NixOS/nixpkgs/commit/593aaf96ced4a7a501ea4d75833b9e9a30bf7a27) | `` vscode-extensions.charliermarsh.ruff: add update script ``                 |
| [`8595ce3e`](https://github.com/NixOS/nixpkgs/commit/8595ce3ed671887b6ef9e883afe8e1299a4d834c) | `` compiledb: 0.10.1 -> 0.10.7 ``                                             |
| [`05a397d3`](https://github.com/NixOS/nixpkgs/commit/05a397d3ef53ad5b686d784b2ea9d19addceff78) | `` vscode-extensions.visualjj.visualjj: 0.13.6 -> 0.14.1 ``                   |
| [`09176212`](https://github.com/NixOS/nixpkgs/commit/09176212819e062d20d011aeb8799df89ba57f4d) | `` vscode-extensions.visualjj.visualjj: add update script ``                  |
| [`bb984408`](https://github.com/NixOS/nixpkgs/commit/bb984408d5c640d4b1eb9f5cc6cbfa500b96a798) | `` lib/tests/release.nix: Use nix.overrideScope for >=2.26 ``                 |
| [`d74838df`](https://github.com/NixOS/nixpkgs/commit/d74838df79a28007d34bc0c84beeecf78d864687) | `` nixVersions.nix_2_26: Add .overrideScope ``                                |
| [`e1b8acf7`](https://github.com/NixOS/nixpkgs/commit/e1b8acf7ca9c56164dfe6f22dbdc2f81c801c50f) | `` change replace to replace-fail ``                                          |
| [`493f1e3b`](https://github.com/NixOS/nixpkgs/commit/493f1e3b8be80df5ecd1ee4566de63ca352af73f) | `` nixVersions.nix_2_26: Improve docs ``                                      |
| [`74a4a305`](https://github.com/NixOS/nixpkgs/commit/74a4a3058cb6c5279a771349f4a2e71f4b192678) | `` one_gadget: Migrate to by-name ``                                          |
| [`7ace4543`](https://github.com/NixOS/nixpkgs/commit/7ace45436bd28777582c3a477953a63a890e200a) | `` texlive: use historic mirrors only for final releases (#394567) ``         |
| [`6b691fac`](https://github.com/NixOS/nixpkgs/commit/6b691fac47dfa2c4558ccee37ba957ae93c15bb5) | `` python312Packages.extractcode: cleanup and skip failing test ``            |
| [`d889b908`](https://github.com/NixOS/nixpkgs/commit/d889b908e89ae3b894925301cc5ec0cf08611c8d) | `` termscp: 0.16.1 -> 0.17.0 ``                                               |
| [`724e1208`](https://github.com/NixOS/nixpkgs/commit/724e12083559bae0cc0af622f94fc6c1d2a9eeb3) | `` singular: 4.4.0p6 -> 4.4.1 ``                                              |