### PR TITLE
chore(flake/srvos): `1c7f04e1` -> `7cf5c3b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -933,11 +933,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747011883,
-        "narHash": "sha256-+Gu0Ni6RZVo1Rx8JICEuDlpGhpHK1ObkfqIaqCNDmyo=",
+        "lastModified": 1747271380,
+        "narHash": "sha256-ITF3Q2RxCn8qzR+anAK2Um22jCmUnDkHDM4dOX0M4+0=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "1c7f04e1fca2b5791a05c39c453a035bb37c7b9e",
+        "rev": "7cf5c3b2ad6bfa4b9915f505bddd17df96844308",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`7cf5c3b2`](https://github.com/nix-community/srvos/commit/7cf5c3b2ad6bfa4b9915f505bddd17df96844308) | `` dev/private/flake.lock: Update `` |
| [`da0d494a`](https://github.com/nix-community/srvos/commit/da0d494a98c2cc6a48e9f49b64b635218e729df6) | `` flake.lock: Update ``             |