### PR TITLE
chore(flake/nur): `9420b19d` -> `ed8f9e5c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1746304271,
-        "narHash": "sha256-MiSl6+bwU0bIpzusuHLWGvD3HFn6oeW0LzRabZINwcg=",
+        "lastModified": 1746331236,
+        "narHash": "sha256-bWznwzrf4MlH1CvLTbBHq/Q+fIx64p3QjQlINdCic2w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9420b19d25629f2675cdd321810ad5d214bb6c87",
+        "rev": "ed8f9e5c582c6aae1995bf223863988be8fd9ddf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ed8f9e5c`](https://github.com/nix-community/NUR/commit/ed8f9e5c582c6aae1995bf223863988be8fd9ddf) | `` automatic update `` |
| [`16ec3401`](https://github.com/nix-community/NUR/commit/16ec340127198ee7ecb4f85fb723d8de47b6d94d) | `` automatic update `` |
| [`3120f2d3`](https://github.com/nix-community/NUR/commit/3120f2d37fead03b656e5c5ba5bf0a6889652ae6) | `` automatic update `` |
| [`45e8c359`](https://github.com/nix-community/NUR/commit/45e8c35935189790d98df411642864b1d7042328) | `` automatic update `` |
| [`a8ace983`](https://github.com/nix-community/NUR/commit/a8ace983eba140d1d3da9573e6b9cc5461eed6c4) | `` automatic update `` |