### PR TITLE
chore(flake/home-manager): `50894120` -> `a5159823`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746703400,
-        "narHash": "sha256-mSqWQsJYMJBI3+X3opqaUqeNsGQxVdaNL5iUF7a6p50=",
+        "lastModified": 1746727295,
+        "narHash": "sha256-0364XVBdfEA8rWfqEPvsgBqGFfq5r9LAo9CS9tvT7tg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "50894120e8ac792a5d3046d23e4e4c4ef32cf09c",
+        "rev": "a51598236f23c89e59ee77eb8e0614358b0e896c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                            |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`a5159823`](https://github.com/nix-community/home-manager/commit/a51598236f23c89e59ee77eb8e0614358b0e896c) | `` lutris: add module (#6964) ``                                   |
| [`3c59c513`](https://github.com/nix-community/home-manager/commit/3c59c5132b64e885faca381e713b579dcbddba75) | `` wayprompt: init module (#7002) ``                               |
| [`c84396bd`](https://github.com/nix-community/home-manager/commit/c84396bda0371cb42147c82ad051bebf8a158bd5) | `` rofi: modes optional (#7003) ``                                 |
| [`cea975d4`](https://github.com/nix-community/home-manager/commit/cea975d46d08293eae3ad0d9f16207f1ce2dfc81) | `` rofi: modes option (#6115) ``                                   |
| [`2ede089d`](https://github.com/nix-community/home-manager/commit/2ede089d11b68d7abfcb022c60cf71249504c3b0) | `` git: configure patdiff through [patdiff] git section (#6978) `` |