### PR TITLE
chore(flake/minimal-emacs-d): `c25ef5c0` -> `732c8adf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -398,11 +398,11 @@
     "minimal-emacs-d": {
       "flake": false,
       "locked": {
-        "lastModified": 1746993797,
-        "narHash": "sha256-jyaYjjQnOYcNdTh/2hkZUNpOKQLlWcrk8PsFPQNqlz4=",
+        "lastModified": 1747152306,
+        "narHash": "sha256-MnE9vnW+FaPPJFUQr4cx5FqdWKexf3kSDz2lUwcgC1M=",
         "owner": "jamescherti",
         "repo": "minimal-emacs.d",
-        "rev": "c25ef5c081e811ddfbd394e8a71a3e7b22a8ad71",
+        "rev": "732c8adf44213e335083859cf0d55c149f4e513d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                          |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`732c8adf`](https://github.com/jamescherti/minimal-emacs.d/commit/732c8adf44213e335083859cf0d55c149f4e513d) | `` Update README.md ``                           |
| [`101a5ed0`](https://github.com/jamescherti/minimal-emacs.d/commit/101a5ed0bb8b67246b310c9d3d0104925ba2a39a) | `` Update README.md ``                           |
| [`ace381ca`](https://github.com/jamescherti/minimal-emacs.d/commit/ace381cab6ec1d307f23ad5e9c574199a3a72139) | `` Update README.md ``                           |
| [`ea52fedb`](https://github.com/jamescherti/minimal-emacs.d/commit/ea52fedbe11f4c4c288563dc0e3d83be608e8f8d) | `` Update README.md ``                           |
| [`fc90ee75`](https://github.com/jamescherti/minimal-emacs.d/commit/fc90ee759ae8799d42296fcde25de7b7ed004fde) | `` Fixes #63: Add trailing whitespace cleanup `` |
| [`146fc32b`](https://github.com/jamescherti/minimal-emacs.d/commit/146fc32bb0cb11c250f67a106b460ab99dbe9259) | `` Update README.md ``                           |