### PR TITLE
chore(flake/home-manager): `da282034` -> `4e9efaa6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748529677,
-        "narHash": "sha256-MJEX3Skt5EAIs/aGHD8/aXXZPcceMMHheyIGSjvxZN0=",
+        "lastModified": 1748570847,
+        "narHash": "sha256-XU1a6wFctd+s3ZvBIFB6s4GhPJ+Oc6pkeOrEsbA2fMo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "da282034f4d30e787b8a10722431e8b650a907ef",
+        "rev": "4e9efaa68b0be7e19127dad4f0506a9b89e28ef4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`4e9efaa6`](https://github.com/nix-community/home-manager/commit/4e9efaa68b0be7e19127dad4f0506a9b89e28ef4) | `` misc: add librewolf native messaging hosts (#7127) ``    |
| [`8a4b3826`](https://github.com/nix-community/home-manager/commit/8a4b38262755fce39551e1182af1621a06ddde35) | `` kodi: make type for settings less restrictive (#5277) `` |
| [`2f4db1cd`](https://github.com/nix-community/home-manager/commit/2f4db1cd5be0afaa0a2ec8fa5da6460f0ebdbc11) | `` yambar: add systemd service (#5469) ``                   |