### PR TITLE
chore(flake/nur): `e561993c` -> `90d73295`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -777,11 +777,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1744782863,
-        "narHash": "sha256-NBvSCE2MXjK7yCLEMsZ+lrImbuoukLGsJYrWCxemGNM=",
+        "lastModified": 1744789608,
+        "narHash": "sha256-tinwszkKn/ZK3jqt+QUhfaiuDQ/crY2QfUJ8qgY+13A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e561993c7848eaa7288e16219c62c8d5bbbe81d8",
+        "rev": "90d73295e4a1f5f48fe815f665d97d377521b40b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`90d73295`](https://github.com/nix-community/NUR/commit/90d73295e4a1f5f48fe815f665d97d377521b40b) | `` automatic update `` |
| [`3f5cc580`](https://github.com/nix-community/NUR/commit/3f5cc58068d2f1df0222c3b3942a6a6568a478d5) | `` automatic update `` |