### PR TITLE
chore(flake/lanzaboote): `995637eb` -> `fa81496a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -49,11 +49,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1741481578,
-        "narHash": "sha256-JBTSyJFQdO3V8cgcL08VaBUByEU6P5kXbTJN6R0PFQo=",
+        "lastModified": 1746291859,
+        "narHash": "sha256-DdWJLA+D5tcmrRSg5Y7tp/qWaD05ATI4Z7h22gd1h7Q=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "bb1c9567c43e4434f54e9481eb4b8e8e0d50f0b5",
+        "rev": "dfd9a8dfd09db9aad544c4d3b6c47b12562544a5",
         "type": "github"
       },
       "original": {
@@ -382,11 +382,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1745271491,
-        "narHash": "sha256-4GAHjus6JRpYHVROMIhFIz/sgLDF/klBM3UHulbSK9s=",
+        "lastModified": 1746717538,
+        "narHash": "sha256-mBPMdT19oLO6zRxTiuoKIKPQ4smlD8om3CZC3F34ZNo=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "995637eb3ab78eac33f8ee6b45cc2ecd5ede12ba",
+        "rev": "fa81496ad7359f62deec2f52882479250b237fc7",
         "type": "github"
       },
       "original": {
@@ -856,11 +856,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741573199,
-        "narHash": "sha256-A2sln1GdCf+uZ8yrERSCZUCqZ3JUlOv1WE2VFqqfaLQ=",
+        "lastModified": 1746671794,
+        "narHash": "sha256-V+mpk2frYIEm85iYf+KPDmCGG3zBRAEhbv0E3lHdG2U=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c777dc8a1e35407b0e80ec89817fe69970f4e81a",
+        "rev": "ceec434b8741c66bb8df5db70d7e629a9d9c598f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                           |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`1a5b789c`](https://github.com/nix-community/lanzaboote/commit/1a5b789ce4816e6e98cf706c681c7926b0724e40) | `` rust: placate clippy more ``                   |
| [`e634dc26`](https://github.com/nix-community/lanzaboote/commit/e634dc26d795073049798ec3d24f162a4294848b) | `` uefi: placate clippy ``                        |
| [`04176ea2`](https://github.com/nix-community/lanzaboote/commit/04176ea207059a50d6e7b582dbc91ce4ceff9610) | `` uefi: bump rust toolchain from 1.78 to 1.86 `` |
| [`92751736`](https://github.com/nix-community/lanzaboote/commit/927517362aece8dc45627d4a5ef037551b47282d) | `` chore(deps): lock file maintenance ``          |
| [`e40b295b`](https://github.com/nix-community/lanzaboote/commit/e40b295b82b1c24c789d569dd94e604554e99372) | `` Fix activationScript enrollKeys option ``      |