### PR TITLE
chore(flake/srvos): `beeea09c` -> `7aefe82e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -933,11 +933,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746407175,
-        "narHash": "sha256-8boiOaVo0c4MEgcoeiLeZU9kiQLf3+LHmsjBLTJoggo=",
+        "lastModified": 1746666190,
+        "narHash": "sha256-XZMa4o1tJQER0jQ+Yjx3MB5P9wRuDuAU3pTm4QgEjC0=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "beeea09cd4aa38fc1889c4a48d97cc93b9c9eff6",
+        "rev": "7aefe82e5d2b362e3b569d6ccbed4c54f49e74c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`7aefe82e`](https://github.com/nix-community/srvos/commit/7aefe82e5d2b362e3b569d6ccbed4c54f49e74c4) | `` dev/private/flake.lock: Update `` |
| [`78ebc194`](https://github.com/nix-community/srvos/commit/78ebc19432d44baf6f971fb40f2427b4df20ff61) | `` flake.lock: Update ``             |