### PR TITLE
chore(flake/emacs-overlay): `3bb5d2b3` -> `b6c911eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1749461020,
-        "narHash": "sha256-EmVW3BNzwpMemCy50+nx8rK+q7U3ioXX3ErhXQFiHEg=",
+        "lastModified": 1749489629,
+        "narHash": "sha256-msG+YGpW+6g5LwRGayuzQBbPSBkjBOd+M+lapvY2L4A=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3bb5d2b3966b1a79258daf1ec62963698cef90d9",
+        "rev": "b6c911ebe26ff235dde39d3a35ab6faf22550d40",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`b6c911eb`](https://github.com/nix-community/emacs-overlay/commit/b6c911ebe26ff235dde39d3a35ab6faf22550d40) | `` Updated emacs ``  |
| [`1283178f`](https://github.com/nix-community/emacs-overlay/commit/1283178f848238268d4992320d5a5088ca4dc9e6) | `` Updated melpa ``  |
| [`d2057f7f`](https://github.com/nix-community/emacs-overlay/commit/d2057f7ffdd7b104fafb5120b2e569d6778ada60) | `` Updated elpa ``   |
| [`ab923c98`](https://github.com/nix-community/emacs-overlay/commit/ab923c9809d81513c37fdaeb0b0fa863c716849f) | `` Updated nongnu `` |