### PR TITLE
chore(flake/srvos): `fa45d58e` -> `c4c51cca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -968,11 +968,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749691166,
-        "narHash": "sha256-JmaVZYP5Z7hR6/ZGZxJXV+kYs7LLnL5aerFDXJnPURg=",
+        "lastModified": 1750036548,
+        "narHash": "sha256-ZwduydIUY0tdF1fLXPGeyNo24vYOhlR/w/r0hGp8OBs=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "fa45d58e2c07eaeb16b8dbeb8021f59d9821eb31",
+        "rev": "c4c51cca77838d2ae0cc4cea36dde3bc3eea57e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`c4c51cca`](https://github.com/nix-community/srvos/commit/c4c51cca77838d2ae0cc4cea36dde3bc3eea57e6) | `` dev/private/flake.lock: Update `` |
| [`d2598741`](https://github.com/nix-community/srvos/commit/d25987410daded669771eb16efbbda0722ea2deb) | `` flake.lock: Update ``             |