### PR TITLE
chore(flake/nur): `01cd2852` -> `0cbb97be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1749843164,
-        "narHash": "sha256-mIjS8p4taoY/54xIPE1Jk09WfUEgBACCrcPbhN9//dU=",
+        "lastModified": 1749872295,
+        "narHash": "sha256-ilr3veAO6UAukQi5SIWTk9dJ1KRjKnqKo9rS36i5Tkg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "01cd28527ab6e575ba4d4cb6ff69d33ab1842312",
+        "rev": "0cbb97be1ad7c3f981a8b284af154485b9561eb8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0cbb97be`](https://github.com/nix-community/NUR/commit/0cbb97be1ad7c3f981a8b284af154485b9561eb8) | `` automatic update `` |
| [`5651bb84`](https://github.com/nix-community/NUR/commit/5651bb84318ec4e5e9a5e616a3fc5e903042f60a) | `` automatic update `` |
| [`3e455b7f`](https://github.com/nix-community/NUR/commit/3e455b7fdd014d35cccffb7a0b0aa61270c10b00) | `` automatic update `` |
| [`81f20de5`](https://github.com/nix-community/NUR/commit/81f20de559c9ea83d6d88dbf958960a1c0006ebd) | `` automatic update `` |
| [`cfa58c04`](https://github.com/nix-community/NUR/commit/cfa58c0472d0db0935c36ede4389b32975cc5842) | `` automatic update `` |