### PR TITLE
chore(flake/nur): `2c0bc52f` -> `58a80c3e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1748730660,
-        "narHash": "sha256-5LKmRYKdPuhm8j5GFe3AfrJL8dd8o57BQ34AGjJl1R0=",
+        "lastModified": 1748748623,
+        "narHash": "sha256-ajFTvgFyRxLMjpJxK+KOEp2+dNRl/Bc8Mnby7W8uPk4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2c0bc52fe14681e9ef60e3553888c4f086e46ecb",
+        "rev": "58a80c3ede0cdfa480f3bd8f0e79c010677f2a07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`58a80c3e`](https://github.com/nix-community/NUR/commit/58a80c3ede0cdfa480f3bd8f0e79c010677f2a07) | `` automatic update `` |
| [`55d7e27c`](https://github.com/nix-community/NUR/commit/55d7e27ce93ca327600eeac92cb41bc1d19c2f15) | `` automatic update `` |