### PR TITLE
chore(flake/nur): `864c38c7` -> `6264d6be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -725,11 +725,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1746663147,
-        "narHash": "sha256-Ua0drDHawlzNqJnclTJGf87dBmaO/tn7iZ+TCkTRpRc=",
+        "lastModified": 1746904237,
+        "narHash": "sha256-3e+AVBczosP5dCLQmMoMEogM57gmZ2qrVSrmq9aResQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dda3dcd3fe03e991015e9a74b22d35950f264a54",
+        "rev": "d89fc19e405cb2d55ce7cc114356846a0ee5e956",
         "type": "github"
       },
       "original": {
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1746949126,
-        "narHash": "sha256-xxT8w1bicBWtBTo8lPtHYMvgctm4PA5DNKPTl5QtoiA=",
+        "lastModified": 1747007151,
+        "narHash": "sha256-dTMquOLcIayAucgY51AQk+DSU/zGC4RO4G+ZYdBijlY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "864c38c7b0a49f1e91901056147f92444c32338c",
+        "rev": "6264d6be75ac82e99689178c52bf57352108284f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6264d6be`](https://github.com/nix-community/NUR/commit/6264d6be75ac82e99689178c52bf57352108284f) | `` automatic update `` |
| [`c0a68484`](https://github.com/nix-community/NUR/commit/c0a68484a5673b121797292888173cfbad13067a) | `` automatic update `` |
| [`da6b9c5a`](https://github.com/nix-community/NUR/commit/da6b9c5a9fd8cfb2eab0d6979fa4db84feddbb53) | `` automatic update `` |
| [`01760ed5`](https://github.com/nix-community/NUR/commit/01760ed5a4849033127ec14b0922eae695332ad2) | `` automatic update `` |
| [`f67bba88`](https://github.com/nix-community/NUR/commit/f67bba88919aa11bd37e56a5caad1aab8b7e2f6f) | `` automatic update `` |
| [`82ab7dec`](https://github.com/nix-community/NUR/commit/82ab7dec9a3c6a472f6f9d73d3b37a69912ea6ca) | `` automatic update `` |
| [`ffc9a482`](https://github.com/nix-community/NUR/commit/ffc9a482e0aece13d1fb0927d2b9c26d09feb17a) | `` automatic update `` |
| [`e2d27e24`](https://github.com/nix-community/NUR/commit/e2d27e24cafa11a1ae2466606a096afa52278f35) | `` automatic update `` |
| [`bb1ad260`](https://github.com/nix-community/NUR/commit/bb1ad2601b9ece43fac8ac2736e1a8d0742ec2b4) | `` automatic update `` |
| [`916aa96e`](https://github.com/nix-community/NUR/commit/916aa96e06f82eb7ff9f3f209565f524975dd0d1) | `` automatic update `` |
| [`d1678cf3`](https://github.com/nix-community/NUR/commit/d1678cf3e5ff2000250d1b86c6e1b4b9d507c981) | `` automatic update `` |
| [`9fc3907b`](https://github.com/nix-community/NUR/commit/9fc3907ba68b6b46b24a5ce1bc16fbe3bdaa0640) | `` automatic update `` |
| [`4e81ff87`](https://github.com/nix-community/NUR/commit/4e81ff87d302e9b6b39398a1398d1b743a52e4e4) | `` automatic update `` |