### PR TITLE
chore(flake/nur): `1f495c92` -> `5ac97105`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -784,11 +784,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1745480132,
-        "narHash": "sha256-u2kpylv8JAwrwfckT6WRRoGZtak6Mkp9uvcyJW4wuMk=",
+        "lastModified": 1745491865,
+        "narHash": "sha256-+ISUnPM8a3amn/etZ4Ky0rvVi0segpBSISVCTZf5YoE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1f495c92e00fcc5446a9fc50487e8f4202872799",
+        "rev": "5ac9710537962330b4787a6cb2fecadeda6195be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5ac97105`](https://github.com/nix-community/NUR/commit/5ac9710537962330b4787a6cb2fecadeda6195be) | `` automatic update `` |
| [`8cec5b78`](https://github.com/nix-community/NUR/commit/8cec5b7802f1363f32d3e8932e062cf93ea82c3a) | `` automatic update `` |
| [`29173a03`](https://github.com/nix-community/NUR/commit/29173a03fdee2db1d9b12d03fb504bb9ca7d8e7f) | `` automatic update `` |
| [`2c8bf030`](https://github.com/nix-community/NUR/commit/2c8bf0303f001f8ca6cc8c6f1386b882b1a3d6e7) | `` automatic update `` |