### PR TITLE
chore(flake/emacs-overlay): `8f31878f` -> `8fb63324`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1749287837,
-        "narHash": "sha256-XuOKjYLYaYDUEGAElyrR4MGe5U2Yl0XaW0+rpwsDkOM=",
+        "lastModified": 1749373492,
+        "narHash": "sha256-bOJGVnmA5QGAhbUPiFIFsjDp7iNgc5tgWCL+LF3ZfHQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8f31878f0f1449608ff02c7e6ddbb883357468af",
+        "rev": "8fb63324abd5635f2dc940825adf8336cdf9652b",
         "type": "github"
       },
       "original": {
@@ -646,11 +646,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1748995628,
-        "narHash": "sha256-bFufQGSAEYQgjtc4wMrobS5HWN0hDP+ZX+zthYcml9U=",
+        "lastModified": 1749173751,
+        "narHash": "sha256-ENY3y3v6S9ZmLDDLI3LUT8MXmfXg/fSt2eA4GCnMVCE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8eb3b6a2366a7095939cd22f0dc0e9991313294b",
+        "rev": "ed29f002b6d6e5e7e32590deb065c34a31dc3e91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`8fb63324`](https://github.com/nix-community/emacs-overlay/commit/8fb63324abd5635f2dc940825adf8336cdf9652b) | `` Updated melpa ``        |
| [`d084c3ca`](https://github.com/nix-community/emacs-overlay/commit/d084c3caceadedc53585bc24897fd2360bd85405) | `` Updated emacs ``        |
| [`390482e1`](https://github.com/nix-community/emacs-overlay/commit/390482e1142c5d2d78c2d5b4566e0804d64f33ec) | `` Updated melpa ``        |
| [`8a5a6034`](https://github.com/nix-community/emacs-overlay/commit/8a5a6034a2371522029b6217febfd0383d934983) | `` Updated elpa ``         |
| [`537ff3a0`](https://github.com/nix-community/emacs-overlay/commit/537ff3a06c1bf4cc6b552a0313af930ba3aa37d1) | `` Updated flake inputs `` |
| [`b313b010`](https://github.com/nix-community/emacs-overlay/commit/b313b010b457ab15ac323975b10bf418a9de074c) | `` Updated emacs ``        |
| [`c0b2fc75`](https://github.com/nix-community/emacs-overlay/commit/c0b2fc7536fde207d61ddc157d0524b044110829) | `` Updated melpa ``        |
| [`bdc33058`](https://github.com/nix-community/emacs-overlay/commit/bdc330582b7374a8dabce17106e6e4493984cd13) | `` Updated elpa ``         |
| [`404d0da2`](https://github.com/nix-community/emacs-overlay/commit/404d0da2ab6ac6cf3a358abc4a00f440620d1d67) | `` Updated nongnu ``       |