### PR TITLE
chore(flake/home-manager): `5adc1a51` -> `34a13086`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748923085,
-        "narHash": "sha256-wXguCR+auZ5eoW8fKlm0C/6LNXL+1r4UXNLylwV7wQU=",
+        "lastModified": 1748979197,
+        "narHash": "sha256-mKYwYcO9RmA2AcAFIXGDBOw5iv/fbjw6adWvMbnfIuk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5adc1a51a2fa8efec9d4eaa4f7df97908cded00d",
+        "rev": "34a13086148cbb3ae65a79f753eb451ce5cac3d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                          |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`34a13086`](https://github.com/nix-community/home-manager/commit/34a13086148cbb3ae65a79f753eb451ce5cac3d3) | `` doc: add a missing subcommand (#7199) ``                      |
| [`bb846c03`](https://github.com/nix-community/home-manager/commit/bb846c031be68a96466b683be32704ef6e07b159) | `` dwm-status: run with --quiet (#7144) ``                       |
| [`593b0c66`](https://github.com/nix-community/home-manager/commit/593b0c667d93404972ad8459ffdfc4f5af465d53) | `` doc: fix instructions for enabling flakes in NixOS (#7189) `` |
| [`cb809ec1`](https://github.com/nix-community/home-manager/commit/cb809ec1ff15cf3237c6592af9bbc7e4d983e98c) | `` fzf: prefer `source` for Zsh integration (#7191) ``           |