### PR TITLE
chore(flake/emacs-overlay): `438dfc04` -> `d496a053`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1746033402,
-        "narHash": "sha256-Pq8Xg9omaw75wDSVdJBjGPoTPdJ1GANJzuCrbEHXWLE=",
+        "lastModified": 1746116666,
+        "narHash": "sha256-OVk7gw5B9BTpIK+zV1gMObiO6ERnM2iBv1qCd+mB8dk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "438dfc0467bb6e194f3a5e5a78ed4bac716940cf",
+        "rev": "d496a053874af07a757eec3e26b4f3cb918aae9f",
         "type": "github"
       },
       "original": {
@@ -646,11 +646,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1745921652,
-        "narHash": "sha256-hEAvEN+y/OQ7wA7+u3bFJwXSe8yoSf2QaOMH3hyTJTQ=",
+        "lastModified": 1746055187,
+        "narHash": "sha256-3dqArYSMP9hM7Qpy5YWhnSjiqniSaT2uc5h2Po7tmg0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b000159bba69b0106a42f65e52dbf27f77aca9d3",
+        "rev": "3e362ce63e16b9572d8c2297c04f7c19ab6725a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`d496a053`](https://github.com/nix-community/emacs-overlay/commit/d496a053874af07a757eec3e26b4f3cb918aae9f) | `` Updated elpa ``         |
| [`a73601c0`](https://github.com/nix-community/emacs-overlay/commit/a73601c07aaa58ae69e73a8630f6060aeb2fdb97) | `` Updated nongnu ``       |
| [`355f8006`](https://github.com/nix-community/emacs-overlay/commit/355f80064e79ed723f1a58e6965e7da4e840c4c1) | `` Updated flake inputs `` |
| [`9a415a8b`](https://github.com/nix-community/emacs-overlay/commit/9a415a8b4c90c1f0719aefed19a80514f7a2f771) | `` Updated emacs ``        |
| [`9595ef04`](https://github.com/nix-community/emacs-overlay/commit/9595ef0438bacfeaa1e5eccc2e386b4a9bf524bf) | `` Updated melpa ``        |
| [`3bfb52dc`](https://github.com/nix-community/emacs-overlay/commit/3bfb52dca0a8dd390fbeacaed48fed4ba408a281) | `` Updated elpa ``         |
| [`229eed26`](https://github.com/nix-community/emacs-overlay/commit/229eed2696a78e456132bc1348d9feb8c7be7f43) | `` Updated nongnu ``       |