### PR TITLE
chore(flake/nur): `5ac97105` -> `d900870b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -784,11 +784,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1745491865,
-        "narHash": "sha256-+ISUnPM8a3amn/etZ4Ky0rvVi0segpBSISVCTZf5YoE=",
+        "lastModified": 1745506616,
+        "narHash": "sha256-m8M88SUdaKeB2+l+tvyh7I4L7NLWsF/E5Td0y7UGIPo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5ac9710537962330b4787a6cb2fecadeda6195be",
+        "rev": "d900870bec8e29aae928c868ecea88f220ae87fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d900870b`](https://github.com/nix-community/NUR/commit/d900870bec8e29aae928c868ecea88f220ae87fa) | `` automatic update `` |
| [`fcab1bcd`](https://github.com/nix-community/NUR/commit/fcab1bcdabf66df507208ee47ace679cb9b4f3c3) | `` automatic update `` |
| [`a995750a`](https://github.com/nix-community/NUR/commit/a995750aee0e635c64ac4ce1a959db68f78366a8) | `` automatic update `` |
| [`f57d31c9`](https://github.com/nix-community/NUR/commit/f57d31c91328f28f3996ccc1d60bd4e547ee52dc) | `` automatic update `` |