### PR TITLE
chore(flake/darwin): `73d59580` -> `43975d78`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743496612,
-        "narHash": "sha256-emPWa5lmKbnyuj8c1mSJUkzJNT+iJoU9GMcXwjp2oVM=",
+        "lastModified": 1744478979,
+        "narHash": "sha256-dyN+teG9G82G+m+PX/aSAagkC+vUv0SgUw3XkPhQodQ=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "73d59580d01e9b9f957ba749f336a272869c42dd",
+        "rev": "43975d782b418ebf4969e9ccba82466728c2851b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                  |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
| [`751a96bc`](https://github.com/nix-darwin/nix-darwin/commit/751a96bc1f97d0771ff6562e4a6c2990db9d8af8) | `` networking: backport `domain`, `fqdn` and `fqdnOrHostName` options `` |
| [`5417dfd5`](https://github.com/nix-darwin/nix-darwin/commit/5417dfd58cbc1c475a0b3ffc5b016b29514d6fb8) | `` services/netdata: add cacheDir option ``                              |