### PR TITLE
chore(flake/nur): `8b266cb4` -> `655b5b45`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1748319458,
-        "narHash": "sha256-raBGzAVExD0z2S7+jk+Sw6Y/ew3nbchSMH5qeVs0eoA=",
+        "lastModified": 1748347333,
+        "narHash": "sha256-nQ9UEMlOp6BoHFc9pMg0ATgqSTk/to4irIEpeHbvoRU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8b266cb4a8e5dd9758d882df5ea4b6ef24cb9156",
+        "rev": "655b5b45beea527cc07437ea4d7ae9d6de70a67f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`655b5b45`](https://github.com/nix-community/NUR/commit/655b5b45beea527cc07437ea4d7ae9d6de70a67f) | `` automatic update `` |
| [`35bf5697`](https://github.com/nix-community/NUR/commit/35bf569767fb8b3ad033bedc4b179cea2b25f1ba) | `` automatic update `` |
| [`e020d389`](https://github.com/nix-community/NUR/commit/e020d389e4ba77c9313ff95c8fc8214303e208a5) | `` automatic update `` |
| [`440645e1`](https://github.com/nix-community/NUR/commit/440645e17d0c4a36bc45a6f6c7362acb17b65b11) | `` automatic update `` |