### PR TITLE
chore(flake/nixos-hardware): `e81fd167` -> `6ac6ec6f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -583,11 +583,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1747129300,
-        "narHash": "sha256-L3clA5YGeYCF47ghsI7Tcex+DnaaN/BbQ4dR2wzoiKg=",
+        "lastModified": 1747723695,
+        "narHash": "sha256-lSXzv33yv1O9r9Ai1MtYFDX3OKhWsZMn/5FFb4Rni/k=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "e81fd167b33121269149c57806599045fd33eeed",
+        "rev": "6ac6ec6fcb410e15a60ef5ec94b8a2b35b5dd282",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                          |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`ee94f43c`](https://github.com/NixOS/nixos-hardware/commit/ee94f43c05e80c7a7e5d94ec78426f2bc92a63dd) | `` Add Lenovo Ideapad 5 Pro 14IMH9 / XiaoXin Pro 14IMH9 2024 ``  |
| [`a9a7323a`](https://github.com/NixOS/nixos-hardware/commit/a9a7323a067284b5546beef7221ce49a1f3b8d24) | `` framework: Add framework12 ``                                 |
| [`687c8fcf`](https://github.com/NixOS/nixos-hardware/commit/687c8fcf681371df084ad98b6211b928163b7394) | `` X1 Yoga: Enable fingerprint reader and FW update ``           |
| [`45da8c8a`](https://github.com/NixOS/nixos-hardware/commit/45da8c8ad8f77302ab3cbbcda7a113507f8ecebb) | `` lenovo/legion/15ich: Use Coffee Lake CPU ``                   |
| [`f139290a`](https://github.com/NixOS/nixos-hardware/commit/f139290af12744eca2a5b460ea6cfb1dceded227) | `` TUXEDO Infinitybook: Enable bluetooth by default ``           |
| [`33d083f5`](https://github.com/NixOS/nixos-hardware/commit/33d083f55bab2d3ce5b02666630860038e9867fb) | `` feat(nvidia-prime): automatic battery-saver specialisation `` |