### PR TITLE
chore(flake/nur): `4b2409ab` -> `239ed05f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -761,11 +761,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1744859599,
-        "narHash": "sha256-Y+uq9pZQtd3XHYYLFJWrAMYOGstHOMPZmauAFFgREJs=",
+        "lastModified": 1744873277,
+        "narHash": "sha256-fdl0cvO3YYT452plqgO+/oZmaEA9Dws4yK/TtCgWEsw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4b2409ab3943a7fe28ca8695f4c013648fa3a8c1",
+        "rev": "239ed05f0da9e47a71b40ca400d39c880cc5555f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`239ed05f`](https://github.com/nix-community/NUR/commit/239ed05f0da9e47a71b40ca400d39c880cc5555f) | `` automatic update `` |
| [`0b639a5e`](https://github.com/nix-community/NUR/commit/0b639a5ea085d3cdf37771b98f54e9b0b9ae506b) | `` automatic update `` |
| [`5bf59d95`](https://github.com/nix-community/NUR/commit/5bf59d957faa081789670c5a464bce4a5d6bd01a) | `` automatic update `` |