### PR TITLE
chore(flake/nur): `dd2b6acd` -> `0cb029dc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1746689455,
-        "narHash": "sha256-nhUz3/4AHEVpMaT4TQN+rXY2EsX4GJWXnVr9eTGptEk=",
+        "lastModified": 1746700024,
+        "narHash": "sha256-+Oo5wlOZ7XzZnOVFN2gdC3XUEhxXE36sDWPLxHa2D84=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dd2b6acde8faac90eab0928c5ad4e4e234ca3488",
+        "rev": "0cb029dc574a43fd63b9a7ade5a6afb8a843d281",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0cb029dc`](https://github.com/nix-community/NUR/commit/0cb029dc574a43fd63b9a7ade5a6afb8a843d281) | `` automatic update `` |
| [`62161e58`](https://github.com/nix-community/NUR/commit/62161e584fcd651968963baf092a4a02931de216) | `` automatic update `` |