### PR TITLE
chore(flake/home-manager): `45c29856` -> `2468b2d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747688838,
-        "narHash": "sha256-FZq4/3OtGV/cti9Vccsy2tGSUrxTO4hkDF9oeGRTen4=",
+        "lastModified": 1747793476,
+        "narHash": "sha256-2qAOSixSrbb9l6MI+SI4zGineOzDcc2dgOOFK9Dx+IY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "45c2985644b60ab64de2a2d93a4d132ecb87cf66",
+        "rev": "2468b2d35512d093aeb04972a1d8c20a0735793f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                       |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`2468b2d3`](https://github.com/nix-community/home-manager/commit/2468b2d35512d093aeb04972a1d8c20a0735793f) | `` files: show colliding files at bottom in checkLinkTargets (#5495) ``                       |
| [`29dda415`](https://github.com/nix-community/home-manager/commit/29dda415f5b2178278283856c6f9f7b48a2a4353) | `` qutebrowser: add support for per domain settings (#7078) ``                                |
| [`3f591550`](https://github.com/nix-community/home-manager/commit/3f591550a99fe5a2a57927ccab15dedb4210e53e) | `` formatter: remove script, add treefmt.toml + keep-sorted (#7056) ``                        |
| [`559f6d36`](https://github.com/nix-community/home-manager/commit/559f6d36b32dd2180ebac40c522dd36290430fc5) | `` news: add some more missing news items (#7097) ``                                          |
| [`d3f5d870`](https://github.com/nix-community/home-manager/commit/d3f5d870e3f33f69fa6c0f9bcc44f8803a30e38e) | `` home-manager: add force option for gtk-2 config (#7073) ``                                 |
| [`65d2282f`](https://github.com/nix-community/home-manager/commit/65d2282ff6cf560f54997013bd1e575fbd0a7ebf) | `` fontconfig: Fix missing default fontconfig files (#7045) ``                                |
| [`20974416`](https://github.com/nix-community/home-manager/commit/20974416338898f0725a87832e4cd9bd82cbdaad) | `` services.home-manager.autoExpire: add support for darwin ``                                |
| [`04ebd2c4`](https://github.com/nix-community/home-manager/commit/04ebd2c4224ad6a78385bbc30f06dd89f0aa843b) | `` services.home-manager.autoExpire: extract cleanup script to new variable ``                |
| [`382b34f6`](https://github.com/nix-community/home-manager/commit/382b34f6569262e92b0e947ca5c49354c61b7f8c) | `` services.home-manager.autoExpire: wrap systemd configuration within a isLinux condition `` |