### PR TITLE
chore(flake/emacs-overlay): `e55eb3c7` -> `b2863692`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1743560066,
-        "narHash": "sha256-TEOXLYzb7to6ilgZxrw2qYbPDZgTXjceC42IzOQZagw=",
+        "lastModified": 1743584818,
+        "narHash": "sha256-6iCK1WgpULxnqg8iPgEVpEZ5nqZI0OBIi19sYCVuG58=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e55eb3c7e5b57cbf8de23e1f720e42ccad09fcee",
+        "rev": "b2863692cfdfa842ee357d7d93e9c781feb92dc7",
         "type": "github"
       },
       "original": {
@@ -623,11 +623,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1743367904,
-        "narHash": "sha256-sOos1jZGKmT6xxPvxGQyPTApOunXvScV4lNjBCXd/CI=",
+        "lastModified": 1743501102,
+        "narHash": "sha256-7PCBQ4aGVF8OrzMkzqtYSKyoQuU2jtpPi4lmABpe5X4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7ffe0edc685f14b8c635e3d6591b0bbb97365e6c",
+        "rev": "02f2af8c8a8c3b2c05028936a1e84daefa1171d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                       |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------- |
| [`b2863692`](https://github.com/nix-community/emacs-overlay/commit/b2863692cfdfa842ee357d7d93e9c781feb92dc7) | `` Updated melpa ``           |
| [`8520c52a`](https://github.com/nix-community/emacs-overlay/commit/8520c52a6a0ea9ab39f9754ae924cfa8f0b2e836) | `` forge-llm: fix src hash `` |
| [`b8bab028`](https://github.com/nix-community/emacs-overlay/commit/b8bab028ca2806eadbe539b20b54bbcbaa520903) | `` Updated flake inputs ``    |