### PR TITLE
chore(flake/emacs-overlay): `24a3e2b6` -> `2b5aba73`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1745745433,
-        "narHash": "sha256-fpb9C7rV2XxWnmr7QAgb9ioh21a7lstZVOYuDnR2Dxc=",
+        "lastModified": 1745894955,
+        "narHash": "sha256-bfw9NmNU16tLMLAkFiaWq2BowA5XtGVgle9WKmSYrsk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "24a3e2b6b0dda50c1afaa3da730f156d0400e95a",
+        "rev": "2b5aba7380821a8be1bb3291083af4431cbf3dd5",
         "type": "github"
       },
       "original": {
@@ -646,11 +646,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1745487689,
-        "narHash": "sha256-FQoi3R0NjQeBAsEOo49b5tbDPcJSMWc3QhhaIi9eddw=",
+        "lastModified": 1745742390,
+        "narHash": "sha256-1rqa/XPSJqJg21BKWjzJZC7yU0l/YTVtjRi0RJmipus=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5630cf13cceac06cefe9fc607e8dfa8fb342dde3",
+        "rev": "26245db0cb552047418cfcef9a25da91b222d6c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`2b5aba73`](https://github.com/nix-community/emacs-overlay/commit/2b5aba7380821a8be1bb3291083af4431cbf3dd5) | `` Updated emacs ``        |
| [`43f387b9`](https://github.com/nix-community/emacs-overlay/commit/43f387b97b21770d8dbf7e575cc93792d9e5dde9) | `` Updated melpa ``        |
| [`fec2a9e0`](https://github.com/nix-community/emacs-overlay/commit/fec2a9e0f550f5687d2e48f77f30ee32f211f85b) | `` Updated elpa ``         |
| [`74c6e173`](https://github.com/nix-community/emacs-overlay/commit/74c6e1737e1a8bce8aacbea490bef6cdca6b270d) | `` Updated nongnu ``       |
| [`c8327eab`](https://github.com/nix-community/emacs-overlay/commit/c8327eab84622ee300ca60f7cedb013e8540770a) | `` Updated elpa ``         |
| [`15e5b1c9`](https://github.com/nix-community/emacs-overlay/commit/15e5b1c90f999c69ab1709a4bb653f852256f32b) | `` Updated nongnu ``       |
| [`2a6d6d06`](https://github.com/nix-community/emacs-overlay/commit/2a6d6d064e33d65dc660b65c28ce17195e539db6) | `` Updated flake inputs `` |