### PR TITLE
chore(flake/nixos-hardware): `2ea3ad8a` -> `3c5e1267`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -568,11 +568,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1746621361,
-        "narHash": "sha256-T9vOxEqI1j1RYugV0b9dgy0AreiZ9yBDKZJYyclF0og=",
+        "lastModified": 1746814339,
+        "narHash": "sha256-hf2lICJzwACWuzHCmZn5NI6LUAOgGdR1yh8ip+duyhk=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "2ea3ad8a1f26a76f8a8e23fc4f7757c46ef30ee5",
+        "rev": "3c5e12673265dfb0de3d9121420c0c2153bf21e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                         |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`3c5e1267`](https://github.com/NixOS/nixos-hardware/commit/3c5e12673265dfb0de3d9121420c0c2153bf21e0) | `` Add kvm-intel kernel module for XPS13 ``     |
| [`c4013507`](https://github.com/NixOS/nixos-hardware/commit/c40135076deb53668394a023c0220303c0126007) | `` Ensure WiFi works out-of-the-box on XPS13 `` |