### PR TITLE
chore(flake/emacs-overlay): `147f6b98` -> `1997c83d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1744535716,
-        "narHash": "sha256-GUYB6p5v1RlI9gpaqh2E0a0dxikhta5UqZpE4/IwuGQ=",
+        "lastModified": 1744564581,
+        "narHash": "sha256-3oYyf8uwhgjvHqa82QqYJJcdertKL/WGYM4cXREKE3o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "147f6b98f17b0d66866eb8923a6ae6fe9c23b65e",
+        "rev": "1997c83d637f2ab52651826d90099e1e1561bab7",
         "type": "github"
       },
       "original": {
@@ -623,11 +623,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1744309437,
-        "narHash": "sha256-QZnNHM823am8apCqKSPdtnzPGTy2ZB4zIXOVoBp5+W0=",
+        "lastModified": 1744440957,
+        "narHash": "sha256-FHlSkNqFmPxPJvy+6fNLaNeWnF1lZSgqVCl/eWaJRc4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f9ebe33a928b5d529c895202263a5ce46bdf12f7",
+        "rev": "26d499fc9f1d567283d5d56fcf367edd815dba1d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`1997c83d`](https://github.com/nix-community/emacs-overlay/commit/1997c83d637f2ab52651826d90099e1e1561bab7) | `` Updated emacs ``        |
| [`60218c88`](https://github.com/nix-community/emacs-overlay/commit/60218c88d2d3a176304d1f518c20dd0493c37d88) | `` Updated melpa ``        |
| [`23e3e143`](https://github.com/nix-community/emacs-overlay/commit/23e3e143f8a550b9dbd4bc5660126aaa082d26d9) | `` Updated elpa ``         |
| [`56ea16bb`](https://github.com/nix-community/emacs-overlay/commit/56ea16bbc5ca66565cdce7a2cfcf19e9c0175cc8) | `` Updated nongnu ``       |
| [`9d6881c3`](https://github.com/nix-community/emacs-overlay/commit/9d6881c300b811da2241d147ae622efbf429e464) | `` Updated flake inputs `` |