### PR TITLE
chore(flake/agenix): `96e078c6` -> `8a4516ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,11 +16,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745630506,
-        "narHash": "sha256-bHCFgGeu8XjWlVuaWzi3QONjDW3coZDqSHvnd4l7xus=",
+        "lastModified": 1747508675,
+        "narHash": "sha256-p89NHqmZh1j0ZclCW5kEIonaZXsMGy+upes3fIo5RHM=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "96e078c646b711aee04b82ba01aefbff87004ded",
+        "rev": "8a4516aed6e9083b30dda064bda85075975ecb07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                             |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`af991e8d`](https://github.com/ryantm/agenix/commit/af991e8dc3899c91012f8c5621568ab7beee30fb) | `` Separate flags from positional args with `--` `` |
| [`cccd5afb`](https://github.com/ryantm/agenix/commit/cccd5afb1c02b71eb5e9facb074f342a44ec46c7) | `` docs: add home-manager module documentation ``   |