### PR TITLE
chore(flake/nur): `0f15df49` -> `e6e4e003`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -784,11 +784,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1745985483,
-        "narHash": "sha256-XyNOPt8aXO9PIsCYlWE+3ESQh6az5/x5R28Bg8tOFf8=",
+        "lastModified": 1746028181,
+        "narHash": "sha256-LXaYyt4uoGXXq6KpYswQuam3Af61yPdq4r0UR+Mc8+g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0f15df49e568d98995e0e8f9cf048ce36722409f",
+        "rev": "e6e4e003d41ff9a8850a5d8834ee8a22c93de879",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e6e4e003`](https://github.com/nix-community/NUR/commit/e6e4e003d41ff9a8850a5d8834ee8a22c93de879) | `` automatic update `` |
| [`20b1f8b2`](https://github.com/nix-community/NUR/commit/20b1f8b216d0ffbabb99e8f1c9625844bdaf3e86) | `` automatic update `` |
| [`5d0d7d36`](https://github.com/nix-community/NUR/commit/5d0d7d366b20806fbac1515dc8be48036b4457c9) | `` automatic update `` |
| [`8d10600f`](https://github.com/nix-community/NUR/commit/8d10600f4a970ed619e5c6c29720257072da9319) | `` automatic update `` |
| [`8ad4c33c`](https://github.com/nix-community/NUR/commit/8ad4c33cf8f2a572a067126851ad13b3a870779d) | `` automatic update `` |
| [`9d9a4217`](https://github.com/nix-community/NUR/commit/9d9a4217852c994dfce48e88841a1419b387da26) | `` automatic update `` |
| [`4b943be2`](https://github.com/nix-community/NUR/commit/4b943be2ca40d999b76fb9c7cd5c5e7b77fe683e) | `` automatic update `` |