### PR TITLE
chore(flake/emacs-overlay): `6f915e3d` -> `4bd92848`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1745428961,
-        "narHash": "sha256-sMXqvI6mCkOGNv3LW7nha1XDrMtC4c9YDQUZMqQSYbc=",
+        "lastModified": 1745633670,
+        "narHash": "sha256-2HsOCrXODR+PZ94kGrMUFrXWHeLTYTNJMi32nHcdLFY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6f915e3dd23b65dd5b1a9d86e171ceb702282680",
+        "rev": "4bd928487268eeb51c5f522c8b8866afb8e376c8",
         "type": "github"
       },
       "original": {
@@ -646,11 +646,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1745279238,
-        "narHash": "sha256-AQ7M9wTa/Pa/kK5pcGTgX/DGqMHyzsyINfN7ktsI7Fo=",
+        "lastModified": 1745487689,
+        "narHash": "sha256-FQoi3R0NjQeBAsEOo49b5tbDPcJSMWc3QhhaIi9eddw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9684b53175fc6c09581e94cc85f05ab77464c7e3",
+        "rev": "5630cf13cceac06cefe9fc607e8dfa8fb342dde3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`4bd92848`](https://github.com/nix-community/emacs-overlay/commit/4bd928487268eeb51c5f522c8b8866afb8e376c8) | `` Updated emacs ``        |
| [`d1dd13f6`](https://github.com/nix-community/emacs-overlay/commit/d1dd13f60fec1cad758de09792f7efddad4ae05e) | `` Updated melpa ``        |
| [`c13007bb`](https://github.com/nix-community/emacs-overlay/commit/c13007bb88589447401b3bef2b78341cfa8f8e36) | `` Updated elpa ``         |
| [`50a91ffb`](https://github.com/nix-community/emacs-overlay/commit/50a91ffb312baae05113117481c501b1e124101b) | `` Updated nongnu ``       |
| [`9232d20a`](https://github.com/nix-community/emacs-overlay/commit/9232d20ad5eb26fc56f16bdb5d4dca44ad74a1d4) | `` Updated nongnu ``       |
| [`7e630e5c`](https://github.com/nix-community/emacs-overlay/commit/7e630e5c5e5b860f89d05a64129e51f342766b70) | `` Updated emacs ``        |
| [`4b4a9f8f`](https://github.com/nix-community/emacs-overlay/commit/4b4a9f8f4984809d8eec285f8232eb47eebc1de1) | `` Updated melpa ``        |
| [`7091cf72`](https://github.com/nix-community/emacs-overlay/commit/7091cf72a7ee24a87490873e91d7652f37d79fe1) | `` Updated elpa ``         |
| [`d57dbbd3`](https://github.com/nix-community/emacs-overlay/commit/d57dbbd3bd341f2fc0aefb8852ff965cc2c7081d) | `` Updated nongnu ``       |
| [`7d75d84a`](https://github.com/nix-community/emacs-overlay/commit/7d75d84a8d5db4ecd5ce03be713e717b5fa2079c) | `` Updated flake inputs `` |
| [`2e939b25`](https://github.com/nix-community/emacs-overlay/commit/2e939b25ef18fd3efbd60829fc7f87c8235cdd40) | `` Updated elpa ``         |
| [`fe215e4a`](https://github.com/nix-community/emacs-overlay/commit/fe215e4a5b487ebfe2bd04e10cb2c303c710b4b6) | `` Updated nongnu ``       |
| [`acf94b5d`](https://github.com/nix-community/emacs-overlay/commit/acf94b5dd33ce8e3fb995421cd1a719bb0d9c804) | `` Updated flake inputs `` |
| [`5131ae06`](https://github.com/nix-community/emacs-overlay/commit/5131ae065291256d4af83be7eda7fcb9196815c3) | `` Updated emacs ``        |
| [`71cb11e4`](https://github.com/nix-community/emacs-overlay/commit/71cb11e48cb83264f86c2cee0b689900df989067) | `` Updated melpa ``        |
| [`3da37baf`](https://github.com/nix-community/emacs-overlay/commit/3da37baf004d3ecbc5c9ef131c27db837ae00a78) | `` Updated elpa ``         |
| [`1bb2aec5`](https://github.com/nix-community/emacs-overlay/commit/1bb2aec516a656432d2b53952caff1af365ff4d0) | `` Updated nongnu ``       |