### PR TITLE
chore(flake/catppuccin): `7a6ccdeb` -> `763394c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1747268376,
-        "narHash": "sha256-JDcdINnB1bfbUAy1eEgwIXLrfZeuntxuxTu7UWcQrQY=",
+        "lastModified": 1747414122,
+        "narHash": "sha256-diCezyxS9//xT1a9YWWyFXpdTLcUpSbFhB7yqcVfId8=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "7a6ccdeba6e761bec9601e2192983e6b9dff630c",
+        "rev": "763394c47f5a8fe4ae97ef0754925efac0d51ec1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                              |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`763394c4`](https://github.com/catppuccin/nix/commit/763394c47f5a8fe4ae97ef0754925efac0d51ec1) | `` fix(mako): deprecated settings.criteria (#563) `` |