### PR TITLE
chore(flake/nur): `844a6a8c` -> `8ac6c576`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1746336606,
-        "narHash": "sha256-MZssTb72jUGU48k3nykIucrRBUEnlbkcJfwuIOcf21A=",
+        "lastModified": 1746354383,
+        "narHash": "sha256-5SXSosJhUJOjveIzvFHIjXQ8rHq39zHfDp2fKSWLJkI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "844a6a8c76a0676bb4730171ae5a9dd4e96f5295",
+        "rev": "8ac6c576b34a0b5a0d07231ecea377c3b2c0a9a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8ac6c576`](https://github.com/nix-community/NUR/commit/8ac6c576b34a0b5a0d07231ecea377c3b2c0a9a3) | `` automatic update `` |
| [`3fe21e4c`](https://github.com/nix-community/NUR/commit/3fe21e4c1526ee6340b34e26685d345d307e93a7) | `` automatic update `` |
| [`538025b5`](https://github.com/nix-community/NUR/commit/538025b5921b45eddbf2522c7cbe59888a8eb22c) | `` automatic update `` |