### PR TITLE
chore(flake/home-manager): `91287a0e` -> `96482a53`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749178927,
-        "narHash": "sha256-bXcEx1aZUNm5hMLVJeuofcOrZyOiapzvQ7K36HYK3YQ=",
+        "lastModified": 1749221014,
+        "narHash": "sha256-mqrpuP/lfyDmta5hJWTwWgdF5lwdiubcGs7oRvcTZ2s=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "91287a0e9d42570754487b7e38c6697e15a9aab2",
+        "rev": "96482a538e6103579d254b139759d0536177370b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`96482a53`](https://github.com/nix-community/home-manager/commit/96482a538e6103579d254b139759d0536177370b) | `` keychain: warn about deprecated options (#7196) ``         |
| [`c18a7679`](https://github.com/nix-community/home-manager/commit/c18a767948ebe573502b564f88fadec448009b88) | `` zed-editor: userKeymaps default to empty array (#7222) ``  |
| [`812b43b4`](https://github.com/nix-community/home-manager/commit/812b43b45d4807e072b261cd00f35c911c3cbef0) | `` tests/thefuck: explicit stubbing ``                        |
| [`b2483b45`](https://github.com/nix-community/home-manager/commit/b2483b45e6ac37ec81192e9ab979ac3b669ae8e9) | `` flake.lock: Update ``                                      |
| [`76e9c6e1`](https://github.com/nix-community/home-manager/commit/76e9c6e14aabba36368bc1c0680c80f018451e43) | `` lib/default.nix: remove inefficient second copy (#7221) `` |