### PR TITLE
chore(flake/nur): `e5bbf11e` -> `63c3a63f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1749440809,
-        "narHash": "sha256-HM+qObNKIRTg7CZ7EjPPu9t9a5bcJRzUOvnF/Xg5IpY=",
+        "lastModified": 1749454952,
+        "narHash": "sha256-i3gH6Oqj+mTtUdCxupTmiU7tGkmjn+ThTcQanpD3kCs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e5bbf11eed30c3253d6398053802bf663b45283c",
+        "rev": "63c3a63f3f420f15c5451ce16834f52362c24ba9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`63c3a63f`](https://github.com/nix-community/NUR/commit/63c3a63f3f420f15c5451ce16834f52362c24ba9) | `` automatic update `` |
| [`e6b2b3c3`](https://github.com/nix-community/NUR/commit/e6b2b3c3407b1b964d0f9c874438ca98b9ecb66b) | `` automatic update `` |
| [`a6890493`](https://github.com/nix-community/NUR/commit/a6890493b85cd43c7a6936a052ccfedf41729f6b) | `` automatic update `` |
| [`8d54c4ce`](https://github.com/nix-community/NUR/commit/8d54c4ce87a10f83c9ca0d9c76f7847b5e0e000a) | `` automatic update `` |