### PR TITLE
chore(flake/darwin): `a9939228` -> `44a7d0e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748149228,
-        "narHash": "sha256-mmonYFesFo42UUS49Hd0bcbVJRWX/aHBCDYUkkvylf4=",
+        "lastModified": 1748352827,
+        "narHash": "sha256-sNUUP6qxGkK9hXgJ+p362dtWLgnIWwOCmiq72LAWtYo=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "a9939228f661df370c4094fe85f683e45d761dbe",
+        "rev": "44a7d0e687a87b73facfe94fba78d323a6686a90",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                      |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
| [`d23a9c26`](https://github.com/nix-darwin/nix-darwin/commit/d23a9c26f37ce6600e452099ee86c916bf51ef87) | `` darwin-rebuild: use `NIX_REMOTE=daemon` even as `root` `` |