### PR TITLE
chore(flake/srvos): `37ce28d3` -> `917442c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -933,11 +933,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748221540,
-        "narHash": "sha256-hlf/ILKLU98P38mXQxm6kxbxjt3eI0vUcDZhXjf2HJg=",
+        "lastModified": 1748481086,
+        "narHash": "sha256-rQ5hUgMThLFQsCB4urDeVAT1xjHuDN41bMH9u3WmhA8=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "37ce28d34cf7b416bf8eb0974a99e85ad65fbe84",
+        "rev": "917442c10abd63809917bb97dfd5292c02c672eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`917442c1`](https://github.com/nix-community/srvos/commit/917442c10abd63809917bb97dfd5292c02c672eb) | `` dev/private/flake.lock: Update `` |
| [`e9f55f38`](https://github.com/nix-community/srvos/commit/e9f55f3850bc49b9f567920a5f0167e78a6a9805) | `` flake.lock: Update ``             |