### PR TITLE
chore(flake/emacs-overlay): `d6a9fa08` -> `8f3e60a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1745947312,
-        "narHash": "sha256-a8LQtoKeHOh920ocOD3RtBe8sHw/TFdxxLWAbCoEOAU=",
+        "lastModified": 1745979602,
+        "narHash": "sha256-MAIfdinwF8Zs5U0b89GwsV8YItXEGGhQ3h//sW19wf0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d6a9fa089a3442f1fb2d98b4e4dd6f847b7b5964",
+        "rev": "8f3e60a5d3c89eba0df8ae395556132bac13533d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`8f3e60a5`](https://github.com/nix-community/emacs-overlay/commit/8f3e60a5d3c89eba0df8ae395556132bac13533d) | `` Updated emacs ``        |
| [`39c9dad7`](https://github.com/nix-community/emacs-overlay/commit/39c9dad7207be7ebc450eb4bc03af19ce325327e) | `` Updated melpa ``        |
| [`ed0cacc0`](https://github.com/nix-community/emacs-overlay/commit/ed0cacc0f692ae3fd7dd6f34d9f2c0086c0ad6f6) | `` Updated elpa ``         |
| [`6dd719a1`](https://github.com/nix-community/emacs-overlay/commit/6dd719a1921c83216d9eec2649dadf3d4d188581) | `` Updated nongnu ``       |
| [`189fb62b`](https://github.com/nix-community/emacs-overlay/commit/189fb62b68ceed28bc0a0377fbf1d5c0cb01ed9e) | `` Updated flake inputs `` |