### PR TITLE
chore(flake/nur): `dad9e8b8` -> `94eea9d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1746848490,
-        "narHash": "sha256-fwX35ACjDCrXEf8C4jiDNyeq1v/LNLj8GQdJl5RR89o=",
+        "lastModified": 1746877516,
+        "narHash": "sha256-XSten3T8jBZwYhmOoZG0W5tEWXWYipoqeJYOUEXQQqY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dad9e8b8e2e4f15a8686eb11f6a4ee416b9c3291",
+        "rev": "94eea9d2337296df61b3b2ae52130deec7b131d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`94eea9d2`](https://github.com/nix-community/NUR/commit/94eea9d2337296df61b3b2ae52130deec7b131d7) | `` automatic update `` |
| [`b1eefd25`](https://github.com/nix-community/NUR/commit/b1eefd25e38c5dd865d0794dc59718f90222768e) | `` automatic update `` |
| [`d219e290`](https://github.com/nix-community/NUR/commit/d219e2903e583ab950f2d82be0957ef409056bbc) | `` automatic update `` |
| [`044a77e9`](https://github.com/nix-community/NUR/commit/044a77e915aa9fcf6e16de78f8afaa7aacfb1b30) | `` automatic update `` |
| [`fc4250b2`](https://github.com/nix-community/NUR/commit/fc4250b2c6c9af2487d6b83107af179ff7a32d67) | `` automatic update `` |
| [`65b95868`](https://github.com/nix-community/NUR/commit/65b95868f1e5e7c68fe303144e44251bf01b2e8d) | `` automatic update `` |
| [`6286572a`](https://github.com/nix-community/NUR/commit/6286572a0a2b8472339c750ba3aa95bb05343459) | `` automatic update `` |
| [`4bd9163f`](https://github.com/nix-community/NUR/commit/4bd9163fe0bd7a31bcd04c297441ae58ef2d179c) | `` automatic update `` |
| [`18f3a79b`](https://github.com/nix-community/NUR/commit/18f3a79b205795fed650a335b34f22015681779b) | `` automatic update `` |