### PR TITLE
chore(flake/nur): `e29c558f` -> `9724bc98`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -725,11 +725,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1746904237,
-        "narHash": "sha256-3e+AVBczosP5dCLQmMoMEogM57gmZ2qrVSrmq9aResQ=",
+        "lastModified": 1747179050,
+        "narHash": "sha256-qhFMmDkeJX9KJwr5H32f1r7Prs7XbQWtO0h3V0a0rFY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d89fc19e405cb2d55ce7cc114356846a0ee5e956",
+        "rev": "adaa24fbf46737f3f1b5497bf64bae750f82942e",
         "type": "github"
       },
       "original": {
@@ -784,11 +784,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1747261242,
-        "narHash": "sha256-6p8kO62jbk+LUrDrLT23XbClNRyosnlfh/KCbE5fwnQ=",
+        "lastModified": 1747338291,
+        "narHash": "sha256-ycj+YD+NRvuFTW8meFl2YSdL1OYWdXrbZbcz6pFsdso=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e29c558fa4174da179e2e7f9a41c34466a200fda",
+        "rev": "9724bc9843ac023dee18fc0d0b7a84e78d345b03",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9724bc98`](https://github.com/nix-community/NUR/commit/9724bc9843ac023dee18fc0d0b7a84e78d345b03) | `` automatic update `` |
| [`d49af04f`](https://github.com/nix-community/NUR/commit/d49af04fcdf846f5b162f5ed2443f130d6336495) | `` automatic update `` |
| [`bb22c31d`](https://github.com/nix-community/NUR/commit/bb22c31d6b17e9f8fe76371c747a5aee9fc95821) | `` automatic update `` |
| [`6b8339ef`](https://github.com/nix-community/NUR/commit/6b8339ef517be0618224555960e1693156de1bf9) | `` automatic update `` |
| [`3a149ecb`](https://github.com/nix-community/NUR/commit/3a149ecb08bb7beebfd18987c8a9dd25038179f1) | `` automatic update `` |
| [`652fcd0b`](https://github.com/nix-community/NUR/commit/652fcd0bdb98c755762b425b4484cd3e93b133fd) | `` automatic update `` |
| [`100c79be`](https://github.com/nix-community/NUR/commit/100c79be99a36113c5c7a7375151d7a43947ab45) | `` automatic update `` |
| [`e7418f3d`](https://github.com/nix-community/NUR/commit/e7418f3dbc2fa43ac5c477ee87dba068ac52628f) | `` automatic update `` |
| [`90942e3e`](https://github.com/nix-community/NUR/commit/90942e3e69802ba374e22d68fe738295ec6e05c9) | `` automatic update `` |
| [`3ff514b2`](https://github.com/nix-community/NUR/commit/3ff514b2b38d47873fd46fc5a79584b7d95cbcfb) | `` automatic update `` |
| [`a1cf53da`](https://github.com/nix-community/NUR/commit/a1cf53dabc89d4fc134324da3430215bf3045460) | `` automatic update `` |
| [`23a114cb`](https://github.com/nix-community/NUR/commit/23a114cb75c6b71a4be7a3b63cc76b18a3d4c8b0) | `` automatic update `` |
| [`29abb282`](https://github.com/nix-community/NUR/commit/29abb282a1d2bb736ec6006424b85fac843e9a99) | `` automatic update `` |
| [`504f20be`](https://github.com/nix-community/NUR/commit/504f20be38e3316303dffbd7eb5f92ae304cc316) | `` automatic update `` |
| [`8bb4cbc2`](https://github.com/nix-community/NUR/commit/8bb4cbc252ca8d608200201c0b68c53058df0d8b) | `` automatic update `` |
| [`20159398`](https://github.com/nix-community/NUR/commit/2015939883d307fcace129d4a7bdd891b6b63473) | `` automatic update `` |
| [`bf0020c8`](https://github.com/nix-community/NUR/commit/bf0020c8ad1a811beb379719bb6281de73a017fa) | `` automatic update `` |
| [`76528b4e`](https://github.com/nix-community/NUR/commit/76528b4ebf3c11c487776ef5bd4bde0ceba25b18) | `` automatic update `` |
| [`8e9e1037`](https://github.com/nix-community/NUR/commit/8e9e103799076781a0bafbb10d57efa5f1c0fe85) | `` automatic update `` |