### PR TITLE
chore(flake/emacs-overlay): `60602c52` -> `d9e6b204`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1746583607,
-        "narHash": "sha256-Gun6JAQos+RmuK/qKufgDaTUTgCEHF9Wacn3t9BVIeU=",
+        "lastModified": 1746635180,
+        "narHash": "sha256-v/lPugIVymeiBMcQqH8050xpKJ6JF+4YaST11BwBeGc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "60602c520d62d95640bf4d8807da1cd48e2f8f61",
+        "rev": "d9e6b2044ed09ad5957306002aef88f7caa05a12",
         "type": "github"
       },
       "original": {
@@ -646,11 +646,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1746422338,
-        "narHash": "sha256-NTtKOTLQv6dPfRe00OGSywg37A1FYqldS6xiNmqBUYc=",
+        "lastModified": 1746557022,
+        "narHash": "sha256-QkNoyEf6TbaTW5UZYX0OkwIJ/ZMeKSSoOMnSDPQuol0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5b35d248e9206c1f3baf8de6a7683fee126364aa",
+        "rev": "1d3aeb5a193b9ff13f63f4d9cc169fb88129f860",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`d9e6b204`](https://github.com/nix-community/emacs-overlay/commit/d9e6b2044ed09ad5957306002aef88f7caa05a12) | `` Updated elpa ``         |
| [`af2834bc`](https://github.com/nix-community/emacs-overlay/commit/af2834bcba9f1204a250ca9fd2c7a76ad4a11b67) | `` Updated nongnu ``       |
| [`e0bc994a`](https://github.com/nix-community/emacs-overlay/commit/e0bc994a32f98e96de9af9eee4cdcb7598a68a3d) | `` Updated emacs ``        |
| [`3ff72fe1`](https://github.com/nix-community/emacs-overlay/commit/3ff72fe166b28786e90834f7febe896efe1afa82) | `` Updated melpa ``        |
| [`d74081b1`](https://github.com/nix-community/emacs-overlay/commit/d74081b100aa84fd6a6e5911f9f01a8bb572d61e) | `` Updated flake inputs `` |