### PR TITLE
chore(flake/darwin): `760a11c8` -> `6cb36e83`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746254942,
-        "narHash": "sha256-Y062AuRx6l+TJNX8wxZcT59SSLsqD9EedAY0mqgTtQE=",
+        "lastModified": 1746708654,
+        "narHash": "sha256-GeC99gu5H6+AjBXsn5dOhP4/ApuioGCBkufdmEIWPRs=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "760a11c87009155afa0140d55c40e7c336d62d7a",
+        "rev": "6cb36e8327421c61e5a3bbd08ed63491b616364a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                    |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------ |
| [`c36b57f2`](https://github.com/nix-darwin/nix-darwin/commit/c36b57f2191bf5c69235765f14a2f3dc9d4fdaee) | `` programs/_1password-gui: init module `` |
| [`24c2d2ba`](https://github.com/nix-darwin/nix-darwin/commit/24c2d2bab7fc718a3356b1c15a8750655d9556c2) | `` programs/_1password: init module ``     |