### PR TITLE
chore(flake/emacs-overlay): `c54fd7dc` -> `90642af1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1744967866,
-        "narHash": "sha256-jWHOSSZ03R1Dvru5rXEForMgkV1RAsCd+IjMmehpmFg=",
+        "lastModified": 1744993365,
+        "narHash": "sha256-YAcjnoRJo7m9Sq9uNorkNM33f1oZIigVuNPvUy6y3po=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c54fd7dc3e696136c8257abfe12815274b42660e",
+        "rev": "90642af1fb7ab5e4c6deb221305acf6fc4472582",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`90642af1`](https://github.com/nix-community/emacs-overlay/commit/90642af1fb7ab5e4c6deb221305acf6fc4472582) | `` Updated nongnu ``       |
| [`e8c9077c`](https://github.com/nix-community/emacs-overlay/commit/e8c9077c469bd6810371c873d80225d46b3135cd) | `` Updated flake inputs `` |