### PR TITLE
chore(flake/home-manager): `1298a341` -> `c0962eee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746169624,
-        "narHash": "sha256-oIAZDng5FYQXnmGJrK4WZX2tsQ1nmxHd9OrcySm/Jf4=",
+        "lastModified": 1746243165,
+        "narHash": "sha256-DQycVmlyLQNLjLJ/FzpokVmbxGQ8HjQQ4zN4nyq2vII=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1298a3418be1a875e9ae6643770b0939814cd441",
+        "rev": "c0962eeeabfb8127713f859ec8a5f0e86dead0f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                              |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`c0962eee`](https://github.com/nix-community/home-manager/commit/c0962eeeabfb8127713f859ec8a5f0e86dead0f2) | `` thunderbird: fix accounts being removed (#6959) ``                                |
| [`123297c5`](https://github.com/nix-community/home-manager/commit/123297c57e77c692fae7e860e701823367afbec4) | `` onagre: add module (#6958) ``                                                     |
| [`1e8c62c6`](https://github.com/nix-community/home-manager/commit/1e8c62c651242fc685b10efc4a48ab777635fb7f) | `` gpg-agent: avoid console output when using ssh ``                                 |
| [`d6b0c054`](https://github.com/nix-community/home-manager/commit/d6b0c054571a444acd2755b038bb7df5eb7954a7) | `` visidata: add module (#6956) ``                                                   |
| [`355a6b93`](https://github.com/nix-community/home-manager/commit/355a6b937d07a95cb0b753ef513bcaad09128dea) | `` nushell: throw instead of abort (#6870) ``                                        |
| [`2eabb26d`](https://github.com/nix-community/home-manager/commit/2eabb26d0859c7710a2aa76c3b0ff4149f41b04a) | `` restic: allow the convenience script to source environmentFile (#6947) ``         |
| [`f15be4fe`](https://github.com/nix-community/home-manager/commit/f15be4feb6e98fc2c52d4f8088400619381fd171) | `` clipcat: add module (#6946) ``                                                    |
| [`c5cad190`](https://github.com/nix-community/home-manager/commit/c5cad190ba252eb94540ee06955a53c7807963f8) | `` zsh: update doc to show how to add `initContent` at multiple location. (#6945) `` |
| [`669e813c`](https://github.com/nix-community/home-manager/commit/669e813c752696c66ad7e1cd34b65ee4315058d9) | `` element-desktop: add module (#6935) ``                                            |
| [`f045bd46`](https://github.com/nix-community/home-manager/commit/f045bd46b73c3b0ed4e46cdb6036b3d5823d7dee) | `` fish: keep all fish-completions packages around ``                                |
| [`361ab448`](https://github.com/nix-community/home-manager/commit/361ab4484e7b91a7b6bdedc6784e2a44d20a3dce) | `` home-environment: add `home.extraDependencies` ``                                 |