### PR TITLE
chore(flake/minimal-emacs-d): `cbe668e1` -> `99167132`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -398,11 +398,11 @@
     "minimal-emacs-d": {
       "flake": false,
       "locked": {
-        "lastModified": 1749743356,
-        "narHash": "sha256-kvG7rEL0mVvwm0cDn67WFGBuUEY3kB1TZmi5rT64KZA=",
+        "lastModified": 1749847488,
+        "narHash": "sha256-LxgIPkrmKuZE1ntuJ50aa3M6TyVdw/fU/8xNb0Pv1h4=",
         "owner": "jamescherti",
         "repo": "minimal-emacs.d",
-        "rev": "cbe668e1338bd7ecb4b99b413b1f2c69a89ce415",
+        "rev": "991671323b9b01cd4bfabc8e7c7fd175a7eedcfb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                                           |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------- |
| [`99167132`](https://github.com/jamescherti/minimal-emacs.d/commit/991671323b9b01cd4bfabc8e7c7fd175a7eedcfb) | `` Update README.md ``                                                            |
| [`0606abc7`](https://github.com/jamescherti/minimal-emacs.d/commit/0606abc7261e635a6f73ccced18957d092d27a9b) | `` Add custom-buffer-done-kill and remove next-error-recenter ``                  |
| [`af92a8be`](https://github.com/jamescherti/minimal-emacs.d/commit/af92a8be9f54052f22ac3acdc4e2781bec345244) | `` Add dabbrev-ignored-buffer-regexps ``                                          |
| [`00e95a15`](https://github.com/jamescherti/minimal-emacs.d/commit/00e95a1534fff57a4654ebcf62252f9b55d603ba) | `` Remove flymake-fringe-indicator-position and flymake-suppress-zero-counters `` |
| [`5bfdb626`](https://github.com/jamescherti/minimal-emacs.d/commit/5bfdb6264be1c4d809e144006b4ecc78e3889429) | `` Enhance eglot defaults ``                                                      |