### PR TITLE
chore(flake/minimal-emacs-d): `e2b06c4c` -> `fff50fa8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -398,11 +398,11 @@
     "minimal-emacs-d": {
       "flake": false,
       "locked": {
-        "lastModified": 1745625038,
-        "narHash": "sha256-48EEACwMGhcQwVuQbD5+sddAgyq/PdxugvC3KT6yUTA=",
+        "lastModified": 1746149937,
+        "narHash": "sha256-GW5mBlcyqcVPmihGyplTm7z3CM1GRsyx9ej5VFz2PNc=",
         "owner": "jamescherti",
         "repo": "minimal-emacs.d",
-        "rev": "e2b06c4cf49280385a05ec0b815533892ce1bafc",
+        "rev": "fff50fa8481fc022580baf1bd6f3396e3487afcc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                                     |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
| [`fff50fa8`](https://github.com/jamescherti/minimal-emacs.d/commit/fff50fa8481fc022580baf1bd6f3396e3487afcc) | `` Update README.md ``                                                      |
| [`c4787911`](https://github.com/jamescherti/minimal-emacs.d/commit/c4787911f95eea57d7d378e86a829ab92f79014e) | `` Remove redisplay-skip-fontification-on-input and move it to README.md `` |