### PR TITLE
chore(flake/emacs-overlay): `77a5dcff` -> `ee6f3f60`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1746289346,
-        "narHash": "sha256-SuzOGPI0suV8+HOUExQSovCVXaC55DNdPrbdCaji3sU=",
+        "lastModified": 1746408337,
+        "narHash": "sha256-ul9ToNHnT4CAXuwEWC9hMCOl1YILnHRvCGbXBqWRWg0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "77a5dcff2b2494e74225d5c70739973241401be6",
+        "rev": "ee6f3f6077dc9504f27801203dcd1b610608aa6a",
         "type": "github"
       },
       "original": {
@@ -646,11 +646,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1746183838,
-        "narHash": "sha256-kwaaguGkAqTZ1oK0yXeQ3ayYjs8u/W7eEfrFpFfIDFA=",
+        "lastModified": 1746301764,
+        "narHash": "sha256-5odz+NZszRya//Zd0P8h+sIwOnV35qJi+73f4I+iv1M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bf3287dac860542719fe7554e21e686108716879",
+        "rev": "537ee98218704e21ea465251de512ab6bbb9012e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`ee6f3f60`](https://github.com/nix-community/emacs-overlay/commit/ee6f3f6077dc9504f27801203dcd1b610608aa6a) | `` Updated flake inputs `` |
| [`a281243e`](https://github.com/nix-community/emacs-overlay/commit/a281243eaec6ac810584f2a73126e8dd48c3a15e) | `` Updated elpa ``         |
| [`afddd57c`](https://github.com/nix-community/emacs-overlay/commit/afddd57cf383f3fa7677ac196eee5664902913d6) | `` Updated nongnu ``       |
| [`5ccae309`](https://github.com/nix-community/emacs-overlay/commit/5ccae3090d7e03bb27b21dc81769d262490e44eb) | `` Updated emacs ``        |
| [`9fb038dd`](https://github.com/nix-community/emacs-overlay/commit/9fb038dd11b0ac1a3676552f8109ed970c099ff2) | `` Updated melpa ``        |
| [`19213615`](https://github.com/nix-community/emacs-overlay/commit/192136152f96590b07a495ab992cdc255208300f) | `` Updated elpa ``         |
| [`9c693028`](https://github.com/nix-community/emacs-overlay/commit/9c693028e9b51d523b5bb8455001f2bbe30cb930) | `` Updated nongnu ``       |
| [`aa70453c`](https://github.com/nix-community/emacs-overlay/commit/aa70453c6e5e8134d3d22bc0c2b1c3cfe7837d39) | `` Updated flake inputs `` |