### PR TITLE
chore(flake/srvos): `7cf5c3b2` -> `755578b0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -933,11 +933,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747271380,
-        "narHash": "sha256-ITF3Q2RxCn8qzR+anAK2Um22jCmUnDkHDM4dOX0M4+0=",
+        "lastModified": 1747619464,
+        "narHash": "sha256-6cQV07xBp46EMUXDFyR3ypXrrJ2nIpav940RvjT6FJw=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "7cf5c3b2ad6bfa4b9915f505bddd17df96844308",
+        "rev": "755578b01c9fb1cc0a798c0d4d54a283077b315d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                 |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`755578b0`](https://github.com/nix-community/srvos/commit/755578b01c9fb1cc0a798c0d4d54a283077b315d) | `` update darwin dummy configuration `` |
| [`af65238a`](https://github.com/nix-community/srvos/commit/af65238a1663d3cd242cb258742cb0e8b797a55e) | `` dev/private/flake.lock: Update ``    |
| [`3f2494ce`](https://github.com/nix-community/srvos/commit/3f2494ceb9b6cd4624f2a2bc5222692ab5f3617e) | `` flake.lock: Update ``                |