### PR TITLE
chore(flake/nur): `850b8715` -> `d18e11e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1748761036,
-        "narHash": "sha256-h0SlrfInTTTYa0PG6y0UHwWpNIpFPE2stwdJZqbsgvA=",
+        "lastModified": 1748769830,
+        "narHash": "sha256-AxQWOdU/8QSmmhFSnqOIIB870fRFLq1MhaaidibCyHc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "850b87151f821a840a09b22283c25344f36dc156",
+        "rev": "d18e11e11b8cdcbe71725e29ef5fb99f2ddebb7a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d18e11e1`](https://github.com/nix-community/NUR/commit/d18e11e11b8cdcbe71725e29ef5fb99f2ddebb7a) | `` automatic update `` |