### PR TITLE
chore(flake/sops-nix): `5e3e92b1` -> `e93ee1d9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -913,11 +913,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745310711,
-        "narHash": "sha256-ePyTpKEJTgX0gvgNQWd7tQYQ3glIkbqcW778RpHlqgA=",
+        "lastModified": 1746485181,
+        "narHash": "sha256-PxrrSFLaC7YuItShxmYbMgSuFFuwxBB+qsl9BZUnRvg=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "5e3e92b16d6fdf9923425a8d4df7496b2434f39c",
+        "rev": "e93ee1d900ad264d65e9701a5c6f895683433386",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                           |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`e4a1bbeb`](https://github.com/Mic92/sops-nix/commit/e4a1bbeb4d0061ddac21160b4df1d2b4125e4a8d) | `` update vendorHash ``                                           |
| [`d1cdad2b`](https://github.com/Mic92/sops-nix/commit/d1cdad2b97f29bee4f34f663c9dbf04175b0ac41) | `` build(deps): bump golang.org/x/crypto from 0.37.0 to 0.38.0 `` |