### PR TITLE
chore(flake/minimal-emacs-d): `6003831f` -> `c25ef5c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -398,11 +398,11 @@
     "minimal-emacs-d": {
       "flake": false,
       "locked": {
-        "lastModified": 1746655459,
-        "narHash": "sha256-xBkU0VllP9YImOR3TuuPEj6JvmWGhwGtqE/5VyNDb38=",
+        "lastModified": 1746993797,
+        "narHash": "sha256-jyaYjjQnOYcNdTh/2hkZUNpOKQLlWcrk8PsFPQNqlz4=",
         "owner": "jamescherti",
         "repo": "minimal-emacs.d",
-        "rev": "6003831fbfb2d4f99265fe23a214003d75ef9944",
+        "rev": "c25ef5c081e811ddfbd394e8a71a3e7b22a8ad71",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                     |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------- |
| [`c25ef5c0`](https://github.com/jamescherti/minimal-emacs.d/commit/c25ef5c081e811ddfbd394e8a71a3e7b22a8ad71) | `` Update README.md ``                      |
| [`e66af5dc`](https://github.com/jamescherti/minimal-emacs.d/commit/e66af5dc271711116eac1cae69fc4b8a0bd933bb) | `` Add missing dot in ~/emacs.d/var path `` |