### PR TITLE
chore(flake/srvos): `0f68c141` -> `fa45d58e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -933,11 +933,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749431367,
-        "narHash": "sha256-gW+9PVxQ0WFYAZTZIs++c++djQBQtLdfPEuoysW14bw=",
+        "lastModified": 1749691166,
+        "narHash": "sha256-JmaVZYP5Z7hR6/ZGZxJXV+kYs7LLnL5aerFDXJnPURg=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "0f68c14174fc0cd94d9aad9ca2cb7947265e379b",
+        "rev": "fa45d58e2c07eaeb16b8dbeb8021f59d9821eb31",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`fa45d58e`](https://github.com/nix-community/srvos/commit/fa45d58e2c07eaeb16b8dbeb8021f59d9821eb31) | `` dev/private/flake.lock: Update `` |
| [`622f3893`](https://github.com/nix-community/srvos/commit/622f3893a363e02015cdf4bdb2c2c08b06995426) | `` flake.lock: Update ``             |