### PR TITLE
chore(flake/nur): `8af99415` -> `b58ed11c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -761,11 +761,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1745188403,
-        "narHash": "sha256-MMzdUXTRfWQs/B9536JPG2iiefn7lv8lOx3HCTPxBoU=",
+        "lastModified": 1745203470,
+        "narHash": "sha256-iNchP1ggX7euTKMA94JmecM+u9emadqTjYg83mcL5fc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8af9941539ff23e18fce666ac2c8020e128b3a0a",
+        "rev": "b58ed11c262bc1e02ba92badf5fa1b4ba428d38a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b58ed11c`](https://github.com/nix-community/NUR/commit/b58ed11c262bc1e02ba92badf5fa1b4ba428d38a) | `` automatic update `` |
| [`e6a66613`](https://github.com/nix-community/NUR/commit/e6a66613e91c0a3107211a6a009d16a63880486d) | `` automatic update `` |
| [`00dc6ab6`](https://github.com/nix-community/NUR/commit/00dc6ab6a2beaef953412312ae015afd9f6c41f5) | `` automatic update `` |