### PR TITLE
chore(flake/srvos): `c6808c5b` -> `be128093`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -892,11 +892,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744443962,
-        "narHash": "sha256-a8zSzdfzZ8hCyvbGo78IuTL62bHGOAzUTyk34gjfkjI=",
+        "lastModified": 1745309546,
+        "narHash": "sha256-cmo852T3LxxkH4RSU6T006R3NJN5dKQaqbxQ8Zm0vAI=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "c6808c5b6575ae3343dc3c21277080f68a574bd6",
+        "rev": "be128093568b7f0d6d9d33941564e78d19bf7c06",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                              |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`4bd6844d`](https://github.com/nix-community/srvos/commit/4bd6844d67252a6d7ff6ec3a8bd1f94e87857b58) | `` nix-experimental: enable ca-derivations and impure-derivations `` |
| [`678142e9`](https://github.com/nix-community/srvos/commit/678142e9df7b56c55eecabbc84da6353cafec666) | `` fix: sudoers are trusted in desktops too ``                       |