### PR TITLE
chore(flake/nur): `ddd3999a` -> `e29c558f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1747108854,
-        "narHash": "sha256-tGD2d7/gIYH/qVIIgnoB/WOVDy7o2stnQdnte+hHV1c=",
+        "lastModified": 1747261242,
+        "narHash": "sha256-6p8kO62jbk+LUrDrLT23XbClNRyosnlfh/KCbE5fwnQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ddd3999ab126cf2b7fa308125a38e5fcfe626543",
+        "rev": "e29c558fa4174da179e2e7f9a41c34466a200fda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                 |
| -------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`e29c558f`](https://github.com/nix-community/NUR/commit/e29c558fa4174da179e2e7f9a41c34466a200fda) | `` automatic update ``                  |
| [`7ae5801b`](https://github.com/nix-community/NUR/commit/7ae5801be62498ace4b99233ab13fb20b9c6d638) | `` automatic update ``                  |
| [`84a3b869`](https://github.com/nix-community/NUR/commit/84a3b86937806a270be335f4e424a43505740dca) | `` automatic update ``                  |
| [`7f2bfae1`](https://github.com/nix-community/NUR/commit/7f2bfae127108ecb076141907ffcf49c0d292e30) | `` automatic update ``                  |
| [`fde7d7ed`](https://github.com/nix-community/NUR/commit/fde7d7ed44baaa2cffcd570c18bb7981d2696d72) | `` automatic update ``                  |
| [`2d5db87d`](https://github.com/nix-community/NUR/commit/2d5db87d9283d281e791ef9cdca55b5848eaf951) | `` automatic update ``                  |
| [`597da5b0`](https://github.com/nix-community/NUR/commit/597da5b04a22044caa3390b02872d2c2fedc4a9d) | `` automatic update ``                  |
| [`aace8e6f`](https://github.com/nix-community/NUR/commit/aace8e6f0db97112d40089b96686101bd0d72c54) | `` automatic update ``                  |
| [`53743fac`](https://github.com/nix-community/NUR/commit/53743facde04bdb7dfd97c4c8ed4518792c71084) | `` automatic update ``                  |
| [`61e17a64`](https://github.com/nix-community/NUR/commit/61e17a643e2d1871a6f3068e632af59a37340f5f) | `` automatic update ``                  |
| [`09bf2fcb`](https://github.com/nix-community/NUR/commit/09bf2fcbe23d7080d3b4e395f76a995f48ae631a) | `` automatic update ``                  |
| [`096fc2e0`](https://github.com/nix-community/NUR/commit/096fc2e08af677a1c867abc0a5516df2999ba1a2) | `` automatic update ``                  |
| [`82093385`](https://github.com/nix-community/NUR/commit/82093385149d108c8bcb4ab01ce6de548ee55f03) | `` automatic update ``                  |
| [`8b508834`](https://github.com/nix-community/NUR/commit/8b50883436d232fd536a9bef6490b8cbf88e443f) | `` automatic update ``                  |
| [`77a3cee2`](https://github.com/nix-community/NUR/commit/77a3cee227b00e1577f407e3814785dd0bb5480a) | `` automatic update ``                  |
| [`ede936be`](https://github.com/nix-community/NUR/commit/ede936be1a002c20d6c565964f60d6505b8a53e6) | `` automatic update ``                  |
| [`9d31d06b`](https://github.com/nix-community/NUR/commit/9d31d06b7a9991b68a9a82deac96ee6561d43f37) | `` add nolith repository ``             |
| [`b7cfc0a5`](https://github.com/nix-community/NUR/commit/b7cfc0a5ea6a759398da4eaa87b80e13f3776c24) | `` automatic update ``                  |
| [`a283fb4c`](https://github.com/nix-community/NUR/commit/a283fb4c7ff3fbaef9fdc9807a9b6ec561781e26) | `` automatic update ``                  |
| [`0c642e72`](https://github.com/nix-community/NUR/commit/0c642e72a1c715a30280893dd601d2d599449bd4) | `` automatic update ``                  |
| [`2378adbb`](https://github.com/nix-community/NUR/commit/2378adbb9ebb4654dc0d41786609839b6ad4a7ef) | `` automatic update ``                  |
| [`2934c7c1`](https://github.com/nix-community/NUR/commit/2934c7c1fd9072b6fe4ee0f0c40c5fa28e5e96eb) | `` automatic update ``                  |
| [`bcf663a3`](https://github.com/nix-community/NUR/commit/bcf663a3cae1830cf1cb110fcc1cc6311dd24551) | `` automatic update ``                  |
| [`ead078b2`](https://github.com/nix-community/NUR/commit/ead078b21fd1537bdcd439946e3014b5888a41b8) | `` automatic update ``                  |
| [`bd33e0fa`](https://github.com/nix-community/NUR/commit/bd33e0fa7a22dd011e2af2f7ba9b9b0ccabd9990) | `` automatic update ``                  |
| [`aa1f4c69`](https://github.com/nix-community/NUR/commit/aa1f4c69df29b2393881ebbc68b0b01eded672e8) | `` automatic update ``                  |
| [`7ce44280`](https://github.com/nix-community/NUR/commit/7ce442805cfa410a10bbbd75c667432ef4294aff) | `` automatic update ``                  |
| [`aabb0907`](https://github.com/nix-community/NUR/commit/aabb0907a8f752f7944da165db94799013b72a23) | `` automatic update ``                  |
| [`0726565e`](https://github.com/nix-community/NUR/commit/0726565e129ab2f24653f61ab3d96c2ee978e3a2) | `` automatic update ``                  |
| [`773ce295`](https://github.com/nix-community/NUR/commit/773ce295449e7c6b3554b7cf87fb84766db94fde) | `` automatic update ``                  |
| [`186d4957`](https://github.com/nix-community/NUR/commit/186d49575e8129eaef0ea4e1d3604b8a2bb8f91c) | `` automatic update ``                  |
| [`e4184f18`](https://github.com/nix-community/NUR/commit/e4184f183dfa0e8fc873952038ab76ce5d9b63e3) | `` automatic update ``                  |
| [`1d5f4d70`](https://github.com/nix-community/NUR/commit/1d5f4d70f29592404844e70f8dfbe1d5ef1db4d7) | `` add cyberleagueaustria repository `` |
| [`2688af40`](https://github.com/nix-community/NUR/commit/2688af408667f0c92a1f0babea0afe934e650b92) | `` automatic update ``                  |
| [`c8033557`](https://github.com/nix-community/NUR/commit/c803355757d8ba2b5c900357a931853ffb9de1cb) | `` automatic update ``                  |
| [`33dadfb9`](https://github.com/nix-community/NUR/commit/33dadfb985b667b866d1175a8519b7583a38ef63) | `` automatic update ``                  |
| [`84d83ddf`](https://github.com/nix-community/NUR/commit/84d83ddf962959c48bb844da73d6ae1a60de7e0b) | `` automatic update ``                  |
| [`b7cc56a6`](https://github.com/nix-community/NUR/commit/b7cc56a65ae02375cf737e39d0400a795084e302) | `` automatic update ``                  |
| [`a84708a1`](https://github.com/nix-community/NUR/commit/a84708a1502c9dfa721bd23f6734aa6436e6411c) | `` automatic update ``                  |
| [`2360d4c1`](https://github.com/nix-community/NUR/commit/2360d4c156f442578d9f8aff6f6fe5ce04681d34) | `` automatic update ``                  |
| [`129854e6`](https://github.com/nix-community/NUR/commit/129854e617f9ee83f05efcd6b27eb3f82407795b) | `` automatic update ``                  |
| [`448d4241`](https://github.com/nix-community/NUR/commit/448d4241c59b53c5760b4267aaa11af41cdf24e2) | `` automatic update ``                  |
| [`545a4dad`](https://github.com/nix-community/NUR/commit/545a4dadca09052fb42d65e76d7429cf4c73690b) | `` automatic update ``                  |
| [`bc1db36f`](https://github.com/nix-community/NUR/commit/bc1db36ff4136e9f0de5c801de66e3ade462306b) | `` automatic update ``                  |
| [`d338ee58`](https://github.com/nix-community/NUR/commit/d338ee58952080bd3ce11b53c8f4e42375477196) | `` automatic update ``                  |
| [`8d382677`](https://github.com/nix-community/NUR/commit/8d382677e3e135bca83aa5c0c43ab070791c1b27) | `` automatic update ``                  |
| [`cc92129d`](https://github.com/nix-community/NUR/commit/cc92129d9f5d5226bdb64e44c110ed2145abc269) | `` automatic update ``                  |