### PR TITLE
chore(flake/nur): `6264d6be` -> `73b714da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1747007151,
-        "narHash": "sha256-dTMquOLcIayAucgY51AQk+DSU/zGC4RO4G+ZYdBijlY=",
+        "lastModified": 1747022504,
+        "narHash": "sha256-J8WTMF/6UgVi90rctW0uBkvUuu5heT+uh6qH4Ksse2Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6264d6be75ac82e99689178c52bf57352108284f",
+        "rev": "73b714da336b5ec5bcb4a73a5f5c05be1b2862d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`73b714da`](https://github.com/nix-community/NUR/commit/73b714da336b5ec5bcb4a73a5f5c05be1b2862d2) | `` automatic update `` |
| [`d0598a89`](https://github.com/nix-community/NUR/commit/d0598a897f19576df2d6509b713b1759bcbf2a8e) | `` automatic update `` |
| [`6cdd9954`](https://github.com/nix-community/NUR/commit/6cdd9954adadbeb5053eb5c18d18913888af1731) | `` automatic update `` |
| [`9fb47f4f`](https://github.com/nix-community/NUR/commit/9fb47f4fbf06ea0b90660690fd1d3e558ef046d7) | `` automatic update `` |
| [`5baef128`](https://github.com/nix-community/NUR/commit/5baef128271ceafeea2b4475fca2e3eddb5c352c) | `` automatic update `` |
| [`fa4a8dcb`](https://github.com/nix-community/NUR/commit/fa4a8dcbdf57afaab7fc8132038e516acc548f04) | `` automatic update `` |
| [`40e81462`](https://github.com/nix-community/NUR/commit/40e81462de303d77d0ca8e13c7077846117f7b28) | `` automatic update `` |
| [`7e890e32`](https://github.com/nix-community/NUR/commit/7e890e3244512305220486b9c8b19701f7e53e0c) | `` automatic update `` |