### PR TITLE
chore(flake/catppuccin): `19919d66` -> `199cb288`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1745571143,
-        "narHash": "sha256-BndQEgBtQh6kPC+2PYdf9iWTSmrbaPjTFkVei2OtuKk=",
+        "lastModified": 1745598511,
+        "narHash": "sha256-GWYB7PngGwTJrp7gr0w6E5nnvwiblPvN2kjRCQw3ZEg=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "19919d666ead54e97f7886813db08f76ae0981dc",
+        "rev": "199cb288a85b15ed203089804c024ae5b3eacd7c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                          |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`199cb288`](https://github.com/catppuccin/nix/commit/199cb288a85b15ed203089804c024ae5b3eacd7c) | `` fix(home-manager/fcitx5): support new enable option (#544) `` |