### PR TITLE
chore(flake/treefmt-nix): `763f1ce0` -> `82bf32e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -993,11 +993,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745848521,
-        "narHash": "sha256-gNrTO3pEjmu3WiuYrUHJrTGCFw9v+qZXCFmX/Vjf5WI=",
+        "lastModified": 1745929750,
+        "narHash": "sha256-k5ELLpTwRP/OElcLpNaFWLNf8GRDq4/eHBmFy06gGko=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "763f1ce0dd12fe44ce6a5c6ea3f159d438571874",
+        "rev": "82bf32e541b30080d94e46af13d46da0708609ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                         |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`82bf32e5`](https://github.com/numtide/treefmt-nix/commit/82bf32e541b30080d94e46af13d46da0708609ea) | `` taplo: add option to pass settings (#348) `` |