### PR TITLE
chore(flake/nur): `ffddf97d` -> `0f15df49`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -725,11 +725,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1745794561,
-        "narHash": "sha256-T36rUZHUART00h3dW4sV5tv4MrXKT7aWjNfHiZz7OHg=",
+        "lastModified": 1745930157,
+        "narHash": "sha256-y3h3NLnzRSiUkYpnfvnS669zWZLoqqI6NprtLQ+5dck=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5461b7fa65f3ca74cef60be837fd559a8918eaa0",
+        "rev": "46e634be05ce9dc6d4db8e664515ba10b78151ae",
         "type": "github"
       },
       "original": {
@@ -784,11 +784,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1745959778,
-        "narHash": "sha256-W53vfOfesbBxQWuZWk7CP1l6ohLLz5q9GuR/Y50iDd0=",
+        "lastModified": 1745985483,
+        "narHash": "sha256-XyNOPt8aXO9PIsCYlWE+3ESQh6az5/x5R28Bg8tOFf8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ffddf97d58d20aa331f2c326816b8640a1848b4b",
+        "rev": "0f15df49e568d98995e0e8f9cf048ce36722409f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0f15df49`](https://github.com/nix-community/NUR/commit/0f15df49e568d98995e0e8f9cf048ce36722409f) | `` automatic update `` |
| [`c3845e44`](https://github.com/nix-community/NUR/commit/c3845e442804cd1ec3748c3bfd061066a616e4c8) | `` automatic update `` |
| [`d62bdb93`](https://github.com/nix-community/NUR/commit/d62bdb93d9517cd45d77c0667d87d66762f95f9c) | `` automatic update `` |
| [`71782c80`](https://github.com/nix-community/NUR/commit/71782c8020f805e5ef9f2ab0fd2faba3ff0fd627) | `` automatic update `` |
| [`c1677060`](https://github.com/nix-community/NUR/commit/c167706027d563769280106eead0d07427bb1740) | `` automatic update `` |
| [`0ea28907`](https://github.com/nix-community/NUR/commit/0ea289078bd8ae91fff2ae679c2ef2b96cac8edc) | `` automatic update `` |
| [`9bd4d7d1`](https://github.com/nix-community/NUR/commit/9bd4d7d1d6a8b5f0f3457633781c7641b793d5ad) | `` automatic update `` |
| [`ad704e23`](https://github.com/nix-community/NUR/commit/ad704e23f037c8d4c855c462879d2cd4d6d887fd) | `` automatic update `` |
| [`311286ba`](https://github.com/nix-community/NUR/commit/311286bad15f58b1b994b846984c691ad48633a3) | `` automatic update `` |