### PR TITLE
chore(flake/nur): `8ac6c576` -> `9398a004`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1746354383,
-        "narHash": "sha256-5SXSosJhUJOjveIzvFHIjXQ8rHq39zHfDp2fKSWLJkI=",
+        "lastModified": 1746387889,
+        "narHash": "sha256-gHGf3sX7FiX2QEZkmRX2322oxT4ArxhgJ95RybAli2g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8ac6c576b34a0b5a0d07231ecea377c3b2c0a9a3",
+        "rev": "9398a004ab3c425c5f59d0dd87e2d58a8e3c1875",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9398a004`](https://github.com/nix-community/NUR/commit/9398a004ab3c425c5f59d0dd87e2d58a8e3c1875) | `` automatic update `` |
| [`76fb40eb`](https://github.com/nix-community/NUR/commit/76fb40ebdb379fed8c6ac638a57c692ab60d6ca8) | `` automatic update `` |
| [`7882dfa3`](https://github.com/nix-community/NUR/commit/7882dfa39dad5ada77012882191e5c94b066a864) | `` automatic update `` |