### PR TITLE
chore(flake/nur): `10e5d941` -> `b8891689`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1746128691,
-        "narHash": "sha256-NGSXhxkR2fnPcZnqqQmLNhaTURPrF8azoHc5woDqe14=",
+        "lastModified": 1746136874,
+        "narHash": "sha256-PbXEgJIc+i4UwKnar2ASVkajJMp4GRrUriuGR73o4lA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "10e5d9414baa0db76e279906ee22dfcc0358ca05",
+        "rev": "b8891689f8d692520497954d2fe3cc5e88e316a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                  |
| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`b8891689`](https://github.com/nix-community/NUR/commit/b8891689f8d692520497954d2fe3cc5e88e316a6) | `` Update cachix/install-nix-action digest to 5261181 `` |
| [`f47ef5e1`](https://github.com/nix-community/NUR/commit/f47ef5e107fc439a963f971fda36a578d99929cf) | `` automatic update ``                                   |
| [`ce4c854d`](https://github.com/nix-community/NUR/commit/ce4c854d22cef2f2e2d2aff6495dd1cc3ac8b7c7) | `` automatic update ``                                   |