### PR TITLE
chore(flake/nur): `cfba0651` -> `10e5d941`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1746099911,
-        "narHash": "sha256-/wPeC8zzeNq9Zd4GkdrayKvlODBKPmnsCMUkXm/mmdI=",
+        "lastModified": 1746128691,
+        "narHash": "sha256-NGSXhxkR2fnPcZnqqQmLNhaTURPrF8azoHc5woDqe14=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cfba06511e599293b29b19b4ac341a9ca2bdfc33",
+        "rev": "10e5d9414baa0db76e279906ee22dfcc0358ca05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`10e5d941`](https://github.com/nix-community/NUR/commit/10e5d9414baa0db76e279906ee22dfcc0358ca05) | `` automatic update `` |
| [`86699df9`](https://github.com/nix-community/NUR/commit/86699df93b89d4a35bd9e06de41afd0bad6aa2bb) | `` automatic update `` |
| [`9a4aaf92`](https://github.com/nix-community/NUR/commit/9a4aaf927694321aeedfec791dfcc7850f8503cd) | `` automatic update `` |
| [`b61a2073`](https://github.com/nix-community/NUR/commit/b61a207319893290cc46630dfe72866c5cab60c1) | `` automatic update `` |
| [`8952ba97`](https://github.com/nix-community/NUR/commit/8952ba976dc42e461cad61c3a6481bd9a3220630) | `` automatic update `` |
| [`d7aa30a1`](https://github.com/nix-community/NUR/commit/d7aa30a196267c13011490920cead5c015858e37) | `` automatic update `` |
| [`1a05c890`](https://github.com/nix-community/NUR/commit/1a05c890fa0883ea4a0b6ddce2ea3e8d9e45f78e) | `` automatic update `` |
| [`562bbc98`](https://github.com/nix-community/NUR/commit/562bbc985ee54b0f6019a140125adf54f2f0b2ef) | `` automatic update `` |
| [`50b4b066`](https://github.com/nix-community/NUR/commit/50b4b0662a8174b46d4187c3d777d87c82e98d25) | `` automatic update `` |