### PR TITLE
chore(flake/nur): `826c10ab` -> `92e36598`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -833,11 +833,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1749929411,
-        "narHash": "sha256-KfVrT+OGZu5LMhyJO3VjBX62cBx0B5xrjX8mwa2IGwo=",
+        "lastModified": 1749940545,
+        "narHash": "sha256-6yPBrESbYk/fLYrqZTK42T/JUVPA8wnoY6LceJUJskg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "826c10abce695e29c10d63c7197ea8a5db6b79ad",
+        "rev": "92e36598f6d5e656ec213f6bd08baae12b9f46ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`92e36598`](https://github.com/nix-community/NUR/commit/92e36598f6d5e656ec213f6bd08baae12b9f46ca) | `` automatic update `` |
| [`da2de770`](https://github.com/nix-community/NUR/commit/da2de77056b07a63601c9198708ff02ddab21fcb) | `` automatic update `` |