### PR TITLE
chore(flake/nur): `0cb029dc` -> `d997cc01`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -725,11 +725,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1746461020,
-        "narHash": "sha256-7+pG1I9jvxNlmln4YgnlW4o+w0TZX24k688mibiFDUE=",
+        "lastModified": 1746592047,
+        "narHash": "sha256-GYYT5Pc+sZZWomgC7EgDSNSfmXd9Jby9nXQ6bAswUCg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3730d8a308f94996a9ba7c7138ede69c1b9ac4ae",
+        "rev": "8fcc71459655f2486b3da197b8d6a62f595a33d2",
         "type": "github"
       },
       "original": {
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1746700024,
-        "narHash": "sha256-+Oo5wlOZ7XzZnOVFN2gdC3XUEhxXE36sDWPLxHa2D84=",
+        "lastModified": 1746748039,
+        "narHash": "sha256-rea3RjwhTDjq/ovrFU1zISyXbv0uG4ZivFg1vtHnzRA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0cb029dc574a43fd63b9a7ade5a6afb8a843d281",
+        "rev": "d997cc011fd3d6373923f6cf18b3e2296baa234d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d997cc01`](https://github.com/nix-community/NUR/commit/d997cc011fd3d6373923f6cf18b3e2296baa234d) | `` automatic update `` |
| [`2bddbb01`](https://github.com/nix-community/NUR/commit/2bddbb01686534b8ab856be9c4f8e4df20077057) | `` automatic update `` |
| [`228d29ab`](https://github.com/nix-community/NUR/commit/228d29ab7ffa3f89d0088917883b179c7bce05f2) | `` automatic update `` |
| [`eb5a9db5`](https://github.com/nix-community/NUR/commit/eb5a9db5d82a059216bdc2df52c86e34b7c355ff) | `` automatic update `` |
| [`983079e1`](https://github.com/nix-community/NUR/commit/983079e14c1ee92c11254734caee6e398e696e2c) | `` automatic update `` |
| [`7dc664a8`](https://github.com/nix-community/NUR/commit/7dc664a884cdbbc9b6a26a4d85481e68172aa8c6) | `` automatic update `` |
| [`c1d19bde`](https://github.com/nix-community/NUR/commit/c1d19bde875c283b2690fb91fc7f444ac035e9d8) | `` automatic update `` |
| [`a66b1a35`](https://github.com/nix-community/NUR/commit/a66b1a35d7d1f5593d0afb6e0c91bed14a5fd37b) | `` automatic update `` |
| [`13d2e10f`](https://github.com/nix-community/NUR/commit/13d2e10fc4126996050d5371fb6a3867a3ec6da6) | `` automatic update `` |
| [`9ff00ad8`](https://github.com/nix-community/NUR/commit/9ff00ad8e28a1f807a24669c0c3d6ffa2124f327) | `` automatic update `` |
| [`f3492743`](https://github.com/nix-community/NUR/commit/f3492743e91bfa1593a99812250c1ecde54a8a2a) | `` automatic update `` |