### PR TITLE
chore(flake/srvos): `be128093` -> `fca14429`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -933,11 +933,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745309546,
-        "narHash": "sha256-cmo852T3LxxkH4RSU6T006R3NJN5dKQaqbxQ8Zm0vAI=",
+        "lastModified": 1746105715,
+        "narHash": "sha256-CApScHWtVdJT7xOpTDfT8lqBdQpj0+mLCXNCFJY4+GI=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "be128093568b7f0d6d9d33941564e78d19bf7c06",
+        "rev": "fca1442996e4ed49b379465f6d211a01147bfecb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                  |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`fc4c4a47`](https://github.com/nix-community/srvos/commit/fc4c4a47f64df99f5a9390e210ce56644c880555) | `` nix-experimental: enable cgroups and blake3 hashes `` |
| [`6c720fca`](https://github.com/nix-community/srvos/commit/6c720fca5be30b74a34b1b6897922ba01034b7a0) | `` update docs ``                                        |
| [`023e3599`](https://github.com/nix-community/srvos/commit/023e3599d6c7a601047211680c3f1f3e17b426cb) | `` dev/private/flake.lock: Update ``                     |
| [`b5512a0d`](https://github.com/nix-community/srvos/commit/b5512a0d96d9b375dc520111f0f22f8fa20e3a7b) | `` flake.lock: Update ``                                 |