### PR TITLE
chore(flake/emacs-overlay): `88ff8a44` -> `dab8132d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1747761969,
-        "narHash": "sha256-nR3kxGtVGtrEeaY/8LvtlZFvbC4gerebRvRE5dE0Jn0=",
+        "lastModified": 1747815851,
+        "narHash": "sha256-Ti5Xoc5nfjj9cEcqqipjAr8un5nRTTfHPUt96bkXdaA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "88ff8a448dec87188f7a5d024bb8838d80a6ffcc",
+        "rev": "dab8132d4a9bffeaadb5af2e5a04140439477b7b",
         "type": "github"
       },
       "original": {
@@ -661,11 +661,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1747485343,
-        "narHash": "sha256-YbsZyuRE1tobO9sv0PUwg81QryYo3L1F3R3rF9bcG38=",
+        "lastModified": 1747676747,
+        "narHash": "sha256-LXkWBVqilgx7Pohwqu/ABxDVw+Cmi5/Mj2S2mpUH0Fw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9b5ac7ad45298d58640540d0323ca217f32a6762",
+        "rev": "72841a4a8761d1aed92ef6169a636872c986c76d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`dab8132d`](https://github.com/nix-community/emacs-overlay/commit/dab8132d4a9bffeaadb5af2e5a04140439477b7b) | `` Updated flake inputs `` |
| [`3f5c5850`](https://github.com/nix-community/emacs-overlay/commit/3f5c585027ef7798de403e4b7093f3005679496f) | `` Updated emacs ``        |
| [`899b5745`](https://github.com/nix-community/emacs-overlay/commit/899b574575e52adb99d24484d27dfb28a959fa83) | `` Updated melpa ``        |
| [`28e53a1d`](https://github.com/nix-community/emacs-overlay/commit/28e53a1d66d5e7e439a773393c3ffaaf7abcbe64) | `` Updated nongnu ``       |
| [`579b6d9f`](https://github.com/nix-community/emacs-overlay/commit/579b6d9f2dcc1c84929b1e7c09c5cbc29e71e68d) | `` Updated flake inputs `` |