### PR TITLE
chore(flake/nur): `1a20bdf2` -> `ce52235c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -725,11 +725,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1746328495,
-        "narHash": "sha256-uKCfuDs7ZM3QpCE/jnfubTg459CnKnJG/LwqEVEdEiw=",
+        "lastModified": 1746461020,
+        "narHash": "sha256-7+pG1I9jvxNlmln4YgnlW4o+w0TZX24k688mibiFDUE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+        "rev": "3730d8a308f94996a9ba7c7138ede69c1b9ac4ae",
         "type": "github"
       },
       "original": {
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1746504923,
-        "narHash": "sha256-l7UB4fnBZJfm1bL1OCPoogQAMcl70h7fXeHgmxqNF/o=",
+        "lastModified": 1746590490,
+        "narHash": "sha256-5Itg/5GRPWOkzQtDl7vqBfCQAiYRgbscwwPjOFhkaac=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1a20bdf2d161bc839fa2338bca7310861abaf93e",
+        "rev": "ce52235ca0f0eabcfb67c92da78ec41b02b64f27",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ce52235c`](https://github.com/nix-community/NUR/commit/ce52235ca0f0eabcfb67c92da78ec41b02b64f27) | `` automatic update `` |
| [`b1ffa303`](https://github.com/nix-community/NUR/commit/b1ffa30365a3d09a5a30d8d272187182bd6acac8) | `` automatic update `` |
| [`eb4a55b7`](https://github.com/nix-community/NUR/commit/eb4a55b7d3259dcfa73894733a11792052578ffa) | `` automatic update `` |
| [`aaec6cfc`](https://github.com/nix-community/NUR/commit/aaec6cfc24af5ca3865f157cafc9c0e2c0b6e3e0) | `` automatic update `` |
| [`29d16321`](https://github.com/nix-community/NUR/commit/29d16321b0f48ad0d24c3eaf5656adfaaf99d19e) | `` automatic update `` |
| [`a8bcd9b4`](https://github.com/nix-community/NUR/commit/a8bcd9b448f2c2581c510486b674bee5c88f1ccd) | `` automatic update `` |
| [`ad493e56`](https://github.com/nix-community/NUR/commit/ad493e561b7b6db3a77c89e5d42eb2444118813e) | `` automatic update `` |
| [`29dfc590`](https://github.com/nix-community/NUR/commit/29dfc590558a45ce79d520fd098047c0b7fa6059) | `` automatic update `` |
| [`f0e5a244`](https://github.com/nix-community/NUR/commit/f0e5a2447f2cf746827d79aceaacd6680412c981) | `` automatic update `` |
| [`633c7b68`](https://github.com/nix-community/NUR/commit/633c7b688b37ff98f9ae412c919d062abbf70483) | `` automatic update `` |
| [`39bf6a2b`](https://github.com/nix-community/NUR/commit/39bf6a2b3e09aafbc63fcbe54efb53e957aeb5c7) | `` automatic update `` |
| [`5b5b8098`](https://github.com/nix-community/NUR/commit/5b5b8098d5dc4df06c7294f9257efefa62cc536f) | `` automatic update `` |
| [`bd50ee51`](https://github.com/nix-community/NUR/commit/bd50ee5106a3c122d1d9f5caea3c061eb0f7c964) | `` automatic update `` |
| [`0a8aa251`](https://github.com/nix-community/NUR/commit/0a8aa25163d51f6378041635669c093df6c30879) | `` automatic update `` |
| [`d902ecb6`](https://github.com/nix-community/NUR/commit/d902ecb6760f768022efc555627e050e4f8c333e) | `` automatic update `` |
| [`42dc4e4a`](https://github.com/nix-community/NUR/commit/42dc4e4ac1a52de9001a32ef9497da0e571ac3af) | `` automatic update `` |
| [`2d521a93`](https://github.com/nix-community/NUR/commit/2d521a93d4962c6374470b8d24054b5922e84724) | `` automatic update `` |
| [`8dccc210`](https://github.com/nix-community/NUR/commit/8dccc210b9e4753695ae3ed39424b95096ca6f29) | `` automatic update `` |
| [`9dd287a8`](https://github.com/nix-community/NUR/commit/9dd287a8ecbbd0e53089fa3d2de630b5fe26ce43) | `` automatic update `` |
| [`cdbb9db5`](https://github.com/nix-community/NUR/commit/cdbb9db52ea30cb5ad1a3d9f5b79e9040be098ad) | `` automatic update `` |
| [`ac01b892`](https://github.com/nix-community/NUR/commit/ac01b89225b235f5699ee4a6e155eec9b5e2db44) | `` automatic update `` |
| [`eb476379`](https://github.com/nix-community/NUR/commit/eb4763794b57bf684bbc8e87d7ec6cc1b0acdf79) | `` automatic update `` |