### PR TITLE
chore(flake/emacs-overlay): `cc39626b` -> `097bb237`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1744710563,
-        "narHash": "sha256-bbYWW6VVeVM+kaJJzo6IkdIqplYpfdedEaLFC6bN8Bo=",
+        "lastModified": 1744737465,
+        "narHash": "sha256-DzCh34+8w5Zqr64qwIloPjT3mmPZNC3CDWFXzYjx8RU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cc39626b787d64e5df5364a529423d624543b6a6",
+        "rev": "097bb2373e84a4c544754bb09d0742f0362818dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`097bb237`](https://github.com/nix-community/emacs-overlay/commit/097bb2373e84a4c544754bb09d0742f0362818dd) | `` Updated emacs ``  |
| [`2657fe95`](https://github.com/nix-community/emacs-overlay/commit/2657fe95abbb3eca5207df6fb82e6522643c7fea) | `` Updated melpa ``  |
| [`30d14807`](https://github.com/nix-community/emacs-overlay/commit/30d14807368f822be183ecb2197e274ee512dc3a) | `` Updated nongnu `` |