### PR TITLE
chore(flake/emacs-overlay): `1997c83d` -> `346003c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1744564581,
-        "narHash": "sha256-3oYyf8uwhgjvHqa82QqYJJcdertKL/WGYM4cXREKE3o=",
+        "lastModified": 1744597099,
+        "narHash": "sha256-Cu3Hxa5P2FQZak58S9UovPKWlAwe2lT4A93clTD+Wgo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1997c83d637f2ab52651826d90099e1e1561bab7",
+        "rev": "346003c50ebfa5597c5e08b17c6683b83ff9cffa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`346003c5`](https://github.com/nix-community/emacs-overlay/commit/346003c50ebfa5597c5e08b17c6683b83ff9cffa) | `` Updated emacs ``  |
| [`59321a67`](https://github.com/nix-community/emacs-overlay/commit/59321a67a04cb7f5e23bd45b8b2933c9579347ed) | `` Updated melpa ``  |
| [`3f0ea006`](https://github.com/nix-community/emacs-overlay/commit/3f0ea0069dc9c68f13ca2e393b42aabc29c825df) | `` Updated elpa ``   |
| [`198f22dd`](https://github.com/nix-community/emacs-overlay/commit/198f22ddc21c0254f8c89485874398c086b1ae5a) | `` Updated nongnu `` |