### PR TITLE
chore(flake/home-manager): `34a13086` -> `13a45ede`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748979197,
-        "narHash": "sha256-mKYwYcO9RmA2AcAFIXGDBOw5iv/fbjw6adWvMbnfIuk=",
+        "lastModified": 1749131129,
+        "narHash": "sha256-tJ+93i7N4QttM75bE8T09LlSU3Mv6Dfi9WaVBvlWilo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "34a13086148cbb3ae65a79f753eb451ce5cac3d3",
+        "rev": "13a45ede6c17b5e923dfc18a40a3f646436f4809",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`13a45ede`](https://github.com/nix-community/home-manager/commit/13a45ede6c17b5e923dfc18a40a3f646436f4809) | `` aichat: fix config example (#7212) ``                        |
| [`86b95fc1`](https://github.com/nix-community/home-manager/commit/86b95fc1ed2b9b04a451a08ccf13d78fb421859c) | `` aichat: init (#7207) ``                                      |
| [`ffab96a8`](https://github.com/nix-community/home-manager/commit/ffab96a8b4a523c4b5e2645ee09e95a75cbdbfab) | `` qutebrowser: null package support (#7203) ``                 |
| [`3830a21a`](https://github.com/nix-community/home-manager/commit/3830a21aa2313239b582e4e4ac97f0b25243cb7a) | `` xdg.desktopEntries: Update outdated links in docs (#7201) `` |