### PR TITLE
chore(flake/sops-nix): `e93ee1d9` -> `8d215e1c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -913,11 +913,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746485181,
-        "narHash": "sha256-PxrrSFLaC7YuItShxmYbMgSuFFuwxBB+qsl9BZUnRvg=",
+        "lastModified": 1747603214,
+        "narHash": "sha256-lAblXm0VwifYCJ/ILPXJwlz0qNY07DDYdLD+9H+Wc8o=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "e93ee1d900ad264d65e9701a5c6f895683433386",
+        "rev": "8d215e1c981be3aa37e47aeabd4e61bb069548fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                          |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`8d215e1c`](https://github.com/Mic92/sops-nix/commit/8d215e1c981be3aa37e47aeabd4e61bb069548fd) | `` README: also set follow for nixpkgs ``        |
| [`0645c5ed`](https://github.com/Mic92/sops-nix/commit/0645c5edc9c457cfa25881b70d29ea34374738e9) | `` README: don't import sops in example usage `` |