### PR TITLE
chore(flake/nix-index-database): `13ba07d5` -> `137fd2bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -469,11 +469,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746054057,
-        "narHash": "sha256-iR+idGZJ191cY6NBXyVjh9QH8GVWTkvZw/w+1Igy45A=",
+        "lastModified": 1746330942,
+        "narHash": "sha256-ShizFaJCAST23tSrHHtFFGF0fwd72AG+KhPZFFQX/0o=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "13ba07d54c6ccc5af30a501df669bf3fe3dd4db8",
+        "rev": "137fd2bd726fff343874f85601b51769b48685cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`137fd2bd`](https://github.com/nix-community/nix-index-database/commit/137fd2bd726fff343874f85601b51769b48685cc) | `` update generated.nix to release 2025-05-04-033656 `` |
| [`1a67f9bd`](https://github.com/nix-community/nix-index-database/commit/1a67f9bd3d2de450cbc81ffea8de0fe4a59bf189) | `` flake.lock: Update ``                                |