### PR TITLE
chore(flake/minimal-emacs-d): `931c0e90` -> `5be624f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -415,11 +415,11 @@
     "minimal-emacs-d": {
       "flake": false,
       "locked": {
-        "lastModified": 1749928109,
-        "narHash": "sha256-YErhSJy68HRuHTFrbpZlkiR0iT2n3xvvA+uNIXvKvAg=",
+        "lastModified": 1750004847,
+        "narHash": "sha256-k5XM9L9Fh6ELITtaJ0n1yrmpgJ5CbVhMBIwZBlJqG8g=",
         "owner": "jamescherti",
         "repo": "minimal-emacs.d",
-        "rev": "931c0e9034af4a8c18cb00b2c36d35e175134d7a",
+        "rev": "5be624f9733997c6f3a2619ea1d78d0f10907662",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                                   |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
| [`5be624f9`](https://github.com/jamescherti/minimal-emacs.d/commit/5be624f9733997c6f3a2619ea1d78d0f10907662) | `` Restore `gc-cons-threshold` only if the user has not overridden it. `` |
| [`c695bfb9`](https://github.com/jamescherti/minimal-emacs.d/commit/c695bfb9da114935442ad8d12f1551992be8cf61) | `` Update README.md ``                                                    |
| [`4d769e9b`](https://github.com/jamescherti/minimal-emacs.d/commit/4d769e9b8be5e172267fd3b44c3d26ac480a9b41) | `` Update README.md ``                                                    |