### PR TITLE
chore(flake/nur): `916bc3d2` -> `1a3564fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -761,11 +761,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1744994687,
-        "narHash": "sha256-c55e47XpHMaTzhHEjHhJrbPOoUOmbLmrL6FUf/exbFQ=",
+        "lastModified": 1745009194,
+        "narHash": "sha256-Y2CsvI0kxTf4F1HAN3uC7EUgrwtMmLcRGcnAr3Q/S1U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "916bc3d240f4d37039768c01a3675ac68e16b434",
+        "rev": "1a3564fa217bf2bf662f5fbcd5476318bfb12c07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1a3564fa`](https://github.com/nix-community/NUR/commit/1a3564fa217bf2bf662f5fbcd5476318bfb12c07) | `` automatic update `` |
| [`e6c853f9`](https://github.com/nix-community/NUR/commit/e6c853f96bcad65ac0dfab1031383ac8b8f850c3) | `` automatic update `` |