### PR TITLE
chore(flake/nur): `90d73295` -> `7971a3bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -777,11 +777,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1744789608,
-        "narHash": "sha256-tinwszkKn/ZK3jqt+QUhfaiuDQ/crY2QfUJ8qgY+13A=",
+        "lastModified": 1744799219,
+        "narHash": "sha256-U4P95AfPSl51EiZ1c76DureGeafWeS0m5W90fwQ/heI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "90d73295e4a1f5f48fe815f665d97d377521b40b",
+        "rev": "7971a3bbb5c553ec14d850ea748b0be8fd4a593c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7971a3bb`](https://github.com/nix-community/NUR/commit/7971a3bbb5c553ec14d850ea748b0be8fd4a593c) | `` automatic update `` |
| [`50c9703a`](https://github.com/nix-community/NUR/commit/50c9703a2f9da7abf3f18b3941e127e546a7f4c4) | `` automatic update `` |