### PR TITLE
chore(flake/nur): `1f692619` -> `a948993b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -761,11 +761,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1745222519,
-        "narHash": "sha256-55G2LJB5yEIl4RIntdp2MRBqUZ/7SEIdao9VwPVD/f0=",
+        "lastModified": 1745240884,
+        "narHash": "sha256-5mlbRdT0XKLMxJmRyotoaFYRHYWLPysEBt//hJL+2LA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1f692619c439ad139993410c05aa91daf98c6d5a",
+        "rev": "a948993b96ca6740d541ad366347b2227bb8ecc0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a948993b`](https://github.com/nix-community/NUR/commit/a948993b96ca6740d541ad366347b2227bb8ecc0) | `` automatic update `` |
| [`7b10e9e5`](https://github.com/nix-community/NUR/commit/7b10e9e5b4ac0731356fdfec941958d0c08a9af2) | `` automatic update `` |
| [`b628adcf`](https://github.com/nix-community/NUR/commit/b628adcfdb627d220823004a8158a84c1b273d8f) | `` automatic update `` |