### PR TITLE
chore(flake/emacs-overlay): `b6c911eb` -> `a1fc4a12`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1749489629,
-        "narHash": "sha256-msG+YGpW+6g5LwRGayuzQBbPSBkjBOd+M+lapvY2L4A=",
+        "lastModified": 1749521434,
+        "narHash": "sha256-iYuO2A6EeCk3yt7i+u5BbKpYUKBWZrWwEvyMzx7JL8o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b6c911ebe26ff235dde39d3a35ab6faf22550d40",
+        "rev": "a1fc4a1252cf8f730d39a6570d36b9b95b478cd5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`a1fc4a12`](https://github.com/nix-community/emacs-overlay/commit/a1fc4a1252cf8f730d39a6570d36b9b95b478cd5) | `` Updated melpa ``  |
| [`5d2ccbca`](https://github.com/nix-community/emacs-overlay/commit/5d2ccbcaf1b8109665e7b990dc176e73ad174720) | `` Updated elpa ``   |
| [`5c1db856`](https://github.com/nix-community/emacs-overlay/commit/5c1db8560e34306f8c7b6b5d1296eea3d7d2b14a) | `` Updated nongnu `` |