### PR TITLE
chore(flake/nur): `e819d429` -> `ac5d7e3b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -761,11 +761,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1745380232,
-        "narHash": "sha256-93jm+vDI4OE4tcobPaqj99+x4D+NyY3vC5KO0vU9x80=",
+        "lastModified": 1745402502,
+        "narHash": "sha256-KNtmTeq6Jl41/P5zJzQBS2sccRJSeGlHYeV4m1ia6VA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e819d4293f11c28582d388945f279d43dc2e5056",
+        "rev": "ac5d7e3b00f84705869880e5008b20b89ea848d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ac5d7e3b`](https://github.com/nix-community/NUR/commit/ac5d7e3b00f84705869880e5008b20b89ea848d9) | `` automatic update `` |
| [`45ce80d7`](https://github.com/nix-community/NUR/commit/45ce80d74a4450378b4446f3069becb72f748ed8) | `` automatic update `` |
| [`3d08f800`](https://github.com/nix-community/NUR/commit/3d08f800c653b188cb98b4738d46fa5dc6028b52) | `` automatic update `` |
| [`6df82cc6`](https://github.com/nix-community/NUR/commit/6df82cc6eb3830e0f8bb30dda9882db57f23e438) | `` automatic update `` |
| [`5e872aed`](https://github.com/nix-community/NUR/commit/5e872aed1eb4b6be11ccaf66b60789dc3110d948) | `` automatic update `` |
| [`d822e3ea`](https://github.com/nix-community/NUR/commit/d822e3ea9a3973cafd49d99ebff8e99068ca9196) | `` automatic update `` |
| [`81458820`](https://github.com/nix-community/NUR/commit/8145882065456ef8d9db0dce60180d4a90d5f7f9) | `` automatic update `` |
| [`7300b34f`](https://github.com/nix-community/NUR/commit/7300b34fcc2a80867e1e125332758814d2082174) | `` automatic update `` |
| [`ba216cca`](https://github.com/nix-community/NUR/commit/ba216cca2fe945c6f3234cd422212c74b4df644f) | `` automatic update `` |
| [`1c080b79`](https://github.com/nix-community/NUR/commit/1c080b79c4751030f07aac7f3f94e026241da3ac) | `` automatic update `` |
| [`0732227b`](https://github.com/nix-community/NUR/commit/0732227b54666388ed826cf9c3554e3f919a4250) | `` automatic update `` |