### PR TITLE
chore(flake/nur): `e0f7ee97` -> `c2636e51`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1748618828,
-        "narHash": "sha256-HwPTAjszZOfDT1ndL7tRwWsDV5GZQ9t2aJSlvizqx/M=",
+        "lastModified": 1748634294,
+        "narHash": "sha256-p9AfgfvFD9B9YuAFx59dMaxuiKtB+X22TJyR8M0VEIk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e0f7ee97d1136bbc9c09a909069913187ee2dba8",
+        "rev": "c2636e5184b6b97afbb3696b15c4ae2524bf0481",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c2636e51`](https://github.com/nix-community/NUR/commit/c2636e5184b6b97afbb3696b15c4ae2524bf0481) | `` automatic update `` |
| [`c4de3ad6`](https://github.com/nix-community/NUR/commit/c4de3ad6d22f0c6d731a718a5ff07557bcc58ee5) | `` automatic update `` |
| [`ed64d190`](https://github.com/nix-community/NUR/commit/ed64d190749a0fae701cd0d1c123b023edb1e376) | `` automatic update `` |
| [`243a9eae`](https://github.com/nix-community/NUR/commit/243a9eae2fa0d61be6d68c947abb295d9ba32391) | `` automatic update `` |