### PR TITLE
chore(flake/nur): `b8891689` -> `8ac5a922`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -725,11 +725,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1745930157,
-        "narHash": "sha256-y3h3NLnzRSiUkYpnfvnS669zWZLoqqI6NprtLQ+5dck=",
+        "lastModified": 1746141548,
+        "narHash": "sha256-IgBWhX7A2oJmZFIrpRuMnw5RAufVnfvOgHWgIdds+hc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "46e634be05ce9dc6d4db8e664515ba10b78151ae",
+        "rev": "f02fddb8acef29a8b32f10a335d44828d7825b78",
         "type": "github"
       },
       "original": {
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1746136874,
-        "narHash": "sha256-PbXEgJIc+i4UwKnar2ASVkajJMp4GRrUriuGR73o4lA=",
+        "lastModified": 1746187675,
+        "narHash": "sha256-3rHcefyJ7girEacTeHZ2qS01aoDpdWQG06WUj3omJ9w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b8891689f8d692520497954d2fe3cc5e88e316a6",
+        "rev": "8ac5a922cb4f6eb620ae8668ee89c94e83a04ad1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8ac5a922`](https://github.com/nix-community/NUR/commit/8ac5a922cb4f6eb620ae8668ee89c94e83a04ad1) | `` automatic update `` |
| [`4a03b662`](https://github.com/nix-community/NUR/commit/4a03b6629dc8ace4b9f5a2ebd207f78063e0a606) | `` automatic update `` |
| [`68db1411`](https://github.com/nix-community/NUR/commit/68db141101c20602e175a53b290bc6064e83bf30) | `` automatic update `` |
| [`00959ea3`](https://github.com/nix-community/NUR/commit/00959ea3f1d607894e2c5489b8907e394286b33b) | `` automatic update `` |
| [`74975d36`](https://github.com/nix-community/NUR/commit/74975d369f13dba230379d242acc1b78c798828e) | `` automatic update `` |
| [`8dd03dc4`](https://github.com/nix-community/NUR/commit/8dd03dc423f74894bb985828c4d4f905e3efa88f) | `` automatic update `` |
| [`f1c7f1ab`](https://github.com/nix-community/NUR/commit/f1c7f1ab86d1803b84d4ac8709a435f0f200d590) | `` automatic update `` |
| [`ec15fd4a`](https://github.com/nix-community/NUR/commit/ec15fd4a4f5a757da43b0f3a4709626ce7af8248) | `` automatic update `` |
| [`ca31d45b`](https://github.com/nix-community/NUR/commit/ca31d45b8628e73fcab2eddfcc282e9485d256bb) | `` automatic update `` |
| [`b0e15a5f`](https://github.com/nix-community/NUR/commit/b0e15a5f646748ef5b73a1b9d7aa1da04c26f797) | `` automatic update `` |
| [`af94798a`](https://github.com/nix-community/NUR/commit/af94798a1998ade8752d3c16a7ed719a7b71b813) | `` automatic update `` |