### PR TITLE
chore(flake/home-manager): `4e9efaa6` -> `6d09fd37`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748570847,
-        "narHash": "sha256-XU1a6wFctd+s3ZvBIFB6s4GhPJ+Oc6pkeOrEsbA2fMo=",
+        "lastModified": 1748654914,
+        "narHash": "sha256-3xn61GBqAaRXvdvr1cSPcDj3kivENs0x9aJHLOHGiNM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4e9efaa68b0be7e19127dad4f0506a9b89e28ef4",
+        "rev": "6d09fd37a7d4110251c1c03cb09fbf6321fbe10d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                     |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`6d09fd37`](https://github.com/nix-community/home-manager/commit/6d09fd37a7d4110251c1c03cb09fbf6321fbe10d) | `` ci: alternative fix for backport if condition (#7169) ``                 |
| [`b65126fa`](https://github.com/nix-community/home-manager/commit/b65126fa71e744c53fbae44d90139d3069711ac4) | `` ci: fix backport if condition (#7167) ``                                 |
| [`7c60ea02`](https://github.com/nix-community/home-manager/commit/7c60ea029602851cdeb2f3246e991fcc117195bc) | `` ci: add 'GitHub App' TODO to update workflow ``                          |
| [`9d2ae595`](https://github.com/nix-community/home-manager/commit/9d2ae59579b61a2137f12d87452733e3ab04d721) | `` ci: add backport workflow ``                                             |
| [`379c9fb8`](https://github.com/nix-community/home-manager/commit/379c9fb858ef9abe92d5590e7502a7c1387c076a) | `` yazi: use mgr instead of manager in example (#7160) ``                   |
| [`6f0a6e7b`](https://github.com/nix-community/home-manager/commit/6f0a6e7ba7ab4fb01ced557378d64740554a0766) | `` Update translation files (#7162) ``                                      |
| [`214f9bd3`](https://github.com/nix-community/home-manager/commit/214f9bd3a693bbc8cc6d705d01421787e04eaacd) | `` linux-wallpaperengine: fix evaluation error when passing null (#7161) `` |
| [`d800d198`](https://github.com/nix-community/home-manager/commit/d800d198b8376ffb6d8f34f12242600308b785ee) | `` podman: use quadlet source from file drv (#7102) ``                      |
| [`d36ac1f0`](https://github.com/nix-community/home-manager/commit/d36ac1f0db0bc5e8f6ac4e230c9cca7f9e35a179) | `` hwatch: add module (#7158) ``                                            |
| [`482c306e`](https://github.com/nix-community/home-manager/commit/482c306ef70785f53d9d90839b6b5643521ac031) | `` home-manager: update xgettext and PO files ``                            |
| [`d3a3aee5`](https://github.com/nix-community/home-manager/commit/d3a3aee558979d9b0dde1c0814d8f9f96884aeed) | `` dconf: Fix Gio module variable breakage (#7146) ``                       |