### PR TITLE
chore(flake/nix-index-database): `a98adbf5` -> `2860bee6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -469,11 +469,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748145500,
-        "narHash": "sha256-t9fx0l61WOxtWxXCqlXPWSuG/0XMF9DtE2T7KXgMqJw=",
+        "lastModified": 1748751003,
+        "narHash": "sha256-i4GZdKAK97S0ZMU3w4fqgEJr0cVywzqjugt2qZPrScs=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "a98adbf54d663395df0b9929f6481d4d80fc8927",
+        "rev": "2860bee699248d828c2ed9097a1cd82c2f991b43",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`2860bee6`](https://github.com/nix-community/nix-index-database/commit/2860bee699248d828c2ed9097a1cd82c2f991b43) | `` update generated.nix to release 2025-06-01-035302 `` |
| [`b02432d9`](https://github.com/nix-community/nix-index-database/commit/b02432d99cfa5a2083efaa5f361591e54988b762) | `` flake.lock: Update ``                                |