### PR TITLE
chore(flake/nur): `0fd91df9` -> `01cd2852`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1749758183,
-        "narHash": "sha256-27zV0W1UHJfGcgGTVX2Hx309jeRQf/r0nJAbi+1AZEY=",
+        "lastModified": 1749843164,
+        "narHash": "sha256-mIjS8p4taoY/54xIPE1Jk09WfUEgBACCrcPbhN9//dU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0fd91df92c07a3c1c02b8d12c9d75e8e4552d734",
+        "rev": "01cd28527ab6e575ba4d4cb6ff69d33ab1842312",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`01cd2852`](https://github.com/nix-community/NUR/commit/01cd28527ab6e575ba4d4cb6ff69d33ab1842312) | `` automatic update `` |
| [`968f74cf`](https://github.com/nix-community/NUR/commit/968f74cf82599e697d7c0c880375fcfb7c7f4019) | `` automatic update `` |
| [`338e51db`](https://github.com/nix-community/NUR/commit/338e51db7280979b1fa59e653c3067982b850ea8) | `` automatic update `` |
| [`84486f96`](https://github.com/nix-community/NUR/commit/84486f96d0471b403512730848ab99f96b510ea2) | `` automatic update `` |
| [`7c388148`](https://github.com/nix-community/NUR/commit/7c388148972b182ef27bddff0f36c515011b3dfe) | `` automatic update `` |
| [`ecfeb020`](https://github.com/nix-community/NUR/commit/ecfeb0204d555a342d4f8214e166b4493755c64b) | `` automatic update `` |
| [`37f210c1`](https://github.com/nix-community/NUR/commit/37f210c1dc1299c335ed5e8d7971047fee4bba12) | `` automatic update `` |
| [`0f9597fa`](https://github.com/nix-community/NUR/commit/0f9597fab433e41e051df2ca4e67078ef2e509a8) | `` automatic update `` |
| [`57930388`](https://github.com/nix-community/NUR/commit/579303886c656e503a20c8f75fe563cf272cd5d5) | `` automatic update `` |
| [`ad14d06c`](https://github.com/nix-community/NUR/commit/ad14d06c7b223c2fb2cb076e9493dbdaf0627693) | `` automatic update `` |
| [`9755dae6`](https://github.com/nix-community/NUR/commit/9755dae6f0ba90eb2b259bf9f157125293a6c4bc) | `` automatic update `` |
| [`6e15f499`](https://github.com/nix-community/NUR/commit/6e15f4990e4c32382a927b68a6533ec254c60bbe) | `` automatic update `` |
| [`4610ec86`](https://github.com/nix-community/NUR/commit/4610ec86baf579c4d008366a578707a8f5a2c598) | `` automatic update `` |
| [`bdfbc1bc`](https://github.com/nix-community/NUR/commit/bdfbc1bcf9d980fc0a67010c19bb40fd60f1a25b) | `` automatic update `` |
| [`eda410a1`](https://github.com/nix-community/NUR/commit/eda410a1ca8de33b08abb2727de067b6882fde49) | `` automatic update `` |
| [`0f19deaa`](https://github.com/nix-community/NUR/commit/0f19deaadb69d71a51f8aacd2e19fd8ca43c0158) | `` automatic update `` |
| [`16406887`](https://github.com/nix-community/NUR/commit/16406887fef7a8cfcab02007db38380464b1d8ec) | `` automatic update `` |
| [`49e68b4d`](https://github.com/nix-community/NUR/commit/49e68b4d3dc27e53be530444ca31a77b602b0766) | `` automatic update `` |
| [`ff005363`](https://github.com/nix-community/NUR/commit/ff00536379522dbf2909f42691d3f5a0ac939c9c) | `` automatic update `` |
| [`cfa772ab`](https://github.com/nix-community/NUR/commit/cfa772ab73a8bd8ad4ee95188c62b6531da0da8b) | `` automatic update `` |
| [`7bf4aa23`](https://github.com/nix-community/NUR/commit/7bf4aa230602b595185eeac364694974bb76ca3b) | `` automatic update `` |
| [`0ce6056c`](https://github.com/nix-community/NUR/commit/0ce6056cfa12df3ac42a425ec273c37e469b6907) | `` automatic update `` |
| [`8a0b2ecc`](https://github.com/nix-community/NUR/commit/8a0b2ecc46c23d44c0b36565503ef6e220ac971a) | `` automatic update `` |