### PR TITLE
chore(flake/emacs-overlay): `c26fc034` -> `761195be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1743819438,
-        "narHash": "sha256-U7Ujvyq3UQRAmyQw1ZWmxVQ9YB8HarabGXR6FMYQcxo=",
+        "lastModified": 1743873242,
+        "narHash": "sha256-z1HQnvpt0doMfB2dmyRfvrgJumazI6gK8EdE+UI59m8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c26fc03462cd33ad9e58f54a8f4e24c322243400",
+        "rev": "761195be1ba33f90242eb52d7be277252c459e38",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`761195be`](https://github.com/nix-community/emacs-overlay/commit/761195be1ba33f90242eb52d7be277252c459e38) | `` Updated emacs `` |
| [`b247d679`](https://github.com/nix-community/emacs-overlay/commit/b247d679cea76b98f9c45dd4b04ef2ec0d1ecfc9) | `` Updated melpa `` |
| [`8eb8960e`](https://github.com/nix-community/emacs-overlay/commit/8eb8960e3aabf5486534c7ffad38504c53bf8d66) | `` Updated elpa ``  |
| [`f529d875`](https://github.com/nix-community/emacs-overlay/commit/f529d87520a4ca4083b94c28a47b33b3d9593669) | `` Updated emacs `` |
| [`8f0d46ac`](https://github.com/nix-community/emacs-overlay/commit/8f0d46ac030b6e9235ed54404e799a9eed2c2d13) | `` Updated melpa `` |