### PR TITLE
chore(flake/nur): `cd8e3b47` -> `373677c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1748145895,
-        "narHash": "sha256-KDyelU7rB/x6Vp0ZRwRyxf7VR8mAwPGyktezcf0Yv44=",
+        "lastModified": 1748159893,
+        "narHash": "sha256-2RxelcdvoJxIB9vZdbvCRv3LZcTrrrHaqlnuNE2I8Do=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cd8e3b478445d0a174a47719e0930fdbe19b96af",
+        "rev": "373677c548986d7fbe85b16377f6daeec67d06e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`373677c5`](https://github.com/nix-community/NUR/commit/373677c548986d7fbe85b16377f6daeec67d06e7) | `` automatic update `` |
| [`a4f3dc46`](https://github.com/nix-community/NUR/commit/a4f3dc4655fb72e8c6cf1b3b316361e123dd919f) | `` automatic update `` |
| [`5bfcc177`](https://github.com/nix-community/NUR/commit/5bfcc177ce00f4447a1baa8d77bc9e568eb6897c) | `` automatic update `` |