### PR TITLE
chore(flake/home-manager): `542efdf2` -> `8638a0b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744208565,
-        "narHash": "sha256-vG3JJOar/r8ognz7wuwMtOJ8Knu1MMlOzHB1N6R2MbY=",
+        "lastModified": 1744315321,
+        "narHash": "sha256-JLfysQTNHdhaqSEuFO7ccCtkrwpyMFjEXf6gazhjBZM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "542efdf2dfac351498f534eb71671525b9bd45ed",
+        "rev": "8638a0b28727a8cdbe851fefded3b8e96f4cf763",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`8638a0b2`](https://github.com/nix-community/home-manager/commit/8638a0b28727a8cdbe851fefded3b8e96f4cf763) | `` sesh: add icons option (#6794) ``                  |
| [`140a7df9`](https://github.com/nix-community/home-manager/commit/140a7df916f6257c755b8663fb27ed79e81c8e89) | `` formatter: use a different treefmt root (#6792) `` |
| [`92266c9a`](https://github.com/nix-community/home-manager/commit/92266c9a6f03b7d86efc056580a1fddb89635a59) | `` btop: adjust `themes` option example (#6793) ``    |
| [`79461936`](https://github.com/nix-community/home-manager/commit/79461936709b12e17adb9c91dd02d1c66d577f09) | `` hyprland: load plugins using exec-once (#6789) ``  |