### PR TITLE
chore(flake/treefmt-nix): `708ec80c` -> `e758f274`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1010,11 +1010,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746989248,
-        "narHash": "sha256-uoQ21EWsAhyskNo8QxrTVZGjG/dV4x5NM1oSgrmNDJY=",
+        "lastModified": 1747299117,
+        "narHash": "sha256-JGjCVbxS+9t3tZ2IlPQ7sdqSM4c+KmIJOXVJPfWmVOU=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "708ec80ca82e2bbafa93402ccb66a35ff87900c5",
+        "rev": "e758f27436367c23bcd63cd973fa5e39254b530e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                      |
| ---------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`2de2a41b`](https://github.com/numtide/treefmt-nix/commit/2de2a41be127a2fae2e43313b29959c851584c1e) | `` Fix formatter spec url `` |