### PR TITLE
chore(flake/emacs-overlay): `f6850858` -> `b284e9ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1749232178,
-        "narHash": "sha256-pekC+SuqoHkoYPuWhC1aADCIP0cD3tvemu4WOF/JMUY=",
+        "lastModified": 1749262139,
+        "narHash": "sha256-BqCBEQl5WFxQOZubZQzP64cxS4c6tBTKb37tm6ziSYE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f6850858f78e2b6328f6e8bb7bf9df10dd0b7973",
+        "rev": "b284e9ae28347d2233cc5a6faa70fef7cb53945b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`b284e9ae`](https://github.com/nix-community/emacs-overlay/commit/b284e9ae28347d2233cc5a6faa70fef7cb53945b) | `` Updated melpa ``        |
| [`c43faab6`](https://github.com/nix-community/emacs-overlay/commit/c43faab6ec82f0e26bd5e4858aa7eb3df8c2f8eb) | `` Updated elpa ``         |
| [`9b3d8897`](https://github.com/nix-community/emacs-overlay/commit/9b3d8897d277e85150207ec7a3f0bb3883df230d) | `` Updated nongnu ``       |
| [`9ab8f6a1`](https://github.com/nix-community/emacs-overlay/commit/9ab8f6a1e9a4a2fb26d5ea7837daca08b80835d1) | `` Updated flake inputs `` |