### PR TITLE
chore(flake/nur): `86f159f9` -> `2db17662`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1748692757,
-        "narHash": "sha256-bY4ddnGVna4oHKpgRfUGtI2S3ZzcLQOTFkznhWR2tfs=",
+        "lastModified": 1748719659,
+        "narHash": "sha256-X2FCGJ24oszEWaVcToolfgmVKKFvr8MvjORL0lQGBh4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "86f159f93d93b0228320ff97aab76355131653ec",
+        "rev": "2db176628319be7299f813498b77ef4aafe03d3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2db17662`](https://github.com/nix-community/NUR/commit/2db176628319be7299f813498b77ef4aafe03d3e) | `` automatic update `` |
| [`6a2e7077`](https://github.com/nix-community/NUR/commit/6a2e7077963107352464a379f76c5f534bdd1f16) | `` automatic update `` |
| [`7ef9c654`](https://github.com/nix-community/NUR/commit/7ef9c6546269642f3a8645bd273388d5761c42da) | `` automatic update `` |
| [`21a78759`](https://github.com/nix-community/NUR/commit/21a78759ae583abe5b470ccfeae2fd1d3e72183b) | `` automatic update `` |
| [`41bbbcfa`](https://github.com/nix-community/NUR/commit/41bbbcfaa03ae3085c10780615ec4db6366636eb) | `` automatic update `` |
| [`84d20e10`](https://github.com/nix-community/NUR/commit/84d20e10373136d5741ff7d53fcf2b5a831518a0) | `` automatic update `` |