### PR TITLE
chore(flake/nur): `c98329e5` -> `dad9e8b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1746805708,
-        "narHash": "sha256-h0i/abrPcCPyikUuTgGdi5dC7hDkVJJ7/cNCObYOAwU=",
+        "lastModified": 1746848490,
+        "narHash": "sha256-fwX35ACjDCrXEf8C4jiDNyeq1v/LNLj8GQdJl5RR89o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c98329e5b69b186f02bc6e2414cc8ff00d7f2245",
+        "rev": "dad9e8b8e2e4f15a8686eb11f6a4ee416b9c3291",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dad9e8b8`](https://github.com/nix-community/NUR/commit/dad9e8b8e2e4f15a8686eb11f6a4ee416b9c3291) | `` automatic update `` |
| [`80d2f04a`](https://github.com/nix-community/NUR/commit/80d2f04aac57c501f4713b75125de8c6d000db92) | `` automatic update `` |
| [`6f3cfdf2`](https://github.com/nix-community/NUR/commit/6f3cfdf23921983a2e76504c3eba75e57a6d4b53) | `` automatic update `` |
| [`ace9fb78`](https://github.com/nix-community/NUR/commit/ace9fb7856d885cac4783c5f4b62e359eda5a96b) | `` automatic update `` |
| [`1470795e`](https://github.com/nix-community/NUR/commit/1470795ec7d4bdd9d0bd5b9f83e403fe858294ad) | `` automatic update `` |
| [`3d7a5a71`](https://github.com/nix-community/NUR/commit/3d7a5a714c9fc337d78ee7fa30c65b9f13df3af5) | `` automatic update `` |
| [`da93effb`](https://github.com/nix-community/NUR/commit/da93effbf4c316f60128699f14a338157502baeb) | `` automatic update `` |
| [`3b8ac668`](https://github.com/nix-community/NUR/commit/3b8ac66842c08065e6ec1499b95e8c30c6d38ed4) | `` automatic update `` |