### PR TITLE
chore(flake/nur): `daf7d8d5` -> `dd2b6acd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1746676661,
-        "narHash": "sha256-x4DQsszGdBizCXyMyHIk+Tb39CdRi1hehYyQSTnScFI=",
+        "lastModified": 1746689455,
+        "narHash": "sha256-nhUz3/4AHEVpMaT4TQN+rXY2EsX4GJWXnVr9eTGptEk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "daf7d8d5e52d68b70d03d25a508a980ab89f24bb",
+        "rev": "dd2b6acde8faac90eab0928c5ad4e4e234ca3488",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dd2b6acd`](https://github.com/nix-community/NUR/commit/dd2b6acde8faac90eab0928c5ad4e4e234ca3488) | `` automatic update `` |
| [`9716fd89`](https://github.com/nix-community/NUR/commit/9716fd891bd8247f82f2e7cf938b12042559357b) | `` automatic update `` |
| [`3f9bd46d`](https://github.com/nix-community/NUR/commit/3f9bd46d7fa79fd0b7323ebc1032b6ac46f240c5) | `` automatic update `` |
| [`13880d5d`](https://github.com/nix-community/NUR/commit/13880d5d49a3770a64762da8a259585e3ba00201) | `` automatic update `` |
| [`ebd3ea05`](https://github.com/nix-community/NUR/commit/ebd3ea05657c254f038690d983a06bc0c800e21c) | `` automatic update `` |
| [`a37ec020`](https://github.com/nix-community/NUR/commit/a37ec0209ff1d546ab36f50199cce8be79d1fa7d) | `` automatic update `` |
| [`c65a89c7`](https://github.com/nix-community/NUR/commit/c65a89c734f32a5c544d7ed3e264290f17bbe267) | `` automatic update `` |
| [`3af8c98a`](https://github.com/nix-community/NUR/commit/3af8c98a0cb2b4c26c312f23ac59ca3d6b8743a5) | `` automatic update `` |
| [`d59ce50d`](https://github.com/nix-community/NUR/commit/d59ce50db8d95885953c6fc6f4ce8abe8d8ed1e3) | `` automatic update `` |