### PR TITLE
chore(flake/darwin): `33220d47` -> `a9939228`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748004251,
-        "narHash": "sha256-XodjkVWTth3A2JpBqGBkdLD9kkWn94rnv98l3xwKukg=",
+        "lastModified": 1748149228,
+        "narHash": "sha256-mmonYFesFo42UUS49Hd0bcbVJRWX/aHBCDYUkkvylf4=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "33220d4791784e4dd4739edd3f6c028020082f91",
+        "rev": "a9939228f661df370c4094fe85f683e45d761dbe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                               |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
| [`0d3dcc55`](https://github.com/nix-darwin/nix-darwin/commit/0d3dcc55f3fef8ed1eb5afd976c6cc07f35071c3) | `` ci: enable merge queue ``                          |
| [`cd6a8a79`](https://github.com/nix-darwin/nix-darwin/commit/cd6a8a796d6d6479f425b56c601b189860e664fe) | `` config/system-path: restructure to mirror NixOS `` |
| [`5374405a`](https://github.com/nix-darwin/nix-darwin/commit/5374405a015f02e866bd4a9bbc551d07d7d3a0c2) | `` config/terminfo: init module ``                    |
| [`7347f725`](https://github.com/nix-darwin/nix-darwin/commit/7347f7250726dba3557ae6d367f5773a0036ed3f) | `` programs/arqbackup: init module ``                 |