### PR TITLE
chore(flake/emacs-overlay): `68768914` -> `b95d4e9d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1747362374,
-        "narHash": "sha256-nHXQ8mq3eYq0aLGkGJudJFmq8NoQ0uCBQ+q2NISmDAY=",
+        "lastModified": 1747447576,
+        "narHash": "sha256-5/5uPQWpRDa/TW48gTCAp0w2dMwmhRvwjCmI2r/8LYM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6876891497fa209feda114600f4170d905abde53",
+        "rev": "b95d4e9dc5bd7962d7f6817855f8d74e2b32911e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                          |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------- |
| [`b95d4e9d`](https://github.com/nix-community/emacs-overlay/commit/b95d4e9dc5bd7962d7f6817855f8d74e2b32911e) | `` Updated melpa ``              |
| [`e6839c80`](https://github.com/nix-community/emacs-overlay/commit/e6839c800a1d786f0ebbde21e346b9cd9b494d06) | `` Updated elpa ``               |
| [`52941c31`](https://github.com/nix-community/emacs-overlay/commit/52941c3156e3723e36ea4182ce7ae3d495fb4027) | `` Updated nongnu ``             |
| [`1799cf8c`](https://github.com/nix-community/emacs-overlay/commit/1799cf8c9df7186a23e0a69ab74d2a310b628f98) | `` Revert "Updated fromElisp" `` |
| [`c52caefb`](https://github.com/nix-community/emacs-overlay/commit/c52caefb7f44578df586759f3ee675b687c5ab65) | `` Updated emacs ``              |
| [`8a4408f1`](https://github.com/nix-community/emacs-overlay/commit/8a4408f147f91dab791e5d5f0baf917fe5858c1a) | `` Updated melpa ``              |
| [`0404f19d`](https://github.com/nix-community/emacs-overlay/commit/0404f19d517fbfa7bce187da98b697e8719bd5d8) | `` Updated elpa ``               |
| [`6983ebec`](https://github.com/nix-community/emacs-overlay/commit/6983ebecec75467b33d96e2bf4a7966682d61628) | `` Updated nongnu ``             |
| [`15acdba2`](https://github.com/nix-community/emacs-overlay/commit/15acdba225ac8abf32c596685bc75aea033071f7) | `` Updated fromElisp ``          |