### PR TITLE
chore(flake/home-manager): `2f5819a9` -> `7b2aae3f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745703610,
-        "narHash": "sha256-KgaGPlmjJItZ+Xf8mSoRmrsso+sf3K54n9oIP9Q17LY=",
+        "lastModified": 1745782215,
+        "narHash": "sha256-mx27J2HYQT+nGXTyUWKrUuxRzpr1FVVr59ZH4oNzOyw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2f5819a962489e037a57835f63ed6ff8dbc2d5fb",
+        "rev": "7b2aae3fb39928aecc5e41c10a9c87c4881614d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`7b2aae3f`](https://github.com/nix-community/home-manager/commit/7b2aae3fb39928aecc5e41c10a9c87c4881614d5) | `` eza: add tests ``                                      |
| [`edaeeda2`](https://github.com/nix-community/home-manager/commit/edaeeda26429aa3d25b9119f358075813bd9d4ba) | `` eza: default disable nushell integration again ``      |
| [`2a264c17`](https://github.com/nix-community/home-manager/commit/2a264c17d5fb3673eeec891ea4a82027a41addc3) | `` zsh: add type to zprof.enable option (#6916) ``        |
| [`adb3fbc5`](https://github.com/nix-community/home-manager/commit/adb3fbc58455de60ad4131c6e59d596ea2bb105f) | `` neomutt: use correct neomutt in config file (#6915) `` |
| [`0fbd8207`](https://github.com/nix-community/home-manager/commit/0fbd8207e913b2d1660a7662f9ae80e5e639de65) | `` news: forward args to file news entries ``             |
| [`9c3b33c2`](https://github.com/nix-community/home-manager/commit/9c3b33c2a7531cd4cbdcc5690cc0f69e93e60aa3) | `` espanso: add wayland test ``                           |
| [`6ed700bf`](https://github.com/nix-community/home-manager/commit/6ed700bfe4fe6b66a9121365056f63041b85ab3d) | `` espanso: fix test ``                                   |
| [`29fce40e`](https://github.com/nix-community/home-manager/commit/29fce40e1391477b66ef3a24ea7867f0bc5b52a1) | `` espanso: add crossplatform support ``                  |
| [`1d2f0b3d`](https://github.com/nix-community/home-manager/commit/1d2f0b3d4be0fed93c31d21603f988c68d5a4d16) | `` espanso: add phanirithvij as maintainer ``             |
| [`50bb714a`](https://github.com/nix-community/home-manager/commit/50bb714a8259b0c29b6c3429099a3b837771dab4) | `` rmpc: add module (#6910) ``                            |
| [`ef47f364`](https://github.com/nix-community/home-manager/commit/ef47f36450b36d437f5c2f6953022648d76c0638) | `` flake.lock: Update (#6912) ``                          |