### PR TITLE
chore(flake/nur): `8ac5a922` -> `44a1b2fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1746187675,
-        "narHash": "sha256-3rHcefyJ7girEacTeHZ2qS01aoDpdWQG06WUj3omJ9w=",
+        "lastModified": 1746244442,
+        "narHash": "sha256-XQdDyhySaLB7DicohmHhr59Oyi+v89JUmjUsAzSYjMI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8ac5a922cb4f6eb620ae8668ee89c94e83a04ad1",
+        "rev": "44a1b2feffe77bf15d049e7546858b75ccfcc35c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`44a1b2fe`](https://github.com/nix-community/NUR/commit/44a1b2feffe77bf15d049e7546858b75ccfcc35c) | `` automatic update `` |
| [`66146714`](https://github.com/nix-community/NUR/commit/6614671440cc1fd3fc71f2c14d9c42f9dbf414af) | `` automatic update `` |
| [`87fc2e78`](https://github.com/nix-community/NUR/commit/87fc2e78dfb9097a1849062bb39135867bc952ea) | `` automatic update `` |
| [`3782ea42`](https://github.com/nix-community/NUR/commit/3782ea42ee0f05f81bc09a661749b2202e2ac872) | `` automatic update `` |
| [`0762f3a8`](https://github.com/nix-community/NUR/commit/0762f3a826ae78104fc99db1b5b7fbd3773e02d3) | `` automatic update `` |
| [`ef8c72e4`](https://github.com/nix-community/NUR/commit/ef8c72e41c6f7f20585835a904166664ebd74a52) | `` automatic update `` |