### PR TITLE
chore(flake/nur): `94eea9d2` -> `7c77c425`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1746877516,
-        "narHash": "sha256-XSten3T8jBZwYhmOoZG0W5tEWXWYipoqeJYOUEXQQqY=",
+        "lastModified": 1746906291,
+        "narHash": "sha256-dX85SDSt4h7281Dkox9NnTPjCIDs5JxkJQB9Czd7ajc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "94eea9d2337296df61b3b2ae52130deec7b131d7",
+        "rev": "7c77c4255a4cda029257090a72806dbd48ea14e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7c77c425`](https://github.com/nix-community/NUR/commit/7c77c4255a4cda029257090a72806dbd48ea14e3) | `` automatic update `` |
| [`04dc40b6`](https://github.com/nix-community/NUR/commit/04dc40b66404c504869a568150779a2f54d46b73) | `` automatic update `` |
| [`446ac67a`](https://github.com/nix-community/NUR/commit/446ac67ac64b09be155b53a203dd0051755b48a6) | `` automatic update `` |
| [`887e5be2`](https://github.com/nix-community/NUR/commit/887e5be213778cb047379434b6bb41ad09d9c8db) | `` automatic update `` |
| [`86239401`](https://github.com/nix-community/NUR/commit/8623940144c68f22bdb22e546f4cf47b4f9b6718) | `` automatic update `` |
| [`d67ad6c3`](https://github.com/nix-community/NUR/commit/d67ad6c3b6aa848a5d2adc1dec263f818e6675ee) | `` automatic update `` |