### PR TITLE
chore(flake/emacs-overlay): `097bb237` -> `fd781321`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1744737465,
-        "narHash": "sha256-DzCh34+8w5Zqr64qwIloPjT3mmPZNC3CDWFXzYjx8RU=",
+        "lastModified": 1744770066,
+        "narHash": "sha256-zzcONhPfZpJSla9Yzl/tFHxGecLXaLgOBicYl0W0Kl8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "097bb2373e84a4c544754bb09d0742f0362818dd",
+        "rev": "fd7813213109317254eeb74ff07ac6bf32c7d56b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                       |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------- |
| [`3b51e6be`](https://github.com/nix-community/emacs-overlay/commit/3b51e6be2d706273cfd58cf060a74ef7a89fea47) | `` Updated emacs ``           |
| [`4c314977`](https://github.com/nix-community/emacs-overlay/commit/4c314977d36fad8db0d596959c13c17401e62a21) | `` Updated melpa ``           |
| [`5dcf49dc`](https://github.com/nix-community/emacs-overlay/commit/5dcf49dc761020e101be476cd1d8c9584b90cc44) | `` Updated elpa ``            |
| [`f37681b8`](https://github.com/nix-community/emacs-overlay/commit/f37681b88e68d622af06a3ed126d4cbdc82080cb) | `` Updated nongnu ``          |
| [`37229afc`](https://github.com/nix-community/emacs-overlay/commit/37229afc3e39b05b565053cded360e8e421ae371) | `` forge-llm: fix src hash `` |