### PR TITLE
chore(flake/emacs-ultra-scroll): `2b90a7f7` -> `489adeda`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
     "emacs-ultra-scroll": {
       "flake": false,
       "locked": {
-        "lastModified": 1748525778,
-        "narHash": "sha256-xUI9ueOnF5InBmKcmlZ5kaF6C4jPElULfpeZso/gSYE=",
+        "lastModified": 1748964846,
+        "narHash": "sha256-KklbdVv584m+zEANeSYQ9xgRIJDYPgmQQsfCwKmuzzA=",
         "owner": "jdtsmith",
         "repo": "ultra-scroll",
-        "rev": "2b90a7f7af81bea120da9ac8b8e202452ef077b6",
+        "rev": "489adeda7380b97d8f5d61d43082cd2d96b55b58",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                        |
| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------- |
| [`489adeda`](https://github.com/jdtsmith/ultra-scroll/commit/489adeda7380b97d8f5d61d43082cd2d96b55b58) | `` Do not warn on scroll-conservatively<100 `` |