### PR TITLE
chore(flake/darwin): `44a7d0e6` -> `d46a0721`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748352827,
-        "narHash": "sha256-sNUUP6qxGkK9hXgJ+p362dtWLgnIWwOCmiq72LAWtYo=",
+        "lastModified": 1748998583,
+        "narHash": "sha256-X8kkfgfqdYa/sqGpMdDkrLytS6mj89PJW+x22+r29Yg=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "44a7d0e687a87b73facfe94fba78d323a6686a90",
+        "rev": "d46a07214fc25b6313f2ea3ba789cd7ff036aeb2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                       |
| ------------------------------------------------------------------------------------------------------ | --------------------------------------------- |
| [`b07a4c8b`](https://github.com/nix-darwin/nix-darwin/commit/b07a4c8be5aea8db66d4ee1754766d8b9c0aa06c) | `` Fix ShellCheck issue in `nixPath` check `` |