### PR TITLE
chore(flake/nur): `9ac6f7fa` -> `9887318d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -761,11 +761,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1745059592,
-        "narHash": "sha256-cF1ZnQVsSMMNOnjJSDodHO0TIYU5lEfLgIBcMvdY00Q=",
+        "lastModified": 1745071326,
+        "narHash": "sha256-sXQJJhZGRaXbf1h/Q69wq2ngwZz35m4+Qu3UN6FYpNM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ac6f7fa6bc83b6069f08448ffcae88c35603b70",
+        "rev": "9887318d5eae081b596a72bb9bdde8b5271ed8ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9887318d`](https://github.com/nix-community/NUR/commit/9887318d5eae081b596a72bb9bdde8b5271ed8ab) | `` automatic update `` |
| [`a86ce067`](https://github.com/nix-community/NUR/commit/a86ce067d898360dbdbe9dc4de50a49b6bf8fabe) | `` automatic update `` |
| [`7fbcea98`](https://github.com/nix-community/NUR/commit/7fbcea98bf14fc67a54cff930cd24b792688b56c) | `` automatic update `` |