### PR TITLE
chore(flake/emacs-overlay): `44ee05e4` -> `8c76e579`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1743646600,
-        "narHash": "sha256-/QFpCsk9EX4hV7ioDOP6CdviJieHpZnmHHM3m7DwGdQ=",
+        "lastModified": 1743700520,
+        "narHash": "sha256-FTgOgaZks+xkyqqukNOe7FXHPshCYmQ38wxzxJ6T3RQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "44ee05e41df82bdc7e38186c4b9a740f84ef48c3",
+        "rev": "8c76e5792ef50a67e89ad54e792769f89d721f4a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`8c76e579`](https://github.com/nix-community/emacs-overlay/commit/8c76e5792ef50a67e89ad54e792769f89d721f4a) | `` Updated emacs ``  |
| [`d429b29a`](https://github.com/nix-community/emacs-overlay/commit/d429b29afa9a398d772ea22fb9901bbfbdb5b0ad) | `` Updated melpa ``  |
| [`5aa617f5`](https://github.com/nix-community/emacs-overlay/commit/5aa617f590dfbfb75f1376584d6a12c15686886f) | `` Updated nongnu `` |
| [`4f1f635f`](https://github.com/nix-community/emacs-overlay/commit/4f1f635f5ae1bc6a77ae7ca20a2699439dd53647) | `` Updated emacs ``  |
| [`eb18749a`](https://github.com/nix-community/emacs-overlay/commit/eb18749a2f536373ea5199cb753f3823d6afd3ac) | `` Updated melpa ``  |