### PR TITLE
chore(flake/emacs-overlay): `58615b78` -> `c26fc034`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1743758740,
-        "narHash": "sha256-w4HdJ3OSe2NfJrxKcsjrKqrzVCXArROAAQntDV4yKAU=",
+        "lastModified": 1743819438,
+        "narHash": "sha256-U7Ujvyq3UQRAmyQw1ZWmxVQ9YB8HarabGXR6FMYQcxo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "58615b780b5944683045d00cd204feefefc43c58",
+        "rev": "c26fc03462cd33ad9e58f54a8f4e24c322243400",
         "type": "github"
       },
       "original": {
@@ -623,11 +623,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1743576891,
-        "narHash": "sha256-vXiKURtntURybE6FMNFAVpRPr8+e8KoLPrYs9TGuAKc=",
+        "lastModified": 1743703532,
+        "narHash": "sha256-s1KLDALEeqy+ttrvqV3jx9mBZEvmthQErTVOAzbjHZs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "44a69ed688786e98a101f02b712c313f1ade37ab",
+        "rev": "bdb91860de2f719b57eef819b5617762f7120c70",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`c26fc034`](https://github.com/nix-community/emacs-overlay/commit/c26fc03462cd33ad9e58f54a8f4e24c322243400) | `` Updated emacs ``        |
| [`ae570549`](https://github.com/nix-community/emacs-overlay/commit/ae5705497f7b49bf69fac2018c211e6924abcfb4) | `` Updated melpa ``        |
| [`774e7e2f`](https://github.com/nix-community/emacs-overlay/commit/774e7e2fa3716f2e9226e1aa73b6c8732846c0dd) | `` Updated elpa ``         |
| [`75050b55`](https://github.com/nix-community/emacs-overlay/commit/75050b559c1b712bd7e8115c7654cf3f5645171a) | `` Updated flake inputs `` |
| [`441e7ba4`](https://github.com/nix-community/emacs-overlay/commit/441e7ba4e4a128422b85039fe6b9662b259ba5eb) | `` Updated nongnu ``       |