### PR TITLE
chore(flake/nur): `4de2d82b` -> `ab9706bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -784,11 +784,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1745657383,
-        "narHash": "sha256-a32VRpw/lLZteDdWqanhbKktvZT6D1sZOjeqeLPgpQk=",
+        "lastModified": 1745682319,
+        "narHash": "sha256-IlE76lRii+1dkx9HgW3rPV74xhzwxOpkKwlKTQ8HK0g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4de2d82b0e51ab03f75ab7c6714a1469645b90d4",
+        "rev": "ab9706bb0ab297103c804f1367585aaa3455a92b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ab9706bb`](https://github.com/nix-community/NUR/commit/ab9706bb0ab297103c804f1367585aaa3455a92b) | `` automatic update `` |
| [`34c80a75`](https://github.com/nix-community/NUR/commit/34c80a75bf09085cfd04a476389a4162c6154d42) | `` automatic update `` |
| [`ad0cac0e`](https://github.com/nix-community/NUR/commit/ad0cac0edf2a3b45f8757381b79d34cdd6f83f0c) | `` automatic update `` |