### PR TITLE
chore(flake/home-manager): `2d7d65f6` -> `06451df4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749243446,
-        "narHash": "sha256-P1gumhZN5N9q+39ndePHYrtwOwY1cGx+VoXGl+vTm7A=",
+        "lastModified": 1749358668,
+        "narHash": "sha256-V91nN4Q9ZwX0N+Gzu+F8SnvzMcdURYnMcIvpfLQzD5M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2d7d65f65b61fdfce23278e59ca266ddd0ef0a36",
+        "rev": "06451df423dd5e555f39857438ffc16c5b765862",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`06451df4`](https://github.com/nix-community/home-manager/commit/06451df423dd5e555f39857438ffc16c5b765862) | `` ghostty: only source fish shell integration script when shell is interactive (#7228) `` |
| [`627157cc`](https://github.com/nix-community/home-manager/commit/627157ccebb4c82b6f60c2795e848e595d566dc7) | `` ludusavi: modernize and clean-up ``                                                     |
| [`bc0012d0`](https://github.com/nix-community/home-manager/commit/bc0012d036b02093c1cf0322866db8ddad707ef6) | `` ludusavi: add frequency option ``                                                       |
| [`515ab1da`](https://github.com/nix-community/home-manager/commit/515ab1da57955e9805348336b0afd6d9a50c0c7e) | `` ludusavi: fix icon on notification ``                                                   |
| [`bd8946c7`](https://github.com/nix-community/home-manager/commit/bd8946c773906d3e331efa02ea25b3a19a063d68) | `` lazysql: add module (#7231) ``                                                          |
| [`980aece3`](https://github.com/nix-community/home-manager/commit/980aece33ab30b127e471a617c4ee30e45f4e8b1) | `` flake.lock: Update (#7235) ``                                                           |