### PR TITLE
chore(flake/nur): `667829f5` -> `d07a4825`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1747972583,
-        "narHash": "sha256-8QbUwT+vOAg8ciKXXydMWr5E8O7Ws1Z3pyZ+iEA8DR8=",
+        "lastModified": 1748058876,
+        "narHash": "sha256-PZFzwj9sAWkypjQa4O8Iwjhi4+Nd/v1ZASjK5iKXs/A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "667829f528bb0cc1c77afc376326fd59bb167dba",
+        "rev": "d07a482532f41529ef4fcc374a221c5039c69737",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                         |
| -------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`d07a4825`](https://github.com/nix-community/NUR/commit/d07a482532f41529ef4fcc374a221c5039c69737) | `` automatic update ``          |
| [`e2dcdadd`](https://github.com/nix-community/NUR/commit/e2dcdadd6da31b1923feb902b47753ddf6017a82) | `` automatic update ``          |
| [`e5c59540`](https://github.com/nix-community/NUR/commit/e5c595401b102eefa0aab3aa2626aad1331b2d2f) | `` automatic update ``          |
| [`5443a0f6`](https://github.com/nix-community/NUR/commit/5443a0f6823b22dc72fee8aa078af8c712ed6140) | `` automatic update ``          |
| [`a5c4d633`](https://github.com/nix-community/NUR/commit/a5c4d63358d093a5d0ca703d2d0b7fe200542fcd) | `` automatic update ``          |
| [`15377eb3`](https://github.com/nix-community/NUR/commit/15377eb37259e43620e6474124dcc230d1e32fba) | `` add Vortriz repository ``    |
| [`3fa89967`](https://github.com/nix-community/NUR/commit/3fa89967c2a0a7ea87348d5d07c9dd7843b2b667) | `` automatic update ``          |
| [`afdda649`](https://github.com/nix-community/NUR/commit/afdda649bd8705c468d3f514889a396fa5baff32) | `` automatic update ``          |
| [`5dc7ef05`](https://github.com/nix-community/NUR/commit/5dc7ef059f2258435d9210e7ded6eb60117198fd) | `` add nanamiiiii repository `` |
| [`80570121`](https://github.com/nix-community/NUR/commit/80570121964b67aa9e53ef44b3c3540f670cebe2) | `` automatic update ``          |
| [`52984ba8`](https://github.com/nix-community/NUR/commit/52984ba888b0bc1b60e1e5a9fe7413fee0375a2a) | `` automatic update ``          |
| [`9d37436c`](https://github.com/nix-community/NUR/commit/9d37436c287cb1ddda617825648c6d002f8d2d31) | `` automatic update ``          |
| [`7e192dbd`](https://github.com/nix-community/NUR/commit/7e192dbd92a2f670cecfcd8628667a7f13ec7bd9) | `` automatic update ``          |
| [`359df820`](https://github.com/nix-community/NUR/commit/359df8208806b64e75b0aa2753482cf007086959) | `` automatic update ``          |
| [`8c0d345a`](https://github.com/nix-community/NUR/commit/8c0d345a5e53261bd447e0678c08ee04950305cc) | `` automatic update ``          |
| [`f92d8416`](https://github.com/nix-community/NUR/commit/f92d8416b8a7e4a0128675be74ddde787b988e2d) | `` automatic update ``          |
| [`d2b83ef5`](https://github.com/nix-community/NUR/commit/d2b83ef5eef6f3799482a626d97d5af4f8607653) | `` automatic update ``          |
| [`21ae3a58`](https://github.com/nix-community/NUR/commit/21ae3a580bc806abf68840bdf6595481725a4514) | `` automatic update ``          |
| [`bd5d62ab`](https://github.com/nix-community/NUR/commit/bd5d62abb5ce1d98698476157003c6645d48edf5) | `` automatic update ``          |
| [`880ae8a2`](https://github.com/nix-community/NUR/commit/880ae8a2fb539ba99e2b3a98a40f5ebd4ee2378c) | `` automatic update ``          |
| [`8dd1d043`](https://github.com/nix-community/NUR/commit/8dd1d043a5ff27befab37f62aae7a3dd5d640c8f) | `` automatic update ``          |
| [`b02a739c`](https://github.com/nix-community/NUR/commit/b02a739c15b3b3df4d4590829f216714ab9c60e0) | `` automatic update ``          |
| [`8308cff4`](https://github.com/nix-community/NUR/commit/8308cff4c10c631a342a1e2575052c52723c74ec) | `` automatic update ``          |
| [`808c926f`](https://github.com/nix-community/NUR/commit/808c926f59c4734a1dfcb99130ce192a1f6c71f6) | `` automatic update ``          |
| [`1b8677f2`](https://github.com/nix-community/NUR/commit/1b8677f210616d2b82cef78a8289538ab8fd58d8) | `` automatic update ``          |
| [`e4fcae41`](https://github.com/nix-community/NUR/commit/e4fcae418dde38789f3f59ea07ad289a4b9bcffe) | `` automatic update ``          |