### PR TITLE
chore(flake/emacs-overlay): `bb1a2819` -> `896bc4ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1744795771,
-        "narHash": "sha256-aXkUfupefUJWdAGwIOYsllP5lyFSSbRvHzCcEKWffHI=",
+        "lastModified": 1744856187,
+        "narHash": "sha256-uc2ds4xZrg3f8VHcyZzyF2s1tvLfysG9dxHTNRmTyvY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bb1a28197681dc640b89a9a9bec75cdcd7e8d6ec",
+        "rev": "896bc4ee7494db74a921559c2fc2771789f9296b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`896bc4ee`](https://github.com/nix-community/emacs-overlay/commit/896bc4ee7494db74a921559c2fc2771789f9296b) | `` Updated emacs ``  |
| [`c9f0db33`](https://github.com/nix-community/emacs-overlay/commit/c9f0db33baed9d70822483a9e7efd8048a748756) | `` Updated melpa ``  |
| [`a2a1ef5a`](https://github.com/nix-community/emacs-overlay/commit/a2a1ef5a9ada7ec05796c07094aef032e9ac3c87) | `` Updated elpa ``   |
| [`99928599`](https://github.com/nix-community/emacs-overlay/commit/99928599699bfcdfb401c5e34ca2a90b7d78704d) | `` Updated nongnu `` |