### PR TITLE
chore(flake/nixos-hardware): `6ac6ec6f` -> `2b911888`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -583,11 +583,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1747723695,
-        "narHash": "sha256-lSXzv33yv1O9r9Ai1MtYFDX3OKhWsZMn/5FFb4Rni/k=",
+        "lastModified": 1747860404,
+        "narHash": "sha256-9IMwxC4g1AyhOHTx8iTimoKnyzl9Rk2OJZiDtFoF3pA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "6ac6ec6fcb410e15a60ef5ec94b8a2b35b5dd282",
+        "rev": "2b9118883d29290a1b16ae3a12aedc478dae2546",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                               |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`4165eb0f`](https://github.com/NixOS/nixos-hardware/commit/4165eb0f7983e0e0aad9b71b5a6aa2bc5389d28c) | `` fix typo in framework audio.nix `` |