### PR TITLE
chore(flake/emacs-ultra-scroll): `93cd969c` -> `ebedc8f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
     "emacs-ultra-scroll": {
       "flake": false,
       "locked": {
-        "lastModified": 1746415363,
-        "narHash": "sha256-DI9fiOtV/yGRx3BxNoKG8ulLdyx6v1RyzFIGMyggKeU=",
+        "lastModified": 1748363492,
+        "narHash": "sha256-ubRTlVp3xTlKPg4xCwmD50NeGTVBq7H8a3CJ6PqxYEI=",
         "owner": "jdtsmith",
         "repo": "ultra-scroll",
-        "rev": "93cd969c2ed1e75a950e6dec112a0ab1e4a6903b",
+        "rev": "ebedc8f8c6b37d4267365fd116f6a89107ab6fe1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                |
| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
| [`ebedc8f8`](https://github.com/jdtsmith/ultra-scroll/commit/ebedc8f8c6b37d4267365fd116f6a89107ab6fe1) | `` Work around vscroll!=0 bug for current buffer in other window(s) `` |
| [`c4cb0836`](https://github.com/jdtsmith/ultra-scroll/commit/c4cb083672724264359d536202ac0569e8c267f1) | `` Simplify example config ``                                          |