### PR TITLE
chore(flake/emacs-overlay): `8530b228` -> `77a5dcff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1746148942,
-        "narHash": "sha256-CSyrSFA3J0xEiuMmo5qEA/CSvD8D7OAJ3qmKntPa1wc=",
+        "lastModified": 1746289346,
+        "narHash": "sha256-SuzOGPI0suV8+HOUExQSovCVXaC55DNdPrbdCaji3sU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8530b2282aaf0a957a881de5001069073ebe9f20",
+        "rev": "77a5dcff2b2494e74225d5c70739973241401be6",
         "type": "github"
       },
       "original": {
@@ -646,11 +646,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1746055187,
-        "narHash": "sha256-3dqArYSMP9hM7Qpy5YWhnSjiqniSaT2uc5h2Po7tmg0=",
+        "lastModified": 1746183838,
+        "narHash": "sha256-kwaaguGkAqTZ1oK0yXeQ3ayYjs8u/W7eEfrFpFfIDFA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3e362ce63e16b9572d8c2297c04f7c19ab6725a5",
+        "rev": "bf3287dac860542719fe7554e21e686108716879",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`77a5dcff`](https://github.com/nix-community/emacs-overlay/commit/77a5dcff2b2494e74225d5c70739973241401be6) | `` Updated elpa ``         |
| [`f438d4f8`](https://github.com/nix-community/emacs-overlay/commit/f438d4f861150aad71e1727d02333b08600c3d90) | `` Updated nongnu ``       |
| [`66bb2d7a`](https://github.com/nix-community/emacs-overlay/commit/66bb2d7a4df96d0c1e63648850b7aed1b2e8d683) | `` Updated emacs ``        |
| [`b0892b5c`](https://github.com/nix-community/emacs-overlay/commit/b0892b5ce1a038cd96724e0836187ca45c9ea457) | `` Updated melpa ``        |
| [`16d196ad`](https://github.com/nix-community/emacs-overlay/commit/16d196ad2e52fbbafa1730c5fd1af3c0e842b13c) | `` Updated flake inputs `` |
| [`a738f51b`](https://github.com/nix-community/emacs-overlay/commit/a738f51b28507d1c68ec612d75840a6165ebe1bf) | `` Updated nongnu ``       |
| [`5c2d3b4a`](https://github.com/nix-community/emacs-overlay/commit/5c2d3b4a84ed5366db6133f2fee58e2a62701280) | `` Updated flake inputs `` |