### PR TITLE
chore(flake/nixos-hardware): `0833dc8b` -> `a4bb30a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -568,11 +568,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1746341346,
-        "narHash": "sha256-WjupK5Xpc+viJlJWiyPHp/dF4aJItp1BPuFsEdv2/fI=",
+        "lastModified": 1746427242,
+        "narHash": "sha256-KvZ6G5sdBdcrglsqcOx8BT6NpHVMVHc8wssMRhv/+1g=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "0833dc8bbc4ffa9cf9b0cbfccf1c5ec8632fc66e",
+        "rev": "a4bb30a9000cf0444ecc8fdca8096d072f77f9e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                             |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`a4bb30a9`](https://github.com/NixOS/nixos-hardware/commit/a4bb30a9000cf0444ecc8fdca8096d072f77f9e8) | `` add asus-zenbook-ux481 ``        |
| [`f5eedd65`](https://github.com/NixOS/nixos-hardware/commit/f5eedd65a342e155585e6d7a4ca7a4bbefecceee) | `` Lenovo ThinkPad X1 Yoga Gen 8 `` |