### PR TITLE
chore(flake/srvos): `917442c1` -> `95ef8b74`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -933,11 +933,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748481086,
-        "narHash": "sha256-rQ5hUgMThLFQsCB4urDeVAT1xjHuDN41bMH9u3WmhA8=",
+        "lastModified": 1748826503,
+        "narHash": "sha256-Io0BI+MvYxoVbWNv467znV3gZUTDC+4Yp6i2Ljy9Xm0=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "917442c10abd63809917bb97dfd5292c02c672eb",
+        "rev": "95ef8b7451e1f13e87c8d4896a0ba62ed001841f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`95ef8b74`](https://github.com/nix-community/srvos/commit/95ef8b7451e1f13e87c8d4896a0ba62ed001841f) | `` dev/private/flake.lock: Update `` |
| [`1ec54c26`](https://github.com/nix-community/srvos/commit/1ec54c26aea94a0605e2eddddf9ab351dcdd49c2) | `` flake.lock: Update ``             |