### PR TITLE
chore(flake/emacs-overlay): `34ec7c1b` -> `c7e8e7be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1743905916,
-        "narHash": "sha256-lqUpFTUWW9uerCaC0hEbS+XtPRTXxAgOf6lLXVCr4Tg=",
+        "lastModified": 1743959986,
+        "narHash": "sha256-PmR93ZHN6CfJVBNalg+zl2M78mNA8LWIfMLhdtT/C3A=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "34ec7c1b36a27952a0c9610f6a701efd8a7324dc",
+        "rev": "c7e8e7beb913fcdde90239c009bf3f7c21a3fdda",
         "type": "github"
       },
       "original": {
@@ -623,11 +623,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1743703532,
-        "narHash": "sha256-s1KLDALEeqy+ttrvqV3jx9mBZEvmthQErTVOAzbjHZs=",
+        "lastModified": 1743813633,
+        "narHash": "sha256-BgkBz4NpV6Kg8XF7cmHDHRVGZYnKbvG0Y4p+jElwxaM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bdb91860de2f719b57eef819b5617762f7120c70",
+        "rev": "7819a0d29d1dd2bc331bec4b327f0776359b1fa6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`c7e8e7be`](https://github.com/nix-community/emacs-overlay/commit/c7e8e7beb913fcdde90239c009bf3f7c21a3fdda) | `` Updated emacs ``        |
| [`59951191`](https://github.com/nix-community/emacs-overlay/commit/599511911cff75a453ff1894256b3135c7a9d51e) | `` Updated melpa ``        |
| [`985e403c`](https://github.com/nix-community/emacs-overlay/commit/985e403c76691e625df5f66a6d57ffd0e66bf88a) | `` Updated elpa ``         |
| [`6b258d37`](https://github.com/nix-community/emacs-overlay/commit/6b258d37244fe9eeb7aacac961df03b407ff1dba) | `` Updated nongnu ``       |
| [`336b7bbf`](https://github.com/nix-community/emacs-overlay/commit/336b7bbf8ceecbc67e0f104324b3ecf9661a27e6) | `` Updated flake inputs `` |
| [`3fb12f3a`](https://github.com/nix-community/emacs-overlay/commit/3fb12f3aacdc18ee1f455cca300c33d5f20de175) | `` Updated emacs ``        |
| [`9f6c0252`](https://github.com/nix-community/emacs-overlay/commit/9f6c02523e4d5e722152b5324b225de24453b4f0) | `` Updated melpa ``        |