### PR TITLE
chore(flake/sops-nix): `4521de68` -> `9bc9b596`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -923,11 +923,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743604509,
-        "narHash": "sha256-Hf5aYGP3hP+uNbcd4NrEMUAR+1o518uGzoeVyMzzJwo=",
+        "lastModified": 1743750430,
+        "narHash": "sha256-ZwEpd2ZqimTaFUNkapLWVsNvSEBTIPOq2W2z2aMFC+k=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "4521de68fba1a36fae8caebce3d6e047179661f7",
+        "rev": "9bc9b59644585aa2f6c96a1abf50d937b433be83",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                             |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`9bc9b596`](https://github.com/Mic92/sops-nix/commit/9bc9b59644585aa2f6c96a1abf50d937b433be83) | `` home-manager/templates: remove restartUnits/reloadUnits ``       |
| [`026b64f8`](https://github.com/Mic92/sops-nix/commit/026b64f86b32a104e5a02f4f271f226787914c8b) | `` docs: we need systemd/user for home-manager ``                   |
| [`d3088f78`](https://github.com/Mic92/sops-nix/commit/d3088f783f36c132d66e4854ec72fc0b13429f9d) | `` module: set `HOME` envvar to avoid warnings on sops >= 3.10.0 `` |