### PR TITLE
chore(flake/nixpkgs): `c2a03962` -> `d3d2d80a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -709,11 +709,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1748929857,
-        "narHash": "sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj+Q=",
+        "lastModified": 1749143949,
+        "narHash": "sha256-QuUtALJpVrPnPeozlUG/y+oIMSLdptHxb3GK6cpSVhA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
+        "rev": "d3d2d80a2191a73d1e86456a751b83aa13085d7d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                       |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`02abef53`](https://github.com/NixOS/nixpkgs/commit/02abef532cfa8dad01813fe3604297ca913c82ec) | `` nusmw:  2.6.0 -> 2.7.0 (#395267) ``                                                        |
| [`944e443d`](https://github.com/NixOS/nixpkgs/commit/944e443d09bfb9677b6ae4778b61f4d34563a892) | `` immich-public-proxy: 1.11.1 -> 1.11.2 ``                                                   |
| [`b4b768e4`](https://github.com/NixOS/nixpkgs/commit/b4b768e44e9d7aa1024614ec0f3835469a48c4a0) | `` osu-lazer: 2025.424.0 -> 2025.605.3 ``                                                     |
| [`027e00a5`](https://github.com/NixOS/nixpkgs/commit/027e00a5ae15d76e44fb8607e28edaafab505105) | `` osu-lazer-bin: 2025.424.0 -> 2025.605.3 ``                                                 |
| [`c03708e5`](https://github.com/NixOS/nixpkgs/commit/c03708e5ffe14985c7a743b755707ba49256a05a) | `` sdcc: disable broken-on-darwin man pages output ``                                         |
| [`5637f51c`](https://github.com/NixOS/nixpkgs/commit/5637f51c4f944299955a6992d5d3b200f47a0682) | `` vscode-extensions.amazonwebservices.amazon-q-vscode: 1.69.0 -> 1.70.0 ``                   |
| [`1a752a03`](https://github.com/NixOS/nixpkgs/commit/1a752a03134f80d2a0c133e11f620ae56a0adba4) | `` python3Packages.cmd2: 2.5.11 -> 2.6.0 ``                                                   |
| [`0ad7514a`](https://github.com/NixOS/nixpkgs/commit/0ad7514a44be58877d5d09953790988b0c19a05f) | `` kdePackages: Gear 25.04.1 -> 25.04.2 ``                                                    |
| [`3a810fc6`](https://github.com/NixOS/nixpkgs/commit/3a810fc6323e94cd77cb280b541142fd47fc6e32) | `` crowdin-cli: 4.7.0 -> 4.7.1 ``                                                             |
| [`cf5377c6`](https://github.com/NixOS/nixpkgs/commit/cf5377c60743cbeb7e3098206e1d0f77d4925a32) | `` Revert "stalwart-mail: build against system jemalloc" ``                                   |
| [`2648e3fb`](https://github.com/NixOS/nixpkgs/commit/2648e3fbf8a07529443ecfc84650d4788652283a) | `` dhcpcd: fix static ``                                                                      |
| [`154cedf1`](https://github.com/NixOS/nixpkgs/commit/154cedf1f454aeabafc9f443b18f3701722c5607) | `` llvmPackages_git: 21.0.0-unstable-2025-05-25 -> 21.0.0-unstable-2025-06-06 ``              |
| [`4a2a4193`](https://github.com/NixOS/nixpkgs/commit/4a2a4193f9f3ad4e62c89a448a79a83ac876fca4) | `` nixos/nginx: fix type of mapHashBucketSize ``                                              |
| [`04412533`](https://github.com/NixOS/nixpkgs/commit/0441253311e751093eafdb5e151fb8ecb1402161) | `` vscode-extensions.robocorp.robotframework-lsp: init at 1.13.0 ``                           |
| [`16727d7e`](https://github.com/NixOS/nixpkgs/commit/16727d7e067fe72c44014859c6d16f72579ba374) | `` rime-wanxiang: 6.8.7 -> 7.0.5 ``                                                           |
| [`6c76fd5f`](https://github.com/NixOS/nixpkgs/commit/6c76fd5f512e3225ecff578ded7cbe74347253cc) | `` sane-backends: more accurate systemd support check ``                                      |
| [`262ceea3`](https://github.com/NixOS/nixpkgs/commit/262ceea379765a7f9ea0ef0bfc4500e04b7c6e3b) | `` vscode-extensions.ms-windows-ai-studio.windows-ai-studio: 0.14.0 -> 0.14.3 ``              |
| [`1ecc3eb3`](https://github.com/NixOS/nixpkgs/commit/1ecc3eb32e391ec6f3764f1f18cd771e4836511c) | `` vscode-extensions.coder.coder-remote: 1.9.0 -> 1.9.1 ``                                    |
| [`f349ba88`](https://github.com/NixOS/nixpkgs/commit/f349ba88b6ab74701a0bb0b0aa1e01b5e454db3a) | `` cli-visualizer: drop ``                                                                    |
| [`ba606757`](https://github.com/NixOS/nixpkgs/commit/ba606757866aea8ca39a0b59f85aca4e5629cc05) | `` nixos-anywhere: 1.10.0 -> 1.11.0 ``                                                        |
| [`957e9588`](https://github.com/NixOS/nixpkgs/commit/957e95887b532b955a0f0d96999e4edf516dbe1d) | `` vscode-extensions.robocorp.robotframework: init at 1.13.0 ``                               |
| [`29550470`](https://github.com/NixOS/nixpkgs/commit/29550470b09fa80d3cc189f40d832a191419d925) | `` vscode-extensions.esbenp.prettier-vscode: fix path to `prettier` ``                        |
| [`453d0a30`](https://github.com/NixOS/nixpkgs/commit/453d0a30a40139ea549418073939f835e398374f) | `` clorinde: 0.15.2 -> 0.16.0 ``                                                              |
| [`b5fa3b31`](https://github.com/NixOS/nixpkgs/commit/b5fa3b319dd9bcb17ff1d279863e571189b443df) | `` teleport_17: 17.4.8 -> 17.5.1 ``                                                           |
| [`6a42e78c`](https://github.com/NixOS/nixpkgs/commit/6a42e78cc3be97f53ee4307c3c79bfaca4c02ece) | `` uv: 0.7.10 -> 0.7.11 ``                                                                    |
| [`90071e65`](https://github.com/NixOS/nixpkgs/commit/90071e65fb2ba240224967e8f3ceb2db8e43c9d2) | `` safety-cli: 3.5.1 -> 3.5.2 ``                                                              |
| [`e5003e13`](https://github.com/NixOS/nixpkgs/commit/e5003e13f4df0846e5418ebdb0b5060087763d02) | `` uwsm: 0.21.4 -> 0.21.6 ``                                                                  |
| [`b5cfb30b`](https://github.com/NixOS/nixpkgs/commit/b5cfb30b7027c9c5188f45ebeee035a2596946d7) | `` warp-terminal: 0.2025.05.28.08.11.stable_02 -> 0.2025.05.28.08.11.stable_03 ``             |
| [`195e553e`](https://github.com/NixOS/nixpkgs/commit/195e553ea6f785d55d27346d25a721c015b03ca0) | `` vimPlugins.kanso-nvim: init at 2025-06-03 ``                                               |
| [`eb596f27`](https://github.com/NixOS/nixpkgs/commit/eb596f27244b545d976f01fb1c0df3fa88fc4065) | `` vscode-extensions.james-yu.latex-workshop: 10.9.1 -> 10.10.0 and moved to own directory `` |
| [`f633b66c`](https://github.com/NixOS/nixpkgs/commit/f633b66c34008394626e708cf0fc820b4905646a) | `` vivaldi: 7.4.3684.43 -> 7.4.3684.46 ``                                                     |
| [`0a00db6f`](https://github.com/NixOS/nixpkgs/commit/0a00db6f7bb5edbab3e8d9f4bbae8acf6195b5ee) | `` ripunzip: 2.0.2 -> 2.0.3 ``                                                                |
| [`3fdac78c`](https://github.com/NixOS/nixpkgs/commit/3fdac78c28427afd3d2a52872439999d4e06d870) | `` nixosTests: migrate `mc config host add` to `mc alias set` ``                              |
| [`38b1b87e`](https://github.com/NixOS/nixpkgs/commit/38b1b87e90340d1a10f3b96cc602ddf9ba950c4c) | `` typescript: prefer npmjs for src ``                                                        |
| [`050d2ca1`](https://github.com/NixOS/nixpkgs/commit/050d2ca17a3a063e27e353e4aa51b24526b7c45e) | `` typescript: add kachick as maintainer ``                                                   |
| [`1ef2f007`](https://github.com/NixOS/nixpkgs/commit/1ef2f0078ca0fd4f61e6851a511cde3f7ad32964) | `` typescript: 5.8.2 -> 5.8.3 ``                                                              |
| [`6262669c`](https://github.com/NixOS/nixpkgs/commit/6262669c6ebcee31e4dfca8289a1ded173affc65) | `` typescript: cleanup ``                                                                     |
| [`c2e3ef65`](https://github.com/NixOS/nixpkgs/commit/c2e3ef65d1f53d332202da13c47fd7ae25d73a5a) | `` typescript: prefer versionCheckHook rather than testers.testVersion ``                     |
| [`0e349bdc`](https://github.com/NixOS/nixpkgs/commit/0e349bdc7688e01944c995b0bac756f7bc72ffec) | `` python3Packages.django_5_2: 5.2.1 -> 5.2.2 ``                                              |
| [`00d8ed7a`](https://github.com/NixOS/nixpkgs/commit/00d8ed7ae2c235763b514308104fa803eecc24ec) | `` python3Packages.django_5_1: 5.1.9 -> 5.1.10 ``                                             |
| [`e38b8180`](https://github.com/NixOS/nixpkgs/commit/e38b81803841ca0c580356c50de44f06a60cd04e) | `` ezstream: 0.6.0 -> 1.0.2 ``                                                                |
| [`cbe71459`](https://github.com/NixOS/nixpkgs/commit/cbe714592881bba16352df4f9d544e7a81a0bd43) | `` knot-dns: 3.4.6 -> 3.4.7 ``                                                                |
| [`3555936f`](https://github.com/NixOS/nixpkgs/commit/3555936f7712f80b4c556748d993d9de93995d20) | `` dive: add shell completion ``                                                              |
| [`2a773a1b`](https://github.com/NixOS/nixpkgs/commit/2a773a1b68b49d02efe02c9f0639d8aa4ffc1fd8) | `` zasm: 4.4.7 -> 4.4.17 ``                                                                   |
| [`a0e101bd`](https://github.com/NixOS/nixpkgs/commit/a0e101bd1bd9f2ca2531861e9a1ebdb200d8be60) | `` python3Packages.pysmlight: fix tests on Darwin ``                                          |
| [`30e3aac8`](https://github.com/NixOS/nixpkgs/commit/30e3aac86abd9bd37b38e094f240c75a4c0114ff) | `` ts_query_ls: 3.1.0 -> 3.2.0 ``                                                             |
| [`6234476b`](https://github.com/NixOS/nixpkgs/commit/6234476b8fe68913052af51ec9708552c79fb24b) | `` python313Packages.nessclient: 1.1.2 -> 1.2.0 ``                                            |
| [`7ec4c430`](https://github.com/NixOS/nixpkgs/commit/7ec4c430e82d3094f2230aaa1ca8fee7b37c8c0b) | `` python313Packages.tencentcloud-sdk-python: 3.0.1392 -> 3.0.1393 ``                         |
| [`12d537f5`](https://github.com/NixOS/nixpkgs/commit/12d537f545c71aede6b230d318758629304c1627) | `` python313Packages.tencentcloud-sdk-python: 3.0.1391 -> 3.0.1392 ``                         |
| [`c912c0f3`](https://github.com/NixOS/nixpkgs/commit/c912c0f3210d6ded130b4c698483fd2fb9242450) | `` home-assistant-custom-lovelace-modules.custom-sidebar: init at 10.2.0 ``                   |
| [`1d717d18`](https://github.com/NixOS/nixpkgs/commit/1d717d180a3df6ca463c171f48ded69dd37b6074) | `` python313Packages.seedir: 0.5.0 -> 0.5.1 ``                                                |
| [`c7c6a3a7`](https://github.com/NixOS/nixpkgs/commit/c7c6a3a73ea54f8e5f7eb04618f5acea1cb34870) | `` plexRaw: 1.41.7.9799-5bce000f7 -> 1.41.7.9823-59f304c16 ``                                 |
| [`cb46c254`](https://github.com/NixOS/nixpkgs/commit/cb46c25408a848e2762364fd26745e7412663b3f) | `` python313Packages.publicsuffixlist: 1.0.2.20250529 -> 1.0.2.20250603 ``                    |
| [`e2cb8c6c`](https://github.com/NixOS/nixpkgs/commit/e2cb8c6cd519bd6fa95ac876306d8f4c730b9042) | `` python313Packages.holidays: 0.73 -> 0.74 ``                                                |
| [`e248093e`](https://github.com/NixOS/nixpkgs/commit/e248093e1af3b5c02e9e30593d5b143402add0b9) | `` python313Packages.boto3-stubs: 1.38.28 -> 1.38.30 ``                                       |
| [`380e689b`](https://github.com/NixOS/nixpkgs/commit/380e689bcb15919504fad726f633ff3be5e6460a) | `` python313Packages.botocore-stubs: 1.38.28 -> 1.38.30 ``                                    |
| [`2bfe9af6`](https://github.com/NixOS/nixpkgs/commit/2bfe9af6c91e544d2602481b26461014ffb7aff5) | `` python312Packages.mypy-boto3-transcribe: 1.38.0 -> 1.38.30 ``                              |
| [`6aaf4bb2`](https://github.com/NixOS/nixpkgs/commit/6aaf4bb2ac8ee3777a76db96622b4e1f09911e3d) | `` python312Packages.mypy-boto3-sagemaker: 1.38.27 -> 1.38.30 ``                              |
| [`47389c0b`](https://github.com/NixOS/nixpkgs/commit/47389c0bcc36d635f652836fd2c31dc52403c5ce) | `` python312Packages.mypy-boto3-network-firewall: 1.38.25 -> 1.38.30 ``                       |
| [`25b105da`](https://github.com/NixOS/nixpkgs/commit/25b105da383e9be7c0c06800814e535e13ec77db) | `` python312Packages.mypy-boto3-mediaconvert: 1.38.16 -> 1.38.30 ``                           |
| [`9941c2bf`](https://github.com/NixOS/nixpkgs/commit/9941c2bfec383956d1d829045849b3c9fd438e7c) | `` python312Packages.mypy-boto3-mediaconnect: 1.38.0 -> 1.38.30 ``                            |
| [`02e6ed21`](https://github.com/NixOS/nixpkgs/commit/02e6ed21fb6024c2c571bbb57cd3efe84ea879f8) | `` python3Packages.torchvision: 0.22.0 -> 0.22.1 ``                                           |
| [`65ac8cfa`](https://github.com/NixOS/nixpkgs/commit/65ac8cfabceeac2658118072942008b8c59ff610) | `` python3Packages.torchaudio: 2.7.0 -> 2.7.1 ``                                              |
| [`77692cfd`](https://github.com/NixOS/nixpkgs/commit/77692cfde2724a612bf1d21ba7fb1751f959caf3) | `` python3Packages.torch-bin: 2.7.0 -> 2.7.1 ``                                               |
| [`7fa057aa`](https://github.com/NixOS/nixpkgs/commit/7fa057aa7ca7a025e1184b27ae84e9ce63a48d44) | `` python312Packages.mypy-boto3-emr-serverless: 1.38.27 -> 1.38.29 ``                         |
| [`5350e14d`](https://github.com/NixOS/nixpkgs/commit/5350e14d55ffcf3e0671e61b92174c61b71d0355) | `` python312Packages.mypy-boto3-apigatewayv2: 1.38.0 -> 1.38.29 ``                            |
| [`b3f4008a`](https://github.com/NixOS/nixpkgs/commit/b3f4008a6b975d6e0184376d982438fe06e0b307) | `` python312Packages.mypy-boto3-apigateway: 1.38.0 -> 1.38.29 ``                              |
| [`e6155d1f`](https://github.com/NixOS/nixpkgs/commit/e6155d1fb49f739ed926976d50c72b00d0632268) | `` python312Packages.mypy-boto3-amplify: 1.38.26 -> 1.38.30 ``                                |
| [`b3144dd0`](https://github.com/NixOS/nixpkgs/commit/b3144dd06198790e7b16ea426216127dc6184f41) | `` cpc: init at 3.0.0 ``                                                                      |
| [`ab778dc6`](https://github.com/NixOS/nixpkgs/commit/ab778dc6b6a3ab3c0490942053bc5589e7d75cea) | `` nixos/tests/broadcast-box: init ``                                                         |
| [`4dbade0a`](https://github.com/NixOS/nixpkgs/commit/4dbade0a185db49fe49e5e5455fa0a827179440f) | `` nixos/broadcast-box: init ``                                                               |
| [`75829dfb`](https://github.com/NixOS/nixpkgs/commit/75829dfb68c43bf0c9e8c21ab58baca5b56122f2) | `` mesa: 25.1.1 -> 25.1.2 ``                                                                  |
| [`0cbfabfa`](https://github.com/NixOS/nixpkgs/commit/0cbfabfa486effc556366e3daecf4919f7a6c527) | `` broadcast-box: init at 2025-06-04 ``                                                       |
| [`ec003ba0`](https://github.com/NixOS/nixpkgs/commit/ec003ba04416c67215deaff74d77537565f95636) | `` python3Packages.cvxpy: 1.6.5 -> 1.6.6 ``                                                   |
| [`db4b9c9d`](https://github.com/NixOS/nixpkgs/commit/db4b9c9d7d494158d359e4d6caa32bc2d2f2938c) | `` fleet: 4.68.0 -> 4.68.1 ``                                                                 |
| [`82b8a1e1`](https://github.com/NixOS/nixpkgs/commit/82b8a1e117609c3da5773d35921570542ad0ffc4) | `` maintainers: rename williamvds -> averyvigolo ``                                           |
| [`b0534865`](https://github.com/NixOS/nixpkgs/commit/b05348651da80907d55802507b45e0e542b8b992) | `` samba: 4.20.4 -> 4.20.8 ``                                                                 |
| [`a395e1ac`](https://github.com/NixOS/nixpkgs/commit/a395e1ac6dd1ce7f7ea3636d9d11057a168ead5c) | `` jujutsu: replace `git` with `gitMinimal` ``                                                |
| [`17f95268`](https://github.com/NixOS/nixpkgs/commit/17f95268f30307f0353cf80f5d99cf78f97c5400) | `` nixos/readeck: add back MemoryDenyWriteExecute ``                                          |
| [`49860b21`](https://github.com/NixOS/nixpkgs/commit/49860b21df19cee7fe6082bb99bbf262ce8459aa) | `` readeck: 0.18.2 -> 0.19.2 ``                                                               |
| [`591327c0`](https://github.com/NixOS/nixpkgs/commit/591327c05d0d2d93ea609d11e7ad24f6051ea781) | `` kubectl-ai: 0.0.9 -> 0.0.11 ``                                                             |
| [`f7464c55`](https://github.com/NixOS/nixpkgs/commit/f7464c553046e3b1f22b4fdd8411a2463d581674) | `` python3Packages.pysmlight: 0.2.5 -> 0.2.6 ``                                               |
| [`4b22b47f`](https://github.com/NixOS/nixpkgs/commit/4b22b47fea0687bfd60181bfab664a358e87b591) | `` nelm: 1.4.1 -> 1.5.0 ``                                                                    |
| [`29b198af`](https://github.com/NixOS/nixpkgs/commit/29b198af62a7a982308f066416272f72e0848201) | `` servo: 0-unstable-2025-05-25 -> 0-unstable-2025-06-04 ``                                   |
| [`6430162b`](https://github.com/NixOS/nixpkgs/commit/6430162b6ac7c70badd9af9cbfecf5dc31b52eb3) | `` dust: 1.2.0 -> 1.2.1 ``                                                                    |
| [`9b15fe08`](https://github.com/NixOS/nixpkgs/commit/9b15fe08d7cf02714b2cc8eea543fce3545c8ea0) | `` pgmoneta: 0.17.0 -> 0.17.1 ``                                                              |
| [`4aae235a`](https://github.com/NixOS/nixpkgs/commit/4aae235aaf100bb63c7d3c7619fb7af03a2e3824) | `` powerstation: 0.5.0 -> 0.5.1 ``                                                            |
| [`e32c4854`](https://github.com/NixOS/nixpkgs/commit/e32c48547d3bf184d858bd1391b979705160e629) | `` jujutsu: 0.29.0 -> 0.30.0 ``                                                               |
| [`934210a0`](https://github.com/NixOS/nixpkgs/commit/934210a0afb3424ba96bfefa11e1826beca8687e) | `` smtprelay: 1.11.2 -> 1.12.0 ``                                                             |
| [`c2cf0107`](https://github.com/NixOS/nixpkgs/commit/c2cf0107ab6bf19ffae1a4b4072bb1e9f439e07d) | `` vals: 0.41.1 -> 0.41.2 ``                                                                  |
| [`0a6b7417`](https://github.com/NixOS/nixpkgs/commit/0a6b7417df35db198888275a2c16a7dd8174220e) | `` efficient-compression-tool: 0.9.1 -> 0.9.5 ``                                              |
| [`c3566866`](https://github.com/NixOS/nixpkgs/commit/c3566866575cea5d5949a531db95893cfe79a81a) | `` az-pim-cli: 1.6.0 -> 1.6.1 ``                                                              |
| [`99b3566b`](https://github.com/NixOS/nixpkgs/commit/99b3566b61ef91909bbf2d7c771018bcccff0795) | `` repomix: 0.3.6 -> 0.3.8 ``                                                                 |
| [`bd4ae328`](https://github.com/NixOS/nixpkgs/commit/bd4ae3282774a9414b0aae059410ec09b8a7c62c) | `` neohtop: 1.1.2 -> 1.2.0 ``                                                                 |
| [`5cd05b7c`](https://github.com/NixOS/nixpkgs/commit/5cd05b7c9bec38ba998fadab2229d3aebcb5b1a5) | `` openscad-unstable: 2025-05-17 -> 2025-06-04 ``                                             |
| [`97262ee8`](https://github.com/NixOS/nixpkgs/commit/97262ee87192c8bd8e95540a3e97e96dea1ddac8) | `` treewide: replace `stdenv.is` with `stdenv.hostPlatform.is` ``                             |
| [`46ef95af`](https://github.com/NixOS/nixpkgs/commit/46ef95aff69d0cadda05591df6e98c0e4253c950) | `` pihole: remove leftover file ``                                                            |
| [`4410ac34`](https://github.com/NixOS/nixpkgs/commit/4410ac3485f7f692baf480793171580e03672124) | `` python3Packages.granian: only use rust-jemalloc-sys on aarch64 ``                          |
| [`9a184762`](https://github.com/NixOS/nixpkgs/commit/9a1847622677ebcc755d521d39bba56c8dea46bd) | `` linux_5_4: 5.4.293 -> 5.4.294 ``                                                           |
| [`535c5c25`](https://github.com/NixOS/nixpkgs/commit/535c5c25b76ec2e35cfa0420681182e9de855906) | `` linux_5_10: 5.10.237 -> 5.10.238 ``                                                        |
| [`34c78b3e`](https://github.com/NixOS/nixpkgs/commit/34c78b3e6b9e6ecfdc7f15e0736ec2665ea758d3) | `` linux_5_15: 5.15.184 -> 5.15.185 ``                                                        |
| [`05544195`](https://github.com/NixOS/nixpkgs/commit/055441950dbc8e52d8c7c79179e8511c90481aba) | `` linux_6_1: 6.1.140 -> 6.1.141 ``                                                           |
| [`1a8f6c1a`](https://github.com/NixOS/nixpkgs/commit/1a8f6c1a58c5ba2f95b6340ffd2b5a797b678cbb) | `` linux_6_6: 6.6.92 -> 6.6.93 ``                                                             |
| [`e21df292`](https://github.com/NixOS/nixpkgs/commit/e21df292407fcce5215ab402645847ae143cffac) | `` linux_6_12: 6.12.31 -> 6.12.32 ``                                                          |
| [`cf7e137a`](https://github.com/NixOS/nixpkgs/commit/cf7e137ae9feeced3b397a60b83a819d8242f3cc) | `` linux_6_14: 6.14.9 -> 6.14.10 ``                                                           |
| [`3aac00b6`](https://github.com/NixOS/nixpkgs/commit/3aac00b659b351c05f2f818468c7d8054076c680) | `` linux_6_15: 6.15 -> 6.15.1 ``                                                              |
| [`529d5138`](https://github.com/NixOS/nixpkgs/commit/529d5138d6b582c7530b864ea4e9efecaf669079) | `` miniserve: add defelo as maintainer ``                                                     |
| [`5058f4a0`](https://github.com/NixOS/nixpkgs/commit/5058f4a040ee547c16e2f24fc63998ef60adbba5) | `` miniserve: 0.28.0 -> 0.29.0 ``                                                             |
| [`d4f2f43e`](https://github.com/NixOS/nixpkgs/commit/d4f2f43e48137eae7e24500b6b80b6e1a1a8a5a4) | `` miniserve: add updateScript ``                                                             |
| [`f31bcc27`](https://github.com/NixOS/nixpkgs/commit/f31bcc275d301e67062b07c43b5bb0793204bc81) | `` miniserve: add versionCheckHook ``                                                         |
| [`9d88cb90`](https://github.com/NixOS/nixpkgs/commit/9d88cb90f604908751bf05e059c1f90d6ad0dc8e) | `` miniserve: use tag in fetchFromGitHub ``                                                   |