### PR TITLE
chore(flake/emacs-overlay): `aafed657` -> `43d0e73d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1747070594,
-        "narHash": "sha256-Ih+HU1QFsdM6aaQctmhnsBaeufsprnMDw/XLTXZrhAs=",
+        "lastModified": 1747242425,
+        "narHash": "sha256-9Msv0xSHBlIyaP3FiWMpqLsfiGla5OhD5pjclY/o3+A=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "aafed657caad955a1c75dc0a2584aaf7c97e628b",
+        "rev": "43d0e73d4a34f470045ac7c13dd45e1a7653f57b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`43d0e73d`](https://github.com/nix-community/emacs-overlay/commit/43d0e73d4a34f470045ac7c13dd45e1a7653f57b) | `` Updated melpa ``  |
| [`e957dccd`](https://github.com/nix-community/emacs-overlay/commit/e957dccdc908017611810dd99e2b9ee0f1b747ef) | `` Updated elpa ``   |
| [`4f7b4f7f`](https://github.com/nix-community/emacs-overlay/commit/4f7b4f7f00dc24aab4f07bfee820a209127e4afd) | `` Updated nongnu `` |
| [`6317599f`](https://github.com/nix-community/emacs-overlay/commit/6317599f5c92ccb08af9e910d0707270b6c7b9ab) | `` Updated emacs ``  |
| [`31d4559a`](https://github.com/nix-community/emacs-overlay/commit/31d4559ab0c8070c0ef5f1614f7aca951737f453) | `` Updated melpa ``  |
| [`6d15ffa9`](https://github.com/nix-community/emacs-overlay/commit/6d15ffa9720fc7d6635238d961593a289062b555) | `` Updated melpa ``  |
| [`1a3ee9a4`](https://github.com/nix-community/emacs-overlay/commit/1a3ee9a437571f28d63785f58f33a29e4dfe819a) | `` Updated elpa ``   |
| [`0398fa5e`](https://github.com/nix-community/emacs-overlay/commit/0398fa5e309d7630e82775c7b680c9592446e839) | `` Updated nongnu `` |
| [`aa9f9769`](https://github.com/nix-community/emacs-overlay/commit/aa9f9769d54ed2d0e062755a82485f99d90f3d5f) | `` Updated emacs ``  |
| [`7174443b`](https://github.com/nix-community/emacs-overlay/commit/7174443b8bf24f753a3f7c2017c9303108b417a5) | `` Updated melpa ``  |
| [`5f40906e`](https://github.com/nix-community/emacs-overlay/commit/5f40906ef216b8d958ea34379ca8e4e92c39498b) | `` Updated elpa ``   |
| [`9ea5d99f`](https://github.com/nix-community/emacs-overlay/commit/9ea5d99f6d08028a75c2eb09c06fb77652eaa1f1) | `` Updated nongnu `` |
| [`dbfb966a`](https://github.com/nix-community/emacs-overlay/commit/dbfb966a6ff9dde58a39dfc6a20254e46c4494b1) | `` Updated emacs ``  |
| [`cd55fd3c`](https://github.com/nix-community/emacs-overlay/commit/cd55fd3c3d51cb79eed19ff3624f7c8159c31f5f) | `` Updated melpa ``  |
| [`c73b3891`](https://github.com/nix-community/emacs-overlay/commit/c73b38912ab03a0de33c83576cff83c4b89eb1b3) | `` Updated emacs ``  |
| [`7b7d0dba`](https://github.com/nix-community/emacs-overlay/commit/7b7d0dbadd33d232860bd60a23f0d242874bdbc7) | `` Updated melpa ``  |
| [`586384c1`](https://github.com/nix-community/emacs-overlay/commit/586384c18822c4ebc2f5bdf54fb145fb1d80b01c) | `` Updated elpa ``   |
| [`4a85fd9b`](https://github.com/nix-community/emacs-overlay/commit/4a85fd9b6964f07ed86e7c97bf9e2c1ddce56fc9) | `` Updated nongnu `` |