### PR TITLE
chore(flake/nur): `087c4a32` -> `24efa6cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -740,11 +740,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1747542820,
-        "narHash": "sha256-GaOZntlJ6gPPbbkTLjbd8BMWaDYafhuuYRNrxCGnPJw=",
+        "lastModified": 1747744144,
+        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "292fa7d4f6519c074f0a50394dbbe69859bb6043",
+        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
         "type": "github"
       },
       "original": {
@@ -815,11 +815,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1747726433,
-        "narHash": "sha256-93T2KaP+19raaqqHRgowSk3LYVqXVBefFg9z3vNkY50=",
+        "lastModified": 1747799866,
+        "narHash": "sha256-yu08UHNosKrGQb3XhP6qalG08VZztOEIRbxu+cKHxgQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "087c4a3279e7369a419f3c95b0d9556ffe91efe9",
+        "rev": "24efa6cfbe1d649ccde6d5869bf28a25db4c5157",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                            |
| -------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`24efa6cf`](https://github.com/nix-community/NUR/commit/24efa6cfbe1d649ccde6d5869bf28a25db4c5157) | `` automatic update ``             |
| [`600976d6`](https://github.com/nix-community/NUR/commit/600976d685c34c20261da2bee9bfdd03aa6980e3) | `` automatic update ``             |
| [`b2c59aab`](https://github.com/nix-community/NUR/commit/b2c59aab813aea0fe161e5a491a1225067255740) | `` automatic update ``             |
| [`2d7b40a3`](https://github.com/nix-community/NUR/commit/2d7b40a33ab556b0b9f2bd67b572d99f2ee556e8) | `` automatic update ``             |
| [`a8eaef65`](https://github.com/nix-community/NUR/commit/a8eaef6559ba4eb2fc2c1a28b6783d4ef40dd90a) | `` automatic update ``             |
| [`054eadb7`](https://github.com/nix-community/NUR/commit/054eadb77838961815f96a7a6ae711878ca0e7a3) | `` automatic update ``             |
| [`866a588d`](https://github.com/nix-community/NUR/commit/866a588df5ac8a9d7dd0c06a7c2d8e3e73b0f723) | `` automatic update ``             |
| [`a5c06d1e`](https://github.com/nix-community/NUR/commit/a5c06d1e7b4156f9ea9b97e02df6c6c90de86089) | `` automatic update ``             |
| [`ee1a191e`](https://github.com/nix-community/NUR/commit/ee1a191e095a2449f97cd1ae769966ffad7ec136) | `` automatic update ``             |
| [`3796e375`](https://github.com/nix-community/NUR/commit/3796e375d3c4b85fa95c19205b966672f945686b) | `` automatic update ``             |
| [`811de9f4`](https://github.com/nix-community/NUR/commit/811de9f4a2a56aee2e37836ddc61e8a887c09bbc) | `` feat: added ohheyrj NUR repo `` |
| [`2418b657`](https://github.com/nix-community/NUR/commit/2418b65712108cce68dd3aca62ffbc8af5ee3ec8) | `` automatic update ``             |
| [`725e1fdd`](https://github.com/nix-community/NUR/commit/725e1fdde3b5643b75d10fe38a9ea743ee4a504d) | `` automatic update ``             |
| [`cd42c67a`](https://github.com/nix-community/NUR/commit/cd42c67a4287c5c5a07d9241045b9b7962ea9e92) | `` automatic update ``             |
| [`b5814fa3`](https://github.com/nix-community/NUR/commit/b5814fa35e56ce5f94997206d07db45a012e8881) | `` automatic update ``             |
| [`e52a85ce`](https://github.com/nix-community/NUR/commit/e52a85ce10a990ac6d7356f3a753fde0860426a8) | `` automatic update ``             |
| [`e73a0858`](https://github.com/nix-community/NUR/commit/e73a0858fa95be21070e1ff65f463490eba6f591) | `` automatic update ``             |
| [`59b25393`](https://github.com/nix-community/NUR/commit/59b25393c30422dd6561f35950da543c5f33a72f) | `` automatic update ``             |
| [`f3d81860`](https://github.com/nix-community/NUR/commit/f3d818608a86f0b525ec1e0c7c8b17c33870ab0b) | `` automatic update ``             |
| [`72435465`](https://github.com/nix-community/NUR/commit/7243546592afeca8373b4b881f257d263023828a) | `` automatic update ``             |