### PR TITLE
chore(flake/emacs-overlay): `f02060c0` -> `aafed657`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1747041229,
-        "narHash": "sha256-ImwhpDe4lHNNdPcCZogOofa4a45mBjYFiv2iS39VB3g=",
+        "lastModified": 1747070594,
+        "narHash": "sha256-Ih+HU1QFsdM6aaQctmhnsBaeufsprnMDw/XLTXZrhAs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f02060c00ccf9a7ce3786ee69e1ffdcd10fcdf9a",
+        "rev": "aafed657caad955a1c75dc0a2584aaf7c97e628b",
         "type": "github"
       },
       "original": {
@@ -646,11 +646,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1746810718,
-        "narHash": "sha256-VljtYzyttmvkWUKTVJVW93qAsJsrBbgAzy7DdnJaQfI=",
+        "lastModified": 1746957726,
+        "narHash": "sha256-k9ut1LSfHCr0AW82ttEQzXVCqmyWVA5+SHJkS5ID/Jo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c0bf9c057382d5f6f63d54fd61f1abd5e1c2f63",
+        "rev": "a39ed32a651fdee6842ec930761e31d1f242cb94",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`aafed657`](https://github.com/nix-community/emacs-overlay/commit/aafed657caad955a1c75dc0a2584aaf7c97e628b) | `` Updated emacs ``        |
| [`1f37fd31`](https://github.com/nix-community/emacs-overlay/commit/1f37fd3121d1c5afa1ecb1584816a3e121a7a92d) | `` Updated melpa ``        |
| [`e45b29b3`](https://github.com/nix-community/emacs-overlay/commit/e45b29b357445ffe81c3a29389d11e6726607410) | `` Updated elpa ``         |
| [`331f1631`](https://github.com/nix-community/emacs-overlay/commit/331f16310703c7ab3013cbec06469b47fabfbb4d) | `` Updated nongnu ``       |
| [`e68d7976`](https://github.com/nix-community/emacs-overlay/commit/e68d7976a40fa55113d722ffbd76bee6f58a9960) | `` Updated flake inputs `` |