### PR TITLE
chore(flake/nur): `ed8f9e5c` -> `844a6a8c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1746331236,
-        "narHash": "sha256-bWznwzrf4MlH1CvLTbBHq/Q+fIx64p3QjQlINdCic2w=",
+        "lastModified": 1746336606,
+        "narHash": "sha256-MZssTb72jUGU48k3nykIucrRBUEnlbkcJfwuIOcf21A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ed8f9e5c582c6aae1995bf223863988be8fd9ddf",
+        "rev": "844a6a8c76a0676bb4730171ae5a9dd4e96f5295",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`844a6a8c`](https://github.com/nix-community/NUR/commit/844a6a8c76a0676bb4730171ae5a9dd4e96f5295) | `` automatic update `` |
| [`1c520165`](https://github.com/nix-community/NUR/commit/1c52016540d2ad35f3c187e35f4e80a5d45cbcd4) | `` automatic update `` |
| [`40894c0c`](https://github.com/nix-community/NUR/commit/40894c0c3128c5186d07b7962ac8bc3eba235f70) | `` automatic update `` |
| [`2296b465`](https://github.com/nix-community/NUR/commit/2296b465e0dce618bef4a5ddfc2c3360fce80831) | `` automatic update `` |