### PR TITLE
chore(flake/nur): `b2b70ade` -> `9ac6f7fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -761,11 +761,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1745039273,
-        "narHash": "sha256-65tcyAuRqTYErz1eNX25FI1/Ia9+BEQRFQkaAxeG8L4=",
+        "lastModified": 1745059592,
+        "narHash": "sha256-cF1ZnQVsSMMNOnjJSDodHO0TIYU5lEfLgIBcMvdY00Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b2b70ade2860ed9526db2f8b4db855ef6bdc2c52",
+        "rev": "9ac6f7fa6bc83b6069f08448ffcae88c35603b70",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9ac6f7fa`](https://github.com/nix-community/NUR/commit/9ac6f7fa6bc83b6069f08448ffcae88c35603b70) | `` automatic update `` |
| [`cae6a279`](https://github.com/nix-community/NUR/commit/cae6a2795545e6ab3e5ed002b2d42057e8e1eaa7) | `` automatic update `` |
| [`c34b27de`](https://github.com/nix-community/NUR/commit/c34b27def51a14065218049d97b3256949d135f8) | `` automatic update `` |
| [`8b42a47b`](https://github.com/nix-community/NUR/commit/8b42a47b35732eacb689b77b3a9fd1a7e19c21b2) | `` automatic update `` |
| [`9374f501`](https://github.com/nix-community/NUR/commit/9374f50177674081a0937c1340eff0db148e36bf) | `` automatic update `` |