### PR TITLE
chore(flake/home-manager): `954615c5` -> `97118a31`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747279714,
-        "narHash": "sha256-UdxlE8yyrKiGq3bgGyJ78AdFwh+fuRAruKtyFY5Zq5I=",
+        "lastModified": 1747565775,
+        "narHash": "sha256-B6jmKHUEX1jxxcdoYHl7RVaeohtAVup8o3nuVkzkloA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "954615c510c9faa3ee7fb6607ff72e55905e69f2",
+        "rev": "97118a310eb8e13bc1b9b12d67267e55b7bee6c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`97118a31`](https://github.com/nix-community/home-manager/commit/97118a310eb8e13bc1b9b12d67267e55b7bee6c8) | `` flake-module: use toString primop ``                                                 |
| [`ee85cfc5`](https://github.com/nix-community/home-manager/commit/ee85cfc5c132e2cf956a7b5ab156ddaedaefcbbc) | `` home-manager: add missing file ``                                                    |
| [`10d13a62`](https://github.com/nix-community/home-manager/commit/10d13a62e3ab95ba904cbc3d2a44ac177d85da65) | `` flake.lock: Update ``                                                                |
| [`9a4a9f1d`](https://github.com/nix-community/home-manager/commit/9a4a9f1d6e43fe4044f6715ae7cc85ccb1d2fe09) | `` home-manager: prepare 25.11 ``                                                       |
| [`e08e6e23`](https://github.com/nix-community/home-manager/commit/e08e6e2389234000b0447e57abf61d8ccd59a68e) | `` home-manager: set 25.05 as stable ``                                                 |
| [`ae755329`](https://github.com/nix-community/home-manager/commit/ae755329092c87369b9e9a1510a8cf1ce2b1c708) | `` templates/nix-darwin: nixpkgs track nixpkgs-unstable ``                              |
| [`5d132608`](https://github.com/nix-community/home-manager/commit/5d13260881eae0e9894f2c1dffd2cb97d6b79a07) | `` treewide: lnl7 -> nix-darwin ``                                                      |
| [`74d31e11`](https://github.com/nix-community/home-manager/commit/74d31e1165341bf510ee2017841a599f5cfc1608) | `` ptyxis: init module (#7075) ``                                                       |
| [`d2263ce5`](https://github.com/nix-community/home-manager/commit/d2263ce5f4c251c0f7608330e8fdb7d1f01f0667) | `` nix-darwin: use `launchctl asuser` now that activation runs as root (#7051) ``       |
| [`a1a72d18`](https://github.com/nix-community/home-manager/commit/a1a72d18ee75ce4559b5f59296a7b2d37f608c1c) | `` pgcli: init (#7072) ``                                                               |
| [`098e365d`](https://github.com/nix-community/home-manager/commit/098e365dd83311cc8236f83ea6be42abb49a6c76) | `` borgmatic: add darwin-specific documentation to services.borgmatic.frequency ``      |
| [`8ae36f8e`](https://github.com/nix-community/home-manager/commit/8ae36f8ea2e0621b6cdea862e938aaa018e0ef27) | `` nix-gc: fix documentation ``                                                         |
| [`dbc90cc3`](https://github.com/nix-community/home-manager/commit/dbc90cc3ae9c8f927200a6ceaf4aa247ea6bc443) | `` rclone: declarative mounts (#7060) ``                                                |
| [`b022c9e3`](https://github.com/nix-community/home-manager/commit/b022c9e3b805484e44aaad1973ed7572b0c1b5c4) | `` vscode: allow specifying paths for VSCode JSON settings (#7055) ``                   |
| [`a99bddfe`](https://github.com/nix-community/home-manager/commit/a99bddfe53cb5ae488bfb0dc0170dae258b2c572) | `` lapce: fix no argument hash for pluginFromRegistry (#7062) ``                        |
| [`ec8205c3`](https://github.com/nix-community/home-manager/commit/ec8205c3d7d4b19998d9b762d2c5abd2fc11faa7) | `` dconf: set env var ``                                                                |
| [`ff73544e`](https://github.com/nix-community/home-manager/commit/ff73544e4a59dce43a6de7051858a453186ae9bb) | `` dconf: Provide dconf package and dbus service file ``                                |
| [`c310818d`](https://github.com/nix-community/home-manager/commit/c310818dca3d92fa6ab769a572c46e04f24b1f87) | `` mako: Fix missing dbus service file (#7065) ``                                       |
| [`c09ccd7d`](https://github.com/nix-community/home-manager/commit/c09ccd7d39eb4c246fcb0e2b3e4be0361a85c19a) | `` services.borgmatic: add initial support for darwin ``                                |
| [`34d44d7f`](https://github.com/nix-community/home-manager/commit/34d44d7f1b7da16509538f72ec6bee121932a3e1) | `` services.borgmatic: wrap systemd configuration within a isLinux condition ``         |
| [`1c2fccef`](https://github.com/nix-community/home-manager/commit/1c2fccef832e5fbf2df4162f742f76a153aa5443) | `` services.nix-gc: extract darwin agent interval code to new library file ``           |
| [`3b930bb6`](https://github.com/nix-community/home-manager/commit/3b930bb653dd9ed7da5fe86c147bbc67492efe2c) | `` services.nix-gc: improve error message when nix.gc.frequency is invalid on darwin `` |
| [`ad1e8bb7`](https://github.com/nix-community/home-manager/commit/ad1e8bb782ed91b4966ab5b642f9b2c5813354ce) | `` dbus: Create with pacakges options (#7064) ``                                        |