### PR TITLE
chore(flake/nixos-hardware): `72081c9f` -> `0833dc8b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -568,11 +568,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1745955289,
-        "narHash": "sha256-mmV2oPhQN+YF2wmnJzXX8tqgYmUYXUj3uUUBSTmYN5o=",
+        "lastModified": 1746341346,
+        "narHash": "sha256-WjupK5Xpc+viJlJWiyPHp/dF4aJItp1BPuFsEdv2/fI=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "72081c9fbbef63765ae82bff9727ea79cc86bd5b",
+        "rev": "0833dc8bbc4ffa9cf9b0cbfccf1c5ec8632fc66e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                          |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`0833dc8b`](https://github.com/NixOS/nixos-hardware/commit/0833dc8bbc4ffa9cf9b0cbfccf1c5ec8632fc66e) | `` gmktec/nucbox/g3-plus: init ``                |
| [`84eb0330`](https://github.com/NixOS/nixos-hardware/commit/84eb0330aed636ed56ce3f3495cc4a329db45278) | `` feat: add Lenovo ThinkPad P16s Intel Gen 2 `` |