### PR TITLE
chore(flake/nur): `d5a9222d` -> `06bec0ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -761,11 +761,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1744946375,
-        "narHash": "sha256-hNO9KjeZ9BmLS9nrK/JcO/aEPNR2v75jd4EelwyDeZM=",
+        "lastModified": 1744975069,
+        "narHash": "sha256-bUxa8L/jK1PlmTJZV3bPcjEY6RzF/5awgpwJd4jSVUk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d5a9222dcff17838f5914b1d19187f8550930d9c",
+        "rev": "06bec0ce4c0e46579ae1436c2812428d6f8cee36",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                      |
| -------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`06bec0ce`](https://github.com/nix-community/NUR/commit/06bec0ce4c0e46579ae1436c2812428d6f8cee36) | `` automatic update ``       |
| [`2f377260`](https://github.com/nix-community/NUR/commit/2f377260b837c9eb29b1cfee1296b63b71d39ee2) | `` automatic update ``       |
| [`88fa5bd9`](https://github.com/nix-community/NUR/commit/88fa5bd962ac00b16580b1cedd965e1e1b6ed110) | `` automatic update ``       |
| [`c2d387e6`](https://github.com/nix-community/NUR/commit/c2d387e6f9e895853816a13d5c84f05f0675e1ea) | `` automatic update ``       |
| [`e1c1ba99`](https://github.com/nix-community/NUR/commit/e1c1ba993753dd83d271622ff2d64be1c7cbe8e3) | `` automatic update ``       |
| [`da6f3d89`](https://github.com/nix-community/NUR/commit/da6f3d89cf863553b3a3c77bd80603a3569642ff) | `` automatic update ``       |
| [`51821c6d`](https://github.com/nix-community/NUR/commit/51821c6de4b9815d92dc05d9872d1d51291b02b6) | `` automatic update ``       |
| [`33f48025`](https://github.com/nix-community/NUR/commit/33f48025dff35582d091707f59074a0b46b9676e) | `` Fix manifest ``           |
| [`6d9cc76e`](https://github.com/nix-community/NUR/commit/6d9cc76e2f94147a79a6b16755efbd889153b8b3) | `` add shackra repository `` |
| [`900b474e`](https://github.com/nix-community/NUR/commit/900b474ec91e7124d46e25f6aab1d3175952d8a2) | `` automatic update ``       |