### PR TITLE
chore(flake/nur): `032af0a6` -> `bc10c9b0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1748935843,
-        "narHash": "sha256-ZTbwljoJXgkGAPlYz0GIcNiXQNfPFHe2A0Dqe9KDyPA=",
+        "lastModified": 1748952011,
+        "narHash": "sha256-1KUHKUuk8Ai7LGpAPz+9m9hIVs9ZnLQe3FXz00u9KRs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "032af0a65aa867a6209718033995f5ba73fee543",
+        "rev": "bc10c9b055c5640b345a4748ad731cf37b137be5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bc10c9b0`](https://github.com/nix-community/NUR/commit/bc10c9b055c5640b345a4748ad731cf37b137be5) | `` automatic update `` |
| [`73b457ac`](https://github.com/nix-community/NUR/commit/73b457ac9f89f0cb03473597ca79e6c5ecea8d9d) | `` automatic update `` |
| [`33a35d4d`](https://github.com/nix-community/NUR/commit/33a35d4d8e1f6c01c4bd10aae0f3ac3e085e1737) | `` automatic update `` |
| [`9c546d3f`](https://github.com/nix-community/NUR/commit/9c546d3f6d658501ebbf0c55102dea8c742b3321) | `` automatic update `` |