### PR TITLE
chore(flake/emacs-ultra-scroll): `b72c507f` -> `e7401732`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
     "emacs-ultra-scroll": {
       "flake": false,
       "locked": {
-        "lastModified": 1741801279,
-        "narHash": "sha256-AehGNc8ll/Q0HVp1OCj1bVBuXNh0Y43kp5EteSpwvmQ=",
+        "lastModified": 1743642021,
+        "narHash": "sha256-MHlHsciVPNyvqwkop9arOQ1VTV5POxJZ+z+IZo/PrMM=",
         "owner": "jdtsmith",
         "repo": "ultra-scroll",
-        "rev": "b72c507f6702db18d971a6b6bdc692e260f21159",
+        "rev": "e74017326f6e38bdaad7b4dd497f2acaeead9f67",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                            |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ |
| [`e7401732`](https://github.com/jdtsmith/ultra-scroll/commit/e74017326f6e38bdaad7b4dd497f2acaeead9f67) | `` if/when-let -> if/when-let* ``                                  |
| [`9b38a1cc`](https://github.com/jdtsmith/ultra-scroll/commit/9b38a1cc4c0f5b000ab22168e947410ad3ea172f) | `` Bump version and document NEWS ``                               |
| [`f1841458`](https://github.com/jdtsmith/ultra-scroll/commit/f1841458650fb4428313959d10bef0fd3ea13994) | `` ultra-scroll-down: handle very large scroll deltas correctly `` |