### PR TITLE
chore(flake/nur): `d997cc01` -> `94807c56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -725,11 +725,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1746592047,
-        "narHash": "sha256-GYYT5Pc+sZZWomgC7EgDSNSfmXd9Jby9nXQ6bAswUCg=",
+        "lastModified": 1746663147,
+        "narHash": "sha256-Ua0drDHawlzNqJnclTJGf87dBmaO/tn7iZ+TCkTRpRc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8fcc71459655f2486b3da197b8d6a62f595a33d2",
+        "rev": "dda3dcd3fe03e991015e9a74b22d35950f264a54",
         "type": "github"
       },
       "original": {
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1746748039,
-        "narHash": "sha256-rea3RjwhTDjq/ovrFU1zISyXbv0uG4ZivFg1vtHnzRA=",
+        "lastModified": 1746770521,
+        "narHash": "sha256-zP0UqlcKhmIFasNBcxZPLuxKOBoEffrHsrNmMp0h+V8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d997cc011fd3d6373923f6cf18b3e2296baa234d",
+        "rev": "94807c56542e960a57146772a66dfd7247f56e5c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`94807c56`](https://github.com/nix-community/NUR/commit/94807c56542e960a57146772a66dfd7247f56e5c) | `` automatic update `` |
| [`98314b39`](https://github.com/nix-community/NUR/commit/98314b39cc2554d0737fa7f50301980b7b1bacde) | `` automatic update `` |
| [`5c9ec883`](https://github.com/nix-community/NUR/commit/5c9ec8836f31d858a172a4109fb39267c5fc9627) | `` automatic update `` |
| [`8931e900`](https://github.com/nix-community/NUR/commit/8931e9009751577d42d702ec783e191008b76e12) | `` automatic update `` |
| [`ac5c4836`](https://github.com/nix-community/NUR/commit/ac5c4836ce9900d858cda5918cded5ba2fd44cf7) | `` automatic update `` |
| [`84269d7c`](https://github.com/nix-community/NUR/commit/84269d7c9da0001dd7a0951b2fb4bcbdebe33517) | `` automatic update `` |
| [`158e36f8`](https://github.com/nix-community/NUR/commit/158e36f8234c81c88ebcf14d0d0c72ba0a71aae9) | `` automatic update `` |