### PR TITLE
chore(flake/emacs-overlay): `21acd667` -> `f02060c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1746983833,
-        "narHash": "sha256-RSyuij0Qw3p6p1HfbDpne/eMfuA9KZEkg9lTUYLaOKg=",
+        "lastModified": 1747041229,
+        "narHash": "sha256-ImwhpDe4lHNNdPcCZogOofa4a45mBjYFiv2iS39VB3g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "21acd66775f610a5dfe4a1a3205406666ddd15d7",
+        "rev": "f02060c00ccf9a7ce3786ee69e1ffdcd10fcdf9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`f02060c0`](https://github.com/nix-community/emacs-overlay/commit/f02060c00ccf9a7ce3786ee69e1ffdcd10fcdf9a) | `` Updated emacs ``        |
| [`ccb78ed9`](https://github.com/nix-community/emacs-overlay/commit/ccb78ed9ae3130498539f013824f4a4a3463dc4c) | `` Updated melpa ``        |
| [`2abf7ff5`](https://github.com/nix-community/emacs-overlay/commit/2abf7ff574d907ab63fa11c5ff569c780c7eb465) | `` Updated emacs ``        |
| [`d1021614`](https://github.com/nix-community/emacs-overlay/commit/d1021614525194fd440fcd20b791af15e171b5c3) | `` Updated melpa ``        |
| [`49bc3230`](https://github.com/nix-community/emacs-overlay/commit/49bc3230f0691182dc7f3747b0857e39d5dc3e12) | `` Updated elpa ``         |
| [`11b0e5b7`](https://github.com/nix-community/emacs-overlay/commit/11b0e5b7d58554b0a170013e4b45ef882b68a679) | `` Updated nongnu ``       |
| [`13cddec1`](https://github.com/nix-community/emacs-overlay/commit/13cddec12e0ca5cd02cf1d2491a0bff667d02270) | `` Updated flake inputs `` |