### PR TITLE
chore(flake/nixos-hardware): `8bf8a2a0` -> `f7bee55a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -568,11 +568,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1745392233,
-        "narHash": "sha256-xmqG4MZArM1JNxPJ33s0MtuBzgnaCO9laARoU3AfP8E=",
+        "lastModified": 1745503349,
+        "narHash": "sha256-bUGjvaPVsOfQeTz9/rLTNLDyqbzhl0CQtJJlhFPhIYw=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "8bf8a2a0822365bd8f44fd1a19d7ed0a1d629d64",
+        "rev": "f7bee55a5e551bd8e7b5b82c9bc559bc50d868d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                         |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`3fd285f3`](https://github.com/NixOS/nixos-hardware/commit/3fd285f3860727e5af8d8859db914392cfdab5ef) | `` lenovo-thinkpad-x13s: Add support for aarch64 system ``                                      |
| [`306ff6c5`](https://github.com/NixOS/nixos-hardware/commit/306ff6c5f6b5554ef5e99af7cc336518d51538d3) | `` surface: revert longterm kernel to 6.12.19 ``                                                |
| [`34f02c32`](https://github.com/NixOS/nixos-hardware/commit/34f02c326d7458750b5ac30fae4b794cc0610ab4) | `` Apply suggestions from code review - option name ``                                          |
| [`0012cffb`](https://github.com/NixOS/nixos-hardware/commit/0012cffb692c640807d1f19b395502499cc9d80b) | `` microsoft/surface: update stable linux-surface to 6.14.2 ``                                  |
| [`33aa2d83`](https://github.com/NixOS/nixos-hardware/commit/33aa2d8399259a2b761ebc52815566b7654ff1c9) | `` microsoft/surface: decouple kernel source and linux-surface package versions ``              |
| [`2034c5d2`](https://github.com/NixOS/nixos-hardware/commit/2034c5d2e7831e8aab82e2fa21821b30767fbe8e) | `` microsoft/surface: rename 'lts' and 'latest' to 'longterm' and 'stable' ``                   |
| [`dab2104c`](https://github.com/NixOS/nixos-hardware/commit/dab2104c1fe488bf5d7ef537e60378a9d9b81a34) | `` microsoft/surface: switch back to using sha256 instead of hash due to connection breaking `` |
| [`bb295c09`](https://github.com/NixOS/nixos-hardware/commit/bb295c09d96dc62b24f101c98a1115552449db92) | `` microsoft/surface: remove repos.nix file and update README ``                                |
| [`9726adf3`](https://github.com/NixOS/nixos-hardware/commit/9726adf371a51e3f6884b190b259e8842c32e6ca) | `` microsoft/surface: add kernel source hash logic ``                                           |
| [`8141742b`](https://github.com/NixOS/nixos-hardware/commit/8141742b12ab3ff3d4769640dad1e1abeeda6171) | `` microsoft/surface: add kernel switching for LTS and latest kernels ``                        |