### PR TITLE
chore(flake/darwin): `8817b00b` -> `8e251e45`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747365160,
-        "narHash": "sha256-4ZVr0x+ry6ybym/VhVYACj0HlJo44YxAaPGOxiS88Hg=",
+        "lastModified": 1747494142,
+        "narHash": "sha256-7TAUwDVZWq82t/x3+zZ5y+Tjl2hLL2c8+8pv9zCUbTo=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "8817b00b0011750381d0d44bb94d61087349b6ba",
+        "rev": "8e251e45346e9d58e0eece2512e40c183f967e8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                              |
| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
| [`b9e580c1`](https://github.com/nix-darwin/nix-darwin/commit/b9e580c1130307c3aee715956a11824c0d8cdc5e) | `` changelog: document user activation removal ``                    |
| [`a0e4dd2a`](https://github.com/nix-darwin/nix-darwin/commit/a0e4dd2af9de4c62319e5ffe5c225d8488e42024) | `` activation-scripts: move `createRun` after `checks` ``            |
| [`7e5c6f7e`](https://github.com/nix-darwin/nix-darwin/commit/7e5c6f7e2156dcece3c30d42d19ce482b8f2a4ff) | `` etc: merge `etcChecks` into `checks` ``                           |
| [`af62c4d1`](https://github.com/nix-darwin/nix-darwin/commit/af62c4d1763fd60a2fbd51df7ce56828e4fa309e) | `` checks: make `nixPath` check more helpful ``                      |
| [`051283a8`](https://github.com/nix-darwin/nix-darwin/commit/051283a8953d08a7c16de5304e8dba5c4418e02e) | `` {activation-scripts,activate-system}: purify environment again `` |
| [`516dbe1f`](https://github.com/nix-darwin/nix-darwin/commit/516dbe1fa40548945f18135875ed22228db4ce33) | `` darwin-rebuild: require running as `root` ``                      |
| [`40d2a159`](https://github.com/nix-darwin/nix-darwin/commit/40d2a159cc6fd4c171613c51f81232b78be0f9be) | `` tests: remove stray `activate-user` references ``                 |
| [`2ca29474`](https://github.com/nix-darwin/nix-darwin/commit/2ca294741f94d74c9d9bdc7171bda41f9f9c975b) | `` activation-scripts: get rid of user activation ``                 |
| [`0abf0126`](https://github.com/nix-darwin/nix-darwin/commit/0abf01266612d3dd72dbf79597282cf33ad721ca) | `` users: refuse to delete the primary user ``                       |
| [`bed70a84`](https://github.com/nix-darwin/nix-darwin/commit/bed70a84af8e4bc28e4050cded929505a030195a) | `` {environment,nix}: remove references to `$HOME` ``                |
| [`2892da83`](https://github.com/nix-darwin/nix-darwin/commit/2892da83ea941e24c5549639ce294971b55840de) | `` applications: use `system.primaryUser` for the legacy path ``     |
| [`f47b8062`](https://github.com/nix-darwin/nix-darwin/commit/f47b8062cbcd1b6867e42dfac27d8e91467b553e) | `` defaults: move `userDefaults` to system activation ``             |
| [`7877cba5`](https://github.com/nix-darwin/nix-darwin/commit/7877cba5f5f462067ccd5e9eda3562fe016852d7) | `` launchd: move `userLaunchd` to system activation ``               |
| [`c449918b`](https://github.com/nix-darwin/nix-darwin/commit/c449918bfbce4211ad2c39a793780b336a737c48) | `` homebrew: move to system activation ``                            |
| [`52ee8c57`](https://github.com/nix-darwin/nix-darwin/commit/52ee8c57c26a31588c61fe9507ec688248d011ca) | `` primary-user: init ``                                             |