### PR TITLE
chore(flake/emacs-overlay): `b95d4e9d` -> `ed6c0f95`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1747447576,
-        "narHash": "sha256-5/5uPQWpRDa/TW48gTCAp0w2dMwmhRvwjCmI2r/8LYM=",
+        "lastModified": 1747535798,
+        "narHash": "sha256-eRPjz79+jDLlrj1ouGjUiZT4EVLjkLAy+vH5iVu/t8c=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b95d4e9dc5bd7962d7f6817855f8d74e2b32911e",
+        "rev": "ed6c0f95acb68734d4419d1912860b697f4c5ea6",
         "type": "github"
       },
       "original": {
@@ -646,11 +646,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1747209494,
-        "narHash": "sha256-fLise+ys+bpyjuUUkbwqo5W/UyIELvRz9lPBPoB0fbM=",
+        "lastModified": 1747335874,
+        "narHash": "sha256-IKKIXTSYJMmUtE+Kav5Rob8SgLPnfnq4Qu8LyT4gdqQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5d736263df906c5da72ab0f372427814de2f52f8",
+        "rev": "ba8b70ee098bc5654c459d6a95dfc498b91ff858",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`ed6c0f95`](https://github.com/nix-community/emacs-overlay/commit/ed6c0f95acb68734d4419d1912860b697f4c5ea6) | `` Updated emacs ``        |
| [`1bee0176`](https://github.com/nix-community/emacs-overlay/commit/1bee0176f33ceebeb907921af39fb689ff375983) | `` Updated melpa ``        |
| [`cffb9948`](https://github.com/nix-community/emacs-overlay/commit/cffb9948ec70d032616b57dbd5018b0273b1a22d) | `` Updated elpa ``         |
| [`370f506a`](https://github.com/nix-community/emacs-overlay/commit/370f506ad6abce27ae844d5b79e759630a266b0d) | `` Updated nongnu ``       |
| [`20bad5fa`](https://github.com/nix-community/emacs-overlay/commit/20bad5faaa8cd9782977d70b8b34638f6449a2a7) | `` Updated flake inputs `` |
| [`59c04dd9`](https://github.com/nix-community/emacs-overlay/commit/59c04dd982a4af9dbf5180da5fcb10b0333bfa7f) | `` Updated melpa ``        |
| [`4aa8b62d`](https://github.com/nix-community/emacs-overlay/commit/4aa8b62d3aeb9afef8975c6fcbda404cc718c8fb) | `` Updated flake inputs `` |