### PR TITLE
chore(flake/nur): `05c0211d` -> `86f159f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1748648788,
-        "narHash": "sha256-CQmFpg3sucUQj1SiO35N/OKYsO7muuZ35PeMP1AeFb8=",
+        "lastModified": 1748692757,
+        "narHash": "sha256-bY4ddnGVna4oHKpgRfUGtI2S3ZzcLQOTFkznhWR2tfs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "05c0211d51d8c37676271fe2f627b971cb08df8a",
+        "rev": "86f159f93d93b0228320ff97aab76355131653ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                        |
| -------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`86f159f9`](https://github.com/nix-community/NUR/commit/86f159f93d93b0228320ff97aab76355131653ec) | `` automatic update ``         |
| [`e07eb426`](https://github.com/nix-community/NUR/commit/e07eb426b07efc1859d6a7de51e77250d2d7e57f) | `` automatic update ``         |
| [`62a16aaf`](https://github.com/nix-community/NUR/commit/62a16aaff61f522d74092b722ef98f8142cee091) | `` automatic update ``         |
| [`e3fca531`](https://github.com/nix-community/NUR/commit/e3fca5319ed6e42e61429c4f4b1c291453290292) | `` automatic update ``         |
| [`0caa6839`](https://github.com/nix-community/NUR/commit/0caa6839fdcc4b669a7b872396ad2f36d998835b) | `` automatic update ``         |
| [`bafd229b`](https://github.com/nix-community/NUR/commit/bafd229b352a3410680b292fb3d719bfcdbca0ec) | `` add Zoneshiyi repository `` |
| [`1401034f`](https://github.com/nix-community/NUR/commit/1401034f4ec9a42b31058561c524f7e838f4f57e) | `` automatic update ``         |
| [`fa6d453c`](https://github.com/nix-community/NUR/commit/fa6d453c9203aa1623577ac81cb1e7b10604904d) | `` automatic update ``         |
| [`b5345bef`](https://github.com/nix-community/NUR/commit/b5345bef5fce1d1259ec6c2647d05bb47c6ae1e1) | `` automatic update ``         |
| [`835dfa9f`](https://github.com/nix-community/NUR/commit/835dfa9fc9d3a3a990c0a4bf54b9e0e0695679cd) | `` automatic update ``         |
| [`9ec775de`](https://github.com/nix-community/NUR/commit/9ec775deca5645048e4e66c7afa627e9ca31ad89) | `` automatic update ``         |
| [`7b4ffeaf`](https://github.com/nix-community/NUR/commit/7b4ffeaf53aa0b4aaa873fc33b2d4e8053bfef70) | `` automatic update ``         |