### PR TITLE
chore(flake/nixos-hardware): `f7bee55a` -> `f1e52a01`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -568,11 +568,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1745503349,
-        "narHash": "sha256-bUGjvaPVsOfQeTz9/rLTNLDyqbzhl0CQtJJlhFPhIYw=",
+        "lastModified": 1745907084,
+        "narHash": "sha256-Q8SpDbTI95vtKXgNcVl1VdSUhhDOORE8R77wWS2rmg8=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "f7bee55a5e551bd8e7b5b82c9bc559bc50d868d1",
+        "rev": "f1e52a018166e1a324f832de913e12c0e55792d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                               |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`f1e52a01`](https://github.com/NixOS/nixos-hardware/commit/f1e52a018166e1a324f832de913e12c0e55792d0) | `` gu605my: enable zeph g16 backlight control ``                      |
| [`342b1b31`](https://github.com/NixOS/nixos-hardware/commit/342b1b319d04d4afe775752523feb643e23f4397) | `` gu605my: modsettings, fn keys and use laptop/ssd ``                |
| [`f16e0cd5`](https://github.com/NixOS/nixos-hardware/commit/f16e0cd51c8bb6df7bfc5b7bbec3b36ed59020ae) | `` Add yt6801 driver for TUXEDO InfinityBook Pro 14 - Gen9 - INTEL `` |
| [`d07bb614`](https://github.com/NixOS/nixos-hardware/commit/d07bb614490b4e55765b5c963ac88375fb53d0da) | `` lenovo-thinkpad-x1-2nd-gen ``                                      |