### PR TITLE
chore(flake/treefmt-nix): `e758f274` -> `ab0378b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1010,11 +1010,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747299117,
-        "narHash": "sha256-JGjCVbxS+9t3tZ2IlPQ7sdqSM4c+KmIJOXVJPfWmVOU=",
+        "lastModified": 1747469671,
+        "narHash": "sha256-bo1ptiFoNqm6m1B2iAhJmWCBmqveLVvxom6xKmtuzjg=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "e758f27436367c23bcd63cd973fa5e39254b530e",
+        "rev": "ab0378b61b0d85e73a8ab05d5c6029b5bd58c9fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                          |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`ab0378b6`](https://github.com/numtide/treefmt-nix/commit/ab0378b61b0d85e73a8ab05d5c6029b5bd58c9fb) | `` buf: doesn't support multiple file targets `` |
| [`42dd9289`](https://github.com/numtide/treefmt-nix/commit/42dd9289571ae3c6884af9885b1a7432e3278f92) | `` README: fix formatting ``                     |
| [`8ceec8b1`](https://github.com/numtide/treefmt-nix/commit/8ceec8b1c06dfaf8a7a8f6335939d96fb69f57e4) | `` Add zizmor as an action linter ``             |
| [`2faace5c`](https://github.com/numtide/treefmt-nix/commit/2faace5cefca955da79be88df944b1c02ac6102d) | `` Add kdlfmt as a formatter (#355) ``           |