### PR TITLE
chore(flake/emacs-overlay): `c2f57f60` -> `cd0ba3fd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1746523569,
-        "narHash": "sha256-PT/AKx72aC7db9xBCtj3w/hOLw7AoBESMLwW48vCMqY=",
+        "lastModified": 1746552390,
+        "narHash": "sha256-s+SVW+VPmU+RUMhm+9xVEG8dA2F4oCCp/DQ1TQKhDG8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c2f57f602ba4f7da96ac08537240774531cb0fb3",
+        "rev": "cd0ba3fdbed27f695be7c2bd1f2d05acdf6de725",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`cd0ba3fd`](https://github.com/nix-community/emacs-overlay/commit/cd0ba3fdbed27f695be7c2bd1f2d05acdf6de725) | `` Updated emacs ``  |
| [`de5f217d`](https://github.com/nix-community/emacs-overlay/commit/de5f217d9657b61773a6d2508f542afdea491244) | `` Updated melpa ``  |
| [`e34ac821`](https://github.com/nix-community/emacs-overlay/commit/e34ac8210719f8c0655269ffc284cf0b7576a914) | `` Updated nongnu `` |