### PR TITLE
chore(flake/sops-nix): `69d5a5a4` -> `61154300`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -889,11 +889,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744103455,
-        "narHash": "sha256-SR6+qjkPjGQG+8eM4dCcVtss8r9bre/LAxFMPJpaZeU=",
+        "lastModified": 1744669848,
+        "narHash": "sha256-pXyanHLUzLNd3MX9vsWG+6Z2hTU8niyphWstYEP3/GU=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "69d5a5a4635c27dae5a742f36108beccc506c1ba",
+        "rev": "61154300d945f0b147b30d24ddcafa159148026a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                  |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`f7e01c30`](https://github.com/Mic92/sops-nix/commit/f7e01c30f0572fae1aee2b6d5761be5f12baa769) | `` update vendorHash ``                                                  |
| [`944bc4e4`](https://github.com/Mic92/sops-nix/commit/944bc4e422c93ed546f2cdf9a171fe8d83c2ddcd) | `` build(deps): bump github.com/getsops/sops/v3 from 3.10.1 to 3.10.2 `` |
| [`345559a7`](https://github.com/Mic92/sops-nix/commit/345559a7da9292f016da825f1e52ebc082b3530b) | `` [create-pull-request] automated change ``                             |