### PR TITLE
chore(flake/emacs-overlay): `ff930b5e` -> `147f6b98`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1744479669,
-        "narHash": "sha256-t2KLWeuwczpXX0ZjsO6l07NFHpoHsfEHjLBn6Ifp/Rc=",
+        "lastModified": 1744535716,
+        "narHash": "sha256-GUYB6p5v1RlI9gpaqh2E0a0dxikhta5UqZpE4/IwuGQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ff930b5e806d659480b70f6ac3b2ba7efb346682",
+        "rev": "147f6b98f17b0d66866eb8923a6ae6fe9c23b65e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`147f6b98`](https://github.com/nix-community/emacs-overlay/commit/147f6b98f17b0d66866eb8923a6ae6fe9c23b65e) | `` Updated emacs ``        |
| [`e3e42579`](https://github.com/nix-community/emacs-overlay/commit/e3e425798c8583e5d1e33cf3e9ac5df9506baea2) | `` Updated melpa ``        |
| [`402c7f07`](https://github.com/nix-community/emacs-overlay/commit/402c7f0793b4356de1d737fcfea820c97974462e) | `` Updated elpa ``         |
| [`400ba5d0`](https://github.com/nix-community/emacs-overlay/commit/400ba5d0c6c93ee4a86ff70cfbb400db05c37769) | `` Updated nongnu ``       |
| [`5494c453`](https://github.com/nix-community/emacs-overlay/commit/5494c453843359d4b03ace92e06cbf8143ef62b0) | `` Updated flake inputs `` |