### PR TITLE
chore(flake/nur): `d900870b` -> `420f0593`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -784,11 +784,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1745506616,
-        "narHash": "sha256-m8M88SUdaKeB2+l+tvyh7I4L7NLWsF/E5Td0y7UGIPo=",
+        "lastModified": 1745526695,
+        "narHash": "sha256-THUxo1O5V7MqkMLQfgjsd3tz9h5lkXqsyGGIRZ/9dl4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d900870bec8e29aae928c868ecea88f220ae87fa",
+        "rev": "420f05931ac6622fa57a704193a9a72d31ed084f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`420f0593`](https://github.com/nix-community/NUR/commit/420f05931ac6622fa57a704193a9a72d31ed084f) | `` automatic update `` |
| [`d32cda01`](https://github.com/nix-community/NUR/commit/d32cda01cec79d042b9c171650ac80dab97094a3) | `` automatic update `` |
| [`137ac06b`](https://github.com/nix-community/NUR/commit/137ac06b943314d8b288d2bcbe199d5a86299c08) | `` automatic update `` |
| [`95b6d3b7`](https://github.com/nix-community/NUR/commit/95b6d3b72d496f14cd7583defa64a21ad908bbe7) | `` automatic update `` |
| [`0ff0221d`](https://github.com/nix-community/NUR/commit/0ff0221dd9f30569108618e19f45d84d575c5a0d) | `` automatic update `` |