### PR TITLE
chore(flake/nur): `cd27988f` -> `ca53a853`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -761,11 +761,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1745128405,
-        "narHash": "sha256-em3wtAx+BG2G7hSHXiDEXkBu3z1B2amsJoZBiLar16w=",
+        "lastModified": 1745178312,
+        "narHash": "sha256-QDQMa94PO/HpXSwPOinMwRP5nNfAPsj2FDoi5Q4FQqw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cd27988fd8321e46df0cdec0c2352f890a42bcff",
+        "rev": "ca53a853f29821e35bbf596dd1b202e4edaa6aae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ca53a853`](https://github.com/nix-community/NUR/commit/ca53a853f29821e35bbf596dd1b202e4edaa6aae) | `` automatic update `` |
| [`0aca111e`](https://github.com/nix-community/NUR/commit/0aca111e57861fc56a9bb65085bb06569d978a27) | `` automatic update `` |
| [`9fbbe614`](https://github.com/nix-community/NUR/commit/9fbbe614bcdd842358105e630cb5fece1004a610) | `` automatic update `` |
| [`3bbd31e8`](https://github.com/nix-community/NUR/commit/3bbd31e8e4cac8576e3cee7a2972de6142d77b1d) | `` automatic update `` |
| [`a1238353`](https://github.com/nix-community/NUR/commit/a1238353b95544ed7ad9745641d1075c2a6dcdc1) | `` automatic update `` |
| [`1b903470`](https://github.com/nix-community/NUR/commit/1b903470d8855603f676ccbc0ce44bdc4ee15cfd) | `` automatic update `` |
| [`7c40554c`](https://github.com/nix-community/NUR/commit/7c40554cc0c614e7ed074b1710e85dcb835236b2) | `` automatic update `` |