### PR TITLE
chore(flake/nur): `a06f01e1` -> `e5bbf11e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1749427072,
-        "narHash": "sha256-tj6RAZlnmtCgOeVNMYVUZYXoig6Eihz3pa6rqBv/CuE=",
+        "lastModified": 1749440809,
+        "narHash": "sha256-HM+qObNKIRTg7CZ7EjPPu9t9a5bcJRzUOvnF/Xg5IpY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a06f01e16a5b44d3ee54f73541168d819e424f5d",
+        "rev": "e5bbf11eed30c3253d6398053802bf663b45283c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e5bbf11e`](https://github.com/nix-community/NUR/commit/e5bbf11eed30c3253d6398053802bf663b45283c) | `` automatic update `` |
| [`45fc9258`](https://github.com/nix-community/NUR/commit/45fc92583f022df532f72960a3e1667fb8fa708a) | `` automatic update `` |
| [`4f15d170`](https://github.com/nix-community/NUR/commit/4f15d170b531ae2f072a7e4811ccdc61bc79bbb5) | `` automatic update `` |
| [`747adf23`](https://github.com/nix-community/NUR/commit/747adf23200d1b6411fab7dc21c2bd37799cd3b7) | `` automatic update `` |
| [`e5557262`](https://github.com/nix-community/NUR/commit/e55572623b12229270cffe6b68dd0c5b7834f7c1) | `` automatic update `` |