### PR TITLE
chore(flake/nixos-facter-modules): `60f8b8f3` -> `58ad9691`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -530,11 +530,11 @@
     },
     "nixos-facter-modules": {
       "locked": {
-        "lastModified": 1738752252,
-        "narHash": "sha256-/nA3tDdp/2g0FBy8966ppC2WDoyXtUWaHkZWL+N3ZKc=",
+        "lastModified": 1743671943,
+        "narHash": "sha256-7sYig0+RcrR3sOL5M+2spbpFUHyEP7cnUvCaqFOBjyU=",
         "owner": "nix-community",
         "repo": "nixos-facter-modules",
-        "rev": "60f8b8f3f99667de6a493a44375e5506bf0c48b1",
+        "rev": "58ad9691670d293a15221d4a78818e0088d2e086",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                              | Message                                                          |
| ------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`ad555ab4`](https://github.com/nix-community/nixos-facter-modules/commit/ad555ab4aa3df5d05ff3e9dd0e9b8732aaab07d4) | `` fixup! fix: add appropriate defaultText entries to options `` |
| [`d95b08c8`](https://github.com/nix-community/nixos-facter-modules/commit/d95b08c8b197570da772c6be729333844dfada0c) | `` fix: add appropriate defaultText entries to options ``        |