### PR TITLE
chore(flake/nix-index-database): `4fc9ea78` -> `69716041`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -469,11 +469,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744518957,
-        "narHash": "sha256-RLBSWQfTL0v+7uyskC5kP6slLK1jvIuhaAh8QvB75m4=",
+        "lastModified": 1745120797,
+        "narHash": "sha256-owQ0VQ+7cSanTVPxaZMWEzI22Q4bGnuvhVjLAJBNQ3E=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "4fc9ea78c962904f4ea11046f3db37c62e8a02fd",
+        "rev": "69716041f881a2af935021c1182ed5b0cc04d40e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`69716041`](https://github.com/nix-community/nix-index-database/commit/69716041f881a2af935021c1182ed5b0cc04d40e) | `` update generated.nix to release 2025-04-20-032939 `` |
| [`41cfaac0`](https://github.com/nix-community/nix-index-database/commit/41cfaac0fcb5952c7bc3ea328c44962c4d7964e0) | `` flake.lock: Update ``                                |