### PR TITLE
chore(flake/nur): `0cbb97be` -> `2a4dbf6c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -725,11 +725,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1749285348,
-        "narHash": "sha256-frdhQvPbmDYaScPFiCnfdh3B/Vh81Uuoo0w5TkWmmjU=",
+        "lastModified": 1749794982,
+        "narHash": "sha256-Kh9K4taXbVuaLC0IL+9HcfvxsSUx8dPB5s5weJcc9pc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3e3afe5174c561dee0df6f2c2b2236990146329f",
+        "rev": "ee930f9755f58096ac6e8ca94a1887e0534e2d81",
         "type": "github"
       },
       "original": {
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1749872295,
-        "narHash": "sha256-ilr3veAO6UAukQi5SIWTk9dJ1KRjKnqKo9rS36i5Tkg=",
+        "lastModified": 1749902193,
+        "narHash": "sha256-3YlxeL3wjg9s5AxoADha9bG95SvDF3qoMNzoRVlLIgo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0cbb97be1ad7c3f981a8b284af154485b9561eb8",
+        "rev": "2a4dbf6cd17b4ccf30a26225add086d7681e351f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2a4dbf6c`](https://github.com/nix-community/NUR/commit/2a4dbf6cd17b4ccf30a26225add086d7681e351f) | `` automatic update `` |
| [`ccc76447`](https://github.com/nix-community/NUR/commit/ccc76447742368e1e4c0f7f7376aa9106d327f05) | `` automatic update `` |
| [`283e571d`](https://github.com/nix-community/NUR/commit/283e571d29e6816821387e8c1dae3f16fefb285b) | `` automatic update `` |
| [`f90225f3`](https://github.com/nix-community/NUR/commit/f90225f386384fa2b599778750e85e492076d124) | `` automatic update `` |
| [`e6dffa4e`](https://github.com/nix-community/NUR/commit/e6dffa4e501400789d74001b1c69538fdad77ee9) | `` automatic update `` |
| [`54e53c35`](https://github.com/nix-community/NUR/commit/54e53c358ee16b153d91ac7bfe7dfa34aedad411) | `` automatic update `` |
| [`5f4fb9f4`](https://github.com/nix-community/NUR/commit/5f4fb9f4e4bcd39e1073e4b776d668a0f6b971d4) | `` automatic update `` |
| [`8eb67b41`](https://github.com/nix-community/NUR/commit/8eb67b414e7140586bd08a10797248a023784a10) | `` automatic update `` |
| [`c70ec5f2`](https://github.com/nix-community/NUR/commit/c70ec5f29a4642d6f412186a9f4d68f536089814) | `` automatic update `` |