### PR TITLE
chore(flake/emacs-overlay): `99a01c9e` -> `029d994c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1745252602,
-        "narHash": "sha256-eE3LH+0rURTnG5Uw5dsEcrT8Z0eEp8f+a5ZX44oHU/U=",
+        "lastModified": 1745342319,
+        "narHash": "sha256-Tl4ZEeGxlGqBdkKyWGadx4jC66eIVjjKSEqy5PZWW1E=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "99a01c9e200ffa1898097865e71a9e8182428de5",
+        "rev": "029d994c584161072f221206b52411dd6c3df227",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`029d994c`](https://github.com/nix-community/emacs-overlay/commit/029d994c584161072f221206b52411dd6c3df227) | `` Updated emacs ``  |
| [`42cab8f8`](https://github.com/nix-community/emacs-overlay/commit/42cab8f8710af3cdafd47ddaec571dc5bb4cf86a) | `` Updated melpa ``  |
| [`7d873a92`](https://github.com/nix-community/emacs-overlay/commit/7d873a92ac91f1d13685d59c31ac73fc032efa06) | `` Updated elpa ``   |
| [`bf179134`](https://github.com/nix-community/emacs-overlay/commit/bf17913474d4ff3305a0551f74ed806dae926ac1) | `` Updated emacs ``  |
| [`490492d7`](https://github.com/nix-community/emacs-overlay/commit/490492d7421c9e903a9874414fd6c05484a9ec2a) | `` Updated melpa ``  |
| [`1ba73bfa`](https://github.com/nix-community/emacs-overlay/commit/1ba73bfaabf674905e715ccd74515eaf2977b19f) | `` Updated elpa ``   |
| [`421149e3`](https://github.com/nix-community/emacs-overlay/commit/421149e3c9f3b39c3c7a13a9cb53748510647042) | `` Updated nongnu `` |