### PR TITLE
chore(flake/nixpkgs): `292fa7d4` -> `2795c506`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -724,11 +724,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1747542820,
-        "narHash": "sha256-GaOZntlJ6gPPbbkTLjbd8BMWaDYafhuuYRNrxCGnPJw=",
+        "lastModified": 1747744144,
+        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "292fa7d4f6519c074f0a50394dbbe69859bb6043",
+        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| [`5c380be4`](https://github.com/NixOS/nixpkgs/commit/5c380be4d39e4c5b0bfc0593817a3cd526cf5307) | `` doctoc: remove dangling symlinks ``                                                            |
| [`33c6d3d1`](https://github.com/NixOS/nixpkgs/commit/33c6d3d15b5affeb6a8c709fa17ded967876a6f7) | `` vscode-extensions.teros-technology.teroshdl: init at 7.0.3 ``                                  |
| [`467486f5`](https://github.com/NixOS/nixpkgs/commit/467486f58b694b469952db696b9f29f190dbce54) | `` maintainers: add lheintzmann1 ``                                                               |
| [`b5bd640a`](https://github.com/NixOS/nixpkgs/commit/b5bd640a9258b12f09f11e6c7fddf8a85129c265) | `` doc: fix nixpkgs-manual not being built under `index.html` (#400816) ``                        |
| [`dbac89ec`](https://github.com/NixOS/nixpkgs/commit/dbac89ecc6f09e58c8cf7ee1596a16245d7c8199) | `` mu: 1.12.9 -> 1.12.11 ``                                                                       |
| [`8f55ad25`](https://github.com/NixOS/nixpkgs/commit/8f55ad257761e92f05f42a4dcb10a31847c41c45) | `` llvmPackages_git: 21.0.0-unstable-2025-05-11 -> 21.0.0-unstable-2025-05-18 ``                  |
| [`46125720`](https://github.com/NixOS/nixpkgs/commit/4612572032f3f37977fe504ac5b86e8769905bec) | `` irccat: 0.4.8 -> 0.4.12 ``                                                                     |
| [`be3bbc5b`](https://github.com/NixOS/nixpkgs/commit/be3bbc5badde3878bf6cea47147de951432af3c3) | `` aider-chat: enable ocaml tests ``                                                              |
| [`17d13f69`](https://github.com/NixOS/nixpkgs/commit/17d13f6906348c954d540e3a0d73108e59d9aac8) | `` python3Packages.tree-sitter-language-pack: add check and update script ``                      |
| [`00efca8c`](https://github.com/NixOS/nixpkgs/commit/00efca8c0ccf7374ac8f4d6a521f6977e6d0bce1) | `` dockerTools: fix build failure when building in vm ``                                          |
| [`9307ece2`](https://github.com/NixOS/nixpkgs/commit/9307ece25756842fce26792b3160d52c86f47661) | `` python3Packages.otpauth: 2.2.0 -> 2.2.1 ``                                                     |
| [`dd7ad02f`](https://github.com/NixOS/nixpkgs/commit/dd7ad02f76af89a7cac43f09446ec9c390f1092d) | `` nixos/prowlarr: add configurable dataDir and user/group options (#408902) ``                   |
| [`1ffcd50d`](https://github.com/NixOS/nixpkgs/commit/1ffcd50db6878076d0cccde5e24e1eb02093a2c2) | `` python3Packages.pytest-scim2-server: 0.1.3 -> 0.1.5 ``                                         |
| [`3adf87de`](https://github.com/NixOS/nixpkgs/commit/3adf87de37f00c7bccfbf53dc2b9391e1c77da89) | `` libretro.mame2003-plus: 0-unstable-2025-05-08 -> 0-unstable-2025-05-16 ``                      |
| [`f5b90478`](https://github.com/NixOS/nixpkgs/commit/f5b9047846de12b540809f8f4d742acab0ba57fa) | `` nixos-anywhere: 1.9.0 -> 1.10.0 ``                                                             |
| [`811c58b7`](https://github.com/NixOS/nixpkgs/commit/811c58b7bff72cacfdd8e3e613c0adbaad7a85ce) | `` python313Packages.argilla: 2.6.0 -> 2.8.0 ``                                                   |
| [`501b5b8f`](https://github.com/NixOS/nixpkgs/commit/501b5b8fe3d5f5ec39fbace761ea9c8ddce43f68) | `` python3Packages.tree-sitter-language-pack: 0.6.1 -> 0.7.3 ``                                   |
| [`36d83e5c`](https://github.com/NixOS/nixpkgs/commit/36d83e5c62df7def363681a8e6ddf25f8a5982ef) | `` kdePackages.kirigami-addons: 1.7.0 -> 1.8.0 ``                                                 |
| [`c2d203ba`](https://github.com/NixOS/nixpkgs/commit/c2d203ba50b416c2b6505867b2adbfb070fdcc4a) | `` k3s: better util-linux patch url ``                                                            |
| [`0c67c3ee`](https://github.com/NixOS/nixpkgs/commit/0c67c3eee0260c95986056bf1d25d12572254cac) | `` goimapnotify: add changelog to meta ``                                                         |
| [`572763cd`](https://github.com/NixOS/nixpkgs/commit/572763cd273604bf9086a8dc17b97534c55e8386) | `` ctre: 3.9.0 -> 3.10.0 ``                                                                       |
| [`d747d7ac`](https://github.com/NixOS/nixpkgs/commit/d747d7ac39e7a074d732aff3727482772101a6ea) | `` cloudflare-warp: update meta.homepage ``                                                       |
| [`03875543`](https://github.com/NixOS/nixpkgs/commit/03875543f1ff97f2ef1108fc71908a352aff802e) | `` oama: 0.19.0 -> 0.20.1 (#408872) ``                                                            |
| [`3f96c18c`](https://github.com/NixOS/nixpkgs/commit/3f96c18c79e734f84b5c12fa12467c8aa44e8c96) | `` docs: add instructions to load development utilities ``                                        |
| [`efbf5563`](https://github.com/NixOS/nixpkgs/commit/efbf556332524db0428afbc91a9bc5fdee77b60a) | `` treefmt: add longDescription linking to Nixpkgs Manual ``                                      |
| [`6e5c68be`](https://github.com/NixOS/nixpkgs/commit/6e5c68be85c6c626ff52cbcdda655d5cf05ea344) | `` treefmt: improve how doc-comments render in the manual ``                                      |
| [`4c638c27`](https://github.com/NixOS/nixpkgs/commit/4c638c27356b52badabedfe2e40b220fced821b2) | `` doc/packages/treefmt: add option reference docs ``                                             |
| [`96f04172`](https://github.com/NixOS/nixpkgs/commit/96f041725f6e92f7159b6d2913f07c18101d92dc) | `` doc/packages/treefmt: add location to function reference docs ``                               |
| [`301824d2`](https://github.com/NixOS/nixpkgs/commit/301824d21698e21025b6136e66833fe3e5b18655) | `` doc/packages/treefmt: add function reference docs ``                                           |
| [`fe586a5d`](https://github.com/NixOS/nixpkgs/commit/fe586a5d59ebb319a7557c83ac44a47428701fdc) | `` doc/packages: add treefmt section ``                                                           |
| [`7dec5f13`](https://github.com/NixOS/nixpkgs/commit/7dec5f132bc146c508c2fe13081f4b02bd614668) | `` pinact: add shell completions ``                                                               |
| [`b0713aca`](https://github.com/NixOS/nixpkgs/commit/b0713aca86c8e04e52351846be23d74c95eea5a1) | `` pinact: prefer finalAttrs ``                                                                   |
| [`65c2222c`](https://github.com/NixOS/nixpkgs/commit/65c2222c22d35803ec859d9b21749a003d73f5c0) | `` flatpak: 1.16.0 -> 1.16.1 ``                                                                   |
| [`c4300810`](https://github.com/NixOS/nixpkgs/commit/c43008108b0e0572000846e98503ea609d97380e) | `` vscode-extensions.eamodio.gitlens: 17.0.3 -> 17.1.0 ``                                         |
| [`9beb192e`](https://github.com/NixOS/nixpkgs/commit/9beb192ef839fb6e2733ce09b0753725ddde72e2) | `` pixi: 0.46.0 -> 0.47.0 ``                                                                      |
| [`43531951`](https://github.com/NixOS/nixpkgs/commit/43531951ab3a18090f9c8ae7e62b8bcd9687d302) | `` pinact: 3.0.5 -> 3.1.2 ``                                                                      |
| [`0a34ae39`](https://github.com/NixOS/nixpkgs/commit/0a34ae39914ed02556daecc3b212b83f26708329) | `` claude-code: 0.2.109 -> 0.2.122 ``                                                             |
| [`dbd06b2f`](https://github.com/NixOS/nixpkgs/commit/dbd06b2fbf88cf94f7b96c8af38c8458dca2c246) | `` uv: 0.7.5 -> 0.7.6 ``                                                                          |
| [`82b03d0e`](https://github.com/NixOS/nixpkgs/commit/82b03d0e4da414332894506af33522d9a079de56) | `` vimPlugins.nvim-spectre: 0-unstable-2025-04-28 -> 0-unstable-2025-05-13 ``                     |
| [`12513349`](https://github.com/NixOS/nixpkgs/commit/12513349a222bf665a20d188a597756be27ed384) | `` beekeeper-studio: 5.2.7 -> 5.2.9 ``                                                            |
| [`6a27c2fe`](https://github.com/NixOS/nixpkgs/commit/6a27c2fefb983fb7d35deb04337d47eb34bacb2d) | `` podman-compose: 1.3.0 -> 1.4.0 ``                                                              |
| [`55e671aa`](https://github.com/NixOS/nixpkgs/commit/55e671aa8885a603444bfb97dd6bd0c01353fb42) | `` share-preview: 0.5.0 -> 1.0.0 ``                                                               |
| [`b8a2f7ff`](https://github.com/NixOS/nixpkgs/commit/b8a2f7fff97f0c6bd08fec90d28e4e6291c86e0f) | `` deliantra-server: remove ``                                                                    |
| [`25363b9a`](https://github.com/NixOS/nixpkgs/commit/25363b9ab177e219fb16e7a3545b120e6b66285c) | `` cryptpad: 2024.12.0 -> 2025.3.0 ``                                                             |
| [`f8163822`](https://github.com/NixOS/nixpkgs/commit/f8163822d8ff93b0a961303713a6ae3d003bda48) | `` cryptpad: use full path for ln in wrapper script ``                                            |
| [`d368ad3a`](https://github.com/NixOS/nixpkgs/commit/d368ad3a662f21289b43c8d31f62412f9a91b432) | `` heliocron: 0.8.1 -> 1.0.0 ``                                                                   |
| [`7bc30ead`](https://github.com/NixOS/nixpkgs/commit/7bc30eadf3c42ef68a91927089f6e9abe3e0f802) | `` swayimg: 3.9 -> 4.0 ``                                                                         |
| [`73c76f92`](https://github.com/NixOS/nixpkgs/commit/73c76f9258fbbb064e5126885f6dbb23a33047d6) | `` clickhouse-backup: 2.6.16 -> 2.6.18 ``                                                         |
| [`6d85cc6c`](https://github.com/NixOS/nixpkgs/commit/6d85cc6c1cf22d7668c665b0cccb01fa4fff83c8) | `` ipmitool: fix IANA registry warnings ``                                                        |
| [`c64cc694`](https://github.com/NixOS/nixpkgs/commit/c64cc694e430e33c2d2f0e5b5743b372dbd5e6f3) | `` libretro.vice-x128: 0-unstable-2025-05-08 -> 0-unstable-2025-05-16 ``                          |
| [`65888ccb`](https://github.com/NixOS/nixpkgs/commit/65888ccba939931820b31123e890bcafabddb41f) | `` geteduroam: init at 0.10 ``                                                                    |
| [`9672fb0c`](https://github.com/NixOS/nixpkgs/commit/9672fb0c9eb402bcd9780ea5adb85a17bb1b1f4e) | `` python313Packages.aiocomelit: 0.12.1 -> 0.12.3 ``                                              |
| [`f7850951`](https://github.com/NixOS/nixpkgs/commit/f7850951c5aa8942653279e9e673b047f4ee8bdb) | `` python313Packages.holidays: 0.72 -> 0.73 ``                                                    |
| [`13d88232`](https://github.com/NixOS/nixpkgs/commit/13d88232f69d798dfd7079c580b833470261fbaa) | `` python313Packages.pysigma-backend-loki: disable out-dated tests ``                             |
| [`b91b532f`](https://github.com/NixOS/nixpkgs/commit/b91b532f82871f6456f19f8d94b58136a5a80ed3) | `` gh: 2.72.0 -> 2.73.0 ``                                                                        |
| [`f0c4e897`](https://github.com/NixOS/nixpkgs/commit/f0c4e8977e1dedcdeed0519af18045be9562d6c8) | `` python312Packages.pysigma-backend-sqlite: 0.2.0 -> 0.2.0-unstable-2025-01-21 ``                |
| [`694d2cde`](https://github.com/NixOS/nixpkgs/commit/694d2cde42f9f74ab590b995d7f1f531af7fd7ac) | `` libretro.ppsspp: 0-unstable-2025-05-08 -> 0-unstable-2025-05-19 ``                             |
| [`6c9a5c5b`](https://github.com/NixOS/nixpkgs/commit/6c9a5c5b1b64a8794d91c896dfb37f0ea0e889bd) | `` python312Packages.pysigma-backend-sqlite: refactor ``                                          |
| [`71c6d58a`](https://github.com/NixOS/nixpkgs/commit/71c6d58a25f3169232d157da03feff31ba9a9896) | `` python313Packages.pysigma: 0.11.20 -> 0.11.23 ``                                               |
| [`beba1d92`](https://github.com/NixOS/nixpkgs/commit/beba1d923f8b0dbf630eb9e303ac1890e10f3f8d) | `` python313Packages.pysigma: 0.11.19 -> 0.11.20 ``                                               |
| [`ba16e853`](https://github.com/NixOS/nixpkgs/commit/ba16e85369c4c676ec352379550b091c8a0724c2) | `` vscode-extensions.ionide.ionide-fsharp: 7.25.8 -> 7.25.10 ``                                   |
| [`9943b728`](https://github.com/NixOS/nixpkgs/commit/9943b72807196b1ec7eee942adc010fbabd4cf44) | `` python313Packages.pystatgrab: disable tests on darwin (seg fault) ``                           |
| [`cb6f5a6d`](https://github.com/NixOS/nixpkgs/commit/cb6f5a6d1ab55f39c598428b97fe3ee0bddc52da) | `` python313Packages.turrishw: disable tests on darwin ``                                         |
| [`27132960`](https://github.com/NixOS/nixpkgs/commit/271329609a3d6f63182f2871465af3518b9b28b5) | `` python3Packages.sqids: 0.5.1 -> 0.5.2 ``                                                       |
| [`d62c17d9`](https://github.com/NixOS/nixpkgs/commit/d62c17d97ef9a9af21aacb254b6561c22157d84b) | `` nixos/bazarr: add dataDir option ``                                                            |
| [`b096c95f`](https://github.com/NixOS/nixpkgs/commit/b096c95f51397375a852b7db4e66f02119cb04c9) | `` python313Packages.turrishw: fix changelog entry ``                                             |
| [`560e00c8`](https://github.com/NixOS/nixpkgs/commit/560e00c88bbede14cafeb0660d1140a6826c8167) | `` python313Packages.iterfzf: 1.6.0.60.3 -> 1.8.0.62.0 ``                                         |
| [`ffb63b26`](https://github.com/NixOS/nixpkgs/commit/ffb63b26475d1e5a633d24f620d004c04d2a9285) | `` frankenphp: 1.5.0 -> 1.6.0 ``                                                                  |
| [`0200335e`](https://github.com/NixOS/nixpkgs/commit/0200335e087166b94428b314ec56e77785aad4cf) | `` bitwarden-cli: add zsh completion ``                                                           |
| [`a1108763`](https://github.com/NixOS/nixpkgs/commit/a1108763e04bf9fd84369425ee2886a013fec239) | `` librespeed-cli: mark as broken on darwin ``                                                    |
| [`b910f2a7`](https://github.com/NixOS/nixpkgs/commit/b910f2a72f6da1b61aab3d22b5cc6b6d635cd706) | `` librespeed-cli: refactor ``                                                                    |
| [`c7661133`](https://github.com/NixOS/nixpkgs/commit/c76611337b7a260980c58022c933abbe4d11d6b6) | `` python313Packages.webexteamssdk: disable bulk updates ``                                       |
| [`cefebce0`](https://github.com/NixOS/nixpkgs/commit/cefebce0031558d6a57bbb822594e7a17fb85f67) | `` conky: fix cross and docs, update derivation to match upstream settings and recommendations `` |
| [`a110cfd9`](https://github.com/NixOS/nixpkgs/commit/a110cfd998ccbfc9d3ae71b4b096311e8a4e7ba5) | `` Revert "python3Packages.webexteamssdk: 1.6.1 -> 2.0.3" ``                                      |
| [`e191bd4f`](https://github.com/NixOS/nixpkgs/commit/e191bd4f41689bae90a359d1576d5915e67eabd1) | `` python313Packages.atenpdu: mark as broken for pysnmp < 7 ``                                    |
| [`96b9fcac`](https://github.com/NixOS/nixpkgs/commit/96b9fcace9ebe90a2839dfa279c1d2b2ff5d4e3e) | `` yara-x: 0.14.0 -> 0.15.0 ``                                                                    |
| [`f969f27f`](https://github.com/NixOS/nixpkgs/commit/f969f27fa5980f4406b66d52987953cf1e9cf60e) | `` routersploit: unstable-2021-02-06 -> 3.4.1-unstable-2025-04-24 ``                              |
| [`c2a54f08`](https://github.com/NixOS/nixpkgs/commit/c2a54f0803c216b4e8716b620d49d9873954ffd5) | `` ast-grep: 0.37.0 -> 0.38.2 ``                                                                  |
| [`1b3b541e`](https://github.com/NixOS/nixpkgs/commit/1b3b541eb14f05f068a3ea4790a16e4f354bfca2) | `` ladybird: 0-unstable-2025-05-07 -> 0-unstable-2025-05-18 ``                                    |
| [`5efd4067`](https://github.com/NixOS/nixpkgs/commit/5efd4067ccff18078b7a9f37697056482be03d6f) | `` vulkan-memory-allocator: 3.2.1 -> 3.3.0 ``                                                     |
| [`0c409284`](https://github.com/NixOS/nixpkgs/commit/0c409284fb5590be2ec54735ecb9fb4386865177) | `` chatmcp: 0.0.45 -> 0.0.51 ``                                                                   |
| [`32f7adad`](https://github.com/NixOS/nixpkgs/commit/32f7adad331db6f46d3ebfe966ad995cd1a8cd73) | `` lix-diff: init at 1.0.1 ``                                                                     |
| [`11e95671`](https://github.com/NixOS/nixpkgs/commit/11e95671b7cc1091a6bc3781ee16750671bb8e0c) | `` yyjson: 0.11.0 -> 0.11.1 ``                                                                    |
| [`d073665f`](https://github.com/NixOS/nixpkgs/commit/d073665f0454867c49c7ca3fddf4b0047794b8bb) | `` donpapi: mark as broken on darwin ``                                                           |
| [`4bd954bb`](https://github.com/NixOS/nixpkgs/commit/4bd954bba190589c5155ec92f690633014f3560c) | `` donpapi: refactor ``                                                                           |
| [`075f82fe`](https://github.com/NixOS/nixpkgs/commit/075f82fe32291acc1d434152f094478dd83f4d2e) | `` deepsecrets: mark as broekn on darwin ``                                                       |
| [`51f6d18c`](https://github.com/NixOS/nixpkgs/commit/51f6d18c054780f0f4b5efd0291bbc084066b5be) | `` deepsecrets: refactor ``                                                                       |
| [`f6d2a400`](https://github.com/NixOS/nixpkgs/commit/f6d2a400a0ab68d15391ba73d3e1ff0df3054f64) | `` poutine: mark as broken on darwin ``                                                           |
| [`c940e6d8`](https://github.com/NixOS/nixpkgs/commit/c940e6d868134f7a2946572193e76c0d91ee9e31) | `` unicorn-angr: mark as broken on darwin ``                                                      |
| [`81da9f29`](https://github.com/NixOS/nixpkgs/commit/81da9f2934247b8b924d96f1b38b74affb78d796) | `` emacs: remove native-comp-compiler-options-28.patch ``                                         |
| [`c0c54903`](https://github.com/NixOS/nixpkgs/commit/c0c54903b13d20a1590abc1963f4a4fd0e24fdef) | `` mx-takeover: disable on darwin ``                                                              |
| [`85cd9822`](https://github.com/NixOS/nixpkgs/commit/85cd98223fd1907300b506c16572d834b0510505) | `` mx-takeover: refactor ``                                                                       |
| [`28422dbc`](https://github.com/NixOS/nixpkgs/commit/28422dbcc97efd82ebd5b0d645fa7dfd4fadfbc1) | `` dnstake: mark as broken on darwin ``                                                           |
| [`abfa1df8`](https://github.com/NixOS/nixpkgs/commit/abfa1df8d341e6ab3862f8ebd613ff2613d7f701) | `` dnstake: refactor ``                                                                           |
| [`a2b13295`](https://github.com/NixOS/nixpkgs/commit/a2b1329535fdf59a3d26a855d7045bf1f94666e5) | `` upbound-main: 0.39.0-0.rc.0.375.gfed05a63 -> 0.39.0-8.gfb176095 ``                             |
| [`b9709f94`](https://github.com/NixOS/nixpkgs/commit/b9709f944d6526ad6981c0ab99d960fa62ac34b8) | `` azurehound: disable on darwin ``                                                               |
| [`f218242a`](https://github.com/NixOS/nixpkgs/commit/f218242aa97ec50563b6c8d39aba72edd5881032) | `` maigret: mark as broken on darwin ``                                                           |
| [`fda9a388`](https://github.com/NixOS/nixpkgs/commit/fda9a388a8c5bd169d138d881c99f60da6996337) | `` open-webui: 0.6.9 -> 0.6.10 ``                                                                 |
| [`676d2f07`](https://github.com/NixOS/nixpkgs/commit/676d2f074ed297c46db1aded226d8e91517020cb) | `` maigret: refactor ``                                                                           |
| [`158d441e`](https://github.com/NixOS/nixpkgs/commit/158d441ea06cf9d8fbf43d25a40c8d763b64329e) | `` rke2: fix validation message for agent token requirement ``                                    |
| [`ee11af99`](https://github.com/NixOS/nixpkgs/commit/ee11af9926df25289714741788fae15290238b13) | `` nuclei: 3.4.3 -> 3.4.4 ``                                                                      |
| [`ed13d8a0`](https://github.com/NixOS/nixpkgs/commit/ed13d8a02f3b9be7b7bd99e358bfa63984f43e40) | `` ares-rs: mark as broken on darwin ``                                                           |