### PR TITLE
chore(flake/emacs-overlay): `90642af1` -> `99a01c9e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1744993365,
-        "narHash": "sha256-YAcjnoRJo7m9Sq9uNorkNM33f1oZIigVuNPvUy6y3po=",
+        "lastModified": 1745252602,
+        "narHash": "sha256-eE3LH+0rURTnG5Uw5dsEcrT8Z0eEp8f+a5ZX44oHU/U=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "90642af1fb7ab5e4c6deb221305acf6fc4472582",
+        "rev": "99a01c9e200ffa1898097865e71a9e8182428de5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`99a01c9e`](https://github.com/nix-community/emacs-overlay/commit/99a01c9e200ffa1898097865e71a9e8182428de5) | `` Updated nongnu `` |
| [`1b9c9238`](https://github.com/nix-community/emacs-overlay/commit/1b9c9238adead881769a70346f9f17207dbcea13) | `` Updated emacs ``  |
| [`6e665457`](https://github.com/nix-community/emacs-overlay/commit/6e66545784d54c078ea464ff7f3b94c8cf3d3f69) | `` Updated melpa ``  |
| [`bb9c4990`](https://github.com/nix-community/emacs-overlay/commit/bb9c49904ec77db95ed5c1a1f1cf60911841559c) | `` Updated emacs ``  |
| [`f0596882`](https://github.com/nix-community/emacs-overlay/commit/f05968823bb35d2559618bb5023dcc9c139bd302) | `` Updated melpa ``  |
| [`8218d67d`](https://github.com/nix-community/emacs-overlay/commit/8218d67d1cd6f8a546cd55e6890fc8dfce364dff) | `` Updated elpa ``   |
| [`02301397`](https://github.com/nix-community/emacs-overlay/commit/02301397cb4539ab09da12b3214641f7bed59076) | `` Updated nongnu `` |
| [`d2422478`](https://github.com/nix-community/emacs-overlay/commit/d24224780e6cb41af7b46a17d39306e5e982aa15) | `` Updated emacs ``  |
| [`e6f04b11`](https://github.com/nix-community/emacs-overlay/commit/e6f04b118076626a54cb97719b1dc12e5d36b768) | `` Updated melpa ``  |
| [`960b0a20`](https://github.com/nix-community/emacs-overlay/commit/960b0a206a243016bc4372e4bb27ad03188cbc61) | `` Updated elpa ``   |
| [`07fc4caa`](https://github.com/nix-community/emacs-overlay/commit/07fc4caaef2dcd9a8526ad6da384d23c9c708de0) | `` Updated nongnu `` |
| [`e1d2be27`](https://github.com/nix-community/emacs-overlay/commit/e1d2be273b54b677cc5179e2c068127bff035c98) | `` Updated emacs ``  |
| [`96632d4a`](https://github.com/nix-community/emacs-overlay/commit/96632d4afa0ac7c9367101e428faba22f2b640f5) | `` Updated melpa ``  |
| [`82c46e0e`](https://github.com/nix-community/emacs-overlay/commit/82c46e0e82832ff51cf0772417b37d008fccb4e2) | `` Updated melpa ``  |
| [`690c4bb1`](https://github.com/nix-community/emacs-overlay/commit/690c4bb1fb83b0ffd8d6c662b8824a6e9fe77092) | `` Updated elpa ``   |
| [`eaea0ec5`](https://github.com/nix-community/emacs-overlay/commit/eaea0ec58d1c09478cdd59f810e627bd73f49f46) | `` Updated nongnu `` |
| [`46b2111a`](https://github.com/nix-community/emacs-overlay/commit/46b2111a95afe41d9f9a09d7f33ff5b324cbd96d) | `` Updated emacs ``  |
| [`d7a385f9`](https://github.com/nix-community/emacs-overlay/commit/d7a385f9569138aab03f3f62564bfeb574ea5281) | `` Updated melpa ``  |
| [`d0ed4d1c`](https://github.com/nix-community/emacs-overlay/commit/d0ed4d1c1128a1e395d6d2d24e848654809a211b) | `` Updated nongnu `` |
| [`ebc08516`](https://github.com/nix-community/emacs-overlay/commit/ebc085160ae5154d0f97accc6f5972e434c2ef9b) | `` Updated emacs ``  |
| [`37c7ddf1`](https://github.com/nix-community/emacs-overlay/commit/37c7ddf183243a8f95db9ff76c53f42477c1c3cd) | `` Updated melpa ``  |
| [`7d65488e`](https://github.com/nix-community/emacs-overlay/commit/7d65488eb308352f94c7bab3d55289b23cc2a391) | `` Updated emacs ``  |
| [`a291d1e4`](https://github.com/nix-community/emacs-overlay/commit/a291d1e4578d24def7c194d7db89807eed1ed4ae) | `` Updated melpa ``  |
| [`112e4f32`](https://github.com/nix-community/emacs-overlay/commit/112e4f326dbd814cbd78a7997ee6cdb24420eed1) | `` Updated elpa ``   |
| [`b7e6cde5`](https://github.com/nix-community/emacs-overlay/commit/b7e6cde5ae589cedb0be5f2bcfbb8b799736a481) | `` Updated nongnu `` |