### PR TITLE
chore(flake/nur): `36c16ef6` -> `4d3eb6b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -702,11 +702,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1744098102,
-        "narHash": "sha256-tzCdyIJj9AjysC3OuKA+tMD/kDEDAF9mICPDU7ix0JA=",
+        "lastModified": 1744463964,
+        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c8cd81426f45942bb2906d5ed2fe21d2f19d95b7",
+        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
         "type": "github"
       },
       "original": {
@@ -777,11 +777,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1744257277,
-        "narHash": "sha256-TpD0L37AKskcfs/4VzbukpGam6Oedrxid+C9bJEb/Us=",
+        "lastModified": 1744774023,
+        "narHash": "sha256-rwCQx+VTnRZBYbLoOVpHURR7llD8FM5NZYZGx66Q6vI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "36c16ef6d49d8edb8eaad63ce788c5870082b4b0",
+        "rev": "4d3eb6b81de445ef2e2f44f49dbec6d25c822fbb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                           |
| -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`4d3eb6b8`](https://github.com/nix-community/NUR/commit/4d3eb6b81de445ef2e2f44f49dbec6d25c822fbb) | `` automatic update ``                                            |
| [`f364c951`](https://github.com/nix-community/NUR/commit/f364c951cee7be00b3368f130dbfd5bb5a06f980) | `` automatic update ``                                            |
| [`00bef437`](https://github.com/nix-community/NUR/commit/00bef4376ded633f24795f7437f34148747690d1) | `` automatic update ``                                            |
| [`e667247d`](https://github.com/nix-community/NUR/commit/e667247df0a6f9cf0e19e991939ce87ada422ffe) | `` automatic update ``                                            |
| [`1736f0da`](https://github.com/nix-community/NUR/commit/1736f0da65fea7f5b4025e9024b94d427ce215af) | `` automatic update ``                                            |
| [`6f7e7406`](https://github.com/nix-community/NUR/commit/6f7e7406290a793d1c9bff22d79d1b2b83d13084) | `` automatic update ``                                            |
| [`7ce59d07`](https://github.com/nix-community/NUR/commit/7ce59d07e2e152760f3514cdccb7613eb21c2be3) | `` automatic update ``                                            |
| [`0a8c66e6`](https://github.com/nix-community/NUR/commit/0a8c66e63f8e9bd8297acf47c616af2140f9fdfa) | `` automatic update ``                                            |
| [`d1afc0cd`](https://github.com/nix-community/NUR/commit/d1afc0cdb422b80617f69bd903c434c3664a8225) | `` automatic update ``                                            |
| [`d2e27015`](https://github.com/nix-community/NUR/commit/d2e27015ab14750d91abb8d6ee12d8d9fa16ea37) | `` automatic update ``                                            |
| [`17352f23`](https://github.com/nix-community/NUR/commit/17352f230e0ee3a2466dabc7226eea9533b5c865) | `` automatic update ``                                            |
| [`55cf9d60`](https://github.com/nix-community/NUR/commit/55cf9d601e84196a5e0500cd4a1a013a5840d52c) | `` automatic update ``                                            |
| [`be95402b`](https://github.com/nix-community/NUR/commit/be95402b424e1dafa2e1e1e8c2781381903ef7b3) | `` automatic update ``                                            |
| [`ea92a843`](https://github.com/nix-community/NUR/commit/ea92a8436d9e82a69b281b4b45c162ca61ff05ec) | `` automatic update ``                                            |
| [`17a1875b`](https://github.com/nix-community/NUR/commit/17a1875b65fe923c96d57aa3688a61c61f694785) | `` automatic update ``                                            |
| [`1675ad90`](https://github.com/nix-community/NUR/commit/1675ad90e9a5560fb35831d26581ae050a798b8d) | `` automatic update ``                                            |
| [`eb754deb`](https://github.com/nix-community/NUR/commit/eb754debdd76656226f0d403523650ef5119267f) | `` automatic update ``                                            |
| [`3236e3bd`](https://github.com/nix-community/NUR/commit/3236e3bdae543136a5f0531183a3cb7181e2f3f9) | `` automatic update ``                                            |
| [`7ee7afc8`](https://github.com/nix-community/NUR/commit/7ee7afc8c8f8d0723f267a862fe8a34e454e1d18) | `` automatic update ``                                            |
| [`5dc46450`](https://github.com/nix-community/NUR/commit/5dc46450df3f77e8372674fc155244af57d573ac) | `` automatic update ``                                            |
| [`2fbf8d8e`](https://github.com/nix-community/NUR/commit/2fbf8d8ecbec6578df27f45ae6f726190433aa2b) | `` automatic update ``                                            |
| [`64a2f77d`](https://github.com/nix-community/NUR/commit/64a2f77d34f5c2a29c937840387fe23388797db7) | `` automatic update ``                                            |
| [`b52a00b4`](https://github.com/nix-community/NUR/commit/b52a00b4e5ae529a13676fbe465f3835d3e4b9f8) | `` automatic update ``                                            |
| [`a0fd02eb`](https://github.com/nix-community/NUR/commit/a0fd02eb827911d886114c9f2680df34ec0a6267) | `` automatic update ``                                            |
| [`7dafbfb0`](https://github.com/nix-community/NUR/commit/7dafbfb09bb704273dec6ddf181f7390be65b69a) | `` automatic update ``                                            |
| [`483b51f0`](https://github.com/nix-community/NUR/commit/483b51f0ae46553cc9532d53db817c6eea3fd7e8) | `` automatic update ``                                            |
| [`50b76e2d`](https://github.com/nix-community/NUR/commit/50b76e2d906dfcabe054eab366b46fac3781a208) | `` automatic update ``                                            |
| [`b46dd67e`](https://github.com/nix-community/NUR/commit/b46dd67e630644492ee7dd93834e9dd6cf58fbd4) | `` automatic update ``                                            |
| [`de60731d`](https://github.com/nix-community/NUR/commit/de60731d619853e037afdf4eab38673932262ada) | `` automatic update ``                                            |
| [`74ec1726`](https://github.com/nix-community/NUR/commit/74ec1726ff57336701d7f2661c7e7514a85eb23c) | `` chore(deps): update cachix/install-nix-action action to v31 `` |
| [`2485e0c4`](https://github.com/nix-community/NUR/commit/2485e0c4c9079c1e75a3769248f7d8a4f56d46d8) | `` automatic update ``                                            |
| [`8bab2f8d`](https://github.com/nix-community/NUR/commit/8bab2f8dd2a32eaa1f18fd29ad70e577a3f070a2) | `` automatic update ``                                            |
| [`12aadc56`](https://github.com/nix-community/NUR/commit/12aadc56720ab7be7301f3a539e1f7c828d9a6e0) | `` automatic update ``                                            |
| [`068a0310`](https://github.com/nix-community/NUR/commit/068a0310209d953e278a28e41091fd473d944a51) | `` automatic update ``                                            |
| [`91cf7254`](https://github.com/nix-community/NUR/commit/91cf72548fc06e8effab92add042cb256b0a5ffa) | `` automatic update ``                                            |
| [`ca12aeab`](https://github.com/nix-community/NUR/commit/ca12aeabfbe453851c94b7ea46d841cf55ad2b8d) | `` automatic update ``                                            |
| [`94b9862c`](https://github.com/nix-community/NUR/commit/94b9862ceacbdb253f66ff7d05f22852a5c2aaaa) | `` automatic update ``                                            |
| [`f4f712a9`](https://github.com/nix-community/NUR/commit/f4f712a9cc017c1d052bda910ef45432818d7f14) | `` automatic update ``                                            |
| [`91cbcbe8`](https://github.com/nix-community/NUR/commit/91cbcbe826eb897e382459365de3fb01dc7905ec) | `` automatic update ``                                            |
| [`a058380c`](https://github.com/nix-community/NUR/commit/a058380c138c5c30402c1bd12992d6849124bf44) | `` automatic update ``                                            |
| [`8fe101f5`](https://github.com/nix-community/NUR/commit/8fe101f5587e97fdb80201b31e4ab50565d6fcee) | `` automatic update ``                                            |
| [`b081f894`](https://github.com/nix-community/NUR/commit/b081f8940a5cc17039e598ec4124e81759f30ad1) | `` automatic update ``                                            |
| [`c8c2f906`](https://github.com/nix-community/NUR/commit/c8c2f906ca4d5a0d89e20a0ec2ae2b5aa54fe87e) | `` automatic update ``                                            |
| [`d6a1f727`](https://github.com/nix-community/NUR/commit/d6a1f727e2a2d5db00a35f26d3c93141c4ce74b4) | `` automatic update ``                                            |
| [`9dcdfc53`](https://github.com/nix-community/NUR/commit/9dcdfc53009ba6187cd8ab3db5cd0874c9cef779) | `` automatic update ``                                            |
| [`48a07916`](https://github.com/nix-community/NUR/commit/48a07916f32915c9a8f16e3eb7848cb21358b28b) | `` automatic update ``                                            |
| [`820d321f`](https://github.com/nix-community/NUR/commit/820d321f8566b371b2831b805f64ff41b1b000c5) | `` automatic update ``                                            |
| [`fb4de678`](https://github.com/nix-community/NUR/commit/fb4de678f84b00896f3a3f116fadb9e937fb8ba8) | `` automatic update ``                                            |
| [`501ade62`](https://github.com/nix-community/NUR/commit/501ade629bf05235b7083c3b943667eb65e2e065) | `` automatic update ``                                            |
| [`33d7ccce`](https://github.com/nix-community/NUR/commit/33d7cccec40f9979127d7911250789181da9a1d4) | `` automatic update ``                                            |
| [`8dc2190d`](https://github.com/nix-community/NUR/commit/8dc2190dc6082e15c3825163b0d449c15159a0bf) | `` automatic update ``                                            |
| [`514bac44`](https://github.com/nix-community/NUR/commit/514bac447115df5cd90dd685aa88a01a960c5cc4) | `` automatic update ``                                            |
| [`4b607eb3`](https://github.com/nix-community/NUR/commit/4b607eb368229c57a2d800ec0a3ed0df62dbb47b) | `` automatic update ``                                            |
| [`8b9d236b`](https://github.com/nix-community/NUR/commit/8b9d236b29fd793d7a1b733cae89088dc50572a0) | `` automatic update ``                                            |
| [`6f4cf66d`](https://github.com/nix-community/NUR/commit/6f4cf66d050cee5fdddd33e420f9d3d80e11f08d) | `` automatic update ``                                            |
| [`40cc26f6`](https://github.com/nix-community/NUR/commit/40cc26f6cb192a68e767b8684e181ccc98227c34) | `` automatic update ``                                            |
| [`3cccb166`](https://github.com/nix-community/NUR/commit/3cccb1665b21d23cf95637cd7342acd5405baead) | `` automatic update ``                                            |
| [`1ed77cf6`](https://github.com/nix-community/NUR/commit/1ed77cf686b717384909827ecf406ed74304002d) | `` automatic update ``                                            |
| [`56a5021c`](https://github.com/nix-community/NUR/commit/56a5021c425ffca1ffc0e3199e580df33e5aeae7) | `` automatic update ``                                            |
| [`540469e5`](https://github.com/nix-community/NUR/commit/540469e5551f3083ec8ec474decab13d3ac91cac) | `` automatic update ``                                            |
| [`8ad29815`](https://github.com/nix-community/NUR/commit/8ad298151e305336cdd753b5e09d34b3851d8383) | `` automatic update ``                                            |
| [`eeaaddd3`](https://github.com/nix-community/NUR/commit/eeaaddd39a60678b3ef28ba470331e8a129fe0d5) | `` automatic update ``                                            |
| [`4e736ced`](https://github.com/nix-community/NUR/commit/4e736cedcee8df1aa936a4b536d7a2c23b577414) | `` automatic update ``                                            |
| [`b616d85c`](https://github.com/nix-community/NUR/commit/b616d85cd0ad6319ea4b7f1c0072e64c98126768) | `` automatic update ``                                            |
| [`3ae28aca`](https://github.com/nix-community/NUR/commit/3ae28acab4df8710ddc3ca64b6d633228b49ef7c) | `` automatic update ``                                            |
| [`db95f221`](https://github.com/nix-community/NUR/commit/db95f2218820c7e281a50de3da6891ba6c2ad702) | `` automatic update ``                                            |
| [`34b3683f`](https://github.com/nix-community/NUR/commit/34b3683ff623cc6de9128f7fe353f731dab7a474) | `` automatic update ``                                            |
| [`09888a63`](https://github.com/nix-community/NUR/commit/09888a636d8572d1d2066e2c1fc03c987b3905e5) | `` automatic update ``                                            |
| [`7954acdc`](https://github.com/nix-community/NUR/commit/7954acdcf07549eff82a2f4ca58f935526e0e039) | `` automatic update ``                                            |
| [`b58c82b0`](https://github.com/nix-community/NUR/commit/b58c82b0cb43d59b9e1307727657356a7f4630d3) | `` automatic update ``                                            |
| [`15eea00a`](https://github.com/nix-community/NUR/commit/15eea00ab0ab9e8856fac24bdb67d8504dc35ab9) | `` automatic update ``                                            |
| [`f4e3a6a1`](https://github.com/nix-community/NUR/commit/f4e3a6a14fdb5b2166e2a2d6eacf35a2b903dc97) | `` automatic update ``                                            |
| [`51a05138`](https://github.com/nix-community/NUR/commit/51a051387761b0ac21d8a7825392422290ee7e31) | `` automatic update ``                                            |
| [`1b9b850d`](https://github.com/nix-community/NUR/commit/1b9b850d8be99177d6d1ef45999511254f69e75d) | `` automatic update ``                                            |
| [`22052cde`](https://github.com/nix-community/NUR/commit/22052cde27aad8bc9525218230d4e048c7dade19) | `` automatic update ``                                            |
| [`96bc1373`](https://github.com/nix-community/NUR/commit/96bc1373445beb864dd3564e09f0ca0b9d623a5a) | `` automatic update ``                                            |
| [`93f032a5`](https://github.com/nix-community/NUR/commit/93f032a5355b330aa87e22caa6c673d6d8e79726) | `` automatic update ``                                            |
| [`02c93541`](https://github.com/nix-community/NUR/commit/02c935415b4e1227b3bec09204f2e5d25556934c) | `` automatic update ``                                            |
| [`3da46ac4`](https://github.com/nix-community/NUR/commit/3da46ac4235060971f07a06e943c138e8361b032) | `` automatic update ``                                            |
| [`d4aafd7c`](https://github.com/nix-community/NUR/commit/d4aafd7c84f836cc89b27424314785e2acacfe51) | `` automatic update ``                                            |
| [`f7016c25`](https://github.com/nix-community/NUR/commit/f7016c2585ccb600d6344e802de3ee5abd5724bb) | `` automatic update ``                                            |
| [`2a814b12`](https://github.com/nix-community/NUR/commit/2a814b12f77f0edff7f043b4c9cc634043b603be) | `` automatic update ``                                            |
| [`6701ef91`](https://github.com/nix-community/NUR/commit/6701ef912d18b2f7b1423f19a3ce4646c598bb3c) | `` automatic update ``                                            |
| [`35cfbb58`](https://github.com/nix-community/NUR/commit/35cfbb58130a81ac726bfacdd10a14b03aac42e0) | `` automatic update ``                                            |
| [`c3b30399`](https://github.com/nix-community/NUR/commit/c3b30399f0a496cd917626e260f0fc281fec7198) | `` automatic update ``                                            |
| [`2ab4c22b`](https://github.com/nix-community/NUR/commit/2ab4c22b19ee39e2875f26f4fcfb2046b49d8747) | `` automatic update ``                                            |
| [`df3270cb`](https://github.com/nix-community/NUR/commit/df3270cbd0e9bb799ce24685606128f2a7d11588) | `` automatic update ``                                            |
| [`db339657`](https://github.com/nix-community/NUR/commit/db339657cc1a2f112dba50548bc6b2a72f03b197) | `` automatic update ``                                            |
| [`88ac5b7f`](https://github.com/nix-community/NUR/commit/88ac5b7f449f2f1e1c6058a881a26e46d38960b5) | `` automatic update ``                                            |
| [`6fc81780`](https://github.com/nix-community/NUR/commit/6fc817802f21f82eff44b95d9e8fdde8b2273d16) | `` automatic update ``                                            |
| [`5b4559e4`](https://github.com/nix-community/NUR/commit/5b4559e4f4a968dac414504be84a135a7818cbce) | `` automatic update ``                                            |
| [`d7896156`](https://github.com/nix-community/NUR/commit/d7896156281a0c1ba9b34fdd6600de05fcaef0c4) | `` automatic update ``                                            |
| [`59f9797b`](https://github.com/nix-community/NUR/commit/59f9797b8999e5fadc66d5d1a150e6194ab63f3f) | `` automatic update ``                                            |
| [`3d57e02e`](https://github.com/nix-community/NUR/commit/3d57e02ef4ab6a22880b31ee279a627725993dfb) | `` automatic update ``                                            |
| [`c0ec8838`](https://github.com/nix-community/NUR/commit/c0ec8838e0f8006373f6c95bfd0c69d4d03c7add) | `` automatic update ``                                            |
| [`fc757fdb`](https://github.com/nix-community/NUR/commit/fc757fdba9206642a66895b4e2cafd982fcddf39) | `` automatic update ``                                            |
| [`3778c704`](https://github.com/nix-community/NUR/commit/3778c7045db602f9badc3c5f440d3b2d1b7bd3d3) | `` automatic update ``                                            |
| [`704f0524`](https://github.com/nix-community/NUR/commit/704f05243844699fea06113ae730310536a3c38e) | `` automatic update ``                                            |
| [`0a1dbbaf`](https://github.com/nix-community/NUR/commit/0a1dbbafad7cbf8e73299bf63ea1da9676c29765) | `` automatic update ``                                            |
| [`4cf6c368`](https://github.com/nix-community/NUR/commit/4cf6c36898f9c28dd9ca714728eb1f0cc5c2f37a) | `` automatic update ``                                            |
| [`6872c95b`](https://github.com/nix-community/NUR/commit/6872c95b202d0a01796bef4ba38c16a6eea74017) | `` automatic update ``                                            |
| [`5c87a9d7`](https://github.com/nix-community/NUR/commit/5c87a9d71d9a66929a518832ca4d6664e880673a) | `` automatic update ``                                            |
| [`babb77ef`](https://github.com/nix-community/NUR/commit/babb77ef20fb6f2e1ab726f41e60fe370384e1fc) | `` automatic update ``                                            |
| [`26dc7315`](https://github.com/nix-community/NUR/commit/26dc7315e93dabb5561e2bda5d389635faad770e) | `` automatic update ``                                            |
| [`f8dd4a4d`](https://github.com/nix-community/NUR/commit/f8dd4a4d689e064ddb613878390558e70a5af3f2) | `` automatic update ``                                            |
| [`1c9a0da5`](https://github.com/nix-community/NUR/commit/1c9a0da5fba8f4a3fbc06dde4659449881abc237) | `` automatic update ``                                            |
| [`389bd960`](https://github.com/nix-community/NUR/commit/389bd960f6f7e851d1a0e485507e71d35694e38a) | `` automatic update ``                                            |
| [`9988da8a`](https://github.com/nix-community/NUR/commit/9988da8af597950a09e741d836ea3935783ca9cc) | `` automatic update ``                                            |
| [`21f971e2`](https://github.com/nix-community/NUR/commit/21f971e226b45bb185b710e06a7518665fb57776) | `` automatic update ``                                            |
| [`8a92039b`](https://github.com/nix-community/NUR/commit/8a92039b8941ba55a62246cd8d699ab9b73f79db) | `` automatic update ``                                            |
| [`ea665362`](https://github.com/nix-community/NUR/commit/ea6653627e7cf098e8333354c8718e266419122c) | `` automatic update ``                                            |
| [`0a36b9c5`](https://github.com/nix-community/NUR/commit/0a36b9c56e469b6ca521de55b0f16cad9e7aa73d) | `` automatic update ``                                            |
| [`abc9c92a`](https://github.com/nix-community/NUR/commit/abc9c92a0ee684a3e9dee32594fa9f5cfb1644df) | `` automatic update ``                                            |
| [`236a5db5`](https://github.com/nix-community/NUR/commit/236a5db5f1885eb1acb5eb83f2412a72ee10c5ba) | `` automatic update ``                                            |
| [`3914564b`](https://github.com/nix-community/NUR/commit/3914564bd6318e13ce2202fc5f1cfaaa272ba2b1) | `` automatic update ``                                            |
| [`8ca8dec6`](https://github.com/nix-community/NUR/commit/8ca8dec6d274c4816e62f4445acda6012bb35e66) | `` automatic update ``                                            |
| [`c5b404ec`](https://github.com/nix-community/NUR/commit/c5b404ec9aa224ae8b33a7a6093ffc5d422caa48) | `` automatic update ``                                            |
| [`407a3f3d`](https://github.com/nix-community/NUR/commit/407a3f3d71dbb7619c2cf8be5e80e469ce5b61d8) | `` automatic update ``                                            |
| [`fe539b1e`](https://github.com/nix-community/NUR/commit/fe539b1e0bb3d9385aa1b2d8630a1f164e3aec86) | `` automatic update ``                                            |
| [`2125985b`](https://github.com/nix-community/NUR/commit/2125985be89941a355c1fb50f75d0e5a56698cc5) | `` automatic update ``                                            |
| [`742ecafd`](https://github.com/nix-community/NUR/commit/742ecafd3c88a1eb3189ffbe9fcb6548ea0669c7) | `` automatic update ``                                            |
| [`ab67d7d5`](https://github.com/nix-community/NUR/commit/ab67d7d5ea3e72e58bb6c0dcbc61846215dcdb61) | `` automatic update ``                                            |
| [`a1f2ce5e`](https://github.com/nix-community/NUR/commit/a1f2ce5ecf89f5d77d0267e6bece8ef7ec8b2b50) | `` automatic update ``                                            |
| [`13c9d0da`](https://github.com/nix-community/NUR/commit/13c9d0da4cd7e5ae92534dae1437489ba4c1bc07) | `` automatic update ``                                            |
| [`aeac0c7a`](https://github.com/nix-community/NUR/commit/aeac0c7ad54ec735f8cf81c4ccad4a5e3ae08135) | `` automatic update ``                                            |
| [`d94a3bed`](https://github.com/nix-community/NUR/commit/d94a3bed849db6165ca897311784a615a70798f5) | `` automatic update ``                                            |
| [`de78b561`](https://github.com/nix-community/NUR/commit/de78b56181f161c1b26c964d561e5c9dc144c9f7) | `` automatic update ``                                            |
| [`cb85fb3d`](https://github.com/nix-community/NUR/commit/cb85fb3dd03d43c2db28dadb43d9bb54857b1150) | `` automatic update ``                                            |
| [`8d02750a`](https://github.com/nix-community/NUR/commit/8d02750a56fc3cecd1be6f6579d0cbda3d39ce1c) | `` automatic update ``                                            |