### PR TITLE
chore(flake/lanzaboote): `fa81496a` -> `2e425f3d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -382,11 +382,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1746717538,
-        "narHash": "sha256-mBPMdT19oLO6zRxTiuoKIKPQ4smlD8om3CZC3F34ZNo=",
+        "lastModified": 1747056319,
+        "narHash": "sha256-qSKcBaISBozadtPq6BomnD+wIYTZIkiua3UuHLaD52c=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "fa81496ad7359f62deec2f52882479250b237fc7",
+        "rev": "2e425f3da6ce7f5b34fa6eaf7a2a7f78dbabcc85",
         "type": "github"
       },
       "original": {
@@ -856,11 +856,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746671794,
-        "narHash": "sha256-V+mpk2frYIEm85iYf+KPDmCGG3zBRAEhbv0E3lHdG2U=",
+        "lastModified": 1747017456,
+        "narHash": "sha256-C/U12fcO+HEF071b5mK65lt4XtAIZyJSSJAg9hdlvTk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "ceec434b8741c66bb8df5db70d7e629a9d9c598f",
+        "rev": "5b07506ae89b025b14de91f697eba23b48654c52",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                           |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`e4eb7b41`](https://github.com/nix-community/lanzaboote/commit/e4eb7b41973e403eac626909582a68ba1e3fc1d0) | `` chore(deps): lock file maintenance ``          |
| [`08d2d49e`](https://github.com/nix-community/lanzaboote/commit/08d2d49e940ed8197380ef5a4c375d53de2ecd35) | `` mark boot.lanzaboote.enrollKeys for testing `` |