### PR TITLE
chore(flake/emacs-overlay): `029d994c` -> `6f915e3d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1745342319,
-        "narHash": "sha256-Tl4ZEeGxlGqBdkKyWGadx4jC66eIVjjKSEqy5PZWW1E=",
+        "lastModified": 1745428961,
+        "narHash": "sha256-sMXqvI6mCkOGNv3LW7nha1XDrMtC4c9YDQUZMqQSYbc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "029d994c584161072f221206b52411dd6c3df227",
+        "rev": "6f915e3dd23b65dd5b1a9d86e171ceb702282680",
         "type": "github"
       },
       "original": {
@@ -646,11 +646,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1744440957,
-        "narHash": "sha256-FHlSkNqFmPxPJvy+6fNLaNeWnF1lZSgqVCl/eWaJRc4=",
+        "lastModified": 1745279238,
+        "narHash": "sha256-AQ7M9wTa/Pa/kK5pcGTgX/DGqMHyzsyINfN7ktsI7Fo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "26d499fc9f1d567283d5d56fcf367edd815dba1d",
+        "rev": "9684b53175fc6c09581e94cc85f05ab77464c7e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`6f915e3d`](https://github.com/nix-community/emacs-overlay/commit/6f915e3dd23b65dd5b1a9d86e171ceb702282680) | `` Updated emacs ``        |
| [`d9570f37`](https://github.com/nix-community/emacs-overlay/commit/d9570f37d337059cf11c89cc7b461649da509d36) | `` Updated melpa ``        |
| [`41785dbb`](https://github.com/nix-community/emacs-overlay/commit/41785dbbb27b5cee0e7c3349400424e4c74b5319) | `` Updated elpa ``         |
| [`838172ec`](https://github.com/nix-community/emacs-overlay/commit/838172ec5a825686cc79ac6cdb21a77c8d9e08f4) | `` Updated nongnu ``       |
| [`d8bad40d`](https://github.com/nix-community/emacs-overlay/commit/d8bad40da349c15b37f83159019a5e7f452cecc6) | `` Updated emacs ``        |
| [`334c3a55`](https://github.com/nix-community/emacs-overlay/commit/334c3a55dca157d123389ff2b8f1dfb16173054b) | `` Updated melpa ``        |
| [`e25b2005`](https://github.com/nix-community/emacs-overlay/commit/e25b20056312115f598bd67426c5cda620456800) | `` Updated elpa ``         |
| [`4f1f718d`](https://github.com/nix-community/emacs-overlay/commit/4f1f718d24f7474d1f8ba7489ac7b8fcf2f2d8de) | `` Updated nongnu ``       |
| [`a300cb5c`](https://github.com/nix-community/emacs-overlay/commit/a300cb5cdcc4c80fe07e900976e00c6eb5553cd4) | `` Updated flake inputs `` |
| [`07106a1d`](https://github.com/nix-community/emacs-overlay/commit/07106a1db062249293fe32fc6588b54bdba43f06) | `` Updated flake inputs `` |