### PR TITLE
chore(flake/minimal-emacs-d): `65be02f1` -> `6003831f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -398,11 +398,11 @@
     "minimal-emacs-d": {
       "flake": false,
       "locked": {
-        "lastModified": 1746567100,
-        "narHash": "sha256-qfK0BiJJS+PaDbvS671wwfIUkCT6DJsNjhL0WS56FSM=",
+        "lastModified": 1746655459,
+        "narHash": "sha256-xBkU0VllP9YImOR3TuuPEj6JvmWGhwGtqE/5VyNDb38=",
         "owner": "jamescherti",
         "repo": "minimal-emacs.d",
-        "rev": "65be02f1d05c428fbfe82106d2925b95eeb7dbb9",
+        "rev": "6003831fbfb2d4f99265fe23a214003d75ef9944",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                    |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------ |
| [`6003831f`](https://github.com/jamescherti/minimal-emacs.d/commit/6003831fbfb2d4f99265fe23a214003d75ef9944) | `` Update README.md ``                     |
| [`5ccc8a06`](https://github.com/jamescherti/minimal-emacs.d/commit/5ccc8a06096eecc6061a6b2a69922fd41ad17e84) | `` Move miscellaneous files to .github/ `` |
| [`e2b9183e`](https://github.com/jamescherti/minimal-emacs.d/commit/e2b9183e74cee8c9b95783213ae950d5b1b04c7b) | `` Update README.md ``                     |
| [`51c628a0`](https://github.com/jamescherti/minimal-emacs.d/commit/51c628a02286ea802516f012340b53bbcd86f558) | `` Update README.md ``                     |
| [`88e5a0e7`](https://github.com/jamescherti/minimal-emacs.d/commit/88e5a0e7a56524af795a6e586169abd6ee2fb730) | `` Update README.md ``                     |