### PR TITLE
chore(flake/emacs-overlay): `757b6e91` -> `8d01f801`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1744164939,
-        "narHash": "sha256-gspNFAyO3o1Mek/C4mpS3mRLgTgIlDefX5qxjbsxO7U=",
+        "lastModified": 1744218590,
+        "narHash": "sha256-C4fQbqgiRN5hpM4oUnvm/xYAPXeT1tNvMqVKwQU4iEI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "757b6e91336f3005527b4648c830cf0de121499b",
+        "rev": "8d01f801846716f6ec32547c32d3f09a31ef3f05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`8d01f801`](https://github.com/nix-community/emacs-overlay/commit/8d01f801846716f6ec32547c32d3f09a31ef3f05) | `` Updated melpa ``        |
| [`162b4ed9`](https://github.com/nix-community/emacs-overlay/commit/162b4ed9b15ca18db5979096f9bce23b2f5c146d) | `` Updated elpa ``         |
| [`b90c535b`](https://github.com/nix-community/emacs-overlay/commit/b90c535b214a74c5ce74c1d28050f556244a944d) | `` Updated nongnu ``       |
| [`be94a29e`](https://github.com/nix-community/emacs-overlay/commit/be94a29ebf72beea675f3d80606f1ad6eb046b76) | `` Updated emacs ``        |
| [`1c4b6c99`](https://github.com/nix-community/emacs-overlay/commit/1c4b6c990807e89ba5e810eb5313416214110c3c) | `` Updated melpa ``        |
| [`ea0057e1`](https://github.com/nix-community/emacs-overlay/commit/ea0057e19e72b4f6005270e82198a23257bd13d0) | `` Updated flake inputs `` |