### PR TITLE
chore(flake/emacs-overlay): `761195be` -> `34ec7c1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1743873242,
-        "narHash": "sha256-z1HQnvpt0doMfB2dmyRfvrgJumazI6gK8EdE+UI59m8=",
+        "lastModified": 1743905916,
+        "narHash": "sha256-lqUpFTUWW9uerCaC0hEbS+XtPRTXxAgOf6lLXVCr4Tg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "761195be1ba33f90242eb52d7be277252c459e38",
+        "rev": "34ec7c1b36a27952a0c9610f6a701efd8a7324dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`34ec7c1b`](https://github.com/nix-community/emacs-overlay/commit/34ec7c1b36a27952a0c9610f6a701efd8a7324dc) | `` Updated emacs ``        |
| [`7ba17c75`](https://github.com/nix-community/emacs-overlay/commit/7ba17c75e171caea0baa7a6d43c4216553b3a4d5) | `` Updated melpa ``        |
| [`baba5a0b`](https://github.com/nix-community/emacs-overlay/commit/baba5a0bbe1a45a2fb8c7e37a646667f01a9aea5) | `` Updated elpa ``         |
| [`12e0fdc7`](https://github.com/nix-community/emacs-overlay/commit/12e0fdc7939a48266277beea0903b87ae5ca0cec) | `` Updated nongnu ``       |
| [`9c1eefd3`](https://github.com/nix-community/emacs-overlay/commit/9c1eefd3f24fcf3752cb8b4e6156f2225136d3d2) | `` Updated flake inputs `` |