### PR TITLE
chore(flake/nur): `e562b025` -> `670e6a28`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -784,11 +784,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1745898793,
-        "narHash": "sha256-yH/vxZrcPMwjCrqsiHXWfGWpWeNjtYTq+AgNJXYOD58=",
+        "lastModified": 1745913556,
+        "narHash": "sha256-hKf2z9fw7vwRBa4CCijolsZt+fqSCixSGai2MS0l+Wg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e562b02568bd42ae68c558276552c4c741a21f4f",
+        "rev": "670e6a286982af78be5fc0b5109356db2d361119",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`670e6a28`](https://github.com/nix-community/NUR/commit/670e6a286982af78be5fc0b5109356db2d361119) | `` automatic update `` |
| [`959f1f51`](https://github.com/nix-community/NUR/commit/959f1f512589b284132bda8b5b5b9e280376a328) | `` automatic update `` |
| [`fc9528d7`](https://github.com/nix-community/NUR/commit/fc9528d7e8d08b9f9ee183e1138172d1d146b8f3) | `` automatic update `` |