### PR TITLE
chore(flake/srvos): `755578b0` -> `20a4a794`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -933,11 +933,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747619464,
-        "narHash": "sha256-6cQV07xBp46EMUXDFyR3ypXrrJ2nIpav940RvjT6FJw=",
+        "lastModified": 1747876980,
+        "narHash": "sha256-ZRoCqZmuHqPaPDIzSIrijalnRUlyb47mpI81gw+pDAU=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "755578b01c9fb1cc0a798c0d4d54a283077b315d",
+        "rev": "20a4a794afc9a25fdaf0d4301de4c47c47a25747",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`20a4a794`](https://github.com/nix-community/srvos/commit/20a4a794afc9a25fdaf0d4301de4c47c47a25747) | `` dev/private/flake.lock: Update `` |
| [`ea02ece9`](https://github.com/nix-community/srvos/commit/ea02ece9d8434c31c5c1eeb14c5f309152d89245) | `` flake.lock: Update ``             |