### PR TITLE
chore(flake/sops-nix): `8d215e1c` -> `50754dfa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -913,11 +913,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747603214,
-        "narHash": "sha256-lAblXm0VwifYCJ/ILPXJwlz0qNY07DDYdLD+9H+Wc8o=",
+        "lastModified": 1749592509,
+        "narHash": "sha256-VunQzfZFA+Y6x3wYi2UE4DEQ8qKoAZZCnZPUlSoqC+A=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "8d215e1c981be3aa37e47aeabd4e61bb069548fd",
+        "rev": "50754dfaa0e24e313c626900d44ef431f3210138",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                     |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`69676d2e`](https://github.com/Mic92/sops-nix/commit/69676d2e37b583b0b9ab0da5e4b1ec7198813063) | `` update vendorHash ``                                                     |
| [`e11bcc63`](https://github.com/Mic92/sops-nix/commit/e11bcc63950791c70e3cea472c22005518234def) | `` build(deps): bump github.com/ProtonMail/go-crypto from 1.2.0 to 1.3.0 `` |
| [`055492dd`](https://github.com/Mic92/sops-nix/commit/055492dd031989821521a22b88b5307c01633dcb) | `` update vendorHash ``                                                     |
| [`1b90745b`](https://github.com/Mic92/sops-nix/commit/1b90745bacf0f412551111ba38c3631337df487c) | `` build(deps): bump github.com/cloudflare/circl from 1.6.0 to 1.6.1 ``     |