### PR TITLE
chore(flake/emacs-overlay): `d9e6b204` -> `3cbccdce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1746635180,
-        "narHash": "sha256-v/lPugIVymeiBMcQqH8050xpKJ6JF+4YaST11BwBeGc=",
+        "lastModified": 1746721524,
+        "narHash": "sha256-DZFZfWKobG/Z+F2Hd99csxUT5Oo4TnnZQV2OSYvblVY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d9e6b2044ed09ad5957306002aef88f7caa05a12",
+        "rev": "3cbccdceacacdb60d18f31272451cfc748039ba4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`3cbccdce`](https://github.com/nix-community/emacs-overlay/commit/3cbccdceacacdb60d18f31272451cfc748039ba4) | `` Updated elpa ``   |
| [`373de9cd`](https://github.com/nix-community/emacs-overlay/commit/373de9cd1923b3d7ef0bef0887f0f52729a12312) | `` Updated nongnu `` |