### PR TITLE
chore(flake/nixpkgs): `b024ced1` -> `c11863f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -686,11 +686,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1744932701,
-        "narHash": "sha256-fusHbZCyv126cyArUwwKrLdCkgVAIaa/fQJYFlCEqiU=",
+        "lastModified": 1745234285,
+        "narHash": "sha256-GfpyMzxwkfgRVN0cTGQSkTC0OHhEkv3Jf6Tcjm//qZ0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef",
+        "rev": "c11863f1e964833214b767f4a369c6e6a7aba141",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                      |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`c11863f1`](https://github.com/NixOS/nixpkgs/commit/c11863f1e964833214b767f4a369c6e6a7aba141) | `` doc, nixos/doc: include roboto font ``                                                    |
| [`4885c47f`](https://github.com/NixOS/nixpkgs/commit/4885c47f705ee5648a9ffe377aec4244bf472166) | `` doc, documentation-highlighter: use variables & add dark mode ``                          |
| [`4c446a47`](https://github.com/NixOS/nixpkgs/commit/4c446a479ea95fe51e00811b0c2fefd4bc01f2ee) | `` doc: center align appendices ``                                                           |
| [`6919a0d0`](https://github.com/NixOS/nixpkgs/commit/6919a0d04697fd40d461481f26b6dfc4968b433a) | `` doc, documentation-highlighter: format css ``                                             |
| [`90383537`](https://github.com/NixOS/nixpkgs/commit/90383537b8de3798fc4c09ccae8b8f58dc102946) | `` weblate: relax constraints on weblate-schemas ``                                          |
| [`29c215a8`](https://github.com/NixOS/nixpkgs/commit/29c215a8b70f3a5aec31a50f4bcc778ad950b9cb) | `` python312Packages.weblate-schemas: 2024.2 -> 2025.1 ``                                    |
| [`bd0df1b7`](https://github.com/NixOS/nixpkgs/commit/bd0df1b71dcb6edc84aef6614a0172e78c6d5739) | `` winbox4: 4.0beta16 -> 4.0beta18 ``                                                        |
| [`40e3ceb5`](https://github.com/NixOS/nixpkgs/commit/40e3ceb51a434dbe39dbf0059c870f38a30780e7) | `` maintainers: kekschen -> willow ``                                                        |
| [`0dbffe62`](https://github.com/NixOS/nixpkgs/commit/0dbffe6286eb13971086e4ea1ac5bf009c469eb3) | `` nh: allow generating completions while cross-compiling ``                                 |
| [`1910d945`](https://github.com/NixOS/nixpkgs/commit/1910d945e8ee90aca66cdef33e1491a0cffa0914) | `` nh, nixos/doc: update repo owner (viperML -> nix-community) ``                            |
| [`8ff62b67`](https://github.com/NixOS/nixpkgs/commit/8ff62b67ae8fcc912ab0632ed8273ad9a1caf5d4) | `` nh: make use of finalAttrs ``                                                             |
| [`96527c01`](https://github.com/NixOS/nixpkgs/commit/96527c018ddd93c936e8f6d3b27a8a86af7f23d6) | `` timewarrior: 1.7.1 -> 1.8.0 ``                                                            |
| [`66cbb62e`](https://github.com/NixOS/nixpkgs/commit/66cbb62ea1a362258547ca6153f33992b67c209e) | `` python312Packages.python-codon-tables: 0.1.13 -> 0.1.15 ``                                |
| [`a44a85c9`](https://github.com/NixOS/nixpkgs/commit/a44a85c96ba88b3ca7c770d77b0218a1352ab6ae) | `` trilium-next-{desktop,server}: 0.92.7 -> 0.93.0 (#400419) ``                              |
| [`090f9b33`](https://github.com/NixOS/nixpkgs/commit/090f9b33f5138e56bb69239f6a96ea8ceebee906) | `` ruff-lsp: remove ``                                                                       |
| [`752e358d`](https://github.com/NixOS/nixpkgs/commit/752e358d81a8379ee820bdc3f66bb6644dc1e875) | `` cargo-mobile2: 0.17.6 -> 0.20.0 ``                                                        |
| [`e8773c4e`](https://github.com/NixOS/nixpkgs/commit/e8773c4e87d02d5c9edc1e5508b0c00624d0956d) | `` python312Packages.pytensor: fix hash ``                                                   |
| [`36d4f28b`](https://github.com/NixOS/nixpkgs/commit/36d4f28b375c8dea4a00ded9a85409f14b3e153d) | `` krillinai: 1.1.0 -> 1.1.3 ``                                                              |
| [`1985b5f5`](https://github.com/NixOS/nixpkgs/commit/1985b5f53191b13f698286ba10259d36c8f09fb4) | `` hedgedoc: use `writableTmpDirAsHomeHook` ``                                               |
| [`3218a420`](https://github.com/NixOS/nixpkgs/commit/3218a4204f02eb8a2f78ec5671207682cc694c2f) | `` doc: do not reuse `pname` ``                                                              |
| [`ac04a5c4`](https://github.com/NixOS/nixpkgs/commit/ac04a5c492f7668882e99c0b5075aaa81a434713) | `` doc: replace `rev` with `tag` ``                                                          |
| [`30eb01e1`](https://github.com/NixOS/nixpkgs/commit/30eb01e120bfa3180542bf6fade9b35c970913f8) | `` doc: remove useless `rec` ``                                                              |
| [`b4515ff6`](https://github.com/NixOS/nixpkgs/commit/b4515ff6c24516b4a19262239a5002d9553ca750) | `` doc: use `finalAttrs` pattern ``                                                          |
| [`47f000d9`](https://github.com/NixOS/nixpkgs/commit/47f000d991220f689bbfb32406cdc4a24b83ac3c) | `` doc: add missing phase hooks ``                                                           |
| [`540ddbcf`](https://github.com/NixOS/nixpkgs/commit/540ddbcf2ff3d194d190bab59ecadf14b1532681) | `` doc: use `writableTmpDirAsHomeHook` ``                                                    |
| [`b362e0e3`](https://github.com/NixOS/nixpkgs/commit/b362e0e3eaa24fd0616ca8973550157eb421c2e1) | `` python312Packages.pyopencl: support Darwin platform ``                                    |
| [`5f0e0cdc`](https://github.com/NixOS/nixpkgs/commit/5f0e0cdc1c20c4863abfe84e626765e166170ab7) | `` python312Packages.pyopencl: doCheck with pocl ``                                          |
| [`cd6a5a15`](https://github.com/NixOS/nixpkgs/commit/cd6a5a15fc232b6273f5413880bfa52f98ae21e2) | `` pocl: remove updateScript ``                                                              |
| [`ebe20c9d`](https://github.com/NixOS/nixpkgs/commit/ebe20c9dbc2447191fb22b0f3cf984aca4a53313) | `` pocl: fix description ``                                                                  |
| [`7a9e0eaa`](https://github.com/NixOS/nixpkgs/commit/7a9e0eaa6ac1304d0268311122a60386233b6869) | `` pocl: migrate to lib.cmakeBool and lib.cmakeFeature ``                                    |
| [`d273f17a`](https://github.com/NixOS/nixpkgs/commit/d273f17af996a1af72ce14bc597ac19c70719a94) | `` pocl: setting KERNELLIB_HOST_CPU_VARIANTS=distro on x86_64 only ``                        |
| [`728eb4ad`](https://github.com/NixOS/nixpkgs/commit/728eb4ad0bc9730356edbb395fc6261eb77a9864) | `` pocl: support Darwin platform ``                                                          |
| [`9e853cca`](https://github.com/NixOS/nixpkgs/commit/9e853cca6b94cf787c7a90051c34ffe0a101a660) | `` pocl: add installCheckPhase ``                                                            |
| [`072302cf`](https://github.com/NixOS/nixpkgs/commit/072302cf6b614f1bf815728bd5305c49822cd24b) | `` pocl: add setupHook to specifies directory to scan for ICDs ``                            |
| [`d60250f1`](https://github.com/NixOS/nixpkgs/commit/d60250f164bea6de7f9503f5ba5040c344434cbd) | `` pocl: fix icd support ``                                                                  |
| [`8c739c78`](https://github.com/NixOS/nixpkgs/commit/8c739c788b12f9539c817568aa4db2f197f05d65) | `` postgresqlPackages.timescaledb-apache: 2.19.2 -> 2.19.3 ``                                |
| [`993d3da7`](https://github.com/NixOS/nixpkgs/commit/993d3da7127e8cc8d5b46f9bec43cceb8039ba75) | `` nwg-dock-hyprland: 0.4.4 -> 0.4.5 ``                                                      |
| [`b4545ada`](https://github.com/NixOS/nixpkgs/commit/b4545adaa42979b8b881d33e2e9282cadb0b1c6a) | `` firezone-headless-client: 1.4.5 -> 1.4.6 ``                                               |
| [`83453744`](https://github.com/NixOS/nixpkgs/commit/83453744d22cb678ba72aa033e63477ddd635aa1) | `` firezone-gateway: 1.4.5 -> 1.4.6 ``                                                       |
| [`ea8b5891`](https://github.com/NixOS/nixpkgs/commit/ea8b5891d9e5d03bb6fb5941ae14ed6dca751cd8) | `` eduli: fix hash ``                                                                        |
| [`a9e79b0f`](https://github.com/NixOS/nixpkgs/commit/a9e79b0f3c00ac2f5ca9a9e772c3f1b39ae9af10) | `` python313Packages.sentry-sdk_2: turn into alias ``                                        |
| [`67d9e12d`](https://github.com/NixOS/nixpkgs/commit/67d9e12dacd91806b8603af19d252c40c6951fed) | `` vimPlugins.cmp-async-path: 0-unstable-2024-10-21 -> 0-unstable-2025-04-13 ``              |
| [`02658aa3`](https://github.com/NixOS/nixpkgs/commit/02658aa368b96d3b4b1387057b315c05ba5ceac1) | `` python313Packages.sentry-sdk_1: drop ``                                                   |
| [`84faa614`](https://github.com/NixOS/nixpkgs/commit/84faa614a5256a84e3dd4e445053ff76f4c0a5d4) | `` python313Packages.proton-vpn-network-manager: mark broken ``                              |
| [`7e5ce749`](https://github.com/NixOS/nixpkgs/commit/7e5ce7491779a041107131080090aafc11d0db9c) | `` pretix: drop geoip2 override ``                                                           |
| [`12a35c2c`](https://github.com/NixOS/nixpkgs/commit/12a35c2c1559b8469485b88fc2176856beb36121) | `` home-assistant-custom-components.xiaomi_miot: 1.0.16 -> 1.0.17 ``                         |
| [`b3d615fe`](https://github.com/NixOS/nixpkgs/commit/b3d615feca13e827de85e8ad929ee8c3f70f5804) | `` home-assistant-custom-components.tuya_local: 2025.3.0 -> 2025.4.0 ``                      |
| [`a9f46ccb`](https://github.com/NixOS/nixpkgs/commit/a9f46ccba955f51ecef80b147b9311797b8c1c15) | `` home-assistant-custom-components.moonraker: 1.7.0 -> 1.7.1 ``                             |
| [`9da85435`](https://github.com/NixOS/nixpkgs/commit/9da85435932708b0eeebddd30aef94e6f7427795) | `` home-assistant-custom-components.midea_ac: 2025.3.1 -> 2025.4.0 ``                        |
| [`85c40767`](https://github.com/NixOS/nixpkgs/commit/85c407678c5659c52930750487c3361fd3816687) | `` home-assistant-custom-components.daikin_onecta: 4.2.3 -> 4.2.6 ``                         |
| [`868a6652`](https://github.com/NixOS/nixpkgs/commit/868a66523e8fd6c5f3f88c2d15fdb0b2ad6d623e) | `` python313Packages.env-canada: fix the 0.10.1 update ``                                    |
| [`19254bd1`](https://github.com/NixOS/nixpkgs/commit/19254bd10a1e3ba028e983a285be38958eb6b0bb) | `` home-assistant.python.pkgs.pytest-homeassistant-custom-component: 0.13.233 -> 0.13.235 `` |
| [`e4e72f0b`](https://github.com/NixOS/nixpkgs/commit/e4e72f0b7849599d77a3e780e89b91f9e75ad5e0) | `` python313Packages.homeassistant-stubs: 2025.4.2 -> 2025.4.3 ``                            |
| [`b9a395ba`](https://github.com/NixOS/nixpkgs/commit/b9a395baeb69231b43abec34feded34b707cf919) | `` home-assistant: 2025.4.2 -> 2025.4.3 ``                                                   |
| [`63e1db1d`](https://github.com/NixOS/nixpkgs/commit/63e1db1da44fd4be22e924487d6234d33f471741) | `` nezha-theme-nazhua: 0.6.4 -> 0.6.6 ``                                                     |
| [`708cdac2`](https://github.com/NixOS/nixpkgs/commit/708cdac2737b6bdb5ab50d4e84af830ad042b610) | `` python313Packages.zigpy: 0.78.0 -> 0.78.1 ``                                              |
| [`c583191b`](https://github.com/NixOS/nixpkgs/commit/c583191be7aa8affb736b16dfa334d717b0c26b2) | `` python313Packages.zha: 0.0.55 -> 0.0.56 ``                                                |
| [`c81ebe69`](https://github.com/NixOS/nixpkgs/commit/c81ebe69efa15183ae115e60c1c7b698cecdeec6) | `` python313Packages.bellows: 0.44.0 -> 0.44.1 ``                                            |
| [`85fef808`](https://github.com/NixOS/nixpkgs/commit/85fef808ad9ad2eda54b8bbe7590b4cafc1a95e2) | `` doc: init Testing Hardware Features section with vwifi ``                                 |
| [`a4371c50`](https://github.com/NixOS/nixpkgs/commit/a4371c50b3ab5b75605363546e8093d5fb6f24d2) | `` release-notes: add kismet and vwifi ``                                                    |
| [`d9d186e1`](https://github.com/NixOS/nixpkgs/commit/d9d186e18dc4d53996a05813ec3e78c3f7c67210) | `` kismet: add nixosTests passthru ``                                                        |
| [`36cddaaa`](https://github.com/NixOS/nixpkgs/commit/36cddaaa6fd4f2dec9c16d220fe6ffe506841a81) | `` nixos/kismet: init module ``                                                              |
| [`583a74d8`](https://github.com/NixOS/nixpkgs/commit/583a74d8ad7545b8791e651aea7865e5f170f44b) | `` nixos/vwifi: init module ``                                                               |
| [`fcc811bb`](https://github.com/NixOS/nixpkgs/commit/fcc811bbb1d420a85de5bfb571509d00e4caf349) | `` golangci-lint-langserver: re-enable check ``                                              |
| [`6af61c93`](https://github.com/NixOS/nixpkgs/commit/6af61c930144bd11ac118aa851e9f8067b096f0e) | `` orthanc-plugin-dicomweb: remove custom patch, cleanup ``                                  |
| [`f2004e84`](https://github.com/NixOS/nixpkgs/commit/f2004e84f6397220d60c46b2037f1f046086a151) | `` orthanc-framework: remove `outputs` attribute ``                                          |
| [`24bb4891`](https://github.com/NixOS/nixpkgs/commit/24bb48919bd9710e0b942ba16355fa873d3a002f) | `` python313Packages.sentry-sdk: 1.45.1 -> 2.25.0 ``                                         |
| [`7970ca6b`](https://github.com/NixOS/nixpkgs/commit/7970ca6bd2bd59e06ce6e10e4f03208cc71e2e00) | `` catppuccin: add alacritty source ``                                                       |
| [`72b32b82`](https://github.com/NixOS/nixpkgs/commit/72b32b828f51af708ffe0a1d85e4e84e8b3f588c) | `` bazel-watcher: 0.25.3 -> 0.26.0 ``                                                        |
| [`4fe4ed76`](https://github.com/NixOS/nixpkgs/commit/4fe4ed760230e1867f048f19c8d7ef8cdcbc68a0) | `` fstar: 2024.09.05 -> 2025.03.25 ``                                                        |
| [`3ed28237`](https://github.com/NixOS/nixpkgs/commit/3ed282378304c03d8a0a43c50f2d3782ed8e7782) | `` protobuf_23: drop ``                                                                      |
| [`e65a310c`](https://github.com/NixOS/nixpkgs/commit/e65a310c20e039882d2f34dd200cf98a64e1101b) | `` libreoffice: use box2d_2 ``                                                               |
| [`a19141a6`](https://github.com/NixOS/nixpkgs/commit/a19141a6d034efca78610465a28a12753b9c29c6) | `` box2d_2: init at 2.4.2 ``                                                                 |
| [`9951d59f`](https://github.com/NixOS/nixpkgs/commit/9951d59fd4ae1ad7b7ce57f12e1a35ec0cd400cf) | `` ultrastardx: add diogotcorreia as maintainer ``                                           |
| [`defc95e0`](https://github.com/NixOS/nixpkgs/commit/defc95e0ea1c33b1836d53882f730b3ef553bccb) | `` monkeysAudio: 11.05 -> 11.08 ``                                                           |
| [`25b9381f`](https://github.com/NixOS/nixpkgs/commit/25b9381f3bd755253676dab259905d79766dcd17) | `` python312Packages.pybind11-protobuf: 0-unstable-2024-11-01 -> 0-unstable-2025-02-10 ``    |
| [`9c1b7551`](https://github.com/NixOS/nixpkgs/commit/9c1b7551e61a397f5b9066061e5dae248b9583e1) | `` kahip: init at 3.18 ``                                                                    |
| [`10673998`](https://github.com/NixOS/nixpkgs/commit/1067399806ae2d37c0e26482f17f2e6011e326c5) | `` qlog: fix installation on darwin ``                                                       |
| [`8a6d7844`](https://github.com/NixOS/nixpkgs/commit/8a6d7844ef50ca9f68a9af5ef1d71620b1992b4a) | `` SDL2_image: remove unused deps ``                                                         |
| [`83754649`](https://github.com/NixOS/nixpkgs/commit/8375464933954bcf54e05f979a3d2aeca0bd2632) | `` SDL2_image_2_0: drop ``                                                                   |
| [`1435e1ed`](https://github.com/NixOS/nixpkgs/commit/1435e1ed87dafaac0a9fc832d03caf272a47eb7a) | `` pygame{,-ce}: use latest version of SDL2_image ``                                         |
| [`3e2fd0eb`](https://github.com/NixOS/nixpkgs/commit/3e2fd0eb8a0342d1b3587d0dc7a40ae6662a8a1f) | `` SDL2_image: add option to build without STB backend ``                                    |
| [`0f819f6c`](https://github.com/NixOS/nixpkgs/commit/0f819f6c6b53f56ae22fd727b29ddcfd47dc95aa) | `` spr: update GitHub url and maintainer's GitHub account ``                                 |
| [`88c60571`](https://github.com/NixOS/nixpkgs/commit/88c60571f5cf28f43d463beda8b1440f82d26687) | `` kalker: fix build by patching cargo lock ``                                               |
| [`3ec60797`](https://github.com/NixOS/nixpkgs/commit/3ec60797a5c9eed73e274b9bd0c5fd057588b373) | `` qt6Packages.qmlbox2d: unstable-2022-08-25 -> 0-unstable-2024-04-15 ``                     |
| [`ebd1be41`](https://github.com/NixOS/nixpkgs/commit/ebd1be41800cb26de0b2159c3ffb64a23d760bd9) | `` box2d: 2.4.2 -> 3.1.0 ``                                                                  |
| [`5d2a9b80`](https://github.com/NixOS/nixpkgs/commit/5d2a9b809f6ccd93a735f2241e40b42d2ef90685) | `` streamrip: relax all dependencies ``                                                      |
| [`e32a27ed`](https://github.com/NixOS/nixpkgs/commit/e32a27edc351e188df549efdcee3ca11bdb4af28) | `` godot: disable autoPatchelf on $debug ``                                                  |
| [`e98c99a4`](https://github.com/NixOS/nixpkgs/commit/e98c99a4f505845ec766c6cd2983f3e884efa9b9) | `` pygame-ce: unbreak ``                                                                     |
| [`d936ca58`](https://github.com/NixOS/nixpkgs/commit/d936ca58b51c51e97704fcb6d55c57bbf3a376c6) | `` exportarr: 2.1.0 -> 2.2.0 ``                                                              |
| [`51a6a636`](https://github.com/NixOS/nixpkgs/commit/51a6a636d6d2694556a51c46d319c55425ab6e50) | `` mathematica: 14.2.0 -> 14.2.1 ``                                                          |
| [`6b9bdb63`](https://github.com/NixOS/nixpkgs/commit/6b9bdb632915c000ce9fb55ebb80477237633182) | `` prometheus-zfs-exporter: 2.3.6 -> 2.3.8 ``                                                |