### PR TITLE
chore(flake/emacs-overlay): `f9a3bc6f` -> `3bb5d2b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1749403155,
-        "narHash": "sha256-NDtAmu/670yRr1z0kXIi2WHe32uEGlMoP5rhFLnBzXE=",
+        "lastModified": 1749461020,
+        "narHash": "sha256-EmVW3BNzwpMemCy50+nx8rK+q7U3ioXX3ErhXQFiHEg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f9a3bc6f0b0a8416df4602e7583aecca8d8cca57",
+        "rev": "3bb5d2b3966b1a79258daf1ec62963698cef90d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`3bb5d2b3`](https://github.com/nix-community/emacs-overlay/commit/3bb5d2b3966b1a79258daf1ec62963698cef90d9) | `` Updated emacs ``  |
| [`3bbccf62`](https://github.com/nix-community/emacs-overlay/commit/3bbccf622a5aac194713b0efecde1531a9347116) | `` Updated melpa ``  |
| [`1f242e34`](https://github.com/nix-community/emacs-overlay/commit/1f242e34e24e88767f9b981fd5c437ddea21ef15) | `` Updated emacs ``  |
| [`af54c588`](https://github.com/nix-community/emacs-overlay/commit/af54c58850148557bf287ad00e5d71103fa836bd) | `` Updated melpa ``  |
| [`355fd897`](https://github.com/nix-community/emacs-overlay/commit/355fd89797bf5e18b54b34abea7f6d3d4cafbcf8) | `` Updated elpa ``   |
| [`ba05300e`](https://github.com/nix-community/emacs-overlay/commit/ba05300e0e1fa6c1a7117880c587f02097c6536b) | `` Updated nongnu `` |