### PR TITLE
chore(flake/nixpkgs): `f771eb40` -> `5461b7fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -709,11 +709,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1745526057,
-        "narHash": "sha256-ITSpPDwvLBZBnPRS2bUcHY3gZSwis/uTe255QgMtTLA=",
+        "lastModified": 1745794561,
+        "narHash": "sha256-T36rUZHUART00h3dW4sV5tv4MrXKT7aWjNfHiZz7OHg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f771eb401a46846c1aebd20552521b233dd7e18b",
+        "rev": "5461b7fa65f3ca74cef60be837fd559a8918eaa0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`2c49798b`](https://github.com/NixOS/nixpkgs/commit/2c49798b87cf17b14dce7da9bfa0d14f939ffaa2) | `` python312Packages.uiprotect: 7.5.4 -> 7.5.5 (#402328) ``                                 |
| [`750cbc21`](https://github.com/NixOS/nixpkgs/commit/750cbc21e2640e1dcea11cae9485384f91fb5352) | `` gitlab-runner: Use substituteInPlace for patching and stop referencing src attributes `` |
| [`b0c0ca03`](https://github.com/NixOS/nixpkgs/commit/b0c0ca03a7f270b61d955ccfbc5ad58a11e3612d) | `` xastir: fix cross, enable strictDeps, update meta, modernize ``                          |
| [`f4abaabe`](https://github.com/NixOS/nixpkgs/commit/f4abaabe3b753b62078319e4b80705fc78bbe980) | `` python-matter-server: update bundled certificates ``                                     |
| [`aacdcbd2`](https://github.com/NixOS/nixpkgs/commit/aacdcbd2b446eb16c31147ca5b4db09aa9d1a928) | `` luaPackages: update on 2025-04-27 ``                                                     |
| [`d5caa0b7`](https://github.com/NixOS/nixpkgs/commit/d5caa0b7307fd96dcfc9ba12d4fcd20e21e63a63) | `` trickster: move to pkgs/by-name ``                                                       |
| [`80478c1f`](https://github.com/NixOS/nixpkgs/commit/80478c1f9056dd4f7735d94de8802508cce493ec) | `` starship: 1.22.1 -> 1.23.0 ``                                                            |
| [`f288d082`](https://github.com/NixOS/nixpkgs/commit/f288d08234e15382ecc7775e782df8e6a1608c44) | `` Revert "file: patch to fix misclassification of some zip files" ``                       |
| [`96945e6d`](https://github.com/NixOS/nixpkgs/commit/96945e6d111f5c6c763479e06f88c936790e5124) | `` python3Packages.gotify: init at 0.6.0 ``                                                 |
| [`02b5fe25`](https://github.com/NixOS/nixpkgs/commit/02b5fe25a4065bb65375cb7186a6355447d12934) | `` Revert "file: patch to fix misclassification of some zip files" ``                       |
| [`bfe3401e`](https://github.com/NixOS/nixpkgs/commit/bfe3401e1a91e741d846b0ebf410161950d3e2dc) | `` vimPlugins.bitbake-vim: remove updateScript ``                                           |
| [`488d37d9`](https://github.com/NixOS/nixpkgs/commit/488d37d95bb5de4ad38cbd647e792574b7147800) | `` mpvScripts.eisa01.simplebookmark: init at 0-unstable-2023-09-22 (#402041) ``             |
| [`ea517c04`](https://github.com/NixOS/nixpkgs/commit/ea517c04f2fd39382057616b0cadfe979b70626f) | `` mpvScripts.eisa01.undoredo: init at 0-unstable-2023-11-25 (#401930) ``                   |
| [`a02812fa`](https://github.com/NixOS/nixpkgs/commit/a02812faafd0a5219ab6d70c12083e5c79ed06a7) | `` stalwart-mail: skip unreliable test ``                                                   |
| [`d7c29a31`](https://github.com/NixOS/nixpkgs/commit/d7c29a31447582c462374035f41ed693aeb5496b) | `` stalwart-mail: cleaup unneeded darwin frameworks ``                                      |
| [`7324d72a`](https://github.com/NixOS/nixpkgs/commit/7324d72a73aefd8588096bdaf1871430a0a01e5d) | `` cutentr: init at 0.3.3 ``                                                                |
| [`6b626f52`](https://github.com/NixOS/nixpkgs/commit/6b626f5255e3076f26db28ea967d85e3279c27cc) | `` vimPlugins: update on 2025-04-26 ``                                                      |
| [`6d750628`](https://github.com/NixOS/nixpkgs/commit/6d75062802a631c0784e9de584b754de8e3dd656) | `` terraform-providers.okta: 4.16.0 -> 4.17.0 ``                                            |
| [`a97be149`](https://github.com/NixOS/nixpkgs/commit/a97be14916c3ecdabbf17415349cc51415141623) | `` mise: 2025.4.1 -> 2025.4.11 ``                                                           |
| [`0c3a155e`](https://github.com/NixOS/nixpkgs/commit/0c3a155e87c26938fee0b39879acdc9cb5f55dce) | `` ps3-disc-dumper: 4.3.1 -> 4.3.2 ``                                                       |
| [`201a8e9d`](https://github.com/NixOS/nixpkgs/commit/201a8e9d386fff30e9b30c2a1c7c64814bec4269) | `` vimPlugins.bitbake-vim: disable auto-updates ``                                          |
| [`84b4273c`](https://github.com/NixOS/nixpkgs/commit/84b4273cc88f8aaf65fd809bd249204100a69304) | `` python3Packages.dtfabric: init at 20230520 ``                                            |
| [`190567fb`](https://github.com/NixOS/nixpkgs/commit/190567fb3b9da7bda5bd0145b4061e59d9dbba9a) | `` python3Packages.cloudflare: fix build ``                                                 |