### PR TITLE
chore(flake/emacs-ultra-scroll): `489adeda` -> `b447044b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
     "emacs-ultra-scroll": {
       "flake": false,
       "locked": {
-        "lastModified": 1748964846,
-        "narHash": "sha256-KklbdVv584m+zEANeSYQ9xgRIJDYPgmQQsfCwKmuzzA=",
+        "lastModified": 1749501373,
+        "narHash": "sha256-GnAn6LjxrfzrNZP2bYSsWuDifKuIbSgKe4ES7906Ig4=",
         "owner": "jdtsmith",
         "repo": "ultra-scroll",
-        "rev": "489adeda7380b97d8f5d61d43082cd2d96b55b58",
+        "rev": "b447044b9de68068139da9ab367126e973a6a0b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                  |
| ------------------------------------------------------------------------------------------------------ | ---------------------------------------- |
| [`b447044b`](https://github.com/jdtsmith/ultra-scroll/commit/b447044b9de68068139da9ab367126e973a6a0b0) | `` Bump version and add NEWS ``          |
| [`c2d9a2be`](https://github.com/jdtsmith/ultra-scroll/commit/c2d9a2bec2057ecd57fbce04ef3c486fc443594a) | `` Be defensive about null posn-x-y's `` |