### PR TITLE
chore(flake/emacs-overlay): `5e55769b` -> `f6850858`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1748107096,
-        "narHash": "sha256-PmQY/yDSlxxma3RBW2v+yWSvpJTubcmXUdoAlaJv7Dk=",
+        "lastModified": 1749232178,
+        "narHash": "sha256-pekC+SuqoHkoYPuWhC1aADCIP0cD3tvemu4WOF/JMUY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5e55769b7a39ab810f761874aff5787c74e981da",
+        "rev": "f6850858f78e2b6328f6e8bb7bf9df10dd0b7973",
         "type": "github"
       },
       "original": {
@@ -646,11 +646,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1747862697,
-        "narHash": "sha256-U4HaNZ1W26cbOVm0Eb5OdGSnfQVWQKbLSPrSSa78KC0=",
+        "lastModified": 1748995628,
+        "narHash": "sha256-bFufQGSAEYQgjtc4wMrobS5HWN0hDP+ZX+zthYcml9U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2baa12ff69913392faf0ace833bc54bba297ea95",
+        "rev": "8eb3b6a2366a7095939cd22f0dc0e9991313294b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                 |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
| [`f6850858`](https://github.com/nix-community/emacs-overlay/commit/f6850858f78e2b6328f6e8bb7bf9df10dd0b7973) | `` Updated emacs ``                                     |
| [`a6f51a83`](https://github.com/nix-community/emacs-overlay/commit/a6f51a837dc9b3e2314174698664f59acc745593) | `` Updated melpa ``                                     |
| [`20700ef2`](https://github.com/nix-community/emacs-overlay/commit/20700ef27d0f39cb23575f1eda400e7e91d7b587) | `` Updated elpa ``                                      |
| [`e76e1c64`](https://github.com/nix-community/emacs-overlay/commit/e76e1c644c18f784daa0f904f83b4c608cfe5182) | `` Updated nongnu ``                                    |
| [`98f08847`](https://github.com/nix-community/emacs-overlay/commit/98f08847b3f1b9d0efc6ecffadce6311370e8306) | `` Updated emacs ``                                     |
| [`fcb038ab`](https://github.com/nix-community/emacs-overlay/commit/fcb038ab90fcc025389c65e30882ad7ac8e4ff92) | `` Updated melpa ``                                     |
| [`7a6fc149`](https://github.com/nix-community/emacs-overlay/commit/7a6fc1493c699fa8255275452a0c7bb39aa31fc0) | `` Updated emacs ``                                     |
| [`98f42400`](https://github.com/nix-community/emacs-overlay/commit/98f424001c170bc9d1f9911044d6c9884d8a5cdf) | `` Updated melpa ``                                     |
| [`4057e1fc`](https://github.com/nix-community/emacs-overlay/commit/4057e1fcd998c653be0db421a3fb268e28d17d8f) | `` Updated elpa ``                                      |
| [`c43d3a84`](https://github.com/nix-community/emacs-overlay/commit/c43d3a844c630784af10e33ce05ba466deda4e64) | `` Updated nongnu ``                                    |
| [`ff324514`](https://github.com/nix-community/emacs-overlay/commit/ff324514304d770d533cfbf9aea1b68d68b46e48) | `` Updated emacs ``                                     |
| [`943c23be`](https://github.com/nix-community/emacs-overlay/commit/943c23bed00256079ddf09a30bc1acf517c63d50) | `` Updated melpa ``                                     |
| [`665fc708`](https://github.com/nix-community/emacs-overlay/commit/665fc70866ec89fb7b75eefd4906d8000a0b977b) | `` Updated elpa ``                                      |
| [`c1750666`](https://github.com/nix-community/emacs-overlay/commit/c17506666090e412a50b01c57944386ab81d2aa8) | `` Updated emacs ``                                     |
| [`5829b314`](https://github.com/nix-community/emacs-overlay/commit/5829b3144e6607337f6618549422538aa749e0f0) | `` Updated melpa ``                                     |
| [`13fae16b`](https://github.com/nix-community/emacs-overlay/commit/13fae16b4ff8b0d1ea11c0a173975d5a47089446) | `` Updated elpa ``                                      |
| [`9ab94993`](https://github.com/nix-community/emacs-overlay/commit/9ab94993d524a7b74c8c9423424394d54672fc98) | `` Updated nongnu ``                                    |
| [`233041cb`](https://github.com/nix-community/emacs-overlay/commit/233041cb05a8cb5c346c6c4e3991e5111de83efe) | `` README.org: update explanation of pure GTK builds `` |
| [`c58bd079`](https://github.com/nix-community/emacs-overlay/commit/c58bd079c0ebbde13972fb3f8221924d42295889) | `` Updated emacs ``                                     |
| [`8806de4a`](https://github.com/nix-community/emacs-overlay/commit/8806de4adc11ca050661b5f375621be5e6f6780d) | `` Updated melpa ``                                     |
| [`cff04d78`](https://github.com/nix-community/emacs-overlay/commit/cff04d78e771311b67c5503b648731a991524b89) | `` Updated elpa ``                                      |
| [`4836cf9b`](https://github.com/nix-community/emacs-overlay/commit/4836cf9bdcf8ba8fc1fd2b4cc1b078a84d82c80e) | `` Updated nongnu ``                                    |
| [`d70931ba`](https://github.com/nix-community/emacs-overlay/commit/d70931babb1968ddd6e0c3b1e93493c7c0447873) | `` Updated flake inputs ``                              |
| [`341c6324`](https://github.com/nix-community/emacs-overlay/commit/341c6324d0780f1846c77b1a13c18934172ca9dd) | `` Updated emacs ``                                     |
| [`08914a60`](https://github.com/nix-community/emacs-overlay/commit/08914a606839c06be2e3ac7a1dc18c07ffb8c729) | `` Updated melpa ``                                     |
| [`734bd730`](https://github.com/nix-community/emacs-overlay/commit/734bd730f2c07c40438562b7505f1e0fca23eb3c) | `` Updated flake inputs ``                              |
| [`92b75bf8`](https://github.com/nix-community/emacs-overlay/commit/92b75bf8b4e26ae3373fbe6331f9a1c63efc1e29) | `` Updated emacs ``                                     |
| [`48df8197`](https://github.com/nix-community/emacs-overlay/commit/48df8197c882eeed04fb4045ca894f1f2d4aa5c4) | `` Updated melpa ``                                     |
| [`b23f5ee5`](https://github.com/nix-community/emacs-overlay/commit/b23f5ee5d26ee40cafbec9e3d1c4d9cefdf93c27) | `` Updated elpa ``                                      |
| [`24fc509f`](https://github.com/nix-community/emacs-overlay/commit/24fc509f8973c1dd030c0c17d75e392ea8c1efaf) | `` Updated nongnu ``                                    |
| [`c0ad0875`](https://github.com/nix-community/emacs-overlay/commit/c0ad08752a8066414d10f05e1ef2fa998e020d9f) | `` README.org: drop now-unused LocalWords entry ``      |
| [`6fad7c0b`](https://github.com/nix-community/emacs-overlay/commit/6fad7c0b0324f06a1e8e93e7ef737c5362cda409) | `` README.org: replace obsolete symbol emacsGit ``      |
| [`52a96356`](https://github.com/nix-community/emacs-overlay/commit/52a963560ebee290e278be63cfda460ce4df5e19) | `` Updated emacs ``                                     |
| [`71027696`](https://github.com/nix-community/emacs-overlay/commit/710276966b2d761a277340b02c6d055e730220ff) | `` Updated melpa ``                                     |
| [`3f4991b0`](https://github.com/nix-community/emacs-overlay/commit/3f4991b0d9a225f9ceccb69538355045b99ff8fa) | `` Updated elpa ``                                      |
| [`63420c7c`](https://github.com/nix-community/emacs-overlay/commit/63420c7ccda26d15a669a7ff20212514ffff9553) | `` Updated nongnu ``                                    |
| [`78278b77`](https://github.com/nix-community/emacs-overlay/commit/78278b770d2c83657657da569544cf20eccee0ef) | `` Updated melpa ``                                     |
| [`d2fa26ea`](https://github.com/nix-community/emacs-overlay/commit/d2fa26ea3ca5cee5b4368086b3f4423cadbb642f) | `` Updated flake inputs ``                              |
| [`65577582`](https://github.com/nix-community/emacs-overlay/commit/6557758212b4056fa0b3d65c537a3a8e503090ed) | `` Updated emacs ``                                     |
| [`f4cd3be0`](https://github.com/nix-community/emacs-overlay/commit/f4cd3be0948d11f06ac921f81080826fa49631e8) | `` Updated melpa ``                                     |
| [`691d191a`](https://github.com/nix-community/emacs-overlay/commit/691d191a324330db4bee9bc87ded0d5b54f72fe4) | `` Updated elpa ``                                      |
| [`74f3c260`](https://github.com/nix-community/emacs-overlay/commit/74f3c260dc3605e3ce194ece102c2db6bd0d4cef) | `` Updated nongnu ``                                    |
| [`a826d9e7`](https://github.com/nix-community/emacs-overlay/commit/a826d9e7655704aadc36ba3f64605b38ebaea2a2) | `` Updated emacs ``                                     |
| [`1be5369c`](https://github.com/nix-community/emacs-overlay/commit/1be5369cdee97b99545091767248277c2ff1fea6) | `` Updated melpa ``                                     |
| [`82b09342`](https://github.com/nix-community/emacs-overlay/commit/82b093426839ed945cee37f4d7fc98ca68aa1506) | `` Updated elpa ``                                      |
| [`c34b2539`](https://github.com/nix-community/emacs-overlay/commit/c34b2539d7d85651d18f4d8c0ded913d6c950cfb) | `` Updated nongnu ``                                    |
| [`778e55ea`](https://github.com/nix-community/emacs-overlay/commit/778e55eaced8cc64c5a364d565e46aab9958d464) | `` Updated emacs ``                                     |
| [`ce98dfc9`](https://github.com/nix-community/emacs-overlay/commit/ce98dfc99db86aa08547fd053a19df15fee7a370) | `` Updated melpa ``                                     |
| [`7f21af85`](https://github.com/nix-community/emacs-overlay/commit/7f21af85151a80b90cb1b514a993e56cb6716275) | `` Updated emacs ``                                     |
| [`27826d97`](https://github.com/nix-community/emacs-overlay/commit/27826d97ee15ea9db4fb8147aa09b25e74af20fd) | `` Updated melpa ``                                     |
| [`6bb8d143`](https://github.com/nix-community/emacs-overlay/commit/6bb8d143201db7c17d0fd8fcf32fa3f58e36856e) | `` Updated elpa ``                                      |
| [`f0c30a37`](https://github.com/nix-community/emacs-overlay/commit/f0c30a37baf8e7c86faee0673fbf15acbad217d4) | `` Updated nongnu ``                                    |
| [`9153c671`](https://github.com/nix-community/emacs-overlay/commit/9153c6719aff5ba4faf817e90d82e9c2f8b886a1) | `` Updated emacs ``                                     |
| [`82c5e352`](https://github.com/nix-community/emacs-overlay/commit/82c5e3524420971433703790a4f3f615674d9e55) | `` Updated melpa ``                                     |
| [`6d87fd52`](https://github.com/nix-community/emacs-overlay/commit/6d87fd5234c95e9ac7c10c47c6d42d168df43b5b) | `` Updated elpa ``                                      |
| [`0f61474b`](https://github.com/nix-community/emacs-overlay/commit/0f61474b56b5405e0bc9e25918bd6ac40dd66953) | `` Updated nongnu ``                                    |
| [`07082af5`](https://github.com/nix-community/emacs-overlay/commit/07082af53b3ed89317562fd02f82383e8f62d3f3) | `` Updated flake inputs ``                              |
| [`7466f302`](https://github.com/nix-community/emacs-overlay/commit/7466f3020aa9f156b15e0495b9de8915b4a1b2d5) | `` Updated emacs ``                                     |
| [`bbb4385a`](https://github.com/nix-community/emacs-overlay/commit/bbb4385aff3f7143fa4fba082e4cb43f8f6c77a1) | `` Updated melpa ``                                     |
| [`f3c97a15`](https://github.com/nix-community/emacs-overlay/commit/f3c97a159bef82077c4742c3abf9bc68794a44ea) | `` Updated elpa ``                                      |
| [`fc0e89b0`](https://github.com/nix-community/emacs-overlay/commit/fc0e89b0d64600c939ed9b8fcce123118559b260) | `` Updated nongnu ``                                    |
| [`51d60eb6`](https://github.com/nix-community/emacs-overlay/commit/51d60eb61a64d58e3086bb227d481ac77a12234c) | `` Updated emacs ``                                     |
| [`8453bd9f`](https://github.com/nix-community/emacs-overlay/commit/8453bd9f0dc54c25c1149e3527df84ab52ce3a6b) | `` Updated melpa ``                                     |
| [`bd14f05a`](https://github.com/nix-community/emacs-overlay/commit/bd14f05adc19cc95d0c516ea6bbf940760be29f2) | `` Updated elpa ``                                      |
| [`13be163f`](https://github.com/nix-community/emacs-overlay/commit/13be163faa226f5c7ba1e59718c3c29038d915d3) | `` Updated nongnu ``                                    |
| [`0abe78b7`](https://github.com/nix-community/emacs-overlay/commit/0abe78b79df5a7d4d1f952b0d9eca17ba2399dd8) | `` Updated emacs ``                                     |
| [`08ab4309`](https://github.com/nix-community/emacs-overlay/commit/08ab4309797b262599c76ca927d0a9012e93e1c9) | `` Updated melpa ``                                     |
| [`e8abde37`](https://github.com/nix-community/emacs-overlay/commit/e8abde37d18efb09d3662d66a5bd36bb517e0db1) | `` Updated emacs ``                                     |
| [`701c1edb`](https://github.com/nix-community/emacs-overlay/commit/701c1edbb332c46284ce6332f117795a0fa8ecba) | `` Updated melpa ``                                     |
| [`19e8e1c6`](https://github.com/nix-community/emacs-overlay/commit/19e8e1c6541c7c2b4f54c5e7cee9bfe46d97f7bd) | `` Updated elpa ``                                      |
| [`f4d411e5`](https://github.com/nix-community/emacs-overlay/commit/f4d411e5e8066f8916a911770dda22506dcb50e3) | `` Updated nongnu ``                                    |
| [`f7dd0287`](https://github.com/nix-community/emacs-overlay/commit/f7dd02872d4acc406355965a6c9bbb4f14782400) | `` Updated emacs ``                                     |
| [`7168e351`](https://github.com/nix-community/emacs-overlay/commit/7168e351ba6a0a65ccea47d5023e3f3427f30d26) | `` Updated melpa ``                                     |
| [`397fd659`](https://github.com/nix-community/emacs-overlay/commit/397fd659a4a7cfb75260b0104f2386cbabdf110e) | `` Updated elpa ``                                      |
| [`dfa2302b`](https://github.com/nix-community/emacs-overlay/commit/dfa2302b404c9d59296b34cac7b2354f5eca4a55) | `` Updated nongnu ``                                    |
| [`5b6b5beb`](https://github.com/nix-community/emacs-overlay/commit/5b6b5beb5c6778d7a7d0b078675dac4de4884cd1) | `` Updated flake inputs ``                              |
| [`5140763f`](https://github.com/nix-community/emacs-overlay/commit/5140763f6b06268375e06698636796fa063b944c) | `` Updated melpa ``                                     |
| [`ff7520b1`](https://github.com/nix-community/emacs-overlay/commit/ff7520b1b7eeaa20f67c1a73da384f53c09bf0d6) | `` Updated emacs ``                                     |
| [`48ea615f`](https://github.com/nix-community/emacs-overlay/commit/48ea615f66c7b01ccbe603418f88ee64e27bed99) | `` Updated melpa ``                                     |
| [`7651658f`](https://github.com/nix-community/emacs-overlay/commit/7651658f1deb2e31d6d5367eb8dc5cfdb0a4f313) | `` Updated elpa ``                                      |
| [`33d7b320`](https://github.com/nix-community/emacs-overlay/commit/33d7b320ab1e8ee2e0473416c1990a8f62d2519d) | `` Updated nongnu ``                                    |
| [`8e1a6d81`](https://github.com/nix-community/emacs-overlay/commit/8e1a6d8182bb59432d0796f4a769ef3b9111bfcb) | `` Updated flake inputs ``                              |
| [`2de3eea4`](https://github.com/nix-community/emacs-overlay/commit/2de3eea4261b2215c732bf81d185179a5e1c2980) | `` Updated emacs ``                                     |
| [`5f06a39a`](https://github.com/nix-community/emacs-overlay/commit/5f06a39a20d22d187191208d6997a95e97c266d4) | `` Updated melpa ``                                     |
| [`2eee58a7`](https://github.com/nix-community/emacs-overlay/commit/2eee58a77e05399ecbebd5ab2d21cdd110abc547) | `` Updated elpa ``                                      |
| [`8a4bcb07`](https://github.com/nix-community/emacs-overlay/commit/8a4bcb07e1d1b7ffafe2b4bca79bce7e374c96af) | `` Updated nongnu ``                                    |
| [`8a6d70fb`](https://github.com/nix-community/emacs-overlay/commit/8a6d70fbe08c7be6b1832a1c4614d5f71e8ccf82) | `` Updated emacs ``                                     |
| [`9c1c0ba8`](https://github.com/nix-community/emacs-overlay/commit/9c1c0ba8fef7d277a1b18a1241c7ac4a645b9257) | `` Updated melpa ``                                     |
| [`56505e6c`](https://github.com/nix-community/emacs-overlay/commit/56505e6c22457630bc62de98351058e378d51f91) | `` Updated elpa ``                                      |
| [`66dcd551`](https://github.com/nix-community/emacs-overlay/commit/66dcd551173d678898d07886cebbc103d0b44645) | `` Updated nongnu ``                                    |
| [`fa919dd3`](https://github.com/nix-community/emacs-overlay/commit/fa919dd368ff59318cdf9d5ac16b61a9eb4f7d8e) | `` follow savannah redirect for atom feed ``            |
| [`44f10e03`](https://github.com/nix-community/emacs-overlay/commit/44f10e03d04b678d13ee9c36a9bd632dbce84103) | `` Updated flake inputs ``                              |
| [`0fba546d`](https://github.com/nix-community/emacs-overlay/commit/0fba546d9aa235fc726fe9c8c3bb703e918c14c4) | `` Updated flake inputs ``                              |
| [`49ba6a14`](https://github.com/nix-community/emacs-overlay/commit/49ba6a14d9e80baa3715984cc2dde8c9fdf00049) | `` Don't overwrite fromElisp on errors. ``              |
| [`dbaa3636`](https://github.com/nix-community/emacs-overlay/commit/dbaa3636560e69e430edc5a340b37c69f8de7d28) | `` Updated fromElisp ``                                 |
| [`e0484338`](https://github.com/nix-community/emacs-overlay/commit/e048433838750a5fd9036e56dd8f59affa6d676b) | `` Updated fromElisp ``                                 |
| [`29430cce`](https://github.com/nix-community/emacs-overlay/commit/29430cce2da82c0f658cd3310191434bf709f245) | `` Updated emacs ``                                     |
| [`076abb92`](https://github.com/nix-community/emacs-overlay/commit/076abb929715022935ad532beebfa9e84e94f280) | `` Updated melpa ``                                     |
| [`c5a55ca8`](https://github.com/nix-community/emacs-overlay/commit/c5a55ca8488fe4590f90fa43e3d6371c37116320) | `` Updated elpa ``                                      |
| [`8fcc8c1c`](https://github.com/nix-community/emacs-overlay/commit/8fcc8c1c51565cfe0a7db742273a05bc2da31340) | `` Updated nongnu ``                                    |
| [`95a64c51`](https://github.com/nix-community/emacs-overlay/commit/95a64c515e22ba212ee0de12509e31b3801e1ba6) | `` Updated emacs ``                                     |
| [`176690b1`](https://github.com/nix-community/emacs-overlay/commit/176690b161c9cf8044d8766308d504b89818e54c) | `` Updated melpa ``                                     |
| [`437a6b24`](https://github.com/nix-community/emacs-overlay/commit/437a6b24aabddda3dfce57838d05f1b173bf46ec) | `` Updated elpa ``                                      |
| [`566f386a`](https://github.com/nix-community/emacs-overlay/commit/566f386a7e716cbde6b60c2cbf5e938655f29911) | `` Updated melpa ``                                     |
| [`7e969bfc`](https://github.com/nix-community/emacs-overlay/commit/7e969bfc4c242458ce068fa7a1476fce1fa78898) | `` Updated flake inputs ``                              |
| [`c1fdaae5`](https://github.com/nix-community/emacs-overlay/commit/c1fdaae5c4c397b66fc63c683945c5c272aef1b4) | `` Updated melpa ``                                     |
| [`464be014`](https://github.com/nix-community/emacs-overlay/commit/464be0142fb4c02b826e4aff67518909dc57f002) | `` Updated elpa ``                                      |
| [`2194e805`](https://github.com/nix-community/emacs-overlay/commit/2194e80576a14c4a81a36c1596dd5ce964d647b0) | `` Updated nongnu ``                                    |
| [`c67f968e`](https://github.com/nix-community/emacs-overlay/commit/c67f968e40ae0f12b925953926a0201d3067438a) | `` Updated flake inputs ``                              |