### PR TITLE
chore(flake/sops-nix): `e7f4d7ed` -> `4521de68`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -923,11 +923,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743502316,
-        "narHash": "sha256-zI2WSkU+ei4zCxT+IVSQjNM9i0ST++T2qSFXTsAND7s=",
+        "lastModified": 1743604509,
+        "narHash": "sha256-Hf5aYGP3hP+uNbcd4NrEMUAR+1o518uGzoeVyMzzJwo=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "e7f4d7ed8bce8dfa7d2f2fe6f8b8f523e54646f8",
+        "rev": "4521de68fba1a36fae8caebce3d6e047179661f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                    |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`3ef71738`](https://github.com/Mic92/sops-nix/commit/3ef71738ad4fcf03207a74e001d964ed25f4535b) | `` don't enable lint for old golang version ``             |
| [`e8d42243`](https://github.com/Mic92/sops-nix/commit/e8d422438adf2d7fc5cf28f6cdc49a19f7147092) | `` update vendorHash ``                                    |
| [`e7bb52cf`](https://github.com/Mic92/sops-nix/commit/e7bb52cfef03369617d0c1752c606aec75f6d66a) | `` Bump github.com/getsops/sops/v3 from 3.9.4 to 3.10.1 `` |