### PR TITLE
chore(flake/nur): `78e2be3e` -> `826c10ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -833,11 +833,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1749907876,
-        "narHash": "sha256-Ib/XpzcNYtIGvfs4Fdz5QPGW5UILOSJ/wKzHfGkflcc=",
+        "lastModified": 1749929411,
+        "narHash": "sha256-KfVrT+OGZu5LMhyJO3VjBX62cBx0B5xrjX8mwa2IGwo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "78e2be3e9720fd0fbba27f38a5be50e53708c1a5",
+        "rev": "826c10abce695e29c10d63c7197ea8a5db6b79ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`826c10ab`](https://github.com/nix-community/NUR/commit/826c10abce695e29c10d63c7197ea8a5db6b79ad) | `` automatic update `` |
| [`7fefcfb3`](https://github.com/nix-community/NUR/commit/7fefcfb3f6cdaf189f55ca9e63bec3376d5859e1) | `` automatic update `` |
| [`91bc806a`](https://github.com/nix-community/NUR/commit/91bc806a886f8ea75a8a87ac511e27f0b3decae7) | `` automatic update `` |