### PR TITLE
chore(flake/nur): `6147cd64` -> `8b266cb4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1748318364,
-        "narHash": "sha256-rl0zpQuffPVoT2uO3QKaUot5h7JIdyjffQ6EDm8nRZc=",
+        "lastModified": 1748319458,
+        "narHash": "sha256-raBGzAVExD0z2S7+jk+Sw6Y/ew3nbchSMH5qeVs0eoA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6147cd64dba71801e06ba856b99f7d4522c6aacb",
+        "rev": "8b266cb4a8e5dd9758d882df5ea4b6ef24cb9156",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8b266cb4`](https://github.com/nix-community/NUR/commit/8b266cb4a8e5dd9758d882df5ea4b6ef24cb9156) | `` automatic update `` |