### PR TITLE
chore(flake/nur): `6ae43e88` -> `a83970fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1748447553,
-        "narHash": "sha256-s0PKIvvjDleROv9xqgEqUpObLRrxkOmmO8gNNC7BpN0=",
+        "lastModified": 1748460688,
+        "narHash": "sha256-Vq25gImLt4uYLkGPoOfrukbB7U6BIngx3OAmwEB8ET0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6ae43e88e38f367149e264d7d8715eaf2b9b59c4",
+        "rev": "a83970feaea9438ab9a4878ff7759889053d3d8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a83970fe`](https://github.com/nix-community/NUR/commit/a83970feaea9438ab9a4878ff7759889053d3d8f) | `` automatic update `` |
| [`87ede2bc`](https://github.com/nix-community/NUR/commit/87ede2bc66275ab2dea55720b1a4055e8c5c06db) | `` automatic update `` |
| [`84de0c27`](https://github.com/nix-community/NUR/commit/84de0c27833a2d5a3c5eac3d478af7f6410ed764) | `` automatic update `` |