### PR TITLE
chore(flake/emacs-ultra-scroll): `ebedc8f8` -> `2b90a7f7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
     "emacs-ultra-scroll": {
       "flake": false,
       "locked": {
-        "lastModified": 1748363492,
-        "narHash": "sha256-ubRTlVp3xTlKPg4xCwmD50NeGTVBq7H8a3CJ6PqxYEI=",
+        "lastModified": 1748525778,
+        "narHash": "sha256-xUI9ueOnF5InBmKcmlZ5kaF6C4jPElULfpeZso/gSYE=",
         "owner": "jdtsmith",
         "repo": "ultra-scroll",
-        "rev": "ebedc8f8c6b37d4267365fd116f6a89107ab6fe1",
+        "rev": "2b90a7f7af81bea120da9ac8b8e202452ef077b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                   |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
| [`2b90a7f7`](https://github.com/jdtsmith/ultra-scroll/commit/2b90a7f7af81bea120da9ac8b8e202452ef077b6) | `` Update NEWS ``                                                         |
| [`0bc255d6`](https://github.com/jdtsmith/ultra-scroll/commit/0bc255d6c831f7a79060d7d2dae37680a34cd9a7) | `` Set make-cursor-line-fully-visible=nil to work around redisplay bug `` |