### PR TITLE
chore(flake/emacs-overlay): `d8949f8c` -> `f2919b67`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1747300110,
-        "narHash": "sha256-mHePt7oDQepKT5jm4ZCjvohAIO0QPVVYZIIIn7VARKo=",
+        "lastModified": 1747330516,
+        "narHash": "sha256-8yvJkWH/VarFQXUS6uBuGveBjFJuWf4kDrCVDYaILs4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d8949f8c77eadcc7b268f994361fd2055cfbf2cb",
+        "rev": "f2919b676a957d15a7ef9976192acddf2b8325b2",
         "type": "github"
       },
       "original": {
@@ -646,11 +646,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1746957726,
-        "narHash": "sha256-k9ut1LSfHCr0AW82ttEQzXVCqmyWVA5+SHJkS5ID/Jo=",
+        "lastModified": 1747209494,
+        "narHash": "sha256-fLise+ys+bpyjuUUkbwqo5W/UyIELvRz9lPBPoB0fbM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a39ed32a651fdee6842ec930761e31d1f242cb94",
+        "rev": "5d736263df906c5da72ab0f372427814de2f52f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`f2919b67`](https://github.com/nix-community/emacs-overlay/commit/f2919b676a957d15a7ef9976192acddf2b8325b2) | `` Updated emacs ``        |
| [`37bfe5bb`](https://github.com/nix-community/emacs-overlay/commit/37bfe5bb312b203ad5a37ffda7477d7fc1d416a7) | `` Updated melpa ``        |
| [`789a32d5`](https://github.com/nix-community/emacs-overlay/commit/789a32d5bd6dc168feb55d609f8f056f2d51f6e3) | `` Updated nongnu ``       |
| [`0f4b8081`](https://github.com/nix-community/emacs-overlay/commit/0f4b808169272debaf14c10bfbf46c2d29eb9dbd) | `` Updated flake inputs `` |