### PR TITLE
chore(flake/emacs-overlay): `8ae92505` -> `21acd667`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1746807886,
-        "narHash": "sha256-gNS0r0JdkdsrqYkzpJK20vDRFSy7+1fuziRWd4BZiu4=",
+        "lastModified": 1746983833,
+        "narHash": "sha256-RSyuij0Qw3p6p1HfbDpne/eMfuA9KZEkg9lTUYLaOKg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8ae925057bad39c6a72f55dd2ff0b281e2cea714",
+        "rev": "21acd66775f610a5dfe4a1a3205406666ddd15d7",
         "type": "github"
       },
       "original": {
@@ -646,11 +646,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1746557022,
-        "narHash": "sha256-QkNoyEf6TbaTW5UZYX0OkwIJ/ZMeKSSoOMnSDPQuol0=",
+        "lastModified": 1746810718,
+        "narHash": "sha256-VljtYzyttmvkWUKTVJVW93qAsJsrBbgAzy7DdnJaQfI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1d3aeb5a193b9ff13f63f4d9cc169fb88129f860",
+        "rev": "0c0bf9c057382d5f6f63d54fd61f1abd5e1c2f63",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`21acd667`](https://github.com/nix-community/emacs-overlay/commit/21acd66775f610a5dfe4a1a3205406666ddd15d7) | `` Updated emacs ``        |
| [`0f1d08e0`](https://github.com/nix-community/emacs-overlay/commit/0f1d08e0f18c990fc4ccdea6e4104c3c04d75560) | `` Updated melpa ``        |
| [`3384a125`](https://github.com/nix-community/emacs-overlay/commit/3384a125e95c77e9d39d6a07ed3976e88cd0a11b) | `` Updated elpa ``         |
| [`3f188376`](https://github.com/nix-community/emacs-overlay/commit/3f18837669f8d9fba26f28da475c08049e7fe454) | `` Updated nongnu ``       |
| [`8a79c78b`](https://github.com/nix-community/emacs-overlay/commit/8a79c78b3d84b550eb48a9988ab79a63478a5768) | `` Updated emacs ``        |
| [`bccc3c8b`](https://github.com/nix-community/emacs-overlay/commit/bccc3c8b3fb243263136fb9430f4099b2b4fffcd) | `` Updated melpa ``        |
| [`21fce8b4`](https://github.com/nix-community/emacs-overlay/commit/21fce8b42450af35f518c1fd8df2fa9574b14753) | `` Updated melpa ``        |
| [`5d426974`](https://github.com/nix-community/emacs-overlay/commit/5d4269746ea5e8f99085ba1f32ec17b7005b6724) | `` Updated elpa ``         |
| [`c69a0fe5`](https://github.com/nix-community/emacs-overlay/commit/c69a0fe562987e33ecfad9f7ca09cc3c81d5b478) | `` Updated nongnu ``       |
| [`bac3e427`](https://github.com/nix-community/emacs-overlay/commit/bac3e4274eb6843e504a6c525580b8f2583d85f7) | `` Updated flake inputs `` |
| [`1c2872c0`](https://github.com/nix-community/emacs-overlay/commit/1c2872c034ec7745aa5cfec7579f9e59b53dbfe2) | `` Updated emacs ``        |
| [`b836c6ec`](https://github.com/nix-community/emacs-overlay/commit/b836c6ec524a150f0a671cff1c3a51ade1d9e497) | `` Updated melpa ``        |
| [`94a17b67`](https://github.com/nix-community/emacs-overlay/commit/94a17b67cf27ee8992fb75a01214412be2e7987f) | `` Updated elpa ``         |
| [`7a9c1a45`](https://github.com/nix-community/emacs-overlay/commit/7a9c1a45a51e7cc6c2b8405a4a46fa1268ab6359) | `` Updated emacs ``        |
| [`2185a4df`](https://github.com/nix-community/emacs-overlay/commit/2185a4df238e290afb8cbb2f3675ed4bd46a5e81) | `` Updated melpa ``        |
| [`5b5ee505`](https://github.com/nix-community/emacs-overlay/commit/5b5ee505fddb64ec36ff1f410d64ed56f313022e) | `` Updated elpa ``         |
| [`e2c1c9e8`](https://github.com/nix-community/emacs-overlay/commit/e2c1c9e8d01395574a1c268f6864682b105acb64) | `` Updated nongnu ``       |