### PR TITLE
chore(flake/emacs-overlay): `346003c5` -> `cc39626b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1744597099,
-        "narHash": "sha256-Cu3Hxa5P2FQZak58S9UovPKWlAwe2lT4A93clTD+Wgo=",
+        "lastModified": 1744710563,
+        "narHash": "sha256-bbYWW6VVeVM+kaJJzo6IkdIqplYpfdedEaLFC6bN8Bo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "346003c50ebfa5597c5e08b17c6683b83ff9cffa",
+        "rev": "cc39626b787d64e5df5364a529423d624543b6a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`cc39626b`](https://github.com/nix-community/emacs-overlay/commit/cc39626b787d64e5df5364a529423d624543b6a6) | `` Updated emacs ``  |
| [`54536e8f`](https://github.com/nix-community/emacs-overlay/commit/54536e8fc37931d76c0a02164986db9383d71c9e) | `` Updated melpa ``  |
| [`d601c3de`](https://github.com/nix-community/emacs-overlay/commit/d601c3de7e1932384a43585408a398ddccf3e1c6) | `` Updated emacs ``  |
| [`4f4a9b3e`](https://github.com/nix-community/emacs-overlay/commit/4f4a9b3e83a234235976191ad2ac76c91add9c1a) | `` Updated melpa ``  |
| [`a4216bb0`](https://github.com/nix-community/emacs-overlay/commit/a4216bb03c069faf34c355b6c915c93a2eeb559e) | `` Updated elpa ``   |
| [`71a0b92e`](https://github.com/nix-community/emacs-overlay/commit/71a0b92e70f73f0b41624e52120fc79d52595ca5) | `` Updated nongnu `` |
| [`f6ea355d`](https://github.com/nix-community/emacs-overlay/commit/f6ea355d7b9818394bb9e073b2bdad4b0d1717be) | `` Updated elpa ``   |
| [`43c27c8f`](https://github.com/nix-community/emacs-overlay/commit/43c27c8fc1544cecd001b7174f91a9f1e9ebdab9) | `` Updated nongnu `` |
| [`3253a4b2`](https://github.com/nix-community/emacs-overlay/commit/3253a4b2cfcfad6810746f5c62d0e6bf53ba97a9) | `` Updated melpa ``  |