### PR TITLE
chore(flake/nur): `1a928072` -> `916bc3d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -761,11 +761,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1744991197,
-        "narHash": "sha256-tGGEuV186TF695MfJpWSFjlMKOnQvqLvOl7ei+7BGlQ=",
+        "lastModified": 1744994687,
+        "narHash": "sha256-c55e47XpHMaTzhHEjHhJrbPOoUOmbLmrL6FUf/exbFQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1a928072a8f47c20643837540ce1fef46b1faa18",
+        "rev": "916bc3d240f4d37039768c01a3675ac68e16b434",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`916bc3d2`](https://github.com/nix-community/NUR/commit/916bc3d240f4d37039768c01a3675ac68e16b434) | `` automatic update `` |