### PR TITLE
chore(flake/emacs-overlay): `4bd92848` -> `24a3e2b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1745633670,
-        "narHash": "sha256-2HsOCrXODR+PZ94kGrMUFrXWHeLTYTNJMi32nHcdLFY=",
+        "lastModified": 1745745433,
+        "narHash": "sha256-fpb9C7rV2XxWnmr7QAgb9ioh21a7lstZVOYuDnR2Dxc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4bd928487268eeb51c5f522c8b8866afb8e376c8",
+        "rev": "24a3e2b6b0dda50c1afaa3da730f156d0400e95a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`24a3e2b6`](https://github.com/nix-community/emacs-overlay/commit/24a3e2b6b0dda50c1afaa3da730f156d0400e95a) | `` Updated emacs ``        |
| [`da7fe3b1`](https://github.com/nix-community/emacs-overlay/commit/da7fe3b169a6e35d1dbf5bd2e7af9c223023739f) | `` Updated melpa ``        |
| [`afe4de20`](https://github.com/nix-community/emacs-overlay/commit/afe4de20891541dd67274ad65e7cce7f2a16cbc6) | `` Updated elpa ``         |
| [`41562988`](https://github.com/nix-community/emacs-overlay/commit/41562988dc594df649380875b0f098342b00817c) | `` Updated nongnu ``       |
| [`5f11758c`](https://github.com/nix-community/emacs-overlay/commit/5f11758ce78b3267b9658dec65fbc1a39a94abd9) | `` Updated emacs ``        |
| [`ba23aed6`](https://github.com/nix-community/emacs-overlay/commit/ba23aed65e7027566fbc3fd11384aa79157480ee) | `` Updated melpa ``        |
| [`6ffae7f5`](https://github.com/nix-community/emacs-overlay/commit/6ffae7f578f152c5b3d63861565c53482fadb241) | `` Updated elpa ``         |
| [`c9da69ce`](https://github.com/nix-community/emacs-overlay/commit/c9da69cefa46d4dc8a9dce3f54fa012132e2dcd4) | `` Updated nongnu ``       |
| [`9b045c00`](https://github.com/nix-community/emacs-overlay/commit/9b045c0040bb1799f62c1d2a31b54764c70102e0) | `` Updated emacs ``        |
| [`01d8fde1`](https://github.com/nix-community/emacs-overlay/commit/01d8fde195d65f63ba7135dd7a6b638ac12539a3) | `` Updated melpa ``        |
| [`dbc579e0`](https://github.com/nix-community/emacs-overlay/commit/dbc579e088c6f297995073d964fb8eaf2eb78524) | `` Updated flake inputs `` |