### PR TITLE
chore(flake/nixos-hardware): `f1e52a01` -> `72081c9f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -568,11 +568,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1745907084,
-        "narHash": "sha256-Q8SpDbTI95vtKXgNcVl1VdSUhhDOORE8R77wWS2rmg8=",
+        "lastModified": 1745955289,
+        "narHash": "sha256-mmV2oPhQN+YF2wmnJzXX8tqgYmUYXUj3uUUBSTmYN5o=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "f1e52a018166e1a324f832de913e12c0e55792d0",
+        "rev": "72081c9fbbef63765ae82bff9727ea79cc86bd5b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                             |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`72081c9f`](https://github.com/NixOS/nixos-hardware/commit/72081c9fbbef63765ae82bff9727ea79cc86bd5b) | `` dell-precision-3490: init module ``                                              |
| [`c06d50ad`](https://github.com/NixOS/nixos-hardware/commit/c06d50adebc684d5659fe8426ac29fb85f3bde3c) | `` Add Framework AMD AI 300 Series ``                                               |
| [`232c204a`](https://github.com/NixOS/nixos-hardware/commit/232c204afb36fa16a928e8c0a289f8cf8313be72) | `` omen/*: check kernel version through `config` instead of `pkgs` ``               |
| [`01f1548e`](https://github.com/NixOS/nixos-hardware/commit/01f1548e40f6f629d370bc43b4623b52b30fef85) | `` lenovo/thinkpad/x13s: source kernel through `config` instead of `pkgs` ``        |
| [`6e802240`](https://github.com/NixOS/nixos-hardware/commit/6e80224000e1ee4a883cb0f26e3ac7510aaefe90) | `` lenovo/thinkpad/p14s: check kernel version through `config` instead of `pkgs` `` |
| [`6267b43a`](https://github.com/NixOS/nixos-hardware/commit/6267b43af934ed22b2402b065ceeec3f9a276312) | `` hp/elitebook/830/g6: check kernel version through `config` instead of `pkgs` ``  |
| [`c56ef7b7`](https://github.com/NixOS/nixos-hardware/commit/c56ef7b7228987345916b74ac9ddb3886c8a0c23) | `` dell-precision-5530: remove unnecessary default nvidia options ``                |