### PR TITLE
chore(flake/nur): `58a80c3e` -> `850b8715`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1748748623,
-        "narHash": "sha256-ajFTvgFyRxLMjpJxK+KOEp2+dNRl/Bc8Mnby7W8uPk4=",
+        "lastModified": 1748761036,
+        "narHash": "sha256-h0SlrfInTTTYa0PG6y0UHwWpNIpFPE2stwdJZqbsgvA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "58a80c3ede0cdfa480f3bd8f0e79c010677f2a07",
+        "rev": "850b87151f821a840a09b22283c25344f36dc156",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`850b8715`](https://github.com/nix-community/NUR/commit/850b87151f821a840a09b22283c25344f36dc156) | `` automatic update `` |
| [`90f29d0d`](https://github.com/nix-community/NUR/commit/90f29d0d63c3d3f3036f24fed870982a1a405f88) | `` automatic update `` |
| [`a8ebdbf2`](https://github.com/nix-community/NUR/commit/a8ebdbf2ec29b612c6c15d04a5f5569ee181e56a) | `` automatic update `` |