### PR TITLE
chore(flake/emacs-overlay): `ac8af15c` -> `0e8ebcd5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1743991507,
-        "narHash": "sha256-sRyA1LOsRSeF8W2drXEuGU2U+actcYEKdk1f+2kDKb8=",
+        "lastModified": 1744048597,
+        "narHash": "sha256-vkOXbsZywjjFl9KEye9rwgptq7F4mWb5hu/dPZG4bEM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ac8af15c5f586879c08cd257b69749f791d94e68",
+        "rev": "0e8ebcd53894f053d5a08b057741191850995983",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`0e8ebcd5`](https://github.com/nix-community/emacs-overlay/commit/0e8ebcd53894f053d5a08b057741191850995983) | `` Updated emacs `` |
| [`00b6ee68`](https://github.com/nix-community/emacs-overlay/commit/00b6ee68e9fef7cce2a827f248ab935bca5eca6e) | `` Updated melpa `` |