### PR TITLE
chore(flake/nur): `8bb84605` -> `e819d429`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -761,11 +761,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1745353885,
-        "narHash": "sha256-pPO6GlommUHHbjIilUCBeZdHI4SUyGfTJFBrT6rKhfk=",
+        "lastModified": 1745380232,
+        "narHash": "sha256-93jm+vDI4OE4tcobPaqj99+x4D+NyY3vC5KO0vU9x80=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8bb84605f2d228a466a10b97fa8aa2dc2995cd7d",
+        "rev": "e819d4293f11c28582d388945f279d43dc2e5056",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e819d429`](https://github.com/nix-community/NUR/commit/e819d4293f11c28582d388945f279d43dc2e5056) | `` automatic update `` |
| [`9c33f5fd`](https://github.com/nix-community/NUR/commit/9c33f5fdc407b7b16a971b56a3a821bbd3ac4e41) | `` automatic update `` |
| [`983b4bea`](https://github.com/nix-community/NUR/commit/983b4bea549352938b92c345455ec69074f63469) | `` automatic update `` |
| [`87ee1d44`](https://github.com/nix-community/NUR/commit/87ee1d4413111d7f55e61d4f6603adc16fd580be) | `` automatic update `` |
| [`5028c2ca`](https://github.com/nix-community/NUR/commit/5028c2ca9b72d249bfebdfe42c0689d0b24eb8c2) | `` automatic update `` |