### PR TITLE
chore(flake/nur): `c2636e51` -> `05c0211d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1748634294,
-        "narHash": "sha256-p9AfgfvFD9B9YuAFx59dMaxuiKtB+X22TJyR8M0VEIk=",
+        "lastModified": 1748648788,
+        "narHash": "sha256-CQmFpg3sucUQj1SiO35N/OKYsO7muuZ35PeMP1AeFb8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c2636e5184b6b97afbb3696b15c4ae2524bf0481",
+        "rev": "05c0211d51d8c37676271fe2f627b971cb08df8a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                       |
| -------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`05c0211d`](https://github.com/nix-community/NUR/commit/05c0211d51d8c37676271fe2f627b971cb08df8a) | `` automatic update ``        |
| [`78a3ab3f`](https://github.com/nix-community/NUR/commit/78a3ab3f97352f72d205596d8f3e776de96c7708) | `` automatic update ``        |
| [`be4de6a7`](https://github.com/nix-community/NUR/commit/be4de6a7dc46e76a0ea90818291aef9cf86daa90) | `` add marven11 repository `` |
| [`cc30d89a`](https://github.com/nix-community/NUR/commit/cc30d89af911f364ca184daf76d09126bc70a800) | `` automatic update ``        |
| [`ea8667d0`](https://github.com/nix-community/NUR/commit/ea8667d0c4c12f25348c98a2a4fbb372d73179c8) | `` automatic update ``        |
| [`af942a66`](https://github.com/nix-community/NUR/commit/af942a669a5e7249e4d2ba8efbe521f1bbb84d87) | `` automatic update ``        |
| [`5f329e65`](https://github.com/nix-community/NUR/commit/5f329e65b95154e243551712a8b7cd453bf875a7) | `` automatic update ``        |
| [`480b6fb5`](https://github.com/nix-community/NUR/commit/480b6fb5de076079b105b62a7f70f0c9af0d8632) | `` automatic update ``        |