### PR TITLE
chore(flake/nur): `fc304844` -> `324221a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1747812816,
-        "narHash": "sha256-ZmehLlglbXc1seK3YCknuBmkMcDIjeaR09f9y0fx1fw=",
+        "lastModified": 1747909603,
+        "narHash": "sha256-vwOHoT2hom9PZ/VG4uQBMAn/m1NynkdwGDSrR/Csx2o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fc304844d108a51e7983fa15b71383f060e80f00",
+        "rev": "324221a83fc9b74bfea8efaa8af195852c746605",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`324221a8`](https://github.com/nix-community/NUR/commit/324221a83fc9b74bfea8efaa8af195852c746605) | `` automatic update `` |
| [`825cebe3`](https://github.com/nix-community/NUR/commit/825cebe36b9ef9d66378b077353ba99652e421ef) | `` automatic update `` |
| [`b2bca40a`](https://github.com/nix-community/NUR/commit/b2bca40a6f66e1ffc4cc714a8e4de10b3f5c85dd) | `` automatic update `` |
| [`83e3c7a2`](https://github.com/nix-community/NUR/commit/83e3c7a2d3f5b90d381eb1951f13588daa2ec8af) | `` automatic update `` |
| [`bb778aef`](https://github.com/nix-community/NUR/commit/bb778aef85544773bcc09cd97debc76f01c4a77f) | `` automatic update `` |
| [`a445d209`](https://github.com/nix-community/NUR/commit/a445d2091a7f60ec13f6c415ac0612530d31ae8c) | `` automatic update `` |
| [`f82ea512`](https://github.com/nix-community/NUR/commit/f82ea512085e8d5f30f2ab39c85c0df8828ea4ce) | `` automatic update `` |
| [`b6accb8a`](https://github.com/nix-community/NUR/commit/b6accb8ad0712eb98972e6660802e8178bb4df54) | `` automatic update `` |
| [`27ab2774`](https://github.com/nix-community/NUR/commit/27ab27740026cae6eb65e9b7bf5551fd19198f75) | `` automatic update `` |
| [`5a5dd7ac`](https://github.com/nix-community/NUR/commit/5a5dd7ac49624ebca4f8dcdf8d28d11d0b379849) | `` automatic update `` |
| [`270df7e8`](https://github.com/nix-community/NUR/commit/270df7e88ac536a45fa26cfada235a823d93d8d2) | `` automatic update `` |
| [`d89efa6e`](https://github.com/nix-community/NUR/commit/d89efa6ee7e685d6badeae6b2d388f7c3d9091a3) | `` automatic update `` |
| [`22a5c4de`](https://github.com/nix-community/NUR/commit/22a5c4de02df229e66f9aa0801cf0212fe170b91) | `` automatic update `` |
| [`897d09d0`](https://github.com/nix-community/NUR/commit/897d09d0d071005a6860b16796ec172297f90677) | `` automatic update `` |
| [`8e7e1a61`](https://github.com/nix-community/NUR/commit/8e7e1a61ac7d0aa10a64fb92e604fda19e013441) | `` automatic update `` |
| [`fc5c6285`](https://github.com/nix-community/NUR/commit/fc5c6285ef1afc79ed18c14960af4a6a427733b0) | `` automatic update `` |
| [`b01e81ed`](https://github.com/nix-community/NUR/commit/b01e81ed226a02c72a54867edecabcf6282bf025) | `` automatic update `` |
| [`b9b668b9`](https://github.com/nix-community/NUR/commit/b9b668b91302e0ee12aaa0114c4a8ae8096871f3) | `` automatic update `` |
| [`af5f52ec`](https://github.com/nix-community/NUR/commit/af5f52ec5253c325f6c0ee359febacacbaa08895) | `` automatic update `` |
| [`44f48704`](https://github.com/nix-community/NUR/commit/44f48704dcbda797c6fe472d7635e7c54eaf3cb9) | `` automatic update `` |
| [`26c6ab1b`](https://github.com/nix-community/NUR/commit/26c6ab1b3f709f2796335951921d2ad0df069e1b) | `` automatic update `` |
| [`a5595aab`](https://github.com/nix-community/NUR/commit/a5595aabe4c56f93b3942b758707e11371f4ec47) | `` automatic update `` |
| [`2a41603d`](https://github.com/nix-community/NUR/commit/2a41603d663c0065eddaf1dde1e405b31e3c7f8b) | `` automatic update `` |
| [`7bd012f9`](https://github.com/nix-community/NUR/commit/7bd012f95832d74ad36d716754a07ad086c9d0c9) | `` automatic update `` |
| [`a8222a0f`](https://github.com/nix-community/NUR/commit/a8222a0f4e9ce81457d053bc047180de5f41b4d2) | `` automatic update `` |