### PR TITLE
chore(flake/nur): `bfdeef80` -> `e3a61a90`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1749325525,
-        "narHash": "sha256-PBC5k9ytIyAyinccytG42ipXJEfzBBPJGpeGQylFK1s=",
+        "lastModified": 1749334897,
+        "narHash": "sha256-EC30zWG/tCKgEbjLplrjQMbhydLm46833/u9viGKbKQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bfdeef803c4ac60f9250e4ec83395bf5d398990b",
+        "rev": "e3a61a9079d9808cb69e19051e7410d45cefe2dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e3a61a90`](https://github.com/nix-community/NUR/commit/e3a61a9079d9808cb69e19051e7410d45cefe2dc) | `` automatic update `` |
| [`58bc477d`](https://github.com/nix-community/NUR/commit/58bc477d7631a9815143e1e31205ddf0e5e40164) | `` automatic update `` |
| [`74847e01`](https://github.com/nix-community/NUR/commit/74847e01b136d27ad12749db014fd54d9f627556) | `` automatic update `` |