### PR TITLE
chore(flake/nur): `ab4d3f2d` -> `f06b95f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1749046819,
-        "narHash": "sha256-BXr1ipGk73YG7KcuDKHH7Zgx+qZHCTsTwwFzMU3PnYY=",
+        "lastModified": 1749065357,
+        "narHash": "sha256-82r3TOuU/Fn+ChVrQ0NNtGD06snUQYzAPuTHJh+H1Xo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ab4d3f2d11336b2a44ce31cfcd298fe36de233ba",
+        "rev": "f06b95f8ff406f73550a31caef49f2327e566a95",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f06b95f8`](https://github.com/nix-community/NUR/commit/f06b95f8ff406f73550a31caef49f2327e566a95) | `` automatic update `` |
| [`a51fc167`](https://github.com/nix-community/NUR/commit/a51fc167bbff9f351419bbf3503164307abc35a4) | `` automatic update `` |
| [`7b9449d1`](https://github.com/nix-community/NUR/commit/7b9449d16e6580dd1f35fa553ca9757ef7e96f0b) | `` automatic update `` |