### PR TITLE
chore(flake/emacs-overlay): `8d01f801` -> `ff930b5e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1744218590,
-        "narHash": "sha256-C4fQbqgiRN5hpM4oUnvm/xYAPXeT1tNvMqVKwQU4iEI=",
+        "lastModified": 1744479669,
+        "narHash": "sha256-t2KLWeuwczpXX0ZjsO6l07NFHpoHsfEHjLBn6Ifp/Rc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8d01f801846716f6ec32547c32d3f09a31ef3f05",
+        "rev": "ff930b5e806d659480b70f6ac3b2ba7efb346682",
         "type": "github"
       },
       "original": {
@@ -623,11 +623,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1743975612,
-        "narHash": "sha256-o4FjFOUmjSRMK7dn0TFdAT0RRWUWD+WsspPHa+qEQT8=",
+        "lastModified": 1744309437,
+        "narHash": "sha256-QZnNHM823am8apCqKSPdtnzPGTy2ZB4zIXOVoBp5+W0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a880f49904d68b5e53338d1e8c7bf80f59903928",
+        "rev": "f9ebe33a928b5d529c895202263a5ce46bdf12f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`ff930b5e`](https://github.com/nix-community/emacs-overlay/commit/ff930b5e806d659480b70f6ac3b2ba7efb346682) | `` Updated emacs ``        |
| [`51e71e8f`](https://github.com/nix-community/emacs-overlay/commit/51e71e8f04f66d487cd5953949dc583fb731823d) | `` Updated melpa ``        |
| [`1fc1a56e`](https://github.com/nix-community/emacs-overlay/commit/1fc1a56e3a6e56ef992f9d3097ba5d39830c7b7d) | `` Updated elpa ``         |
| [`bfbb1016`](https://github.com/nix-community/emacs-overlay/commit/bfbb101605cfb53ba1632bdfb9ff3636bd779be9) | `` Updated nongnu ``       |
| [`ff148db0`](https://github.com/nix-community/emacs-overlay/commit/ff148db04653261fa37c10816b293e43efac3cfb) | `` Updated emacs ``        |
| [`84dd46a4`](https://github.com/nix-community/emacs-overlay/commit/84dd46a42402cb530154ece11210b73f8573f06c) | `` Updated melpa ``        |
| [`97d803e4`](https://github.com/nix-community/emacs-overlay/commit/97d803e417dbf766b2ada1b7f971d6b45961d0a3) | `` Updated emacs ``        |
| [`56cd7f22`](https://github.com/nix-community/emacs-overlay/commit/56cd7f22729aa95a08097028df1c871622a20bf7) | `` Updated melpa ``        |
| [`260c8c09`](https://github.com/nix-community/emacs-overlay/commit/260c8c09409bd89f3e530267c7a9fadac11824f2) | `` Updated elpa ``         |
| [`0b6f1ff4`](https://github.com/nix-community/emacs-overlay/commit/0b6f1ff4327d6af1eed0fc8d2d4bc4b559f7b1f4) | `` Updated nongnu ``       |
| [`2d35141c`](https://github.com/nix-community/emacs-overlay/commit/2d35141c7cfac4d784498427f3ad6f28bf980c3d) | `` Updated emacs ``        |
| [`b7b033ae`](https://github.com/nix-community/emacs-overlay/commit/b7b033aeb63bf3f39d928198abc88e1aba7f1974) | `` Updated melpa ``        |
| [`566511cb`](https://github.com/nix-community/emacs-overlay/commit/566511cb2be359ac3744061ea3bf71a34d6361c1) | `` Updated elpa ``         |
| [`1f2952c4`](https://github.com/nix-community/emacs-overlay/commit/1f2952c45202c860601b1ce1c54e1b5dba880c7c) | `` Updated nongnu ``       |
| [`56acf060`](https://github.com/nix-community/emacs-overlay/commit/56acf06006e4e5dd451398f2a35ce00b156c1434) | `` Updated flake inputs `` |
| [`63490862`](https://github.com/nix-community/emacs-overlay/commit/6349086278c4a5ecc1bb93286edfe9b618685c2d) | `` Updated emacs ``        |
| [`57fbca38`](https://github.com/nix-community/emacs-overlay/commit/57fbca3813e60c0a6a69a5a874ab8293895941cc) | `` Updated melpa ``        |
| [`8aa1c071`](https://github.com/nix-community/emacs-overlay/commit/8aa1c071bbcb8a270bb841e4797a0d14528709d4) | `` Updated emacs ``        |
| [`d7d05ef6`](https://github.com/nix-community/emacs-overlay/commit/d7d05ef6bccf1f6256617ef65fc44bc76c271d71) | `` Updated melpa ``        |
| [`a084beaf`](https://github.com/nix-community/emacs-overlay/commit/a084beaf62e48727f0a99734864c043ac5265aa7) | `` Updated elpa ``         |
| [`8ae077c2`](https://github.com/nix-community/emacs-overlay/commit/8ae077c2e3ebe723028e0b9e7029604df8795e19) | `` Updated nongnu ``       |
| [`e41a1c92`](https://github.com/nix-community/emacs-overlay/commit/e41a1c92e062d5ef07c58b5d781d46d3921d9b13) | `` Updated emacs ``        |
| [`f16aec4d`](https://github.com/nix-community/emacs-overlay/commit/f16aec4d9c9608ba3084ae402eb20760abfee8fb) | `` Updated melpa ``        |
| [`aeb20cfd`](https://github.com/nix-community/emacs-overlay/commit/aeb20cfd71e98867c7416a1959d8c426f7b65791) | `` Updated elpa ``         |
| [`a58c0013`](https://github.com/nix-community/emacs-overlay/commit/a58c00135108be1d6bdfbe4bcd15baae7f4b0e2e) | `` Updated nongnu ``       |
| [`be75f7ec`](https://github.com/nix-community/emacs-overlay/commit/be75f7ec9e7d6eee5a0f98b702716b3d55e7a8a7) | `` Updated emacs ``        |
| [`c4861650`](https://github.com/nix-community/emacs-overlay/commit/c48616503e63e2f98ab18aff257e4f5a19088a9c) | `` Updated melpa ``        |
| [`8b3ca61c`](https://github.com/nix-community/emacs-overlay/commit/8b3ca61c2811c31d90ab8d6b1b30bcd83a8be483) | `` Updated emacs ``        |
| [`b6b3b866`](https://github.com/nix-community/emacs-overlay/commit/b6b3b866d7269dd0129270222231d97619a6bcc3) | `` Updated melpa ``        |
| [`1dc8f505`](https://github.com/nix-community/emacs-overlay/commit/1dc8f5052510c3f1cd8ef3517a24de670c3f6682) | `` Updated elpa ``         |
| [`dc0ad90f`](https://github.com/nix-community/emacs-overlay/commit/dc0ad90f083fee12c5b9f3ae6b3cbfc01f011264) | `` Updated flake inputs `` |