### PR TITLE
chore(flake/emacs-overlay): `c7e8e7be` -> `ac8af15c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1743959986,
-        "narHash": "sha256-PmR93ZHN6CfJVBNalg+zl2M78mNA8LWIfMLhdtT/C3A=",
+        "lastModified": 1743991507,
+        "narHash": "sha256-sRyA1LOsRSeF8W2drXEuGU2U+actcYEKdk1f+2kDKb8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c7e8e7beb913fcdde90239c009bf3f7c21a3fdda",
+        "rev": "ac8af15c5f586879c08cd257b69749f791d94e68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`ac8af15c`](https://github.com/nix-community/emacs-overlay/commit/ac8af15c5f586879c08cd257b69749f791d94e68) | `` Updated melpa ``  |
| [`6e7df2e8`](https://github.com/nix-community/emacs-overlay/commit/6e7df2e86c47c815dd6c09ffa280c2991f270a9f) | `` Updated elpa ``   |
| [`2cc68dac`](https://github.com/nix-community/emacs-overlay/commit/2cc68dac4e32d102c583502ffa84e4731a8f712b) | `` Updated nongnu `` |