### PR TITLE
chore(flake/minimal-emacs-d): `99167132` -> `931c0e90`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -415,11 +415,11 @@
     "minimal-emacs-d": {
       "flake": false,
       "locked": {
-        "lastModified": 1749847488,
-        "narHash": "sha256-LxgIPkrmKuZE1ntuJ50aa3M6TyVdw/fU/8xNb0Pv1h4=",
+        "lastModified": 1749928109,
+        "narHash": "sha256-YErhSJy68HRuHTFrbpZlkiR0iT2n3xvvA+uNIXvKvAg=",
         "owner": "jamescherti",
         "repo": "minimal-emacs.d",
-        "rev": "991671323b9b01cd4bfabc8e7c7fd175a7eedcfb",
+        "rev": "931c0e9034af4a8c18cb00b2c36d35e175134d7a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                            |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
| [`931c0e90`](https://github.com/jamescherti/minimal-emacs.d/commit/931c0e9034af4a8c18cb00b2c36d35e175134d7a) | `` Add vc-git-diff-switches ``                     |
| [`2a170f3f`](https://github.com/jamescherti/minimal-emacs.d/commit/2a170f3f03f1164331a958adfa850fbf23bb1ec6) | `` Move frame-resize-pixelwise to early-init.el `` |