### PR TITLE
chore(flake/sops-nix): `9bc9b596` -> `04eb34c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -889,11 +889,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743750430,
-        "narHash": "sha256-ZwEpd2ZqimTaFUNkapLWVsNvSEBTIPOq2W2z2aMFC+k=",
+        "lastModified": 1744070144,
+        "narHash": "sha256-ZB6q4xnSWm1eIKjpH195NJ7rlOzQ84BWSCoc002gdLI=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "9bc9b59644585aa2f6c96a1abf50d937b433be83",
+        "rev": "04eb34c6c5be9298e0628ef6532acad4fadbfa21",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                        |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`6adfebc0`](https://github.com/Mic92/sops-nix/commit/6adfebc066221c0396901404c425b39ad86255f6) | `` update vendorHash ``                                                        |
| [`f512315f`](https://github.com/Mic92/sops-nix/commit/f512315f28821faf4befc12f1a2acced590e24db) | `` Bump golang.org/x/crypto from 0.36.0 to 0.37.0 ``                           |
| [`0ee9c7b1`](https://github.com/Mic92/sops-nix/commit/0ee9c7b1186b6a045df8e820282f4e2424db9858) | `` [create-pull-request] automated change ``                                   |
| [`cff8437c`](https://github.com/Mic92/sops-nix/commit/cff8437c5fe8c68fc3a840a21bf1f4dc801da40d) | `` secrets-for-users: set `HOME` envvar to avoid warnings on sops >= 3.10.0 `` |