### PR TITLE
chore(flake/home-manager): `6d09fd37` -> `60e46243`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748654914,
-        "narHash": "sha256-3xn61GBqAaRXvdvr1cSPcDj3kivENs0x9aJHLOHGiNM=",
+        "lastModified": 1748668774,
+        "narHash": "sha256-fYk/vk4ClmvHIgnGv/5GNRiDLtNCwXo9aLq36L/x+P4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6d09fd37a7d4110251c1c03cb09fbf6321fbe10d",
+        "rev": "60e4624302d956fe94d3f7d96a560d14d70591b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`60e46243`](https://github.com/nix-community/home-manager/commit/60e4624302d956fe94d3f7d96a560d14d70591b9) | `` news: re-add dropped news entries (#7173) ``              |
| [`6587238e`](https://github.com/nix-community/home-manager/commit/6587238e406dcb64cd74a7f17b9d3e2461908519) | `` lib: remove 22.11 deprecations ``                         |
| [`cc8896c3`](https://github.com/nix-community/home-manager/commit/cc8896c32130182c9d6633fd4dea16b096073f1f) | `` ci: remove literalExpression step ``                      |
| [`765ceb93`](https://github.com/nix-community/home-manager/commit/765ceb93d1b75401b9b85da00a36c58864a3fb27) | `` lib: remove literalExpression and literalDocBook logic `` |
| [`7ccda857`](https://github.com/nix-community/home-manager/commit/7ccda8574fc76a3e1361ae482a301a1d883a90f3) | `` ci: labels dedupe and reorganize ``                       |
| [`5118087a`](https://github.com/nix-community/home-manager/commit/5118087a159f448e2a569f03282eac7ceeb75793) | `` ci: sort label categories ``                              |
| [`b6bd7c62`](https://github.com/nix-community/home-manager/commit/b6bd7c629fcb34aec25781478fa7a228f59ebbfd) | `` ci: add more modules to labeler ``                        |