### PR TITLE
chore(flake/treefmt-nix): `ab0378b6` -> `020cb423`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1010,11 +1010,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747469671,
-        "narHash": "sha256-bo1ptiFoNqm6m1B2iAhJmWCBmqveLVvxom6xKmtuzjg=",
+        "lastModified": 1747912973,
+        "narHash": "sha256-XgxghfND8TDypxsMTPU2GQdtBEsHTEc3qWE6RVEk8O0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "ab0378b61b0d85e73a8ab05d5c6029b5bd58c9fb",
+        "rev": "020cb423808365fa3f10ff4cb8c0a25df35065a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                             |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`020cb423`](https://github.com/numtide/treefmt-nix/commit/020cb423808365fa3f10ff4cb8c0a25df35065a3) | `` Add support for rstfmt (#359) `` |