### PR TITLE
chore(flake/nur): `239ed05f` -> `2a0d5604`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -761,11 +761,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1744873277,
-        "narHash": "sha256-fdl0cvO3YYT452plqgO+/oZmaEA9Dws4yK/TtCgWEsw=",
+        "lastModified": 1744885614,
+        "narHash": "sha256-zARDYqGVlUaW2s6kn3l9fP4MIcyVrfYqbrlc/aV9s6s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "239ed05f0da9e47a71b40ca400d39c880cc5555f",
+        "rev": "2a0d560406c69f1c4d8f89a66be95b194eda9b25",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2a0d5604`](https://github.com/nix-community/NUR/commit/2a0d560406c69f1c4d8f89a66be95b194eda9b25) | `` automatic update `` |
| [`5c1cf845`](https://github.com/nix-community/NUR/commit/5c1cf845d7c93feb6e5c0ea12809d88ce3fbd3fd) | `` automatic update `` |