### PR TITLE
chore(flake/nur): `e3a61a90` -> `a06f01e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -725,11 +725,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1749143949,
-        "narHash": "sha256-QuUtALJpVrPnPeozlUG/y+oIMSLdptHxb3GK6cpSVhA=",
+        "lastModified": 1749285348,
+        "narHash": "sha256-frdhQvPbmDYaScPFiCnfdh3B/Vh81Uuoo0w5TkWmmjU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d3d2d80a2191a73d1e86456a751b83aa13085d7d",
+        "rev": "3e3afe5174c561dee0df6f2c2b2236990146329f",
         "type": "github"
       },
       "original": {
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1749334897,
-        "narHash": "sha256-EC30zWG/tCKgEbjLplrjQMbhydLm46833/u9viGKbKQ=",
+        "lastModified": 1749427072,
+        "narHash": "sha256-tj6RAZlnmtCgOeVNMYVUZYXoig6Eihz3pa6rqBv/CuE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e3a61a9079d9808cb69e19051e7410d45cefe2dc",
+        "rev": "a06f01e16a5b44d3ee54f73541168d819e424f5d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                            |
| -------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`a06f01e1`](https://github.com/nix-community/NUR/commit/a06f01e16a5b44d3ee54f73541168d819e424f5d) | `` automatic update ``             |
| [`b2031e2c`](https://github.com/nix-community/NUR/commit/b2031e2c707c0fa4860e9afeba98766eb9b09d11) | `` automatic update ``             |
| [`73d91ecf`](https://github.com/nix-community/NUR/commit/73d91ecf207a0796b50f5a60c824073363dc52ae) | `` automatic update ``             |
| [`90cdff17`](https://github.com/nix-community/NUR/commit/90cdff175a83aab2fa1af2b58bfcec73ffd3cbf2) | `` automatic update ``             |
| [`89e48f0d`](https://github.com/nix-community/NUR/commit/89e48f0d5aeb551c5249656968b4d40b341f80cb) | `` automatic update ``             |
| [`362e89a9`](https://github.com/nix-community/NUR/commit/362e89a9b976207d80d32293a79bb62d2849f268) | `` automatic update ``             |
| [`e1d241e0`](https://github.com/nix-community/NUR/commit/e1d241e09d9b293cf1d170c11027a5ca2dfb6276) | `` automatic update ``             |
| [`d8c0a645`](https://github.com/nix-community/NUR/commit/d8c0a6456c1c6b13e0de3a5797f11ec7d6b7a5ec) | `` automatic update ``             |
| [`c8b06567`](https://github.com/nix-community/NUR/commit/c8b06567e3bb39bdedc1bbe01a12e89b5e71b580) | `` automatic update ``             |
| [`2f2b1e38`](https://github.com/nix-community/NUR/commit/2f2b1e388f2c8216ae16b52dbb013479aaf6671d) | `` automatic update ``             |
| [`7502ee79`](https://github.com/nix-community/NUR/commit/7502ee791dfee0ed3f32382eaabb4d73451f472b) | `` automatic update ``             |
| [`31c477ff`](https://github.com/nix-community/NUR/commit/31c477ffe92da8531f55c71333a394e89fc2438f) | `` automatic update ``             |
| [`900c019f`](https://github.com/nix-community/NUR/commit/900c019f348d5eda2d55f6ea33822a6b7b828afd) | `` remove nukdokplex repository `` |
| [`76dd5c2e`](https://github.com/nix-community/NUR/commit/76dd5c2ed0cb8c935feff92803555ac4e453095b) | `` automatic update ``             |
| [`1e7a9ce8`](https://github.com/nix-community/NUR/commit/1e7a9ce80e7f282654a0cb98ead35ceae75dfcbb) | `` automatic update ``             |
| [`d99eda30`](https://github.com/nix-community/NUR/commit/d99eda3059b70e930e92507c6f3f2ff756b279e1) | `` automatic update ``             |
| [`8b34a905`](https://github.com/nix-community/NUR/commit/8b34a9050362bfa2a8f91c05c371764df22de606) | `` automatic update ``             |
| [`ac9f2c93`](https://github.com/nix-community/NUR/commit/ac9f2c93c943ec0eef98043151636fc569f1e608) | `` automatic update ``             |
| [`51ec46dc`](https://github.com/nix-community/NUR/commit/51ec46dc8e02170b18905edcbeef666262a13cce) | `` automatic update ``             |
| [`5d014ec7`](https://github.com/nix-community/NUR/commit/5d014ec71062bf56a3f13cfdd3fb8c64393bdfc1) | `` automatic update ``             |
| [`2ff1514c`](https://github.com/nix-community/NUR/commit/2ff1514c8d905506bae2885dc461e6b230d8f20d) | `` automatic update ``             |
| [`a684d0e1`](https://github.com/nix-community/NUR/commit/a684d0e1720a7a08bae3dde113c352cd25e0e41a) | `` automatic update ``             |