### PR TITLE
chore(flake/nur): `9887318d` -> `38cd9c1e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -761,11 +761,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1745071326,
-        "narHash": "sha256-sXQJJhZGRaXbf1h/Q69wq2ngwZz35m4+Qu3UN6FYpNM=",
+        "lastModified": 1745091977,
+        "narHash": "sha256-M7h+omxmXlXv9TzRWBWwniFsd17G4y8GfgkCEG99quY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9887318d5eae081b596a72bb9bdde8b5271ed8ab",
+        "rev": "38cd9c1e5f169b6a544f4b1c54b7734c6925263e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`38cd9c1e`](https://github.com/nix-community/NUR/commit/38cd9c1e5f169b6a544f4b1c54b7734c6925263e) | `` automatic update `` |
| [`5c9fd6f8`](https://github.com/nix-community/NUR/commit/5c9fd6f8edb33dfcf9690ec13b140fea71a7519f) | `` automatic update `` |