### PR TITLE
chore(flake/nur): `1ba9c808` -> `bfdeef80`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1749295401,
-        "narHash": "sha256-3gfVEPVXRPOGWiVXrbvdPVFV/nsbhbtt796VwcjLPXM=",
+        "lastModified": 1749325525,
+        "narHash": "sha256-PBC5k9ytIyAyinccytG42ipXJEfzBBPJGpeGQylFK1s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1ba9c8089747346fe5d6422c7461308aed440ab0",
+        "rev": "bfdeef803c4ac60f9250e4ec83395bf5d398990b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bfdeef80`](https://github.com/nix-community/NUR/commit/bfdeef803c4ac60f9250e4ec83395bf5d398990b) | `` automatic update `` |
| [`59bb408e`](https://github.com/nix-community/NUR/commit/59bb408e87b9e124ed3e8d40c93ea6489f5bea2a) | `` automatic update `` |
| [`6e4f2e99`](https://github.com/nix-community/NUR/commit/6e4f2e9903b1f7179101849901cd835666fffdd0) | `` automatic update `` |
| [`c9d238c8`](https://github.com/nix-community/NUR/commit/c9d238c8a9568d1632bd2a58e660bc4f1ab4dd84) | `` automatic update `` |
| [`1864ca66`](https://github.com/nix-community/NUR/commit/1864ca666a54841bae02abb30e7a16a317f663fa) | `` automatic update `` |
| [`500bfa3a`](https://github.com/nix-community/NUR/commit/500bfa3a22d3ee6514c1562d4fd1a91026b2b258) | `` automatic update `` |
| [`da271064`](https://github.com/nix-community/NUR/commit/da271064af31c632bb26a06a16307e7ec20cbbe1) | `` automatic update `` |