### PR TITLE
chore(flake/emacs-overlay): `2b5aba73` -> `d6a9fa08`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1745894955,
-        "narHash": "sha256-bfw9NmNU16tLMLAkFiaWq2BowA5XtGVgle9WKmSYrsk=",
+        "lastModified": 1745947312,
+        "narHash": "sha256-a8LQtoKeHOh920ocOD3RtBe8sHw/TFdxxLWAbCoEOAU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2b5aba7380821a8be1bb3291083af4431cbf3dd5",
+        "rev": "d6a9fa089a3442f1fb2d98b4e4dd6f847b7b5964",
         "type": "github"
       },
       "original": {
@@ -646,11 +646,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1745742390,
-        "narHash": "sha256-1rqa/XPSJqJg21BKWjzJZC7yU0l/YTVtjRi0RJmipus=",
+        "lastModified": 1745868005,
+        "narHash": "sha256-hZScOyQphT4RUmSEJX+2OxjIlGgLwSd8iW1LNtAWIOs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "26245db0cb552047418cfcef9a25da91b222d6c7",
+        "rev": "330d0a4167924b43f31cc9406df363f71b768a02",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`d6a9fa08`](https://github.com/nix-community/emacs-overlay/commit/d6a9fa089a3442f1fb2d98b4e4dd6f847b7b5964) | `` Updated emacs ``        |
| [`54497d5d`](https://github.com/nix-community/emacs-overlay/commit/54497d5d2379fa5c034e0245462f89308d054506) | `` Updated melpa ``        |
| [`22aa1dc5`](https://github.com/nix-community/emacs-overlay/commit/22aa1dc560e6d394a9fa89445b6c45a212a2c861) | `` Updated elpa ``         |
| [`2da7c494`](https://github.com/nix-community/emacs-overlay/commit/2da7c494c2ab4aae052dcf565c2281640945cfd0) | `` Updated flake inputs `` |
| [`841c18a6`](https://github.com/nix-community/emacs-overlay/commit/841c18a6fe787b669ea362e3e14f54a5bd12a63c) | `` Updated emacs ``        |
| [`839bdeb0`](https://github.com/nix-community/emacs-overlay/commit/839bdeb05c9f17fe977adcf2b14aeb3a89375527) | `` Updated melpa ``        |
| [`05af93bd`](https://github.com/nix-community/emacs-overlay/commit/05af93bd5e29158d58fe39d6f9d0763b1d3de668) | `` Updated flake inputs `` |