### PR TITLE
chore(flake/minimal-emacs-d): `4b680d7b` -> `711b557b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -398,11 +398,11 @@
     "minimal-emacs-d": {
       "flake": false,
       "locked": {
-        "lastModified": 1744769694,
-        "narHash": "sha256-+hyPWN0/qwYVOVy+uInz8eWpDc4cX/m6WE3wFBTsBzE=",
+        "lastModified": 1744983348,
+        "narHash": "sha256-Alk5BU13Qa3iQZ+mj3jPaK68XrJ1jJ7xAicEAZFwpCE=",
         "owner": "jamescherti",
         "repo": "minimal-emacs.d",
-        "rev": "4b680d7be374d3a8291aaa1de026eff1699d1849",
+        "rev": "711b557bd1b96c03161238c985064346742d2637",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                      |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------------- |
| [`711b557b`](https://github.com/jamescherti/minimal-emacs.d/commit/711b557bd1b96c03161238c985064346742d2637) | `` Update README.md ``                       |
| [`b31befba`](https://github.com/jamescherti/minimal-emacs.d/commit/b31befba673c2ceb447f78104d4c4a3eff107ae3) | `` Update README.md ``                       |
| [`bfef6edd`](https://github.com/jamescherti/minimal-emacs.d/commit/bfef6edd7878347a142c3e1fa2f27e503a4006b1) | `` Better tramp defaults ``                  |
| [`1f81090a`](https://github.com/jamescherti/minimal-emacs.d/commit/1f81090a9b7a20400cc47c54eae3ca65b277eb6e) | `` Increase message-log-max in debug mode `` |