### PR TITLE
chore(flake/nur): `b867f29b` -> `7bb85e8f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1749246388,
-        "narHash": "sha256-Dwwn4G27Tb3ErlErOThqXI+bIJ3usoHogzmFE20XgBw=",
+        "lastModified": 1749268860,
+        "narHash": "sha256-4WOgTMofw/dhfZOlWQyNC9oV2veZlp0HphKwho6PF1E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b867f29b2dd10e29477a15aebc4c3f6354ca723d",
+        "rev": "7bb85e8f796240d58b729976d013de623b77c7d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7bb85e8f`](https://github.com/nix-community/NUR/commit/7bb85e8f796240d58b729976d013de623b77c7d7) | `` automatic update `` |
| [`6e40eba6`](https://github.com/nix-community/NUR/commit/6e40eba6340c0787c694800c443e3f70c7c2dd60) | `` automatic update `` |
| [`a0487f9d`](https://github.com/nix-community/NUR/commit/a0487f9dfad839f766f62836eabb29807eaf6602) | `` automatic update `` |
| [`31b9eb08`](https://github.com/nix-community/NUR/commit/31b9eb0895dcf40c362ec94ad92d0f5e7eed1801) | `` automatic update `` |
| [`6348f843`](https://github.com/nix-community/NUR/commit/6348f8434f9d230c0275a98ab9b9184721e85720) | `` automatic update `` |