### PR TITLE
chore(flake/nix-index-database): `c1f63a0c` -> `ec179dd1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -469,11 +469,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747470409,
-        "narHash": "sha256-R9TP2//BDKyjNzuZybplIZm7HQEnwL8khs7EmmTPYP4=",
+        "lastModified": 1747540584,
+        "narHash": "sha256-cxCQ413JTUuRv9Ygd8DABJ1D6kuB/nTfQqC0Lu9C0ls=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "c1f63a0c3bf1b2fe05124ccb099333163e2184a7",
+        "rev": "ec179dd13fb7b4c6844f55be91436f7857226dce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`ec179dd1`](https://github.com/nix-community/nix-index-database/commit/ec179dd13fb7b4c6844f55be91436f7857226dce) | `` update generated.nix to release 2025-05-18-033800 `` |
| [`dbc173ab`](https://github.com/nix-community/nix-index-database/commit/dbc173abd9c1639597965fd17a95e8cdb86eadc2) | `` flake.lock: Update ``                                |