### PR TITLE
chore(flake/nur): `4cce78af` -> `767dc9e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1748578784,
-        "narHash": "sha256-88ubtcmdMt1AGCVprlZ1taIixUjWDsuM6Mvkhd++0h0=",
+        "lastModified": 1748604420,
+        "narHash": "sha256-TpGjB8lehR8u00YtcWkwE3daevoGto6r5CZNn7wA1a8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4cce78af34a5c8742df1064a9c7be7d27c66d736",
+        "rev": "767dc9e05f7e94bc64e70adca701fd696673d251",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`767dc9e0`](https://github.com/nix-community/NUR/commit/767dc9e05f7e94bc64e70adca701fd696673d251) | `` automatic update `` |
| [`2d9325d8`](https://github.com/nix-community/NUR/commit/2d9325d80f2ad3e296adeea8867bf06df6652c4e) | `` automatic update `` |
| [`afd797bc`](https://github.com/nix-community/NUR/commit/afd797bcc3093a33a5b0c5fcc57c145a26a881d1) | `` automatic update `` |
| [`133e72e3`](https://github.com/nix-community/NUR/commit/133e72e392d124db6b91d4eb3a27c7642d86e25a) | `` automatic update `` |