### PR TITLE
chore(flake/nur): `767dc9e0` -> `e0f7ee97`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -725,11 +725,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1748370509,
-        "narHash": "sha256-QlL8slIgc16W5UaI3w7xHQEP+Qmv/6vSNTpoZrrSlbk=",
+        "lastModified": 1748460289,
+        "narHash": "sha256-7doLyJBzCllvqX4gszYtmZUToxKvMUrg45EUWaUYmBg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4faa5f5321320e49a78ae7848582f684d64783e9",
+        "rev": "96ec055edbe5ee227f28cdbc3f1ddf1df5965102",
         "type": "github"
       },
       "original": {
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1748604420,
-        "narHash": "sha256-TpGjB8lehR8u00YtcWkwE3daevoGto6r5CZNn7wA1a8=",
+        "lastModified": 1748618828,
+        "narHash": "sha256-HwPTAjszZOfDT1ndL7tRwWsDV5GZQ9t2aJSlvizqx/M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "767dc9e05f7e94bc64e70adca701fd696673d251",
+        "rev": "e0f7ee97d1136bbc9c09a909069913187ee2dba8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e0f7ee97`](https://github.com/nix-community/NUR/commit/e0f7ee97d1136bbc9c09a909069913187ee2dba8) | `` automatic update `` |
| [`658eca19`](https://github.com/nix-community/NUR/commit/658eca19992a19259cee8861ae8886375b625490) | `` automatic update `` |
| [`6a10730f`](https://github.com/nix-community/NUR/commit/6a10730f50349d83b6af03394206a7821e0769e8) | `` automatic update `` |
| [`8cba06af`](https://github.com/nix-community/NUR/commit/8cba06affc8fe0b5cab1ea59409f4ac9ef373ce9) | `` automatic update `` |