### PR TITLE
chore(flake/nur): `7971a3bb` -> `78a26d76`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -761,11 +761,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1744799219,
-        "narHash": "sha256-U4P95AfPSl51EiZ1c76DureGeafWeS0m5W90fwQ/heI=",
+        "lastModified": 1744834763,
+        "narHash": "sha256-GBIhfBAf38pRvpfX/EDu1giv0B0ZXsK2zgG0pC/BT9k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7971a3bbb5c553ec14d850ea748b0be8fd4a593c",
+        "rev": "78a26d768b673174084a28833e0d44cb22804c7b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`78a26d76`](https://github.com/nix-community/NUR/commit/78a26d768b673174084a28833e0d44cb22804c7b) | `` automatic update `` |
| [`32a412b0`](https://github.com/nix-community/NUR/commit/32a412b00577c07f340b24df9c67664449ace5e3) | `` automatic update `` |
| [`61057485`](https://github.com/nix-community/NUR/commit/6105748505426f789e6b11c6189e9419dbb556f2) | `` automatic update `` |
| [`8662e035`](https://github.com/nix-community/NUR/commit/8662e035a20d6e03adb48a56de7c8343b5623897) | `` automatic update `` |
| [`c0f6df50`](https://github.com/nix-community/NUR/commit/c0f6df50d518518215cd42e9ecff3b1dd15723d7) | `` automatic update `` |
| [`2fa25636`](https://github.com/nix-community/NUR/commit/2fa25636926a472fac18914f9e70d9df4460f6d2) | `` automatic update `` |
| [`1f4a5361`](https://github.com/nix-community/NUR/commit/1f4a53614f34b25da57e46192d8b23ae274f1eee) | `` automatic update `` |
| [`d244a53f`](https://github.com/nix-community/NUR/commit/d244a53fbe2b0c567b5a5ef95f9647b96945437f) | `` automatic update `` |