### PR TITLE
chore(flake/home-manager): `1d0e1390` -> `abfad3d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745380081,
-        "narHash": "sha256-bUy25YkdRfdWPxSyx22igWi6g3rd3HXKFg+yL4dfBPY=",
+        "lastModified": 1745494811,
+        "narHash": "sha256-YZCh2o9Ua1n9uCvrvi5pRxtuVNml8X2a03qIFfRKpFs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1d0e13904bd8c444ab1595f686ede5eff377e881",
+        "rev": "abfad3d2958c9e6300a883bd443512c55dfeb1be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                   |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`abfad3d2`](https://github.com/nix-community/home-manager/commit/abfad3d2958c9e6300a883bd443512c55dfeb1be) | `` treewide: substituteAll -> replaceVars/substitute ``                   |
| [`d31710fb`](https://github.com/nix-community/home-manager/commit/d31710fb2cd536b1966fee2af74e99a0816a61a8) | `` fcitx5: fix iniFormat usage (#6899) ``                                 |
| [`6d1f834c`](https://github.com/nix-community/home-manager/commit/6d1f834ca63700604a96d8c38aa8ac272d95071a) | `` fcitx5: add upstream options (#6892) ``                                |
| [`59de2dfb`](https://github.com/nix-community/home-manager/commit/59de2dfb0a08ebcbc73e3bb8488d2c23057e6ad8) | `` workflows: only run conflicts and update flake on main repo (#6893) `` |
| [`b7527e2d`](https://github.com/nix-community/home-manager/commit/b7527e2daf755437a2948f09761a8ed07debd075) | `` vesktop: only generate settings when configured (#6897) ``             |
| [`ff6adf83`](https://github.com/nix-community/home-manager/commit/ff6adf83b9cfdc88dc0b035a608e08d3eb674b3a) | `` input-method: fix enable condition (#6896) ``                          |
| [`6c132a09`](https://github.com/nix-community/home-manager/commit/6c132a098e61163fb559db986efe913acd3df4e7) | `` tests/darwinScrublist: add more darwin stubs ``                        |
| [`a3e713cb`](https://github.com/nix-community/home-manager/commit/a3e713cb82af628105480ae54dc7500b5ec8ebd1) | `` tests/darwinScrublist: move darwin scrub list to new file ``           |
| [`b01a9411`](https://github.com/nix-community/home-manager/commit/b01a94118403af8a3ce646b3d703ba3d18bed042) | `` tests/default: add more darwin stubs ``                                |
| [`814521fd`](https://github.com/nix-community/home-manager/commit/814521fdc16813b036415edb4bb42a8733729dd5) | `` flake.lock: Update (#6891) ``                                          |