### PR TITLE
chore(flake/nur): `24efa6cf` -> `fc304844`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -815,11 +815,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1747799866,
-        "narHash": "sha256-yu08UHNosKrGQb3XhP6qalG08VZztOEIRbxu+cKHxgQ=",
+        "lastModified": 1747812816,
+        "narHash": "sha256-ZmehLlglbXc1seK3YCknuBmkMcDIjeaR09f9y0fx1fw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "24efa6cfbe1d649ccde6d5869bf28a25db4c5157",
+        "rev": "fc304844d108a51e7983fa15b71383f060e80f00",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fc304844`](https://github.com/nix-community/NUR/commit/fc304844d108a51e7983fa15b71383f060e80f00) | `` automatic update `` |
| [`0fc77782`](https://github.com/nix-community/NUR/commit/0fc77782b63975ec5cf1560d4739b2d24c700267) | `` automatic update `` |
| [`2fa1189f`](https://github.com/nix-community/NUR/commit/2fa1189f2dc0978099124bcca90e12b687bbed7f) | `` automatic update `` |