### PR TITLE
chore(flake/nur): `ab9706bb` -> `effaeb3c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -784,11 +784,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1745682319,
-        "narHash": "sha256-IlE76lRii+1dkx9HgW3rPV74xhzwxOpkKwlKTQ8HK0g=",
+        "lastModified": 1745696698,
+        "narHash": "sha256-GTp4lsii7PA294/SXvRXtEl+cjHyJCDsiXRlIUABC54=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ab9706bb0ab297103c804f1367585aaa3455a92b",
+        "rev": "effaeb3c6ca87b43f66e1ff63fc76af52f7ba8c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`effaeb3c`](https://github.com/nix-community/NUR/commit/effaeb3c6ca87b43f66e1ff63fc76af52f7ba8c2) | `` automatic update `` |
| [`393b2e51`](https://github.com/nix-community/NUR/commit/393b2e51dd315b4bd6f03ed8faa36b6d14c86bc0) | `` automatic update `` |
| [`ca8eb793`](https://github.com/nix-community/NUR/commit/ca8eb793012412f763b64330bd21ebbb7df1b265) | `` automatic update `` |