### PR TITLE
chore(flake/nur): `e6e4e003` -> `dac13670`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -784,11 +784,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1746028181,
-        "narHash": "sha256-LXaYyt4uoGXXq6KpYswQuam3Af61yPdq4r0UR+Mc8+g=",
+        "lastModified": 1746042279,
+        "narHash": "sha256-tH6Z0kUHLIlHLysr7FZrNhyyAPRGKN01Asd6wJ6Vbd4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e6e4e003d41ff9a8850a5d8834ee8a22c93de879",
+        "rev": "dac13670d1a6ec1ed7753e9c3f8e717439e39f1c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dac13670`](https://github.com/nix-community/NUR/commit/dac13670d1a6ec1ed7753e9c3f8e717439e39f1c) | `` automatic update `` |
| [`4e46cc1f`](https://github.com/nix-community/NUR/commit/4e46cc1f37159dea648edb216a290d57749858fd) | `` automatic update `` |
| [`898dff90`](https://github.com/nix-community/NUR/commit/898dff909da75c0a73317defbc9f18952414858d) | `` automatic update `` |
| [`a2447388`](https://github.com/nix-community/NUR/commit/a2447388d1f8b41070bfabca9589c7ce0755686f) | `` automatic update `` |