### PR TITLE
chore(flake/srvos): `fca14429` -> `beeea09c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -933,11 +933,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746105715,
-        "narHash": "sha256-CApScHWtVdJT7xOpTDfT8lqBdQpj0+mLCXNCFJY4+GI=",
+        "lastModified": 1746407175,
+        "narHash": "sha256-8boiOaVo0c4MEgcoeiLeZU9kiQLf3+LHmsjBLTJoggo=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "fca1442996e4ed49b379465f6d211a01147bfecb",
+        "rev": "beeea09cd4aa38fc1889c4a48d97cc93b9c9eff6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                      |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`beeea09c`](https://github.com/nix-community/srvos/commit/beeea09cd4aa38fc1889c4a48d97cc93b9c9eff6) | `` dev/private/flake.lock: Update ``         |
| [`1a8eb0e2`](https://github.com/nix-community/srvos/commit/1a8eb0e2c3b022ec6ebf8928554d9a73d7d583ec) | `` flake.lock: Update ``                     |
| [`65f1ca9e`](https://github.com/nix-community/srvos/commit/65f1ca9ed4f2e149fd094b10f0c9c6150e3e37a4) | `` disable use-cgroups until nix is fixed `` |
| [`eb891035`](https://github.com/nix-community/srvos/commit/eb89103594cecbfc1a587f39273a963bb8c3e0d1) | `` darwin/nix: enable optimise by default `` |