### PR TITLE
chore(flake/nur): `1a3564fa` -> `fcc31702`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -761,11 +761,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1745009194,
-        "narHash": "sha256-Y2CsvI0kxTf4F1HAN3uC7EUgrwtMmLcRGcnAr3Q/S1U=",
+        "lastModified": 1745034827,
+        "narHash": "sha256-uVIAhfJTnfyHSRUH9gLOzSzGZevZmMkF7e1fFisyPvM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1a3564fa217bf2bf662f5fbcd5476318bfb12c07",
+        "rev": "fcc317022a9d56dfaddaa872909a912fa684859b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                  |
| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`fcc31702`](https://github.com/nix-community/NUR/commit/fcc317022a9d56dfaddaa872909a912fa684859b) | `` automatic update ``                                   |
| [`a13fede9`](https://github.com/nix-community/NUR/commit/a13fede9964af434a0419812258f7e71c816b738) | `` Update cachix/install-nix-action digest to 754537a `` |
| [`4a267bc7`](https://github.com/nix-community/NUR/commit/4a267bc78b30147dcc47e5c74860b723413f0c29) | `` automatic update ``                                   |
| [`f70c2a3f`](https://github.com/nix-community/NUR/commit/f70c2a3f62a54a4fbfa87884d9f793e368062e06) | `` automatic update ``                                   |