### PR TITLE
chore(flake/nur): `63c3a63f` -> `67f26e8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1749454952,
-        "narHash": "sha256-i3gH6Oqj+mTtUdCxupTmiU7tGkmjn+ThTcQanpD3kCs=",
+        "lastModified": 1749469605,
+        "narHash": "sha256-M8QyLtNzhJfDGE9mXj4gd//HjBAF86hxMt758Ng0Mxg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "63c3a63f3f420f15c5451ce16834f52362c24ba9",
+        "rev": "67f26e8ee005586f7327c4ba59f08c9f8b3f1074",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`67f26e8e`](https://github.com/nix-community/NUR/commit/67f26e8ee005586f7327c4ba59f08c9f8b3f1074) | `` automatic update `` |
| [`9482626b`](https://github.com/nix-community/NUR/commit/9482626b0c8210eaecf6669b6af085fe4ccbd7da) | `` automatic update `` |
| [`287e360e`](https://github.com/nix-community/NUR/commit/287e360e18badeceb09eb1d4f045b11436955299) | `` automatic update `` |
| [`b40eb65f`](https://github.com/nix-community/NUR/commit/b40eb65f7baf98d65ceb49510c1d55211b72a508) | `` automatic update `` |