### PR TITLE
chore(flake/nur): `34c28c4e` -> `8f18fdd3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1748274613,
-        "narHash": "sha256-FtJRAlgnM5rT1wMOkWpi7oLVBk8HT1MDdh5amMUVBGI=",
+        "lastModified": 1748280483,
+        "narHash": "sha256-v3Z9bewJut6ZFgzD4bYDvSbCP/R5salBgjkc7MksPkw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "34c28c4e788f9ef2e721fb4dcf8777455b3f6d1c",
+        "rev": "8f18fdd363421cdc71cf73dfcb0cdb827dac94f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8f18fdd3`](https://github.com/nix-community/NUR/commit/8f18fdd363421cdc71cf73dfcb0cdb827dac94f4) | `` automatic update `` |