### PR TITLE
chore(flake/nixos-hardware): `de6fc555` -> `9a049b4a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -545,11 +545,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1743420942,
-        "narHash": "sha256-b/exDDQSLmENZZgbAEI3qi9yHkuXAXCPbormD8CSJXo=",
+        "lastModified": 1744633460,
+        "narHash": "sha256-fbWE4Xpw6eH0Q6in+ymNuDwTkqmFmtxcQEmtRuKDTTk=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "de6fc5551121c59c01e2a3d45b277a6d05077bc4",
+        "rev": "9a049b4a421076d27fee3eec664a18b2066824cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                            |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`e3a967ba`](https://github.com/NixOS/nixos-hardware/commit/e3a967ba29a3fdb55373231a70fe791cd19945ed) | `` Fixed build issues for imx8mq-evk ``            |
| [`48a8eaea`](https://github.com/NixOS/nixos-hardware/commit/48a8eaeac8059c23a2f8d6f41e8486a47d6ba95f) | `` Fixed native build issues for imx8mp-evk atf `` |
| [`c7034bb5`](https://github.com/NixOS/nixos-hardware/commit/c7034bb57b045c0b6d4fb9180abe42a96f4d1add) | `` Fix compilation issue ``                        |