### PR TITLE
chore(flake/home-manager): `fb061f55` -> `954615c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747021744,
-        "narHash": "sha256-IDsM/9/tHQBlhG3tXI2fTM84AUN1uRa7JDPT1LMlGes=",
+        "lastModified": 1747279714,
+        "narHash": "sha256-UdxlE8yyrKiGq3bgGyJ78AdFwh+fuRAruKtyFY5Zq5I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fb061f555f821fe4fb49f8f6f2a0cc3d5728bd52",
+        "rev": "954615c510c9faa3ee7fb6607ff72e55905e69f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                           |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`954615c5`](https://github.com/nix-community/home-manager/commit/954615c510c9faa3ee7fb6607ff72e55905e69f2) | `` flake.lock: Update (#7058) ``                                                  |
| [`02ea7985`](https://github.com/nix-community/home-manager/commit/02ea79853ce42853d019ce689f533dc93e462862) | `` emacs: respect `defaultEditor` on Darwin (#7063) ``                            |
| [`6bf057fc`](https://github.com/nix-community/home-manager/commit/6bf057fc8326e83bda05a669fc08d106547679fb) | `` zsh: do not duplicate zsh.{profile,login,logout,env}Extra in prezto (#7061) `` |
| [`7c1cefb9`](https://github.com/nix-community/home-manager/commit/7c1cefb98369cc85440642fdccc1c1394ca6dd2c) | `` zsh: avoid IFD while sourcing prezto ``                                        |
| [`5f36563a`](https://github.com/nix-community/home-manager/commit/5f36563a5cae05bcfbaa5e08a69d2e8d94242f61) | `` zsh: consider zsh.{profile,login,logout,env}Extra in prezto ``                 |
| [`b44c39cf`](https://github.com/nix-community/home-manager/commit/b44c39cf4618ccf58df2b68827ca95a3fecf0655) | `` foliate: fix theme settings example (#7053) ``                                 |
| [`8d832ddf`](https://github.com/nix-community/home-manager/commit/8d832ddfda9facf538f3dda9b6985fb0234f151c) | `` foliate: init (#7049) ``                                                       |
| [`df556f2a`](https://github.com/nix-community/home-manager/commit/df556f2a17b7b94148d0275c1a57fed20e62ad18) | `` tests/mako: add a original deprecation test ``                                 |
| [`78ad8e3c`](https://github.com/nix-community/home-manager/commit/78ad8e3c31cc5239674dfd7ca6159e5ca14da0e8) | `` tests/mako: add a deprecation test ``                                          |
| [`0be2c246`](https://github.com/nix-community/home-manager/commit/0be2c246e37a5b6e851111bfcf07ab37194e4954) | `` mako: deprecate criteria option ``                                             |
| [`dc589997`](https://github.com/nix-community/home-manager/commit/dc5899978f8fa5d72424d5242784fb7e84e8573e) | `` services/mako: refactor settings to support INI sections ``                    |
| [`535a541b`](https://github.com/nix-community/home-manager/commit/535a541b429c1e89f0955c160df1d6d2bfeaf802) | `` halloy: fix themes example (#7046) ``                                          |
| [`012cc9e1`](https://github.com/nix-community/home-manager/commit/012cc9e1666b8ce0d6f677b902651f6858dfbe45) | `` halloy: add note about server being required (#7047) ``                        |
| [`665c49e0`](https://github.com/nix-community/home-manager/commit/665c49e0c2982d94f30a9826712850a59f70eeb4) | `` gnome-terminal: add package option (#7048) ``                                  |
| [`628d8cfa`](https://github.com/nix-community/home-manager/commit/628d8cfa5441eabe07fbb24861df1236a8e6dde5) | `` news: migrate news entries to YYYY/MM directory structure ``                   |
| [`bc13c13e`](https://github.com/nix-community/home-manager/commit/bc13c13ed7f7545a9f34010fa8c3febd1a92c58b) | `` news: reorganize news into YYYY/MM directory structure ``                      |
| [`f0a7db5e`](https://github.com/nix-community/home-manager/commit/f0a7db5ec1d369721e770a45e4d19f8e48186a69) | `` direnv: update nushell env conversion logic (#7015) ``                         |
| [`0b24658e`](https://github.com/nix-community/home-manager/commit/0b24658ec09908e5a6515cacc54f29d589c8423b) | `` halloy: add themes option (#7043) ``                                           |
| [`58795314`](https://github.com/nix-community/home-manager/commit/587953146298b13e897b827181967ff2298fb63c) | `` wayprompt: tweak example (#7040) ``                                            |