### PR TITLE
chore(flake/nix-on-droid): `5d88ff25` -> `7f68d674`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
         "nmd": "nmd"
       },
       "locked": {
-        "lastModified": 1725658585,
-        "narHash": "sha256-P29z4Gt89n5ps1U7+qmIrj0BuRXGZQSIaOe2+tsPgfw=",
+        "lastModified": 1747158007,
+        "narHash": "sha256-uwRCd2RAAdMOvReceeaWHGp8RoGjFyIouQN053MsMSk=",
         "owner": "nix-community",
         "repo": "nix-on-droid",
-        "rev": "5d88ff2519e4952f8d22472b52c531bb5f1635fc",
+        "rev": "7f68d674b30997434868c9e93784724fdbf37367",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`7f68d674`](https://github.com/nix-community/nix-on-droid/commit/7f68d674b30997434868c9e93784724fdbf37367) | `` nix-on-droid: passthrough --override-input arg ``            |
| [`af711651`](https://github.com/nix-community/nix-on-droid/commit/af711651ca02d6918a479942be5d87fde2c352ee) | `` Allow unfree packages when building droidctl ``              |
| [`7c84363a`](https://github.com/nix-community/nix-on-droid/commit/7c84363a358aee4444d5fde2dfe8b941eb6af33f) | `` Replace magic-nix-cache-action ``                            |
| [`a7befd8c`](https://github.com/nix-community/nix-on-droid/commit/a7befd8c98f02bbaf48fb229cb20b9a450d9ffad) | `` flake.nix: pkgs.system -> pkgs.stdenv.hostPlatform.system `` |
| [`010aa48c`](https://github.com/nix-community/nix-on-droid/commit/010aa48cf613ce3b4a0ed57457920f66ff3239f8) | `` allow both group and username to be changed ``               |