### PR TITLE
chore(flake/emacs-overlay): `43d0e73d` -> `d8949f8c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1747242425,
-        "narHash": "sha256-9Msv0xSHBlIyaP3FiWMpqLsfiGla5OhD5pjclY/o3+A=",
+        "lastModified": 1747300110,
+        "narHash": "sha256-mHePt7oDQepKT5jm4ZCjvohAIO0QPVVYZIIIn7VARKo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "43d0e73d4a34f470045ac7c13dd45e1a7653f57b",
+        "rev": "d8949f8c77eadcc7b268f994361fd2055cfbf2cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`d8949f8c`](https://github.com/nix-community/emacs-overlay/commit/d8949f8c77eadcc7b268f994361fd2055cfbf2cb) | `` Updated melpa ``        |
| [`f40f761f`](https://github.com/nix-community/emacs-overlay/commit/f40f761f9e576c39770c9e252b89f73d41e23eaa) | `` Updated flake inputs `` |
| [`4267e51c`](https://github.com/nix-community/emacs-overlay/commit/4267e51c6c5fed605eecfd8a2c05cac080b6a32f) | `` Updated emacs ``        |
| [`36988f77`](https://github.com/nix-community/emacs-overlay/commit/36988f77dedc750e7ac81f7c328636a021a721d1) | `` Updated melpa ``        |
| [`1fa37cb3`](https://github.com/nix-community/emacs-overlay/commit/1fa37cb302ac9da82f78da4a51e6f5e4bca56da1) | `` Updated elpa ``         |
| [`e5647be5`](https://github.com/nix-community/emacs-overlay/commit/e5647be5ff26a1df571757a008e20c2237745cfc) | `` Updated nongnu ``       |