### PR TITLE
chore(flake/nur): `cd45a3f0` -> `e2549db8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1749167355,
-        "narHash": "sha256-/bYo6Jq5PPbVdhaaN3u7gEMPykHn6nEIqnsnSDMsSHM=",
+        "lastModified": 1749195656,
+        "narHash": "sha256-EpZ5xaH73G0WdF5yMQqinanYQQbHGxU84CTfY6JMEyA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cd45a3f0542262e9d2e52a60e38ff6d6ef67bf59",
+        "rev": "e2549db8187bce9e7a410e7ba5e0d4dbfd638351",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e2549db8`](https://github.com/nix-community/NUR/commit/e2549db8187bce9e7a410e7ba5e0d4dbfd638351) | `` automatic update `` |
| [`44803a25`](https://github.com/nix-community/NUR/commit/44803a2579b8f314ee7d0b5780f986154bedcc09) | `` automatic update `` |
| [`2c16ffbb`](https://github.com/nix-community/NUR/commit/2c16ffbb0c9f47f8158162377644401291361706) | `` automatic update `` |
| [`d33352cf`](https://github.com/nix-community/NUR/commit/d33352cf6b7d1439b130445b4ed9cb2cf45098cd) | `` automatic update `` |
| [`2ef5aa38`](https://github.com/nix-community/NUR/commit/2ef5aa38bb60d3769e29ffae077e04da305d00a0) | `` automatic update `` |
| [`23f6f7a6`](https://github.com/nix-community/NUR/commit/23f6f7a65d0797d278c58a4da97265d5c8848514) | `` automatic update `` |
| [`630d2e2e`](https://github.com/nix-community/NUR/commit/630d2e2ec7dc22756e875ac016884e0f1720def1) | `` automatic update `` |