### PR TITLE
chore(flake/nur): `74f88e01` -> `0fd91df9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1749670360,
-        "narHash": "sha256-YmJ5Zffr6tJID0nA3XkQaoeDLFhOZKBtvZl31jXsqQg=",
+        "lastModified": 1749758183,
+        "narHash": "sha256-27zV0W1UHJfGcgGTVX2Hx309jeRQf/r0nJAbi+1AZEY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "74f88e0178318b15c3c6d8832c681cc4e72c3d92",
+        "rev": "0fd91df92c07a3c1c02b8d12c9d75e8e4552d734",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0fd91df9`](https://github.com/nix-community/NUR/commit/0fd91df92c07a3c1c02b8d12c9d75e8e4552d734) | `` automatic update `` |
| [`248f53cb`](https://github.com/nix-community/NUR/commit/248f53cb50c3d2bcc650977ae1570c4ffc7c4e0f) | `` automatic update `` |
| [`4f194b8e`](https://github.com/nix-community/NUR/commit/4f194b8e03171554ddaac3a2d9f73bdd1eb27dfb) | `` automatic update `` |
| [`38b03397`](https://github.com/nix-community/NUR/commit/38b033973a5eaa472b89427e7856f2cd38a686a9) | `` automatic update `` |
| [`773f16d4`](https://github.com/nix-community/NUR/commit/773f16d49f89166c6b302e45e0b9a845921c2d20) | `` automatic update `` |
| [`e48e3b8e`](https://github.com/nix-community/NUR/commit/e48e3b8eb4f6bbf0c733dfe68d7be9c0d063a910) | `` automatic update `` |
| [`41f960a8`](https://github.com/nix-community/NUR/commit/41f960a8c103ea9401a876e38dffb56c3e3040b8) | `` automatic update `` |
| [`f6c2cf5a`](https://github.com/nix-community/NUR/commit/f6c2cf5ac856c2c5000428d586d50d371c39f617) | `` automatic update `` |
| [`fb566e7c`](https://github.com/nix-community/NUR/commit/fb566e7ccbf21af5cdea509282abe0e90e907540) | `` automatic update `` |
| [`5c2b030d`](https://github.com/nix-community/NUR/commit/5c2b030d3d1cf8f33d7447291d9a36e6a2d047e2) | `` automatic update `` |
| [`d6baf026`](https://github.com/nix-community/NUR/commit/d6baf0261b2a9d147ced00a8e37c32932f256c2b) | `` automatic update `` |
| [`7380d1d2`](https://github.com/nix-community/NUR/commit/7380d1d2684e04fd07c64e94e75901b5f7e79f7e) | `` automatic update `` |
| [`7d7ff356`](https://github.com/nix-community/NUR/commit/7d7ff356f3fe8d41498e6d31496a43ee5c3c371b) | `` automatic update `` |
| [`ba440d81`](https://github.com/nix-community/NUR/commit/ba440d81438ff47c3b5e11e46f4132bc58f24a4b) | `` automatic update `` |
| [`6b5f5ca0`](https://github.com/nix-community/NUR/commit/6b5f5ca0b9fa270e96d8d7781ca0f43f0148d6f5) | `` automatic update `` |
| [`23a8f65d`](https://github.com/nix-community/NUR/commit/23a8f65d671b7c3fc6f4b4aa5ab55529f61633e1) | `` automatic update `` |
| [`43cc7b9a`](https://github.com/nix-community/NUR/commit/43cc7b9a736dd88fbf6ba726a690894896d8d292) | `` automatic update `` |
| [`299057ec`](https://github.com/nix-community/NUR/commit/299057ec19a946ef9de718270461b86853a62cfd) | `` automatic update `` |
| [`29eca35b`](https://github.com/nix-community/NUR/commit/29eca35bd28188f09d7e5b27ede367c56b1bb943) | `` automatic update `` |
| [`dd2e6083`](https://github.com/nix-community/NUR/commit/dd2e608338e8541a2fe342954aec5db14f179473) | `` automatic update `` |
| [`ea05d5b4`](https://github.com/nix-community/NUR/commit/ea05d5b4f286ed764d00ca2e9b7d4f82e4bbe951) | `` automatic update `` |
| [`c9bed565`](https://github.com/nix-community/NUR/commit/c9bed565b19beed3e9141db0de6c8cccfd92b721) | `` automatic update `` |
| [`8bbcf372`](https://github.com/nix-community/NUR/commit/8bbcf37230034a09105e07ac547f56493ee9e71b) | `` automatic update `` |
| [`964c1aad`](https://github.com/nix-community/NUR/commit/964c1aad2e65cc03aa409389a5a664c502f2ad5f) | `` automatic update `` |
| [`95e1cb22`](https://github.com/nix-community/NUR/commit/95e1cb226184093d27ebaa9e665c5e5397537677) | `` automatic update `` |
| [`0e8328c1`](https://github.com/nix-community/NUR/commit/0e8328c18d801a253ed5dfd17bd78254d9669d06) | `` automatic update `` |