### PR TITLE
chore(flake/sops-nix): `61154300` -> `5e3e92b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -872,11 +872,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744669848,
-        "narHash": "sha256-pXyanHLUzLNd3MX9vsWG+6Z2hTU8niyphWstYEP3/GU=",
+        "lastModified": 1745310711,
+        "narHash": "sha256-ePyTpKEJTgX0gvgNQWd7tQYQ3glIkbqcW778RpHlqgA=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "61154300d945f0b147b30d24ddcafa159148026a",
+        "rev": "5e3e92b16d6fdf9923425a8d4df7496b2434f39c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                           |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`1d4fbfb9`](https://github.com/Mic92/sops-nix/commit/1d4fbfb9274dd0b03ee999e36be889c4f787e8fc) | `` [create-pull-request] automated change ``      |
| [`4a195bda`](https://github.com/Mic92/sops-nix/commit/4a195bdac0600a6a4ab5ccb24e3478556ff4ca06) | `` docs: install and configure with nix-darwin `` |