### PR TITLE
chore(flake/nur): `14f8439a` -> `cca4a810`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1749614785,
-        "narHash": "sha256-yn6eDwnUr9vZYpneg+XNh0/tC1KA9a+yXxvFMEzOfco=",
+        "lastModified": 1749628084,
+        "narHash": "sha256-8TA9qlekMPMmG+z1LkbU5fAaSG1VSm88p4LN+hNL4Z8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "14f8439ad1190d3dd09f9fcc6a033d9710d68806",
+        "rev": "cca4a810b97c3935f4a99b8d4997140b28159150",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cca4a810`](https://github.com/nix-community/NUR/commit/cca4a810b97c3935f4a99b8d4997140b28159150) | `` automatic update `` |
| [`64adb8f7`](https://github.com/nix-community/NUR/commit/64adb8f7880d578006cf309df086385a8326e888) | `` automatic update `` |
| [`3d50ee0f`](https://github.com/nix-community/NUR/commit/3d50ee0f6cea8a37c83a1f13a974b8804d99d112) | `` automatic update `` |