### PR TITLE
chore(flake/nur): `b3d016e4` -> `087c4a32`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -815,11 +815,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1747713721,
-        "narHash": "sha256-HoDn3HoYZcKmyR90W7Q/lnKsDJb9hrY+vLZmYT0SD1w=",
+        "lastModified": 1747726433,
+        "narHash": "sha256-93T2KaP+19raaqqHRgowSk3LYVqXVBefFg9z3vNkY50=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b3d016e4d117922f3fffdc7d698733e28452ad09",
+        "rev": "087c4a3279e7369a419f3c95b0d9556ffe91efe9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`087c4a32`](https://github.com/nix-community/NUR/commit/087c4a3279e7369a419f3c95b0d9556ffe91efe9) | `` automatic update `` |
| [`7c239259`](https://github.com/nix-community/NUR/commit/7c239259399ed5f628fc1ebde14d63e346f0ea72) | `` automatic update `` |