### PR TITLE
chore(flake/home-manager): `107352dd` -> `a802defb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743648554,
-        "narHash": "sha256-23JFd+zd2GamTTdnGuFVeIg8x8C3hLpQJRh/PGTORzo=",
+        "lastModified": 1743781299,
+        "narHash": "sha256-wLz6pjEVMXAb8EGDbXtyW98GQ8vm9cEyKhZTf/TTu24=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "107352dde4ff3c01cb5a0b3fe17f5beef37215bc",
+        "rev": "a802defb16dcdcc7fd0ff5a2d7be913ce2fe79e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                  |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`a802defb`](https://github.com/nix-community/home-manager/commit/a802defb16dcdcc7fd0ff5a2d7be913ce2fe79e7) | `` playerctld: add to `$PATH` (#6753) ``                                 |
| [`f3ac07f2`](https://github.com/nix-community/home-manager/commit/f3ac07f2f7c368952a9e7da64ec0991526f49020) | `` smug: init module (#6696) ``                                          |
| [`66a6ec65`](https://github.com/nix-community/home-manager/commit/66a6ec65f84255b3defb67ff45af86c844dd451b) | `` cliphist: use configured systemdTargets throughout service (#6751) `` |