### PR TITLE
chore(flake/srvos): `7a4dc5c1` -> `c6808c5b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -909,11 +909,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743041209,
-        "narHash": "sha256-ANo3g355dNIF0Rtv3eLrJPu1h58Pn6O6mK0oBrcBq8A=",
+        "lastModified": 1744443962,
+        "narHash": "sha256-a8zSzdfzZ8hCyvbGo78IuTL62bHGOAzUTyk34gjfkjI=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "7a4dc5c1112b2cde72ab05f70f522cfecb9c48d1",
+        "rev": "c6808c5b6575ae3343dc3c21277080f68a574bd6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                 |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`1e475337`](https://github.com/nix-community/srvos/commit/1e475337ce3eeb01b400291cef4c187ae76649c0) | `` nixos/server: use mkDefault for watchdog settings `` |