### PR TITLE
chore(flake/nix-index-database): `ec179dd1` -> `a98adbf5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -469,11 +469,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747540584,
-        "narHash": "sha256-cxCQ413JTUuRv9Ygd8DABJ1D6kuB/nTfQqC0Lu9C0ls=",
+        "lastModified": 1748145500,
+        "narHash": "sha256-t9fx0l61WOxtWxXCqlXPWSuG/0XMF9DtE2T7KXgMqJw=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "ec179dd13fb7b4c6844f55be91436f7857226dce",
+        "rev": "a98adbf54d663395df0b9929f6481d4d80fc8927",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`a98adbf5`](https://github.com/nix-community/nix-index-database/commit/a98adbf54d663395df0b9929f6481d4d80fc8927) | `` update generated.nix to release 2025-05-25-034005 `` |
| [`44cc62e8`](https://github.com/nix-community/nix-index-database/commit/44cc62e814ad26cbe4d0ab0f03e710acac8b35c4) | `` flake.lock: Update ``                                |