### PR TITLE
chore(flake/emacs-overlay): `cd0ba3fd` -> `60602c52`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1746552390,
-        "narHash": "sha256-s+SVW+VPmU+RUMhm+9xVEG8dA2F4oCCp/DQ1TQKhDG8=",
+        "lastModified": 1746583607,
+        "narHash": "sha256-Gun6JAQos+RmuK/qKufgDaTUTgCEHF9Wacn3t9BVIeU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cd0ba3fdbed27f695be7c2bd1f2d05acdf6de725",
+        "rev": "60602c520d62d95640bf4d8807da1cd48e2f8f61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`60602c52`](https://github.com/nix-community/emacs-overlay/commit/60602c520d62d95640bf4d8807da1cd48e2f8f61) | `` Updated melpa ``        |
| [`e3e507d9`](https://github.com/nix-community/emacs-overlay/commit/e3e507d94b4df0cf8111dfc0161762dd183421d6) | `` Updated elpa ``         |
| [`b2e4ff5b`](https://github.com/nix-community/emacs-overlay/commit/b2e4ff5b3348eda9f84b181962e5f988021faae1) | `` Updated flake inputs `` |