### PR TITLE
chore(flake/srvos): `20a4a794` -> `37ce28d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -933,11 +933,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747876980,
-        "narHash": "sha256-ZRoCqZmuHqPaPDIzSIrijalnRUlyb47mpI81gw+pDAU=",
+        "lastModified": 1748221540,
+        "narHash": "sha256-hlf/ILKLU98P38mXQxm6kxbxjt3eI0vUcDZhXjf2HJg=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "20a4a794afc9a25fdaf0d4301de4c47c47a25747",
+        "rev": "37ce28d34cf7b416bf8eb0974a99e85ad65fbe84",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`37ce28d3`](https://github.com/nix-community/srvos/commit/37ce28d34cf7b416bf8eb0974a99e85ad65fbe84) | `` dev/private/flake.lock: Update `` |
| [`f76908b0`](https://github.com/nix-community/srvos/commit/f76908b002cec88464bb749b2ebf9d02c70e5c1c) | `` flake.lock: Update ``             |