### PR TITLE
chore(flake/darwin): `4515daca` -> `760a11c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745816321,
-        "narHash": "sha256-Gyh/fkCDqVNGM0BWvk+4UAS17w2UI6iwnbQQCmc1TDI=",
+        "lastModified": 1746254942,
+        "narHash": "sha256-Y062AuRx6l+TJNX8wxZcT59SSLsqD9EedAY0mqgTtQE=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "4515dacafb0ccd42e5395aacc49fd58a43027e01",
+        "rev": "760a11c87009155afa0140d55c40e7c336d62d7a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                              |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------ |
| [`a6d73d09`](https://github.com/nix-darwin/nix-darwin/commit/a6d73d09045384a325eabe8827edd95ee3969a58) | `` nix-tools: use replaceVarsWith `` |