### PR TITLE
chore(flake/darwin): `b9b927dd` -> `9ed53ae9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747521943,
-        "narHash": "sha256-GMAJcB8oB9cC+TbYTE7QDfw9fwHZyloxUWnUpHnQRko=",
+        "lastModified": 1747752313,
+        "narHash": "sha256-Z5OnPIZ3/ijo5xLCOpWoVbUE5JNnGxSHGhnJ3u9f2GE=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "b9b927dd1f24094b271e8ec5277a672dc4fc860d",
+        "rev": "9ed53ae9abb5b125e453f37e475da5b8c368e676",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                      |
| ------------------------------------------------------------------------------------------------------ | ---------------------------- |
| [`0c0f423d`](https://github.com/nix-darwin/nix-darwin/commit/0c0f423db8f67a7b1400827139951c4950918018) | `` version: bump to 25.11 `` |