### PR TITLE
chore(flake/emacs-overlay): `fd781321` -> `bb1a2819`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1744770066,
-        "narHash": "sha256-zzcONhPfZpJSla9Yzl/tFHxGecLXaLgOBicYl0W0Kl8=",
+        "lastModified": 1744795771,
+        "narHash": "sha256-aXkUfupefUJWdAGwIOYsllP5lyFSSbRvHzCcEKWffHI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fd7813213109317254eeb74ff07ac6bf32c7d56b",
+        "rev": "bb1a28197681dc640b89a9a9bec75cdcd7e8d6ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`bb1a2819`](https://github.com/nix-community/emacs-overlay/commit/bb1a28197681dc640b89a9a9bec75cdcd7e8d6ec) | `` Updated emacs `` |
| [`0a61d7a5`](https://github.com/nix-community/emacs-overlay/commit/0a61d7a5c08530cb0f43350a3487681bb82aba1c) | `` Updated melpa `` |