### PR TITLE
chore(flake/srvos): `a6784a02` -> `1c7f04e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -933,11 +933,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746712786,
-        "narHash": "sha256-xNaoH62qyEWFNLgyq4QsENwFyG/l9a/dVPN8z5i7+RI=",
+        "lastModified": 1747011883,
+        "narHash": "sha256-+Gu0Ni6RZVo1Rx8JICEuDlpGhpHK1ObkfqIaqCNDmyo=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "a6784a02b6d101edc90a3202f4ba03860115f149",
+        "rev": "1c7f04e1fca2b5791a05c39c453a035bb37c7b9e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`1c7f04e1`](https://github.com/nix-community/srvos/commit/1c7f04e1fca2b5791a05c39c453a035bb37c7b9e) | `` dev/private/flake.lock: Update `` |
| [`861d186f`](https://github.com/nix-community/srvos/commit/861d186f7ffc6bf9589f30b556aa2edee6b1718d) | `` flake.lock: Update ``             |