### PR TITLE
chore(flake/emacs-overlay): `527c14f4` -> `88ff8a44`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1747585320,
-        "narHash": "sha256-sdJkqFwYlRkijgRoOTH6cg+N6w41qXtFkrC79vMHUYg=",
+        "lastModified": 1747761969,
+        "narHash": "sha256-nR3kxGtVGtrEeaY/8LvtlZFvbC4gerebRvRE5dE0Jn0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "527c14f4280d37d857f7e9e70330168ed95a69b4",
+        "rev": "88ff8a448dec87188f7a5d024bb8838d80a6ffcc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                           |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
| [`88ff8a44`](https://github.com/nix-community/emacs-overlay/commit/88ff8a448dec87188f7a5d024bb8838d80a6ffcc) | `` Updated emacs ``                                               |
| [`17b363c1`](https://github.com/nix-community/emacs-overlay/commit/17b363c108535e549243ed309544a1b38a369bb0) | `` Updated melpa ``                                               |
| [`581955c1`](https://github.com/nix-community/emacs-overlay/commit/581955c15127c12a548602e58ef2e07d52e79aa7) | `` Updated elpa ``                                                |
| [`8afd5b5b`](https://github.com/nix-community/emacs-overlay/commit/8afd5b5b988448ce2e8caec4dae8265a77e03bc7) | `` Updated nongnu ``                                              |
| [`3cc961f9`](https://github.com/nix-community/emacs-overlay/commit/3cc961f94c5db4e2cdfb498f2d6f02e3511b4991) | `` Revert "Updated fromElisp" ``                                  |
| [`f66e9712`](https://github.com/nix-community/emacs-overlay/commit/f66e9712f1b4f61d59f079e2ca46a68547c9d4c4) | `` Updated fromElisp ``                                           |
| [`4549e0cb`](https://github.com/nix-community/emacs-overlay/commit/4549e0cb468aa26b77dfa3d0f242dbf4d3730b13) | `` Updated melpa ``                                               |
| [`f45ca856`](https://github.com/nix-community/emacs-overlay/commit/f45ca856fb711c568ecebfe8365897e0d6625ad6) | `` Manually update Emacs, and remove now-merged unstable patch `` |
| [`61324f11`](https://github.com/nix-community/emacs-overlay/commit/61324f118f2ba0a2e3244c1bffbc7954670d2af3) | `` Updated elpa ``                                                |
| [`0da1350a`](https://github.com/nix-community/emacs-overlay/commit/0da1350a4013afba144fe3a152949291cb8ef93b) | `` Updated nongnu ``                                              |
| [`1b2bc802`](https://github.com/nix-community/emacs-overlay/commit/1b2bc802bbac29f4695e39fbf982944c0999b45d) | `` Updated flake inputs ``                                        |