### PR TITLE
chore(flake/nur): `aef75de0` -> `6ae43e88`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -725,11 +725,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1748190013,
-        "narHash": "sha256-R5HJFflOfsP5FBtk+zE8FpL8uqE7n62jqOsADvVshhE=",
+        "lastModified": 1748370509,
+        "narHash": "sha256-QlL8slIgc16W5UaI3w7xHQEP+Qmv/6vSNTpoZrrSlbk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "62b852f6c6742134ade1abdd2a21685fd617a291",
+        "rev": "4faa5f5321320e49a78ae7848582f684d64783e9",
         "type": "github"
       },
       "original": {
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1748433522,
-        "narHash": "sha256-V+YTmpCokIb0iAl6+5c02KCsABgeEAPhvfARIdatwHI=",
+        "lastModified": 1748447553,
+        "narHash": "sha256-s0PKIvvjDleROv9xqgEqUpObLRrxkOmmO8gNNC7BpN0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aef75de07385a1f988c333615c9f72a83591860c",
+        "rev": "6ae43e88e38f367149e264d7d8715eaf2b9b59c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6ae43e88`](https://github.com/nix-community/NUR/commit/6ae43e88e38f367149e264d7d8715eaf2b9b59c4) | `` automatic update `` |
| [`dfd9c24c`](https://github.com/nix-community/NUR/commit/dfd9c24c9067bab9c7bf7b31dd8e3c3ad9f19110) | `` automatic update `` |
| [`c68efc61`](https://github.com/nix-community/NUR/commit/c68efc6197f91cae2904f68937bdfb235c3c7799) | `` automatic update `` |
| [`8a53c552`](https://github.com/nix-community/NUR/commit/8a53c552c60c4616c2689dad91e9541c1435bd15) | `` automatic update `` |
| [`cc59c871`](https://github.com/nix-community/NUR/commit/cc59c871120ee0ea17ba17dd3f26d60bb21bc49d) | `` automatic update `` |
| [`e9bfe021`](https://github.com/nix-community/NUR/commit/e9bfe021e1887c23566b17cab461180cf3076406) | `` automatic update `` |