### PR TITLE
chore(flake/srvos): `0bd69fd1` -> `0f68c141`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -933,11 +933,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749198898,
-        "narHash": "sha256-tmMZfpmrdolQrnomFiKsXkgrtKCrY/BXKwLE56z04Kg=",
+        "lastModified": 1749431367,
+        "narHash": "sha256-gW+9PVxQ0WFYAZTZIs++c++djQBQtLdfPEuoysW14bw=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "0bd69fd1d82f6eab4ca95109cba617dfd06109d0",
+        "rev": "0f68c14174fc0cd94d9aad9ca2cb7947265e379b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`0f68c141`](https://github.com/nix-community/srvos/commit/0f68c14174fc0cd94d9aad9ca2cb7947265e379b) | `` dev/private/flake.lock: Update `` |
| [`afc433f5`](https://github.com/nix-community/srvos/commit/afc433f56eec477b3893258ba18c93bf681ffb9b) | `` flake.lock: Update ``             |