### PR TITLE
chore(flake/minimal-emacs-d): `9c6fd765` -> `cbe668e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -398,11 +398,11 @@
     "minimal-emacs-d": {
       "flake": false,
       "locked": {
-        "lastModified": 1749421505,
-        "narHash": "sha256-tq+kaSEMsB4MMdLcWcH8zCRRlCjbEV/0BdX+1ZemMxg=",
+        "lastModified": 1749743356,
+        "narHash": "sha256-kvG7rEL0mVvwm0cDn67WFGBuUEY3kB1TZmi5rT64KZA=",
         "owner": "jamescherti",
         "repo": "minimal-emacs.d",
-        "rev": "9c6fd76524acee4bc92d70299ed61402d1fa601b",
+        "rev": "cbe668e1338bd7ecb4b99b413b1f2c69a89ce415",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                                                                       |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
| [`cbe668e1`](https://github.com/jamescherti/minimal-emacs.d/commit/cbe668e1338bd7ecb4b99b413b1f2c69a89ce415) | `` Add option to specify wait time before restoring gc-cons-threshold ``                                      |
| [`758b6673`](https://github.com/jamescherti/minimal-emacs.d/commit/758b66736e50b03db810906448b967cfef92ae29) | `` Update README.md ``                                                                                        |
| [`b980ce1b`](https://github.com/jamescherti/minimal-emacs.d/commit/b980ce1bc2275870f604824933725840c2f5bcd8) | `` Update README.md ``                                                                                        |
| [`93c96c7e`](https://github.com/jamescherti/minimal-emacs.d/commit/93c96c7ed3f15b672fcb22a3471e30ab89216cd0) | `` When minimal-emacs-setup-native-compilation is nil, leave native-comp variables to their default values `` |
| [`eaf87000`](https://github.com/jamescherti/minimal-emacs.d/commit/eaf87000ac3bdfec154bbb6db2e1a351a6e4d664) | `` Declare package-archive-priorities using setq and other minor changes ``                                   |