### PR TITLE
chore(flake/home-manager): `d23d20f5` -> `f5b12be8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748227609,
-        "narHash": "sha256-SaSdslyo6UGDpPUlmrPA4dWOEuxCy2ihRN9K6BnqYsA=",
+        "lastModified": 1748391243,
+        "narHash": "sha256-7sCuihzsTRZemtbTXaFUoGJUfuQErhKEcL9v7HKIo1k=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d23d20f55d49d8818ac1f1b2783671e8a6725022",
+        "rev": "f5b12be834874f7661db4ced969a621ab2d57971",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`f5b12be8`](https://github.com/nix-community/home-manager/commit/f5b12be834874f7661db4ced969a621ab2d57971) | `` polkit-gnome: Change `After` target (#7137) ``      |
| [`ad22169e`](https://github.com/nix-community/home-manager/commit/ad22169efa67448badd870076e441778f4cf7948) | `` jellyfin-mpv-shim: add module (#7129) ``            |
| [`8cb8a04c`](https://github.com/nix-community/home-manager/commit/8cb8a04cb1383fe08bb6cbf672f00ed60c92bbbd) | `` home-cursor: set hyprcursor size default (#7145) `` |