### PR TITLE
chore(flake/nur): `7c77c425` -> `70927a54`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1746906291,
-        "narHash": "sha256-dX85SDSt4h7281Dkox9NnTPjCIDs5JxkJQB9Czd7ajc=",
+        "lastModified": 1746913511,
+        "narHash": "sha256-rx+EvvjU9wJHT3kABMt5dG2J7auwhxddS60o23P9Egk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7c77c4255a4cda029257090a72806dbd48ea14e3",
+        "rev": "70927a547efa4ccab230ae3e429b17616687f364",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                    |
| -------------------------------------------------------------------------------------------------- | -------------------------- |
| [`70927a54`](https://github.com/nix-community/NUR/commit/70927a547efa4ccab230ae3e429b17616687f364) | `` automatic update ``     |
| [`ab7954ec`](https://github.com/nix-community/NUR/commit/ab7954ecc0151c22b5733c2c7f84fd40a63a0f10) | `` automatic update ``     |
| [`42c8594f`](https://github.com/nix-community/NUR/commit/42c8594f3cdb1f3636518e9afbe43433ab0efa01) | `` add chap9 repository `` |