### PR TITLE
chore(flake/catppuccin): `0ba11b12` -> `311a6e04`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1748080874,
-        "narHash": "sha256-sUebEzAkrY8Aq5G0GHFyRddmRNGP/a2iTtV7ISNvi/c=",
+        "lastModified": 1749198634,
+        "narHash": "sha256-5pClXOW5oblBcSwyydnjUMttaBeG4v5l/U18JURRiMM=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "0ba11b12be81f0849a89ed17ab635164ea8f0112",
+        "rev": "311a6e045995f7944da3dd57c595a5b51047a6b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                 |
| ----------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`311a6e04`](https://github.com/catppuccin/nix/commit/311a6e045995f7944da3dd57c595a5b51047a6b0) | `` chore: update port sources (#575) `` |