### PR TITLE
chore(flake/emacs-overlay): `972d4819` -> `5e55769b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1748078251,
-        "narHash": "sha256-wkuQa28OX+N/eJXokvau7yOF0rKEUfKHtN6YvB7z4AA=",
+        "lastModified": 1748107096,
+        "narHash": "sha256-PmQY/yDSlxxma3RBW2v+yWSvpJTubcmXUdoAlaJv7Dk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "972d48193efde5e8618d907e0a4d2751a329a434",
+        "rev": "5e55769b7a39ab810f761874aff5787c74e981da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`5e55769b`](https://github.com/nix-community/emacs-overlay/commit/5e55769b7a39ab810f761874aff5787c74e981da) | `` Updated emacs ``  |
| [`1195950d`](https://github.com/nix-community/emacs-overlay/commit/1195950de932f579d887b28b55cbc751158203e7) | `` Updated melpa ``  |
| [`59bb0142`](https://github.com/nix-community/emacs-overlay/commit/59bb0142a330bf4def630e68b0abd8b040fd123a) | `` Updated elpa ``   |
| [`11bb7cc7`](https://github.com/nix-community/emacs-overlay/commit/11bb7cc7fd71828b0fce809bfb59020f5d61c4fe) | `` Updated nongnu `` |