### PR TITLE
chore(flake/nur): `b57b25de` -> `864c38c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1746935061,
-        "narHash": "sha256-0BDuu4RVu/l/xDc/Fx6cz/MI3qDEmg+n5I6VWMPYH7s=",
+        "lastModified": 1746949126,
+        "narHash": "sha256-xxT8w1bicBWtBTo8lPtHYMvgctm4PA5DNKPTl5QtoiA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b57b25de6ad12b544bbf80a3d72085590da1b877",
+        "rev": "864c38c7b0a49f1e91901056147f92444c32338c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`864c38c7`](https://github.com/nix-community/NUR/commit/864c38c7b0a49f1e91901056147f92444c32338c) | `` automatic update `` |
| [`6cde43e9`](https://github.com/nix-community/NUR/commit/6cde43e97c9fe43a5d3ee668d592bcbb35f12cb5) | `` automatic update `` |
| [`2d3cbdc3`](https://github.com/nix-community/NUR/commit/2d3cbdc3ee7a5448b1ef0f8ce02e8d25802d67ad) | `` automatic update `` |