### PR TITLE
chore(flake/nur): `94807c56` -> `c98329e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1746770521,
-        "narHash": "sha256-zP0UqlcKhmIFasNBcxZPLuxKOBoEffrHsrNmMp0h+V8=",
+        "lastModified": 1746805708,
+        "narHash": "sha256-h0i/abrPcCPyikUuTgGdi5dC7hDkVJJ7/cNCObYOAwU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "94807c56542e960a57146772a66dfd7247f56e5c",
+        "rev": "c98329e5b69b186f02bc6e2414cc8ff00d7f2245",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c98329e5`](https://github.com/nix-community/NUR/commit/c98329e5b69b186f02bc6e2414cc8ff00d7f2245) | `` automatic update `` |
| [`b282b384`](https://github.com/nix-community/NUR/commit/b282b3844579e65b1a97e7e3f4508c167c3bcae3) | `` automatic update `` |
| [`45c43c77`](https://github.com/nix-community/NUR/commit/45c43c77238e598e667c7a08052bf22909612f05) | `` automatic update `` |
| [`8a59a861`](https://github.com/nix-community/NUR/commit/8a59a8618b2ac9b7663803d75cb8d14712b9ab23) | `` automatic update `` |
| [`3543448d`](https://github.com/nix-community/NUR/commit/3543448d231603931560d7f04914fcef44827a27) | `` automatic update `` |
| [`e57020e8`](https://github.com/nix-community/NUR/commit/e57020e88e8d89f5975716771967cdf2bf6aefc2) | `` automatic update `` |
| [`22183e31`](https://github.com/nix-community/NUR/commit/22183e31d5766efa50eddf1542689d5c02e279cd) | `` automatic update `` |