### PR TITLE
chore(flake/emacs-overlay): `f2919b67` -> `68768914`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1747330516,
-        "narHash": "sha256-8yvJkWH/VarFQXUS6uBuGveBjFJuWf4kDrCVDYaILs4=",
+        "lastModified": 1747362374,
+        "narHash": "sha256-nHXQ8mq3eYq0aLGkGJudJFmq8NoQ0uCBQ+q2NISmDAY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f2919b676a957d15a7ef9976192acddf2b8325b2",
+        "rev": "6876891497fa209feda114600f4170d905abde53",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`68768914`](https://github.com/nix-community/emacs-overlay/commit/6876891497fa209feda114600f4170d905abde53) | `` Updated emacs ``  |
| [`1f6e78de`](https://github.com/nix-community/emacs-overlay/commit/1f6e78de7117037c77d3426e58da4ec87ad72adb) | `` Updated melpa ``  |
| [`bcf998c0`](https://github.com/nix-community/emacs-overlay/commit/bcf998c005e0542dd6a9d1389055a30700be8ba0) | `` Updated elpa ``   |
| [`95871133`](https://github.com/nix-community/emacs-overlay/commit/95871133ae3622901c094fd94eb01f34c38e0e6c) | `` Updated nongnu `` |