### PR TITLE
chore(flake/emacs-overlay): `896bc4ee` -> `c54fd7dc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1744856187,
-        "narHash": "sha256-uc2ds4xZrg3f8VHcyZzyF2s1tvLfysG9dxHTNRmTyvY=",
+        "lastModified": 1744967866,
+        "narHash": "sha256-jWHOSSZ03R1Dvru5rXEForMgkV1RAsCd+IjMmehpmFg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "896bc4ee7494db74a921559c2fc2771789f9296b",
+        "rev": "c54fd7dc3e696136c8257abfe12815274b42660e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`c54fd7dc`](https://github.com/nix-community/emacs-overlay/commit/c54fd7dc3e696136c8257abfe12815274b42660e) | `` Updated emacs ``  |
| [`267181fa`](https://github.com/nix-community/emacs-overlay/commit/267181fa5b73ab1fedfafef6f8031c4563c510e6) | `` Updated melpa ``  |
| [`fc950eda`](https://github.com/nix-community/emacs-overlay/commit/fc950eda6b8a2b0b1e2085317a3185a96cbf1ba6) | `` Updated emacs ``  |
| [`6e7999fb`](https://github.com/nix-community/emacs-overlay/commit/6e7999fb70859ac71f7931f303b73720451ac7e9) | `` Updated melpa ``  |
| [`58b60b8e`](https://github.com/nix-community/emacs-overlay/commit/58b60b8e735b8b4285657dce8f1dce1781a041de) | `` Updated elpa ``   |
| [`ecd7a457`](https://github.com/nix-community/emacs-overlay/commit/ecd7a457955429c08826e1582565f401e7ef823f) | `` Updated nongnu `` |