### PR TITLE
chore(flake/home-manager): `e95a7c5b` -> `6991569c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746798521,
-        "narHash": "sha256-axfz/jBEH9XHpS7YSumstV7b2PrPf7L8bhWUtLBv3nA=",
+        "lastModified": 1746950680,
+        "narHash": "sha256-tSEJ/8Tjtoy4yKbfMhIgKcSR/UJ4GjYlM4BT84+YKW8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e95a7c5b6fa93304cd2fd78cf676c4f6d23c422c",
+        "rev": "6991569cb7cdde9891f52b43abe9916779df45b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                            |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`6991569c`](https://github.com/nix-community/home-manager/commit/6991569cb7cdde9891f52b43abe9916779df45b0) | `` flake.lock: Update ``                                           |
| [`de496c9c`](https://github.com/nix-community/home-manager/commit/de496c9ccb705ed76c1f23c2cad13e8970c37f0b) | `` television: add support for channels (#7026) ``                 |
| [`9ef92f1c`](https://github.com/nix-community/home-manager/commit/9ef92f1c6b77944198fd368ec805ced842352a1d) | `` waveterm: fix markdown in description ``                        |
| [`13289f06`](https://github.com/nix-community/home-manager/commit/13289f06429700f3ecf8f5109ed8831839f09145) | `` services.autorandr: improve systemd unit description ``         |
| [`1875b5a1`](https://github.com/nix-community/home-manager/commit/1875b5a1606a897d9285d80600c7ab566911c7bc) | `` services.autorandr: improve configurability ``                  |
| [`555f88ad`](https://github.com/nix-community/home-manager/commit/555f88ad3452f1d2ce1560e7209b0b6af0c6033b) | `` services.autorandr: add package option ``                       |
| [`4f442217`](https://github.com/nix-community/home-manager/commit/4f44221724ce074404fb0e569acdd6c456ed22d2) | `` services.autorandr: add lowlevl to maintainers ``               |
| [`b96c332d`](https://github.com/nix-community/home-manager/commit/b96c332dce9a1974ee046a4dcd5860a5f41009f5) | `` maintainers: add lowlevl ``                                     |
| [`12e67385`](https://github.com/nix-community/home-manager/commit/12e67385964d9c9304daa81d0ad5ba3b01fdd35e) | `` docs: remove recommendation to wait for maintainers for news `` |
| [`6fd639db`](https://github.com/nix-community/home-manager/commit/6fd639dbe5183850b6c4a7fb47ae04c4808cb891) | `` docs: update news.md to highlight create-news-entry command ``  |
| [`c4bd004d`](https://github.com/nix-community/home-manager/commit/c4bd004d9d8981837d958264b809f7edc93d9957) | `` flake.nix: expose create-news-entry as a package ``             |