### PR TITLE
chore(flake/nur): `4bad7f2c` -> `4b2409ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -761,11 +761,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1744847816,
-        "narHash": "sha256-64APLubFniEpygB319BPU15QUPRtx24SvtjGMLaZarE=",
+        "lastModified": 1744859599,
+        "narHash": "sha256-Y+uq9pZQtd3XHYYLFJWrAMYOGstHOMPZmauAFFgREJs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4bad7f2cd3e6bb3a51f49cf094ad818db1647a18",
+        "rev": "4b2409ab3943a7fe28ca8695f4c013648fa3a8c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4b2409ab`](https://github.com/nix-community/NUR/commit/4b2409ab3943a7fe28ca8695f4c013648fa3a8c1) | `` automatic update `` |
| [`ebea6e73`](https://github.com/nix-community/NUR/commit/ebea6e7335e803b3d6a8e1ff0788ca670f976705) | `` automatic update `` |
| [`54f88fd9`](https://github.com/nix-community/NUR/commit/54f88fd95f99030ce74789cd7d0c906c0f8bc2d9) | `` automatic update `` |
| [`30e36577`](https://github.com/nix-community/NUR/commit/30e3657773c61206c515d13fe57fb5a46da1cdff) | `` automatic update `` |
| [`af985d60`](https://github.com/nix-community/NUR/commit/af985d60a69c6c1a1e758581224531087fe34aa6) | `` automatic update `` |