### PR TITLE
chore(flake/nur): `dac13670` -> `cfba0651`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -784,11 +784,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1746042279,
-        "narHash": "sha256-tH6Z0kUHLIlHLysr7FZrNhyyAPRGKN01Asd6wJ6Vbd4=",
+        "lastModified": 1746099911,
+        "narHash": "sha256-/wPeC8zzeNq9Zd4GkdrayKvlODBKPmnsCMUkXm/mmdI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dac13670d1a6ec1ed7753e9c3f8e717439e39f1c",
+        "rev": "cfba06511e599293b29b19b4ac341a9ca2bdfc33",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cfba0651`](https://github.com/nix-community/NUR/commit/cfba06511e599293b29b19b4ac341a9ca2bdfc33) | `` automatic update `` |
| [`144e99f6`](https://github.com/nix-community/NUR/commit/144e99f6e9176bcf0f32a37607b7ae1eeeb5ead1) | `` automatic update `` |
| [`5ef4843d`](https://github.com/nix-community/NUR/commit/5ef4843da25edff082e0be1404ee4468112f49ff) | `` automatic update `` |
| [`bfce2318`](https://github.com/nix-community/NUR/commit/bfce2318230a2d5640c526d39294ff1af0444a5c) | `` automatic update `` |
| [`88952868`](https://github.com/nix-community/NUR/commit/88952868f3b10fc704e5ce4936fba9d2104ca1d4) | `` automatic update `` |
| [`3f03285c`](https://github.com/nix-community/NUR/commit/3f03285c93aacb3f8cfb9ddd4681592cca45779c) | `` automatic update `` |
| [`d476cd09`](https://github.com/nix-community/NUR/commit/d476cd0972dd6242d76374fcc277e6735715c167) | `` automatic update `` |
| [`e3f0bd2f`](https://github.com/nix-community/NUR/commit/e3f0bd2f75f20d74b48a3dccead5f032e0e9e9df) | `` automatic update `` |
| [`689fd96b`](https://github.com/nix-community/NUR/commit/689fd96be2b48b9ba2fb6dfef61046f54bc56694) | `` automatic update `` |
| [`d39e972b`](https://github.com/nix-community/NUR/commit/d39e972bb57ed9a782dc6309a8bc759c520b008d) | `` automatic update `` |