### PR TITLE
chore(flake/home-manager): `5a096a88` -> `db7738e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744659400,
-        "narHash": "sha256-q0wwsR/hvOjj1G8ogdudX5cU0IE/Vgvgjo9g9OpQv5U=",
+        "lastModified": 1744735751,
+        "narHash": "sha256-OPpfgL3qUIbQdbmp1/ZwnlsuTLooHN4or0EABnZTFRY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5a096a8822cb98584c5dc4f2616dcd5ed394bfd7",
+        "rev": "db7738e67a101ad945abbcb447e1310147afaf1b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                        |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`db7738e6`](https://github.com/nix-community/home-manager/commit/db7738e67a101ad945abbcb447e1310147afaf1b) | `` nh: remove incorrect warning on gc conflicts (#6802) ``     |
| [`85c513aa`](https://github.com/nix-community/home-manager/commit/85c513aa862228d5b51295b20ccbdcc5fdf086bc) | `` home-manager: Feature test for flake support (#6824) ``     |
| [`d5cdf55b`](https://github.com/nix-community/home-manager/commit/d5cdf55bd9f19a3debd55b6cb5d38f7831426265) | `` direnv: add tests for silent option ``                      |
| [`ae5fcad7`](https://github.com/nix-community/home-manager/commit/ae5fcad746ac79ea2f791c6369089e4db7ad6bc1) | `` direnv: fix silent option after update to direnv v2.36.0 `` |