### PR TITLE
chore(flake/nix-index-database): `e9b21b01` -> `c1f63a0c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -469,11 +469,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746934494,
-        "narHash": "sha256-3n6i+F0sDASjkhbvgFDpPDZGp7z19IrRtjfF9TwJpCA=",
+        "lastModified": 1747470409,
+        "narHash": "sha256-R9TP2//BDKyjNzuZybplIZm7HQEnwL8khs7EmmTPYP4=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "e9b21b01e4307176b9718a29ac514838e7f6f4ff",
+        "rev": "c1f63a0c3bf1b2fe05124ccb099333163e2184a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                          |
| ----------------------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`b1f78db9`](https://github.com/nix-community/nix-index-database/commit/b1f78db975af80aacba3b45fd6035a979fa54534) | `` README: fix ad-hoc example `` |