### PR TITLE
chore(flake/nixpkgs): `c8cd8142` -> `f675531b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -686,11 +686,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1744098102,
-        "narHash": "sha256-tzCdyIJj9AjysC3OuKA+tMD/kDEDAF9mICPDU7ix0JA=",
+        "lastModified": 1744232761,
+        "narHash": "sha256-gbl9hE39nQRpZaLjhWKmEu5ejtQsgI5TWYrIVVJn30U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c8cd81426f45942bb2906d5ed2fe21d2f19d95b7",
+        "rev": "f675531bc7e6657c10a18b565cfebd8aa9e24c14",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`96c81c3f`](https://github.com/NixOS/nixpkgs/commit/96c81c3f8fe38f77e678122f1ca83ef273645923) | `` vimPluginsUpdater: fix format of generated output ``                         |
| [`33a287eb`](https://github.com/NixOS/nixpkgs/commit/33a287eb135fa5af141f6f889771917b17465296) | `` ocamlPackages.gettext: 0.4.2 → 0.5.0 ``                                      |
| [`eb763f53`](https://github.com/NixOS/nixpkgs/commit/eb763f5307748fd3ac055ab39daf7aee2c2c0004) | `` gatekeeper: 3.18.2 -> 3.19.0 ``                                              |
| [`1b62e27a`](https://github.com/NixOS/nixpkgs/commit/1b62e27af66cfdc05619ddd790aa063eb787c840) | `` python312Packages.iminuit: 2.30.1 -> 2.31.1 ``                               |
| [`6c0017a0`](https://github.com/NixOS/nixpkgs/commit/6c0017a0a10a6b24bce358ebe1266bc9efa61ee8) | `` gickup: 0.10.36 -> 0.10.38 ``                                                |
| [`ff1a8591`](https://github.com/NixOS/nixpkgs/commit/ff1a8591bc3200a02ebb1214dfc9050c7a122320) | `` aws-workspaces: 4.7.0.4312 -> 2024.8.5191 (#396863) ``                       |
| [`35949250`](https://github.com/NixOS/nixpkgs/commit/35949250088ef24fc4b707136744a1e46bbfd215) | `` vscode-extensions.huacnlee.autocorrect: init at 2.6.4 ``                     |
| [`8e81c6d2`](https://github.com/NixOS/nixpkgs/commit/8e81c6d24ed2eadd16bd18d35e5aad274a07c512) | `` meerk40t: 0.9.7020 -> 0.9.7030 (#397415) ``                                  |
| [`3f5286d0`](https://github.com/NixOS/nixpkgs/commit/3f5286d0c5ed8355c9f2c539a65d7c13143955fb) | `` vimPlugins.diagflow-nvim: init at 2025-03-04 ``                              |
| [`75b0624f`](https://github.com/NixOS/nixpkgs/commit/75b0624f9898b0774855193ea507b334c76a1528) | `` vscode: 1.99.0 -> 1.99.1 ``                                                  |
| [`1d020b22`](https://github.com/NixOS/nixpkgs/commit/1d020b221ec22327751c809f246fbf584cb9bd4c) | `` runmd: init at 1.4.1 ``                                                      |
| [`bc0b105e`](https://github.com/NixOS/nixpkgs/commit/bc0b105ed11afa4d073e2b60ce6b94c1a72253bc) | `` python312Packages.uiprotect: 7.5.1 -> 7.5.2 (#397296) ``                     |
| [`60d76e35`](https://github.com/NixOS/nixpkgs/commit/60d76e35f8404e8ec63e3db05d86bf3911ae3682) | `` zed-editor: 0.180.2 -> 0.181.5 ``                                            |
| [`fcb15418`](https://github.com/NixOS/nixpkgs/commit/fcb15418b713fc7b159eac353179b6e90e39363a) | `` livekit-libwebrtc: m114 -> 125-unstable-2025-03-24 ``                        |
| [`dae8e0d6`](https://github.com/NixOS/nixpkgs/commit/dae8e0d6fb07e1d0f109a9b4a04d4c634953c064) | `` dracula-theme: 4.0.0-unstable-2025-03-22 -> 4.0.0-unstable-2025-04-01 ``     |
| [`2d9f8c09`](https://github.com/NixOS/nixpkgs/commit/2d9f8c09b4066ff694a9d388743053d4f0395c5b) | `` fwupd: 2.0.7 -> 2.0.8 ``                                                     |
| [`310aa175`](https://github.com/NixOS/nixpkgs/commit/310aa17516f0ad5596ce32a02eface2a1585c415) | `` age: add age-plugin-sss to `passthru.plugins` ``                             |
| [`cf5f2ec2`](https://github.com/NixOS/nixpkgs/commit/cf5f2ec29e76b46f3c12f5eeccf744fbf881beb6) | `` nixVersions.git: 2025-04-07 -> 2025-04-09 ``                                 |
| [`6f9871b6`](https://github.com/NixOS/nixpkgs/commit/6f9871b6ed3b45af49dfe97709cbf94f2dbff210) | `` python312Packages.pytensor: 2.30.2 -> 2.30.3 ``                              |
| [`066ed9a8`](https://github.com/NixOS/nixpkgs/commit/066ed9a8f2e39294b89b76889d35a90907586948) | `` open-web-calendar: 1.48 -> 1.49 ``                                           |
| [`3c92fed9`](https://github.com/NixOS/nixpkgs/commit/3c92fed9c79d41d15f5627e289aafe16c3386a5a) | `` harbor-cli: 0.0.3 -> 0.0.4 ``                                                |
| [`93a9e4d7`](https://github.com/NixOS/nixpkgs/commit/93a9e4d7a17f7feade59c1fbf78a2d9b78812702) | `` rav1d: init at 1.0.0 ``                                                      |
| [`8002e292`](https://github.com/NixOS/nixpkgs/commit/8002e2926c94ba482ce191f90defe28e8c0485b5) | `` parca: add update script ``                                                  |
| [`bee2c4a7`](https://github.com/NixOS/nixpkgs/commit/bee2c4a789c244d00f7d7bd71c15c2cb3afb44f3) | `` tbox: 1.7.6 -> 1.7.7 ``                                                      |
| [`1486129b`](https://github.com/NixOS/nixpkgs/commit/1486129b1bf30faacedabb02add7bc912392185d) | `` trilium-next-{desktop,server}: 0.92.4 -> 0.92.6 ``                           |
| [`df82752e`](https://github.com/NixOS/nixpkgs/commit/df82752eb91eaf5f47ed648b964dad52c277abd5) | `` roddhjav-apparmor-rules: 0-unstable-2025-03-28 -> 0-unstable-2025-04-07 ``   |
| [`9efe0c42`](https://github.com/NixOS/nixpkgs/commit/9efe0c425a0721e54d62fd970c9977cc2213dbfc) | `` python3Packages.craft-cli: use `writableTmpDirAsHomeHook` for checks ``      |
| [`2e5e140f`](https://github.com/NixOS/nixpkgs/commit/2e5e140f0288467ab0e3aba8ada62568498300bf) | `` codesnap: 0.10.5 -> 0.10.7 ``                                                |
| [`e131f002`](https://github.com/NixOS/nixpkgs/commit/e131f00232fd45105837095659392dad79f7def9) | `` python3Packages.pillow: update homepage ``                                   |
| [`c093725a`](https://github.com/NixOS/nixpkgs/commit/c093725ab750a39292b4cb709a57cd1fdaba5ca6) | `` pywal16: 3.8.4 -> 3.8.5 ``                                                   |
| [`b64bbcf1`](https://github.com/NixOS/nixpkgs/commit/b64bbcf19dfc66a9c245626db0fa1d3982cd9aba) | `` rockcraft: use `writableTmpDirAsHomeHook` for checks ``                      |
| [`0acd35f8`](https://github.com/NixOS/nixpkgs/commit/0acd35f8bf53de9db5746c96819a89e3de710fbc) | `` nixVersions.nix_2_26: fix self_attribute_name and src hash ``                |
| [`62ec6630`](https://github.com/NixOS/nixpkgs/commit/62ec6630a73a4fd8d9be1fc6d917afbf98af6b3b) | `` chirp: 0.4.0-unstable-2025-03-27 -> 0.4.0-unstable-2025-04-01 ``             |
| [`e971bd88`](https://github.com/NixOS/nixpkgs/commit/e971bd884c870bc40d77637698afe00fdca87929) | `` sofa: init at 24.12.00 ``                                                    |
| [`af417b98`](https://github.com/NixOS/nixpkgs/commit/af417b98416dd850bc67d3b7d049a2846fb11282) | `` eigenmath: 338-unstable-2025-03-27 -> 338-unstable-2025-04-03 ``             |
| [`87076301`](https://github.com/NixOS/nixpkgs/commit/87076301d359d8a1d161f9077e9b0e625567dace) | `` nix: Fix cross ``                                                            |
| [`c5c77ad7`](https://github.com/NixOS/nixpkgs/commit/c5c77ad7f769e39699ed02c90f56ec9ce517b795) | `` snapcraft: 8.7.3 -> 8.8.0 ``                                                 |
| [`a2560753`](https://github.com/NixOS/nixpkgs/commit/a25607539d4ce5063061b146525a419537f82fc2) | `` rockcraft: 1.9.0 -> 1.10.0 ``                                                |
| [`24c32b0c`](https://github.com/NixOS/nixpkgs/commit/24c32b0ce4fb94a3ba568d153a0ae7f22aca69a5) | `` python3Packages.craft-cli: 2.15.0 -> 3.0.0 ``                                |
| [`9d0ca0f5`](https://github.com/NixOS/nixpkgs/commit/9d0ca0f59a02116c906c65a29cc7e63e5d798e71) | `` python3Packages.craft-platforms: 0.6.0 -> 0.7.0 ``                           |
| [`e879f23e`](https://github.com/NixOS/nixpkgs/commit/e879f23e8365889ba97e213ccac5d2eee6af9720) | `` parca: 0.22.0 -> 0.23.1 ``                                                   |
| [`1d0c1c88`](https://github.com/NixOS/nixpkgs/commit/1d0c1c88709b0a2ded4b946222b68f915706a38d) | `` google-chrome: 135.0.7049.52 -> 135.0.7049.84 ``                             |
| [`5f64a161`](https://github.com/NixOS/nixpkgs/commit/5f64a1615cfc8f7ca028ce19d9cd2a408b6489f7) | `` sabnzbd: 4.4.1 -> 4.5.0 ``                                                   |
| [`df1e1ab4`](https://github.com/NixOS/nixpkgs/commit/df1e1ab4ad898a52fdd5da95d3360c28a6a4570c) | `` signal-export: 3.4.1 -> 3.5.1 ``                                             |
| [`0ba8b2b6`](https://github.com/NixOS/nixpkgs/commit/0ba8b2b69726c7ccff5273787998941c7deb8bd1) | `` albert: 0.27.5 -> 0.27.8 ``                                                  |
| [`365863c6`](https://github.com/NixOS/nixpkgs/commit/365863c670a6c44ebfbd9ec564ef65da705f974b) | `` godns: 3.2.2 -> 3.2.3 ``                                                     |
| [`4c3d61fb`](https://github.com/NixOS/nixpkgs/commit/4c3d61fb1efa246b89ff509b216f84e0dfe86bae) | `` bcachefs-tools: 1.20.0 -> 1.25.1 ``                                          |
| [`9291be5a`](https://github.com/NixOS/nixpkgs/commit/9291be5a7e85345ebb690c87c09ef3acb3ab7fd1) | `` python312Packages.granian: 2.2.0 -> 2.2.2 ``                                 |
| [`ba200968`](https://github.com/NixOS/nixpkgs/commit/ba200968e8c797ba014b6df71d35d7a6498d18b9) | `` python3Packages.debugpy: use retry plugin ``                                 |
| [`60a57466`](https://github.com/NixOS/nixpkgs/commit/60a5746676ba370e66698ac9cf76e3135e8dfd55) | `` mlxbf-bootimages: 4.8.0-13249 -> 4.10.0-13520 ``                             |
| [`9a432c9a`](https://github.com/NixOS/nixpkgs/commit/9a432c9ae7fdf7856ed4f0bb5ff85c697fde9e0e) | `` dartsim: init at 6.15.0 ``                                                   |
| [`fbfd554f`](https://github.com/NixOS/nixpkgs/commit/fbfd554f12736815180be8de73668909ae59b49e) | `` python312Packages.transformers: 4.50.3 -> 4.51.1 ``                          |
| [`33a6a345`](https://github.com/NixOS/nixpkgs/commit/33a6a3451b268378b3fd3cff4a5d276c6afae7e3) | `` python312Packages.huggingface-hub: 0.29.3 -> 0.30.2 ``                       |
| [`3d7faf71`](https://github.com/NixOS/nixpkgs/commit/3d7faf716eb287331d66d9777d7a9f42afb923c5) | `` emcee: init at 0.4.5 ``                                                      |
| [`676d47f9`](https://github.com/NixOS/nixpkgs/commit/676d47f9fc41f23b8be94f6d768db1b81823a66e) | `` frr: fix cross compilation ``                                                |
| [`b7a19441`](https://github.com/NixOS/nixpkgs/commit/b7a194413f769c6f428f1ac7d73f63e9786c1e47) | `` signal-desktop-source: build ringrtc & webrtc from source ``                 |
| [`76fc7de2`](https://github.com/NixOS/nixpkgs/commit/76fc7de2a316f69d50ed1929d4b4f369a9e1c7b2) | `` incus-ui-canonical: 0.15.1 -> 0.15.2 ``                                      |
| [`1913a364`](https://github.com/NixOS/nixpkgs/commit/1913a364e047d0c2860e4ed89d75c91d738288c4) | `` steel: 0.6.0-unstable-2025-03-28 -> 0.6.0-unstable-2025-04-08 ``             |
| [`544753ae`](https://github.com/NixOS/nixpkgs/commit/544753ae2fedbcc6041e8d2ca529c7b5b1281b85) | `` authentik: Unbreak on aarch64-linux ``                                       |
| [`5a84ee3e`](https://github.com/NixOS/nixpkgs/commit/5a84ee3ebdd20bc3f2c0a4e25c8ce0114cb6ecd4) | `` vscode-extensions.github.copilot-chat: 0.26.2025030506 -> 0.26.2025040204 `` |
| [`62e3f188`](https://github.com/NixOS/nixpkgs/commit/62e3f188c3b5fabf290f25549b43b0e3c39a9108) | `` keeps-sorted: 0.6.0 -> 0.6.1 ``                                              |
| [`a14c1622`](https://github.com/NixOS/nixpkgs/commit/a14c1622401726d9b39ad8589f9c4366a74bbec7) | `` ocamlPackages.bitwuzla-cxx: init at 0.6.1 ``                                 |
| [`5218fdd7`](https://github.com/NixOS/nixpkgs/commit/5218fdd71b2bf7c181af5093d7eb5a2bed70af00) | `` cargo-tally: 1.0.61 -> 1.0.62 ``                                             |
| [`d6d4ac85`](https://github.com/NixOS/nixpkgs/commit/d6d4ac85c4866d7202930309f50e47c91bade865) | `` seventeenlands: 0.1.42 -> 0.1.43 ``                                          |
| [`a9d96036`](https://github.com/NixOS/nixpkgs/commit/a9d960362eff26e1d389803bb7224f96121ed009) | `` ecapture: 1.0.0 -> 1.0.1 ``                                                  |
| [`8bb328e0`](https://github.com/NixOS/nixpkgs/commit/8bb328e0dd51ab437f274adb7d046702727fc395) | `` nixVersions.2_25: drop ``                                                    |
| [`d82a5b3e`](https://github.com/NixOS/nixpkgs/commit/d82a5b3ed0e4fdadcc647861ee41c963ccc16ae8) | `` vscode-extensions.ms-pyright.pyright: 1.1.398 -> 1.1.399 ``                  |
| [`00f81357`](https://github.com/NixOS/nixpkgs/commit/00f81357aac4fbe778861a86bbf9ea945f6db0bb) | `` astal: move source to a separate package ``                                  |
| [`8db5666d`](https://github.com/NixOS/nixpkgs/commit/8db5666df28023bb5fb7e8bd4e3e35bb88e6f5b0) | `` nixVersions: update nix-fallback-paths (2.24.14 -> 2.28.1) ``                |
| [`18fa1a13`](https://github.com/NixOS/nixpkgs/commit/18fa1a13b90de72d97a5eb8bd5ed13e87776ea1d) | `` clorinde: 0.14.2 -> 0.14.3 ``                                                |
| [`676f0778`](https://github.com/NixOS/nixpkgs/commit/676f07788fd1f609df1002f7217b5fec1ad62489) | `` servo: 0-unstable-2025-03-29 -> 0-unstable-2025-04-08 ``                     |
| [`fce5edc7`](https://github.com/NixOS/nixpkgs/commit/fce5edc7552b2174da48361151960e78db8f7cd2) | `` lxcfs: wrap lxc.reboot.hook ``                                               |
| [`00ed4686`](https://github.com/NixOS/nixpkgs/commit/00ed468673ba9c1a8c0ca20f9092059b04419ded) | `` python312Packages.firecrawl-py: 1.6.0 -> 1.7.0 ``                            |
| [`1d7763e2`](https://github.com/NixOS/nixpkgs/commit/1d7763e2fcf418479ad0fb556f7211ce5d8200d9) | `` release-cuda: add sunshine ``                                                |
| [`4ad172db`](https://github.com/NixOS/nixpkgs/commit/4ad172dbcaa748fc54604ba0f6ea2256d8916d06) | `` firefox-bin-unwrapped: 137.0 -> 137.0.1 ``                                   |
| [`9553d40c`](https://github.com/NixOS/nixpkgs/commit/9553d40cadc3fecce19c8fcf2c7f274252813e3e) | `` firefox-unwrapped: 137.0 -> 137.0.1 ``                                       |
| [`a6b27afa`](https://github.com/NixOS/nixpkgs/commit/a6b27afa5331d742b93e71a73f45ea4233526a51) | `` open62541pp: 0.17.0 -> 0.18.0 ``                                             |
| [`c38a109a`](https://github.com/NixOS/nixpkgs/commit/c38a109ae1f5a3e1706e1cdc65bfbac5167e4d86) | `` webkitgtk_6_0: 2.48.0 → 2.48.1 ``                                            |
| [`4b92da53`](https://github.com/NixOS/nixpkgs/commit/4b92da53ca82cb09e68d29e9151d41af07f00434) | `` sendgmail: init at 0-unstable-2025-03-06 ``                                  |
| [`d7a6d3e3`](https://github.com/NixOS/nixpkgs/commit/d7a6d3e33b316f4fe88126e793a29f5b19e2ecaf) | `` python312Packages.ctranslate2: migrate to pep517 builder ``                  |
| [`b0a34d31`](https://github.com/NixOS/nixpkgs/commit/b0a34d3180ebb4e84cf3655b7b4f0f878243bc33) | `` ctranslate2: 4.5.0 -> 4.6.0 ``                                               |
| [`f84c9b24`](https://github.com/NixOS/nixpkgs/commit/f84c9b2463517d75dd81efefe42054705012cdf3) | `` dioxionary: 1.1.4 -> 1.2.0 ``                                                |
| [`439103b9`](https://github.com/NixOS/nixpkgs/commit/439103b95b24ca7c65e543eca7b8aa54336b7025) | `` vimPlugins.bitbake-vim: 2.8.8 -> 2.10.4 ``                                   |
| [`34a88239`](https://github.com/NixOS/nixpkgs/commit/34a88239ca1b4e78bc72e56d4decbbcfced8dacb) | `` maintainers: caralice -> magistau ``                                         |
| [`240c7ae6`](https://github.com/NixOS/nixpkgs/commit/240c7ae697c01a2a81f74da9180ebc96b4acf17e) | `` yarn-berry: 4.8.0 -> 4.8.1 ``                                                |
| [`f43947e2`](https://github.com/NixOS/nixpkgs/commit/f43947e2006a39d78e4c496b03ba36f4415651c8) | `` archipelago: 0.6.0 -> 0.6.1 ``                                               |
| [`12cafc6c`](https://github.com/NixOS/nixpkgs/commit/12cafc6c3a0141d9c547484a7118604eb9b88ffc) | `` wine: add myself as a maintainer ``                                          |
| [`52b8951f`](https://github.com/NixOS/nixpkgs/commit/52b8951f6c669701b9759bc8344ebb6651a2834c) | `` winePackages: add pinned wine variant for yabridge ``                        |
| [`c56194b2`](https://github.com/NixOS/nixpkgs/commit/c56194b2acaa40e83a410885fc649d4caf9c60c1) | `` squashfuse: Use fuse3 instead of fuse ``                                     |
| [`876edfb3`](https://github.com/NixOS/nixpkgs/commit/876edfb33785759c94fede408be1891d8e2e2e62) | `` vscode-extensions.bodil.blueprint-gtk: init at 0.2.0 ``                      |
| [`47139435`](https://github.com/NixOS/nixpkgs/commit/471394356316095ba9a150136c3d759754141380) | `` hydra: 0-unstable-2025-02-12 -> 0-unstable-2025-04-07 ``                     |
| [`3a980656`](https://github.com/NixOS/nixpkgs/commit/3a980656214187d8e6ea584a335593569101ddd2) | `` termshot: 0.4.1 -> 0.5.0 ``                                                  |
| [`a85de548`](https://github.com/NixOS/nixpkgs/commit/a85de54826322dade2a1ead886900a5b0a3c939d) | `` python312Packages.mcp: Replace dotlambda with josh as maintainer ``          |
| [`b80de3ca`](https://github.com/NixOS/nixpkgs/commit/b80de3ca290e69429e17fef0bd52f0d8e1fb8dd5) | `` buf: 1.51.0 -> 1.52.0 ``                                                     |
| [`60852fa7`](https://github.com/NixOS/nixpkgs/commit/60852fa717e17dc4c9afd4b87423d1b0f9a360f0) | `` cosmic-packages: add passthru.tests ``                                       |
| [`5c695204`](https://github.com/NixOS/nixpkgs/commit/5c695204e167b3b2445e637404cf4833f73faacf) | `` myks: 4.6.1 -> 4.8.0 ``                                                      |
| [`3bc50ee7`](https://github.com/NixOS/nixpkgs/commit/3bc50ee7c74ac045f94c8667514d66e6b37fa246) | `` [python312Packages.]private-gpt: fix by relaxing docx2txt dependency ``      |