### PR TITLE
chore(flake/srvos): `7aefe82e` -> `a6784a02`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -933,11 +933,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746666190,
-        "narHash": "sha256-XZMa4o1tJQER0jQ+Yjx3MB5P9wRuDuAU3pTm4QgEjC0=",
+        "lastModified": 1746712786,
+        "narHash": "sha256-xNaoH62qyEWFNLgyq4QsENwFyG/l9a/dVPN8z5i7+RI=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "7aefe82e5d2b362e3b569d6ccbed4c54f49e74c4",
+        "rev": "a6784a02b6d101edc90a3202f4ba03860115f149",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                        |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`fbbbf8c9`](https://github.com/nix-community/srvos/commit/fbbbf8c97f662c9aef2da53b6bd0fd4cbf324c0b) | `` improve wording in telegraf mixin documentation ``          |
| [`c398f2e0`](https://github.com/nix-community/srvos/commit/c398f2e043b6bb961279d46c663eb8ac265267ba) | `` mention telegraf mixin in prometheus mixin documentation `` |