### PR TITLE
chore(flake/nur): `44a1b2fe` -> `0150847d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1746244442,
-        "narHash": "sha256-XQdDyhySaLB7DicohmHhr59Oyi+v89JUmjUsAzSYjMI=",
+        "lastModified": 1746245226,
+        "narHash": "sha256-CbL6CJnspsyr4T23IKWZ3BERApRkNIhzltvPjyVpngA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "44a1b2feffe77bf15d049e7546858b75ccfcc35c",
+        "rev": "0150847d90961f362980d7dd662868dc6ee0907a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0150847d`](https://github.com/nix-community/NUR/commit/0150847d90961f362980d7dd662868dc6ee0907a) | `` automatic update `` |