### PR TITLE
chore(flake/emacs-overlay): `8c2a905f` -> `77d295df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1749895881,
-        "narHash": "sha256-ae4O/LUhTbbf5ZOFm+9zF6RZPdwqGGLZq8xRUgUCLjU=",
+        "lastModified": 1749954440,
+        "narHash": "sha256-/Abdch4cOk5XIJ3icv30FPmB/Lw7XLeLBFXarL0wml0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8c2a905f516d6662a9ed0ce70d9db0e054cd3faa",
+        "rev": "77d295df371cf9c716c54759dc19900b2bb3a161",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`77d295df`](https://github.com/nix-community/emacs-overlay/commit/77d295df371cf9c716c54759dc19900b2bb3a161) | `` Updated melpa ``  |
| [`89a36866`](https://github.com/nix-community/emacs-overlay/commit/89a36866e97bace7cf6fc0d4795593b51611883e) | `` Updated elpa ``   |
| [`59eff251`](https://github.com/nix-community/emacs-overlay/commit/59eff2510803fa546e93332e44ed42b0ef83215c) | `` Updated nongnu `` |
| [`5479bde4`](https://github.com/nix-community/emacs-overlay/commit/5479bde495cf43766d53b3789a316e83ef7f8905) | `` Updated emacs ``  |
| [`f44880a7`](https://github.com/nix-community/emacs-overlay/commit/f44880a7f566f8ee0797a8dac490dfa77d3fdf52) | `` Updated melpa ``  |
| [`90d12e22`](https://github.com/nix-community/emacs-overlay/commit/90d12e22421147992240f87578dee2e8ff0635af) | `` Updated elpa ``   |
| [`8d18042e`](https://github.com/nix-community/emacs-overlay/commit/8d18042e9bf06ad7fcaf600fa5922ea64b710e0f) | `` Updated nongnu `` |