### PR TITLE
chore(flake/nur): `76ed327e` -> `e562b025`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -725,11 +725,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1745526057,
-        "narHash": "sha256-ITSpPDwvLBZBnPRS2bUcHY3gZSwis/uTe255QgMtTLA=",
+        "lastModified": 1745794561,
+        "narHash": "sha256-T36rUZHUART00h3dW4sV5tv4MrXKT7aWjNfHiZz7OHg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f771eb401a46846c1aebd20552521b233dd7e18b",
+        "rev": "5461b7fa65f3ca74cef60be837fd559a8918eaa0",
         "type": "github"
       },
       "original": {
@@ -784,11 +784,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1745870390,
-        "narHash": "sha256-ON2xNtqlyAl5OziE2plD6t/nBSSLeH51Pj7UJQotx6Q=",
+        "lastModified": 1745898793,
+        "narHash": "sha256-yH/vxZrcPMwjCrqsiHXWfGWpWeNjtYTq+AgNJXYOD58=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "76ed327e9d4b7a1fbdb4716fa69edeebad1a849b",
+        "rev": "e562b02568bd42ae68c558276552c4c741a21f4f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e562b025`](https://github.com/nix-community/NUR/commit/e562b02568bd42ae68c558276552c4c741a21f4f) | `` automatic update `` |
| [`fa1140fc`](https://github.com/nix-community/NUR/commit/fa1140fc2542b794464b41740382255f6805627c) | `` automatic update `` |
| [`8ece22bf`](https://github.com/nix-community/NUR/commit/8ece22bf8573a6b7e76840fcfd9a9b5dcb6f918f) | `` automatic update `` |
| [`d0e99b46`](https://github.com/nix-community/NUR/commit/d0e99b46d5253e5a179422a8a76cd221c0fe280b) | `` automatic update `` |
| [`67c5b283`](https://github.com/nix-community/NUR/commit/67c5b283a7c891248bdc48fcc02e15422744a7e9) | `` automatic update `` |
| [`e0771be0`](https://github.com/nix-community/NUR/commit/e0771be0fe8ee2d1ced8c878c1a73d43032ef271) | `` automatic update `` |
| [`0dfb3f8c`](https://github.com/nix-community/NUR/commit/0dfb3f8c58d63e6f4f1b59f43d8087a8b15a88c9) | `` automatic update `` |
| [`8a0f777d`](https://github.com/nix-community/NUR/commit/8a0f777df32fc20834ddf7091bf0833e5581cb39) | `` automatic update `` |
| [`a9f7c32c`](https://github.com/nix-community/NUR/commit/a9f7c32cd43522079f9dc8b59b79c651c067607c) | `` automatic update `` |
| [`9b5a277b`](https://github.com/nix-community/NUR/commit/9b5a277b8881ab8fd8d4e840aceb96fb8726149a) | `` automatic update `` |