### PR TITLE
chore(flake/nur): `2db17662` -> `2c0bc52f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1748719659,
-        "narHash": "sha256-X2FCGJ24oszEWaVcToolfgmVKKFvr8MvjORL0lQGBh4=",
+        "lastModified": 1748730660,
+        "narHash": "sha256-5LKmRYKdPuhm8j5GFe3AfrJL8dd8o57BQ34AGjJl1R0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2db176628319be7299f813498b77ef4aafe03d3e",
+        "rev": "2c0bc52fe14681e9ef60e3553888c4f086e46ecb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2c0bc52f`](https://github.com/nix-community/NUR/commit/2c0bc52fe14681e9ef60e3553888c4f086e46ecb) | `` automatic update `` |
| [`3360e2be`](https://github.com/nix-community/NUR/commit/3360e2bed9ad2b5de58b975df5ae9e9616fbce97) | `` automatic update `` |
| [`324a167c`](https://github.com/nix-community/NUR/commit/324a167ce298504c15d415af48a01863873b8b1c) | `` automatic update `` |
| [`2f6328cd`](https://github.com/nix-community/NUR/commit/2f6328cd0d025a3064457c5e290a7a0a2308d3ff) | `` automatic update `` |
| [`7f75a288`](https://github.com/nix-community/NUR/commit/7f75a2883395c96a9456c7afbaff6610ac5e15fd) | `` automatic update `` |