### PR TITLE
chore(flake/emacs-overlay): `0e8ebcd5` -> `affd3c65`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1744048597,
-        "narHash": "sha256-vkOXbsZywjjFl9KEye9rwgptq7F4mWb5hu/dPZG4bEM=",
+        "lastModified": 1744078413,
+        "narHash": "sha256-8GG5UEczXP3cX16edu4EzUCXpajd0msrvh4XJ3tt6d4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0e8ebcd53894f053d5a08b057741191850995983",
+        "rev": "affd3c65261ebefc1d78a9d8fe16bb0dbce310f1",
         "type": "github"
       },
       "original": {
@@ -623,11 +623,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1743813633,
-        "narHash": "sha256-BgkBz4NpV6Kg8XF7cmHDHRVGZYnKbvG0Y4p+jElwxaM=",
+        "lastModified": 1743975612,
+        "narHash": "sha256-o4FjFOUmjSRMK7dn0TFdAT0RRWUWD+WsspPHa+qEQT8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7819a0d29d1dd2bc331bec4b327f0776359b1fa6",
+        "rev": "a880f49904d68b5e53338d1e8c7bf80f59903928",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`affd3c65`](https://github.com/nix-community/emacs-overlay/commit/affd3c65261ebefc1d78a9d8fe16bb0dbce310f1) | `` Updated emacs ``        |
| [`9e1692ee`](https://github.com/nix-community/emacs-overlay/commit/9e1692ee163411c9d8b44b23ff92b3aee18bff8a) | `` Updated melpa ``        |
| [`2ebddbab`](https://github.com/nix-community/emacs-overlay/commit/2ebddbabd7428499640618e6f6942542e5c13185) | `` Updated elpa ``         |
| [`2b322396`](https://github.com/nix-community/emacs-overlay/commit/2b32239699f4fcf0ae390cb4d1059ef9a59291c5) | `` Updated nongnu ``       |
| [`3602ed70`](https://github.com/nix-community/emacs-overlay/commit/3602ed70285b776c525512c345ac29c4b689eaee) | `` Updated flake inputs `` |