### PR TITLE
chore(flake/nur): `a948993b` -> `af348f73`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -761,11 +761,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1745240884,
-        "narHash": "sha256-5mlbRdT0XKLMxJmRyotoaFYRHYWLPysEBt//hJL+2LA=",
+        "lastModified": 1745267475,
+        "narHash": "sha256-tEP3odwByxCKdFFtnXIG6r80BAGUMt/AtUC8YPV5LxU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a948993b96ca6740d541ad366347b2227bb8ecc0",
+        "rev": "af348f73e190e52b6527d33ffb21f1d3e441f35f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`af348f73`](https://github.com/nix-community/NUR/commit/af348f73e190e52b6527d33ffb21f1d3e441f35f) | `` automatic update `` |
| [`9ee84d14`](https://github.com/nix-community/NUR/commit/9ee84d14a2ab446c01ae3ae2f8260d7f19dd16f0) | `` automatic update `` |
| [`15154303`](https://github.com/nix-community/NUR/commit/151543031bf252bdf3b2d4a497dd4fdd58cd787f) | `` automatic update `` |
| [`8d352d01`](https://github.com/nix-community/NUR/commit/8d352d019dcf199dc13812e1d12fa2fc4e057034) | `` automatic update `` |