### PR TITLE
chore(flake/nur): `655b5b45` -> `9638f420`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1748347333,
-        "narHash": "sha256-nQ9UEMlOp6BoHFc9pMg0ATgqSTk/to4irIEpeHbvoRU=",
+        "lastModified": 1748357499,
+        "narHash": "sha256-WHakqXxCBfggTLa0IA9A4CN1iz0Ba9MzBobMdf9pKhA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "655b5b45beea527cc07437ea4d7ae9d6de70a67f",
+        "rev": "9638f42001fd8c306df7e171d4bbeaf95049eafe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9638f420`](https://github.com/nix-community/NUR/commit/9638f42001fd8c306df7e171d4bbeaf95049eafe) | `` automatic update `` |
| [`a738c8a5`](https://github.com/nix-community/NUR/commit/a738c8a505813b8dfc986325deb85c45a8445101) | `` automatic update `` |
| [`6718d7dc`](https://github.com/nix-community/NUR/commit/6718d7dc36e8b9066007ed1ce6d8c9410d764cc4) | `` automatic update `` |
| [`38d55cde`](https://github.com/nix-community/NUR/commit/38d55cde58d5815e296ff7c683692907d7b99722) | `` automatic update `` |