### PR TITLE
chore(flake/treefmt-nix): `82bf32e5` -> `29ec5026`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1010,11 +1010,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745929750,
-        "narHash": "sha256-k5ELLpTwRP/OElcLpNaFWLNf8GRDq4/eHBmFy06gGko=",
+        "lastModified": 1746216483,
+        "narHash": "sha256-4h3s1L/kKqt3gMDcVfN8/4v2jqHrgLIe4qok4ApH5x4=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "82bf32e541b30080d94e46af13d46da0708609ea",
+        "rev": "29ec5026372e0dec56f890e50dbe4f45930320fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                          |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`29ec5026`](https://github.com/numtide/treefmt-nix/commit/29ec5026372e0dec56f890e50dbe4f45930320fd) | `` fix defaultText for `pkgs` option using `literalMD` (#350) `` |