### PR TITLE
chore(flake/emacs-overlay): `3cbccdce` -> `8ae92505`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1746721524,
-        "narHash": "sha256-DZFZfWKobG/Z+F2Hd99csxUT5Oo4TnnZQV2OSYvblVY=",
+        "lastModified": 1746807886,
+        "narHash": "sha256-gNS0r0JdkdsrqYkzpJK20vDRFSy7+1fuziRWd4BZiu4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3cbccdceacacdb60d18f31272451cfc748039ba4",
+        "rev": "8ae925057bad39c6a72f55dd2ff0b281e2cea714",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`8ae92505`](https://github.com/nix-community/emacs-overlay/commit/8ae925057bad39c6a72f55dd2ff0b281e2cea714) | `` Updated elpa ``         |
| [`7d1167d2`](https://github.com/nix-community/emacs-overlay/commit/7d1167d2ef4958c8fbb76e30bac9d2e75c55c099) | `` Updated nongnu ``       |
| [`be5aec38`](https://github.com/nix-community/emacs-overlay/commit/be5aec380e041a8b8d5aee9ebf89d9b3f1006c29) | `` Updated emacs ``        |
| [`b1d393ea`](https://github.com/nix-community/emacs-overlay/commit/b1d393ea110071da349e395151b8e656bef800fd) | `` Updated melpa ``        |
| [`91800e69`](https://github.com/nix-community/emacs-overlay/commit/91800e6973d6b6eae46dfbb0691ecc3b4fc0d9f5) | `` Updated nongnu ``       |
| [`551f6a3b`](https://github.com/nix-community/emacs-overlay/commit/551f6a3b8af9113d1d663625b04757f3c46cc121) | `` Updated flake inputs `` |