### PR TITLE
chore(flake/catppuccin): `f746600f` -> `bbc926d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1746650299,
-        "narHash": "sha256-4+pxk1KcSH8ww3tgN808nNJ3E7Q8gNWI+U0sesW7mBQ=",
+        "lastModified": 1746896926,
+        "narHash": "sha256-rrpqPPUI+8xJ2ye2UsR5wFjhZo9lp+BZ/RAtPwsSrj0=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "f746600f15b69df05c84e3037749a3be5b1276d1",
+        "rev": "bbc926d6f93a7cdad1cd38dc1410cea23589a40e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                    |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`bbc926d6`](https://github.com/catppuccin/nix/commit/bbc926d6f93a7cdad1cd38dc1410cea23589a40e) | `` fix(mako): inherit from theme (#560) `` |
| [`b605159b`](https://github.com/catppuccin/nix/commit/b605159bcb8c2ea5dd5457e9974a04077939b2e4) | `` fix(mako): use theme directly (#559) `` |