### PR TITLE
chore(flake/nur): `0150847d` -> `ad9a7c55`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1746245226,
-        "narHash": "sha256-CbL6CJnspsyr4T23IKWZ3BERApRkNIhzltvPjyVpngA=",
+        "lastModified": 1746290006,
+        "narHash": "sha256-LKvcXXMvyekIr+kOi1Yb641HQNtUuXR1EBtquduZDPY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0150847d90961f362980d7dd662868dc6ee0907a",
+        "rev": "ad9a7c554a3cacc9bfc168afe847cfc4c8fab966",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ad9a7c55`](https://github.com/nix-community/NUR/commit/ad9a7c554a3cacc9bfc168afe847cfc4c8fab966) | `` automatic update `` |
| [`ad58c578`](https://github.com/nix-community/NUR/commit/ad58c578f14534a879d1e674e5b21e1d665c028a) | `` automatic update `` |
| [`e4be6680`](https://github.com/nix-community/NUR/commit/e4be6680a4b231e712fef9c1cd5714f08a1ce51b) | `` automatic update `` |
| [`7d89a209`](https://github.com/nix-community/NUR/commit/7d89a2092973370db813fe87ab45d7bb5c4e1edd) | `` automatic update `` |
| [`e9f82bca`](https://github.com/nix-community/NUR/commit/e9f82bca29aafaa484abf30e5657fe6935b2e6bb) | `` automatic update `` |
| [`eb1b09ca`](https://github.com/nix-community/NUR/commit/eb1b09ca8bfee519fbaf133819f4af32bee2bf16) | `` automatic update `` |
| [`e4223684`](https://github.com/nix-community/NUR/commit/e42236846f62fda1479b1c7a3a709bca8f60e3c0) | `` automatic update `` |
| [`4f60d2e3`](https://github.com/nix-community/NUR/commit/4f60d2e37ef598d0f0912937f3b325332cee5a0b) | `` automatic update `` |