### PR TITLE
chore(flake/emacs-overlay): `dab8132d` -> `783e12a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1747815851,
-        "narHash": "sha256-Ti5Xoc5nfjj9cEcqqipjAr8un5nRTTfHPUt96bkXdaA=",
+        "lastModified": 1747880714,
+        "narHash": "sha256-djK1m31NlLOchzyf+j6EYOHkQH0nvlvcXZ9hWBa8B68=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "dab8132d4a9bffeaadb5af2e5a04140439477b7b",
+        "rev": "783e12a65f2284fbaf88a77f50c167a28a7d9e1c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`783e12a6`](https://github.com/nix-community/emacs-overlay/commit/783e12a65f2284fbaf88a77f50c167a28a7d9e1c) | `` Updated emacs ``  |
| [`dbc7eeea`](https://github.com/nix-community/emacs-overlay/commit/dbc7eeea24157e9c453fed3ddfd75c403bf0d06f) | `` Updated melpa ``  |
| [`346006d7`](https://github.com/nix-community/emacs-overlay/commit/346006d7b5407b97fde7790d970b500ffca1069f) | `` Updated elpa ``   |
| [`b12c721b`](https://github.com/nix-community/emacs-overlay/commit/b12c721b19d42a6eec952b8d319dce3aed0287d0) | `` Updated nongnu `` |