### PR TITLE
chore(flake/darwin): `e2676937` -> `33220d47`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747820204,
-        "narHash": "sha256-oY/mH8K1LOd+YbO58sw9ORtOdTxy3rR9lvTzOJKVUtA=",
+        "lastModified": 1748004251,
+        "narHash": "sha256-XodjkVWTth3A2JpBqGBkdLD9kkWn94rnv98l3xwKukg=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "e2676937faf868111dcea6a4a9cf4b6549907c9d",
+        "rev": "33220d4791784e4dd4739edd3f6c028020082f91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                              |
| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
| [`acf6b460`](https://github.com/nix-darwin/nix-darwin/commit/acf6b46011d044d1e99fedf111a8e7c4ef6c93cd) | `` system.build: Treat as variables, make lazy ``    |
| [`0e3b8554`](https://github.com/nix-darwin/nix-darwin/commit/0e3b855456ca38cc2c23cf24eade14b43b72032a) | `` add test ``                                       |
| [`e09c1aef`](https://github.com/nix-darwin/nix-darwin/commit/e09c1aefe489d1cb2f057ed443eb47e21ef3e3d6) | `` feat(services.openssh): add extraConfig option `` |