### PR TITLE
chore(flake/nur): `38cd9c1e` -> `cd27988f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -761,11 +761,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1745091977,
-        "narHash": "sha256-M7h+omxmXlXv9TzRWBWwniFsd17G4y8GfgkCEG99quY=",
+        "lastModified": 1745128405,
+        "narHash": "sha256-em3wtAx+BG2G7hSHXiDEXkBu3z1B2amsJoZBiLar16w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "38cd9c1e5f169b6a544f4b1c54b7734c6925263e",
+        "rev": "cd27988fd8321e46df0cdec0c2352f890a42bcff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cd27988f`](https://github.com/nix-community/NUR/commit/cd27988fd8321e46df0cdec0c2352f890a42bcff) | `` automatic update `` |
| [`667ce1ca`](https://github.com/nix-community/NUR/commit/667ce1ca767d19b59a204568a0a8faf9c300c790) | `` automatic update `` |
| [`5881c9d0`](https://github.com/nix-community/NUR/commit/5881c9d061795509d3fa0ea631e9cfd3e61f3d7d) | `` automatic update `` |
| [`c44b2a63`](https://github.com/nix-community/NUR/commit/c44b2a634451618fece003c6406b026fb02b933e) | `` automatic update `` |
| [`9e1ceeaf`](https://github.com/nix-community/NUR/commit/9e1ceeafa012ddf23abeb0ebc20d7521009b3865) | `` automatic update `` |
| [`28a70feb`](https://github.com/nix-community/NUR/commit/28a70feb83d4ef32b862a49a7e8a0ec8d9b63ca7) | `` automatic update `` |
| [`aebb8866`](https://github.com/nix-community/NUR/commit/aebb88667ce1a30d8872174381b957ae0fa520ce) | `` automatic update `` |
| [`8e4041f0`](https://github.com/nix-community/NUR/commit/8e4041f0d5b4dfe954938c7514297e965b312784) | `` automatic update `` |