### PR TITLE
chore(flake/nur): `9724bc98` -> `c9cc0950`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -784,11 +784,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1747338291,
-        "narHash": "sha256-ycj+YD+NRvuFTW8meFl2YSdL1OYWdXrbZbcz6pFsdso=",
+        "lastModified": 1747367930,
+        "narHash": "sha256-Q5ug8cGKQ0dcChdcx//xrXyp4r+loHwqjm9hRYij+78=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9724bc9843ac023dee18fc0d0b7a84e78d345b03",
+        "rev": "c9cc095080ae88a2b7bf7f4871d4954d8e72b101",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c9cc0950`](https://github.com/nix-community/NUR/commit/c9cc095080ae88a2b7bf7f4871d4954d8e72b101) | `` automatic update `` |
| [`deacd0e0`](https://github.com/nix-community/NUR/commit/deacd0e03e1d586506814c70461a425032ff6009) | `` automatic update `` |
| [`003faf82`](https://github.com/nix-community/NUR/commit/003faf8221419b0c8d6636f7967df140bfd4e2d7) | `` automatic update `` |
| [`b38b7cc3`](https://github.com/nix-community/NUR/commit/b38b7cc328f95c9bdc432bf73ced76d6d057c773) | `` automatic update `` |
| [`ec40131f`](https://github.com/nix-community/NUR/commit/ec40131fece2302efdc0f7c7313828e8b7e3e348) | `` automatic update `` |
| [`a0e2f09d`](https://github.com/nix-community/NUR/commit/a0e2f09d393b63071848ae4c47705687a64ed711) | `` automatic update `` |
| [`0a9de4ee`](https://github.com/nix-community/NUR/commit/0a9de4eef73cf74339297b2ea4681d75effa065a) | `` automatic update `` |