### PR TITLE
chore(flake/emacs-overlay): `b2863692` -> `44ee05e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1743584818,
-        "narHash": "sha256-6iCK1WgpULxnqg8iPgEVpEZ5nqZI0OBIi19sYCVuG58=",
+        "lastModified": 1743646600,
+        "narHash": "sha256-/QFpCsk9EX4hV7ioDOP6CdviJieHpZnmHHM3m7DwGdQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b2863692cfdfa842ee357d7d93e9c781feb92dc7",
+        "rev": "44ee05e41df82bdc7e38186c4b9a740f84ef48c3",
         "type": "github"
       },
       "original": {
@@ -623,11 +623,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1743501102,
-        "narHash": "sha256-7PCBQ4aGVF8OrzMkzqtYSKyoQuU2jtpPi4lmABpe5X4=",
+        "lastModified": 1743576891,
+        "narHash": "sha256-vXiKURtntURybE6FMNFAVpRPr8+e8KoLPrYs9TGuAKc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "02f2af8c8a8c3b2c05028936a1e84daefa1171d4",
+        "rev": "44a69ed688786e98a101f02b712c313f1ade37ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`44ee05e4`](https://github.com/nix-community/emacs-overlay/commit/44ee05e41df82bdc7e38186c4b9a740f84ef48c3) | `` Updated emacs ``        |
| [`cb631280`](https://github.com/nix-community/emacs-overlay/commit/cb6312802128587651a0e8042021499e361a6155) | `` Updated melpa ``        |
| [`3a4cc0a6`](https://github.com/nix-community/emacs-overlay/commit/3a4cc0a640f371ddaa7b60e69e504e6187091b88) | `` Updated elpa ``         |
| [`6a4ee5a6`](https://github.com/nix-community/emacs-overlay/commit/6a4ee5a6397d15fe320ea15bf2cba764cdbbb884) | `` Updated nongnu ``       |
| [`44d956da`](https://github.com/nix-community/emacs-overlay/commit/44d956daf53daacc0b1316a851189f0593c44736) | `` Updated flake inputs `` |
| [`513da799`](https://github.com/nix-community/emacs-overlay/commit/513da799bd6dc36b9ee69db71f102257dab665e6) | `` Updated emacs ``        |
| [`10d05194`](https://github.com/nix-community/emacs-overlay/commit/10d05194480b19d4cfecf920702562c778120e84) | `` Updated melpa ``        |
| [`fa36f304`](https://github.com/nix-community/emacs-overlay/commit/fa36f3040ca690af3fecf3e961e00bff4a8f122a) | `` Updated elpa ``         |
| [`f605d671`](https://github.com/nix-community/emacs-overlay/commit/f605d671012752f0c70648241219227e58d9eb7b) | `` Updated nongnu ``       |