### PR TITLE
chore(flake/treefmt-nix): `49d05555` -> `8d404a69`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -969,11 +969,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744707583,
-        "narHash": "sha256-IPFcShGro/UUp8BmwMBkq+6KscPlWQevZi9qqIwVUWg=",
+        "lastModified": 1744961264,
+        "narHash": "sha256-aRmUh0AMwcbdjJHnytg1e5h5ECcaWtIFQa6d9gI85AI=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "49d05555ccdd2592300099d6a657cc33571f4fe0",
+        "rev": "8d404a69efe76146368885110f29a2ca3700bee6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`8d404a69`](https://github.com/numtide/treefmt-nix/commit/8d404a69efe76146368885110f29a2ca3700bee6) | `` Revert "programs.dprint: update plugins example" `` |
| [`81e3ad10`](https://github.com/numtide/treefmt-nix/commit/81e3ad1094549a1a32d4ebbe3c1beb01b0b0adc6) | `` mypy: deprecate files option ``                     |
| [`ab07ff38`](https://github.com/numtide/treefmt-nix/commit/ab07ff380d60d6f5c217e43b9c616ecba65766a9) | `` mypy: fix recursive globbing ``                     |
| [`bf6ad93a`](https://github.com/numtide/treefmt-nix/commit/bf6ad93a99f0e985974074f9d6a4335fa4b19bef) | `` programs.dprint: update plugins example ``          |