### PR TITLE
chore(flake/home-manager): `e980d0e0` -> `5a096a88`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744600951,
-        "narHash": "sha256-LNAAfQTDXSwtYYlh/v/tMwnCqeQAEHlBC9PgyQK5b/Q=",
+        "lastModified": 1744659400,
+        "narHash": "sha256-q0wwsR/hvOjj1G8ogdudX5cU0IE/Vgvgjo9g9OpQv5U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e980d0e0e216f527ea73cfd12c7b019eceffa7f1",
+        "rev": "5a096a8822cb98584c5dc4f2616dcd5ed394bfd7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                   |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`5a096a88`](https://github.com/nix-community/home-manager/commit/5a096a8822cb98584c5dc4f2616dcd5ed394bfd7) | `` superfile: initial support (#6610) ``  |
| [`273ad32f`](https://github.com/nix-community/home-manager/commit/273ad32fbb4769ac56e15caccdbdaad2c2e6b88a) | `` tests/nh: init tests (#6819) ``        |
| [`33754144`](https://github.com/nix-community/home-manager/commit/337541447773985f825512afd0f9821a975186be) | `` helix: fix str + path theme (#6816) `` |
| [`85dd758c`](https://github.com/nix-community/home-manager/commit/85dd758c703ffbf9d97f34adcef3a898b54b4014) | `` yazi: remove assertions (#6817) ``     |