### PR TITLE
chore(flake/nur): `d4f47d77` -> `1a20bdf2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1746395134,
-        "narHash": "sha256-XU4kz54w4kVOlNKU6uMt/AKejnBJfNuwLTcooDFWM24=",
+        "lastModified": 1746504923,
+        "narHash": "sha256-l7UB4fnBZJfm1bL1OCPoogQAMcl70h7fXeHgmxqNF/o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d4f47d772344dc46d4f190e9faa61ce03b98f454",
+        "rev": "1a20bdf2d161bc839fa2338bca7310861abaf93e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1a20bdf2`](https://github.com/nix-community/NUR/commit/1a20bdf2d161bc839fa2338bca7310861abaf93e) | `` automatic update `` |
| [`68201206`](https://github.com/nix-community/NUR/commit/68201206f9566bc527992718074f77e0a271f69b) | `` automatic update `` |
| [`547402f9`](https://github.com/nix-community/NUR/commit/547402f96048d6612b39723c6fcf1a250fc7c680) | `` automatic update `` |
| [`171d40ef`](https://github.com/nix-community/NUR/commit/171d40ef2e50b56576c6e12548a9d5d06f3c59d5) | `` automatic update `` |
| [`735532b4`](https://github.com/nix-community/NUR/commit/735532b43aa5ea14aa07ab950fa6874bf051f7dd) | `` automatic update `` |
| [`5cac0e97`](https://github.com/nix-community/NUR/commit/5cac0e97bbbf28cf7e98003a2e45c19934902504) | `` automatic update `` |
| [`74e7ede6`](https://github.com/nix-community/NUR/commit/74e7ede61ff7681a7d5196ce85cb160a7018773f) | `` automatic update `` |
| [`5829ebf4`](https://github.com/nix-community/NUR/commit/5829ebf4b8fc9ed2cde88f1a59ba1f285412858e) | `` automatic update `` |
| [`a3642764`](https://github.com/nix-community/NUR/commit/a3642764d37a08c6a51d12fe1e89cc6ec86778c4) | `` automatic update `` |
| [`8f80bc45`](https://github.com/nix-community/NUR/commit/8f80bc45341c6cb920be080878f84445a9a924ce) | `` automatic update `` |
| [`4c5dfa3d`](https://github.com/nix-community/NUR/commit/4c5dfa3de65dfa3198e65cf757eb8491d7cce1ac) | `` automatic update `` |
| [`781d73e9`](https://github.com/nix-community/NUR/commit/781d73e955f4159fe9d5c21327d26d964e2e2293) | `` automatic update `` |
| [`46e118bd`](https://github.com/nix-community/NUR/commit/46e118bddfc79f64348684637ca74fafc9b0cb94) | `` automatic update `` |
| [`0cd46436`](https://github.com/nix-community/NUR/commit/0cd46436be97b6a334cc4f5676b74153dfcb89be) | `` automatic update `` |
| [`2547c4c3`](https://github.com/nix-community/NUR/commit/2547c4c3009aef38d30a092cc10e3cc63f76caf2) | `` automatic update `` |
| [`1e56b844`](https://github.com/nix-community/NUR/commit/1e56b8444784dfded852767672e3038213037ff1) | `` automatic update `` |
| [`28a5ad53`](https://github.com/nix-community/NUR/commit/28a5ad53c9444a94f56041a685a446680905b19f) | `` automatic update `` |
| [`fce799ca`](https://github.com/nix-community/NUR/commit/fce799ca5f9de092ed27f5c31ed98ab0c83308c6) | `` automatic update `` |
| [`f82c5537`](https://github.com/nix-community/NUR/commit/f82c5537daf2afcf1edabbfe8b0c20bf302c5ae4) | `` automatic update `` |
| [`d13cb380`](https://github.com/nix-community/NUR/commit/d13cb380ea07386b0768c5024b44f4dfe7598649) | `` automatic update `` |
| [`03e0bf3d`](https://github.com/nix-community/NUR/commit/03e0bf3d96c3b2136418b5b3264cb4dd374c05a3) | `` automatic update `` |
| [`8d11f1d8`](https://github.com/nix-community/NUR/commit/8d11f1d8c7db10d5c71c5b18badd8065d3bf2a75) | `` automatic update `` |
| [`2365a6f6`](https://github.com/nix-community/NUR/commit/2365a6f60fdae3562c022b1ad57fc01ada41afff) | `` automatic update `` |
| [`7c9fadc0`](https://github.com/nix-community/NUR/commit/7c9fadc09b7206e1ba0d9f7943fa48b6427e6f2e) | `` automatic update `` |
| [`4a6e0201`](https://github.com/nix-community/NUR/commit/4a6e02016dcc23154b67353d29a7c55d16f3f9e5) | `` automatic update `` |
| [`030166ad`](https://github.com/nix-community/NUR/commit/030166adb35048e8ba7ecb7c20c698175304973e) | `` automatic update `` |
| [`50e2666e`](https://github.com/nix-community/NUR/commit/50e2666ecc25e636bded7552595e5f4a629de340) | `` automatic update `` |
| [`af9518fa`](https://github.com/nix-community/NUR/commit/af9518fae5ce63205ee236a6913c86a7e3ac67c9) | `` automatic update `` |