### PR TITLE
chore(flake/nur): `ca53a853` -> `8af99415`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -761,11 +761,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1745178312,
-        "narHash": "sha256-QDQMa94PO/HpXSwPOinMwRP5nNfAPsj2FDoi5Q4FQqw=",
+        "lastModified": 1745188403,
+        "narHash": "sha256-MMzdUXTRfWQs/B9536JPG2iiefn7lv8lOx3HCTPxBoU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ca53a853f29821e35bbf596dd1b202e4edaa6aae",
+        "rev": "8af9941539ff23e18fce666ac2c8020e128b3a0a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8af99415`](https://github.com/nix-community/NUR/commit/8af9941539ff23e18fce666ac2c8020e128b3a0a) | `` automatic update `` |
| [`5de9bb36`](https://github.com/nix-community/NUR/commit/5de9bb36bfae286a0d0d42b66cd6dae5ec4d4fb1) | `` automatic update `` |
| [`f46989ed`](https://github.com/nix-community/NUR/commit/f46989ed03316ee330d199d7ec84beb12967d8e7) | `` automatic update `` |