### PR TITLE
chore(flake/nur): `b58ed11c` -> `1f692619`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -761,11 +761,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1745203470,
-        "narHash": "sha256-iNchP1ggX7euTKMA94JmecM+u9emadqTjYg83mcL5fc=",
+        "lastModified": 1745222519,
+        "narHash": "sha256-55G2LJB5yEIl4RIntdp2MRBqUZ/7SEIdao9VwPVD/f0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b58ed11c262bc1e02ba92badf5fa1b4ba428d38a",
+        "rev": "1f692619c439ad139993410c05aa91daf98c6d5a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1f692619`](https://github.com/nix-community/NUR/commit/1f692619c439ad139993410c05aa91daf98c6d5a) | `` automatic update `` |
| [`9632a713`](https://github.com/nix-community/NUR/commit/9632a713e5890a0a67f2044a47b65c21a2037908) | `` automatic update `` |
| [`27b58eb7`](https://github.com/nix-community/NUR/commit/27b58eb7e24d525195edb16fbeba40d13b655357) | `` automatic update `` |
| [`f4b49401`](https://github.com/nix-community/NUR/commit/f4b494015e88a296786d3f83a6591f84d357aa62) | `` automatic update `` |
| [`46669eac`](https://github.com/nix-community/NUR/commit/46669eac2bcb500828a406440403ec8c48e1272c) | `` automatic update `` |
| [`7832e9d8`](https://github.com/nix-community/NUR/commit/7832e9d8e01e254f0e5f37899f80d0f64fd7d24a) | `` automatic update `` |
| [`88f5bf13`](https://github.com/nix-community/NUR/commit/88f5bf1390d24191404e5ce3c56a0744309a2758) | `` automatic update `` |
| [`6768d720`](https://github.com/nix-community/NUR/commit/6768d720457316f8fd7d3430c6dd7935d836c4f9) | `` automatic update `` |
| [`3b91f41b`](https://github.com/nix-community/NUR/commit/3b91f41be6b43668e7800b7ab53c645f66ad9b54) | `` automatic update `` |