### PR TITLE
chore(flake/nur): `26835ebb` -> `14f8439a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1749584818,
-        "narHash": "sha256-ceSuhCfsAIullY/OCrUY4SxzaUX8L4/B4/Xr+N9LCro=",
+        "lastModified": 1749614785,
+        "narHash": "sha256-yn6eDwnUr9vZYpneg+XNh0/tC1KA9a+yXxvFMEzOfco=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "26835ebbcace9ee869576f81fb960009a9429e14",
+        "rev": "14f8439ad1190d3dd09f9fcc6a033d9710d68806",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`14f8439a`](https://github.com/nix-community/NUR/commit/14f8439ad1190d3dd09f9fcc6a033d9710d68806) | `` automatic update `` |
| [`bfc6a8cf`](https://github.com/nix-community/NUR/commit/bfc6a8cfd41a76ad2309ee5131e1a9711bcae967) | `` automatic update `` |
| [`eb144be6`](https://github.com/nix-community/NUR/commit/eb144be6ac0f3212e67ff3d0a57ef78eb529ccfc) | `` automatic update `` |
| [`551eb935`](https://github.com/nix-community/NUR/commit/551eb9355042df98b8bde22c6cf9e51ed2997bf2) | `` automatic update `` |
| [`ba099af6`](https://github.com/nix-community/NUR/commit/ba099af6f61e580af4140fb713cc4c51050dc020) | `` automatic update `` |
| [`2be3b5c3`](https://github.com/nix-community/NUR/commit/2be3b5c3cfda98dbdaa75624091f583add873568) | `` automatic update `` |
| [`1cf972a2`](https://github.com/nix-community/NUR/commit/1cf972a2363c84a1b9b1edbd7600b6d9d9b1f8ed) | `` automatic update `` |