### PR TITLE
chore(flake/nixos-hardware): `3c5e1267` -> `e81fd167`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -568,11 +568,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1746814339,
-        "narHash": "sha256-hf2lICJzwACWuzHCmZn5NI6LUAOgGdR1yh8ip+duyhk=",
+        "lastModified": 1747129300,
+        "narHash": "sha256-L3clA5YGeYCF47ghsI7Tcex+DnaaN/BbQ4dR2wzoiKg=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "3c5e12673265dfb0de3d9121420c0c2153bf21e0",
+        "rev": "e81fd167b33121269149c57806599045fd33eeed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`ff949f78`](https://github.com/NixOS/nixos-hardware/commit/ff949f78d6b04a5294ff059cf7cdce9638ea8a86) | `` ideacentr-k330: include nvidia-fermi architecture ``     |
| [`5aa1b0f0`](https://github.com/NixOS/nixos-hardware/commit/5aa1b0f04942d01cb51b4e865d2ca161ce14a818) | `` dell-xps-15-9530-nvidia: include ada-lovelace profile `` |
| [`91dc75a8`](https://github.com/NixOS/nixos-hardware/commit/91dc75a805501815969342ad1672e9b553d1f95b) | `` fix system.stateVersion for tests ``                     |
| [`d371c70b`](https://github.com/NixOS/nixos-hardware/commit/d371c70b454935c787c237550bc21debab684f30) | `` docs/CONTRIBUTING: replace bors with mergify ``          |
| [`b83e517b`](https://github.com/NixOS/nixos-hardware/commit/b83e517bfc92868c6e7e216d4373ea3edb19d876) | `` bump tests/flake.nix to 24.11 ``                         |
| [`16023fe3`](https://github.com/NixOS/nixos-hardware/commit/16023fe3d4d48a79deaa3ebd9385716ef038a211) | `` lenovo/yoga/7/14ILL10: init ``                           |
| [`0d3ca753`](https://github.com/NixOS/nixos-hardware/commit/0d3ca7531030e2a405e6e7f885cc07681cac6aba) | `` add asus-rog-strix-g533zw ``                             |