### PR TITLE
chore(flake/home-manager): `5f217e5a` -> `1298a341`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746040799,
-        "narHash": "sha256-osgPX/SzIpkR50vev/rqoTEAVkEcOWXoQXmbzsaI4KU=",
+        "lastModified": 1746169624,
+        "narHash": "sha256-oIAZDng5FYQXnmGJrK4WZX2tsQ1nmxHd9OrcySm/Jf4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5f217e5a319f6c186283b530f8c975e66c028433",
+        "rev": "1298a3418be1a875e9ae6643770b0939814cd441",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`1298a341`](https://github.com/nix-community/home-manager/commit/1298a3418be1a875e9ae6643770b0939814cd441) | `` ci: remove release-24.05 from dependabot setup ``          |
| [`015f1913`](https://github.com/nix-community/home-manager/commit/015f1913109d44c36e683b55f0e47e283b383caa) | `` ci: remove GitLab rycee/nur-expression update ``           |
| [`4e7ee4d0`](https://github.com/nix-community/home-manager/commit/4e7ee4d02cc323fc338ff978ca4a2b72e08f5d8d) | `` home-manager: new formatting of generated configuration `` |
| [`81431b6d`](https://github.com/nix-community/home-manager/commit/81431b6d6fa756db641109461fc943ba23b550b7) | `` gpg-agent: fix typo (#6950) ``                             |