### PR TITLE
chore(flake/nur): `373677c5` -> `b47c95c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1748159893,
-        "narHash": "sha256-2RxelcdvoJxIB9vZdbvCRv3LZcTrrrHaqlnuNE2I8Do=",
+        "lastModified": 1748173519,
+        "narHash": "sha256-lFeGoidhN/GTnW05VrXGZlTOAepPRnrYIx1YFU0MtUs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "373677c548986d7fbe85b16377f6daeec67d06e7",
+        "rev": "b47c95c381aafc0efe28a8d9638cec546654384f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b47c95c3`](https://github.com/nix-community/NUR/commit/b47c95c381aafc0efe28a8d9638cec546654384f) | `` automatic update `` |
| [`bb29133d`](https://github.com/nix-community/NUR/commit/bb29133da4285054b9f48abf67e353e77b53ca34) | `` automatic update `` |
| [`59c94c4a`](https://github.com/nix-community/NUR/commit/59c94c4ace41c2fd1f59a37a56d411f5744f21f3) | `` automatic update `` |
| [`65968ead`](https://github.com/nix-community/NUR/commit/65968ead3694fd01a9f0ed9e9027de67273d0b53) | `` automatic update `` |
| [`2a7c9e4e`](https://github.com/nix-community/NUR/commit/2a7c9e4e4f6e10827d860685693e37e754fe232a) | `` automatic update `` |
| [`a994b73f`](https://github.com/nix-community/NUR/commit/a994b73ff7a63c59baab6bca4e0037e1d6708a90) | `` automatic update `` |