### PR TITLE
chore(flake/emacs-overlay): `8717bed0` -> `757b6e91`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1744103226,
-        "narHash": "sha256-mz/Tu+fiWOqnPyhOgFAmAzc+i/czeXP+boST5/9LrYo=",
+        "lastModified": 1744164939,
+        "narHash": "sha256-gspNFAyO3o1Mek/C4mpS3mRLgTgIlDefX5qxjbsxO7U=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8717bed057a7955dd95b5532d01314b2772af1f9",
+        "rev": "757b6e91336f3005527b4648c830cf0de121499b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`757b6e91`](https://github.com/nix-community/emacs-overlay/commit/757b6e91336f3005527b4648c830cf0de121499b) | `` Updated emacs `` |
| [`cc0f5cf8`](https://github.com/nix-community/emacs-overlay/commit/cc0f5cf82032d73a788830d5c1e922ee7d626176) | `` Updated melpa `` |
| [`bfa6ce27`](https://github.com/nix-community/emacs-overlay/commit/bfa6ce27bfad29111f7316113a64c9eae274387b) | `` Updated elpa ``  |
| [`1a0e36d7`](https://github.com/nix-community/emacs-overlay/commit/1a0e36d797582e1a3fc82a36f151ef3d9409fd3c) | `` Updated elpa ``  |