### PR TITLE
chore(flake/catppuccin): `592094a0` -> `6268e50d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1745006048,
-        "narHash": "sha256-4ONXaEwnyZGPp84d6wjiqoR4xyTWygUobBTcSkILPzU=",
+        "lastModified": 1745352209,
+        "narHash": "sha256-u3vJEzi6zxgG59KXjMR5koERsdKT5nd1OEKCpr6zgn8=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "592094a02c4e43a9fa33559ade84d1ca015e8ada",
+        "rev": "6268e50dbb0ac9375e110560395b5dc199e4dfb8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                 |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`6268e50d`](https://github.com/catppuccin/nix/commit/6268e50dbb0ac9375e110560395b5dc199e4dfb8) | `` refactor: zsh-syntax-highlighting initExtra -> initContent (#543) `` |
| [`6ed70ca3`](https://github.com/catppuccin/nix/commit/6ed70ca322f24a8a6575ac7c5e35e7f66f15160e) | `` feat(home-manager): add atuin (#541) ``                              |