### PR TITLE
chore(flake/treefmt-nix): `8d404a69` -> `b2b6c027`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -993,11 +993,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744961264,
-        "narHash": "sha256-aRmUh0AMwcbdjJHnytg1e5h5ECcaWtIFQa6d9gI85AI=",
+        "lastModified": 1745780832,
+        "narHash": "sha256-jGzkZoJWx+nJnPe0Z2xQBUOqMKuR1slVFQrMjFTKgeM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "8d404a69efe76146368885110f29a2ca3700bee6",
+        "rev": "b2b6c027d708fbf4b01c9c11f6e80f2800b5a624",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`5298eac2`](https://github.com/numtide/treefmt-nix/commit/5298eac276cd1ed18d3d5971938dfc2ab522faa6) | `` fix example of global.excludes `` |