### PR TITLE
chore(flake/darwin): `8e251e45` -> `b9b927dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747494142,
-        "narHash": "sha256-7TAUwDVZWq82t/x3+zZ5y+Tjl2hLL2c8+8pv9zCUbTo=",
+        "lastModified": 1747521943,
+        "narHash": "sha256-GMAJcB8oB9cC+TbYTE7QDfw9fwHZyloxUWnUpHnQRko=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "8e251e45346e9d58e0eece2512e40c183f967e8f",
+        "rev": "b9b927dd1f24094b271e8ec5277a672dc4fc860d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                  |
| ------------------------------------------------------------------------------------------------------ | ------------------------ |
| [`24952f03`](https://github.com/nix-darwin/nix-darwin/commit/24952f03f90cc7fe3d935618d2332ff53b414191) | `` Update default.nix `` |
| [`58f268e0`](https://github.com/nix-darwin/nix-darwin/commit/58f268e065cd556bbaed56dbd894c88ab703cd9b) | `` Update CHANGELOG ``   |
| [`a4cc5477`](https://github.com/nix-darwin/nix-darwin/commit/a4cc54778d91c1e9631aa510b304e9a369d4f7a7) | `` Update repo link ``   |