### PR TITLE
chore(flake/nur): `bc10c9b0` -> `1c764f6e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1748952011,
-        "narHash": "sha256-1KUHKUuk8Ai7LGpAPz+9m9hIVs9ZnLQe3FXz00u9KRs=",
+        "lastModified": 1748982388,
+        "narHash": "sha256-LTeW3PfWqxEFLcqfcG/i+So4IB2HGI8IxZgn/cFamHc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bc10c9b055c5640b345a4748ad731cf37b137be5",
+        "rev": "1c764f6eebc40f6db3a3b64a5fc5a192fc2a70e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1c764f6e`](https://github.com/nix-community/NUR/commit/1c764f6eebc40f6db3a3b64a5fc5a192fc2a70e2) | `` automatic update `` |
| [`1cb78d3e`](https://github.com/nix-community/NUR/commit/1cb78d3e2dc5479c2cfc58e787b46d9ddeb01882) | `` automatic update `` |
| [`154ac42f`](https://github.com/nix-community/NUR/commit/154ac42f3a2cf7bba906789e06a6a99cd43c72a2) | `` automatic update `` |
| [`90add463`](https://github.com/nix-community/NUR/commit/90add46380908ba4395f5f1dfec84224a3b0d4b9) | `` automatic update `` |
| [`396147b1`](https://github.com/nix-community/NUR/commit/396147b13e2b364076ef5103f5a2f81efff4e969) | `` automatic update `` |
| [`65e971e8`](https://github.com/nix-community/NUR/commit/65e971e810ada6d41343bf26fa7055788934a2b4) | `` automatic update `` |
| [`dcf2e56f`](https://github.com/nix-community/NUR/commit/dcf2e56f6e06869a64396b4054b94a035458d914) | `` automatic update `` |
| [`753739b5`](https://github.com/nix-community/NUR/commit/753739b5a3c21db4a9926dd0f7f9e6f60dcc9a95) | `` automatic update `` |
| [`0f3c9ccc`](https://github.com/nix-community/NUR/commit/0f3c9ccce1d63b0fd1d60ce41d9714932760f3a8) | `` automatic update `` |
| [`0a89c1e3`](https://github.com/nix-community/NUR/commit/0a89c1e3638dfc61c94e1e87f4ebfe0952c9cace) | `` automatic update `` |