### PR TITLE
chore(flake/catppuccin): `3a42cd79` -> `fe78fa55`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1749223974,
-        "narHash": "sha256-/GAQYRW1duU81KG//2wI9ax8EkHVG/e1UOD97NdwLOY=",
+        "lastModified": 1750013871,
+        "narHash": "sha256-UQx3rC3QDjD/sIen51+5Juk1rqN3y/sTeMY1WinmhqQ=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "3a42cd79c647360ee8742659e42aeec0947dd3b4",
+        "rev": "fe78fa558d6603481c03eb03a946eadb970d1801",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                       |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`fe78fa55`](https://github.com/catppuccin/nix/commit/fe78fa558d6603481c03eb03a946eadb970d1801) | `` refactor: add `lib.mkFlavorName` (#586) `` |