### PR TITLE
chore(flake/home-manager): `a4d80208` -> `fefb6ae1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -333,14 +333,15 @@
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1744038920,
-        "narHash": "sha256-9a4V1wQXS8hXZtc7mRtz0qINkGW+C99aDrmXY6oYBFg=",
+        "lastModified": 1744127405,
+        "narHash": "sha256-Cqkmsb3CDcUREjszRe2/qkvztFzEujkaaqV5/nqfdlk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a4d8020820a85b47f842eae76ad083b0ec2a886a",
+        "rev": "fefb6ae1b301b620a81645789e19945092b079da",
         "type": "github"
       },
       "original": {
@@ -419,7 +420,7 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "treefmt-nix": "treefmt-nix"
+        "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
         "lastModified": 1743892901,
@@ -774,7 +775,7 @@
       "inputs": {
         "flake-parts": "flake-parts_2",
         "nixpkgs": "nixpkgs_5",
-        "treefmt-nix": "treefmt-nix_2"
+        "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
         "lastModified": 1744108015,
@@ -820,7 +821,7 @@
         "sops-nix": "sops-nix",
         "srvos": "srvos",
         "systems": "systems",
-        "treefmt-nix": "treefmt-nix_3",
+        "treefmt-nix": "treefmt-nix_4",
         "truecolor-check": "truecolor-check"
       }
     },
@@ -940,7 +941,7 @@
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
-          "nix-fast-build",
+          "home-manager",
           "nixpkgs"
         ]
       },
@@ -961,6 +962,27 @@
     "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
+          "nix-fast-build",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1743748085,
+        "narHash": "sha256-uhjnlaVTWo5iD3LXics1rp9gaKgDRQj6660+gbUU3cE=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "815e4121d6a5d504c0f96e5be2dd7f871e4fd99d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_3": {
+      "inputs": {
+        "nixpkgs": [
           "nur",
           "nixpkgs"
         ]
@@ -979,7 +1001,7 @@
         "type": "github"
       }
     },
-    "treefmt-nix_3": {
+    "treefmt-nix_4": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                       |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`fefb6ae1`](https://github.com/nix-community/home-manager/commit/fefb6ae1b301b620a81645789e19945092b079da) | `` .git-blame-ignore-revs: add treewide reformat ``                           |
| [`cba2f9ce`](https://github.com/nix-community/home-manager/commit/cba2f9ce95c8d10b66cacf05a275e3ad71959638) | `` treewide: reformat nixfmt-rfc-style ``                                     |
| [`5df48c42`](https://github.com/nix-community/home-manager/commit/5df48c425569a638a7471af3ad61fb62e4c18c60) | `` flake.nix: add formatter check ``                                          |
| [`04a2e5ce`](https://github.com/nix-community/home-manager/commit/04a2e5cedeeaf6c1dd69f4356c87902054669cce) | `` format: use nixfmt-tree treefmt ``                                         |
| [`74b681d6`](https://github.com/nix-community/home-manager/commit/74b681d66552e24248a3c36524c932c4c796f985) | `` flake.nix: nixfmt -> treefmt ``                                            |
| [`7137c8ae`](https://github.com/nix-community/home-manager/commit/7137c8ae4e63fe010cb86676f2d3da9752da566c) | `` tests/aerospace: include on-window-detected ``                             |
| [`95861b5d`](https://github.com/nix-community/home-manager/commit/95861b5d9fc73f080b385776167c3dd2874e355b) | `` aerospace: Add flattenOnWindowDetected function ``                         |
| [`80ae77ee`](https://github.com/nix-community/home-manager/commit/80ae77eed3a3b48597ec9c1d23ce6e4784214071) | `` kdeconnect: trigger indicator service after generic tray.target (#6711) `` |
| [`5966fc8b`](https://github.com/nix-community/home-manager/commit/5966fc8bd1e3da947e917767d0a3b5936f7cc9db) | `` xdg-portal: improve description of `extraPortals` (#6760) ``               |
| [`df09fb59`](https://github.com/nix-community/home-manager/commit/df09fb59817f68fa4c8049b58d12a9b398b92aee) | `` tests: stub more packages on darwin (#6780) ``                             |
| [`05cd3420`](https://github.com/nix-community/home-manager/commit/05cd34203e04ed9b948c06929924017008c1eb4c) | `` kitty: fromJSON to importJSON ``                                           |
| [`cbdf1c1e`](https://github.com/nix-community/home-manager/commit/cbdf1c1e330fd2aae62ffcfa0892b3457b0c60d8) | `` astroid: fromJSON to importJSON ``                                         |
| [`e741f979`](https://github.com/nix-community/home-manager/commit/e741f97967aa8225c7d866c76833634b7df32202) | `` astroid: Fix use of `fromJSON` ``                                          |
| [`0daadc77`](https://github.com/nix-community/home-manager/commit/0daadc77840a1ed34cafa581f8b0ab08cb2fcadc) | `` btop: add `themes` option (#6777) ``                                       |
| [`bd33ce40`](https://github.com/nix-community/home-manager/commit/bd33ce4000800a44b66e9d5a596d8abe6bf4bb16) | `` tests: stub neovim and vimPlugins and darwin (#6779) ``                    |