### PR TITLE
chore(flake/darwin): `6cb36e83` -> `f88be002`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746708654,
-        "narHash": "sha256-GeC99gu5H6+AjBXsn5dOhP4/ApuioGCBkufdmEIWPRs=",
+        "lastModified": 1747138802,
+        "narHash": "sha256-Ou4zV3OskaDKlkuiM2VT+1w/xceXoZ5RRM4ZuW7n5+I=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "6cb36e8327421c61e5a3bbd08ed63491b616364a",
+        "rev": "f88be00227161a1e9369a1d199f452dd5d720feb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                |
| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
| [`4cabc9c2`](https://github.com/nix-darwin/nix-darwin/commit/4cabc9c286e5c74bb6f8ba73f4edf94918e35be5) | `` gitlab-runner: write config as toml, don't clobber existing file `` |
| [`84644435`](https://github.com/nix-darwin/nix-darwin/commit/846444354b4ce9ea20db88c89a38fb7da7ecb087) | `` services/buildkite-agents: support multi-tags ``                    |