### PR TITLE
chore(flake/emacs-overlay): `783e12a6` -> `dd47e0eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1747880714,
-        "narHash": "sha256-djK1m31NlLOchzyf+j6EYOHkQH0nvlvcXZ9hWBa8B68=",
+        "lastModified": 1747963600,
+        "narHash": "sha256-PkZyUSY2hDG2fVufLyYQHyE5Hkg8i0+8GPNf+raYXVU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "783e12a65f2284fbaf88a77f50c167a28a7d9e1c",
+        "rev": "dd47e0eb0d5114c39967d4aa1d2abb9725294737",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`dd47e0eb`](https://github.com/nix-community/emacs-overlay/commit/dd47e0eb0d5114c39967d4aa1d2abb9725294737) | `` Updated elpa ``   |
| [`11a3c5ab`](https://github.com/nix-community/emacs-overlay/commit/11a3c5ab4d08127e3d49ee562ed7ca462096299f) | `` Updated nongnu `` |
| [`67fa10fd`](https://github.com/nix-community/emacs-overlay/commit/67fa10fdfd0e958dceb60ce893956aad1ed6bce4) | `` Updated elpa ``   |
| [`4a1d8da4`](https://github.com/nix-community/emacs-overlay/commit/4a1d8da46c56a3593798438edbfe9a00d2ab5456) | `` Updated nongnu `` |