### PR TITLE
chore(flake/emacs-ultra-scroll): `e7401732` -> `c36c253f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
     "emacs-ultra-scroll": {
       "flake": false,
       "locked": {
-        "lastModified": 1743642021,
-        "narHash": "sha256-MHlHsciVPNyvqwkop9arOQ1VTV5POxJZ+z+IZo/PrMM=",
+        "lastModified": 1743726213,
+        "narHash": "sha256-aAYPIsyoSAM6Qy8hZQ4+KJAd9OBkQr8U7HEqWAWRhaI=",
         "owner": "jdtsmith",
         "repo": "ultra-scroll",
-        "rev": "e74017326f6e38bdaad7b4dd497f2acaeead9f67",
+        "rev": "c36c253f15974d9b78fde69700ab3128f3a84050",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                         |
| ------------------------------------------------------------------------------------------------------ | ------------------------------- |
| [`e46f9767`](https://github.com/jdtsmith/ultra-scroll/commit/e46f976741d2006741a34fa9610d42052f0cd732) | `` Fix date typo in NEWS.org `` |