### PR TITLE
chore(flake/nur): `ac5d7e3b` -> `49396910`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -784,11 +784,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1745402502,
-        "narHash": "sha256-KNtmTeq6Jl41/P5zJzQBS2sccRJSeGlHYeV4m1ia6VA=",
+        "lastModified": 1745467175,
+        "narHash": "sha256-aghUFJj0558+JQxfS9/3en0haAgA4DYjyt00G4zm/ZU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ac5d7e3b00f84705869880e5008b20b89ea848d9",
+        "rev": "493969109243187ef0b7ca233df766e4dd5a153f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`49396910`](https://github.com/nix-community/NUR/commit/493969109243187ef0b7ca233df766e4dd5a153f) | `` automatic update `` |
| [`50982fc0`](https://github.com/nix-community/NUR/commit/50982fc02ae7489bf4d90efb9f9ae67af7ba63a3) | `` automatic update `` |
| [`dbc4ba32`](https://github.com/nix-community/NUR/commit/dbc4ba3233b2bf951521177bf0ee0a7679959035) | `` automatic update `` |
| [`d9693a24`](https://github.com/nix-community/NUR/commit/d9693a24c7eb532abb20088742ca10f007786fe7) | `` automatic update `` |
| [`3fb3215a`](https://github.com/nix-community/NUR/commit/3fb3215af626c2fa80f05152a5bdc23b3513773d) | `` automatic update `` |
| [`6d04ab16`](https://github.com/nix-community/NUR/commit/6d04ab16a01981326374c50442471130f212c810) | `` automatic update `` |
| [`3b16e74e`](https://github.com/nix-community/NUR/commit/3b16e74eae922df0a2ad3a4da3d1779fcd426c3d) | `` automatic update `` |
| [`110f1c9a`](https://github.com/nix-community/NUR/commit/110f1c9aaab3707a16af9d8a30322721543e65f8) | `` automatic update `` |
| [`5cff05c2`](https://github.com/nix-community/NUR/commit/5cff05c222e79567d6534270c05ecd69435bb84f) | `` automatic update `` |
| [`a5724250`](https://github.com/nix-community/NUR/commit/a5724250ee4c962f1fbfe992061e296955277961) | `` automatic update `` |
| [`04cf3d1a`](https://github.com/nix-community/NUR/commit/04cf3d1af1518268ca18e91dbe8fc9b6d53f2163) | `` automatic update `` |