### PR TITLE
chore(flake/emacs-overlay): `81213938` -> `d2113e15`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1750065684,
-        "narHash": "sha256-XBcE3zhcWA6PosLTzWrYXTQA9Wrur27P/C2FJTuD8qE=",
+        "lastModified": 1750093689,
+        "narHash": "sha256-L2QmD1sJtQXmCqcUCFJaEIpMHXqA85zesTsV2YzlngU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "81213938251b6d623de6dce400db7e89e442ffcc",
+        "rev": "d2113e151e11f32b5cc9c42e3e67a4235e818aa7",
         "type": "github"
       },
       "original": {
@@ -663,11 +663,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1749834526,
-        "narHash": "sha256-izgPGLeUeFB9loC+n2X6TO2n8pOGvVcR3jKqxTGOwgc=",
+        "lastModified": 1749995256,
+        "narHash": "sha256-LEGfcombb0otUf23oAmYCXR4+lMQKa49XmU0G5HItGI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "db8414903dd6b3042e1ac471eafc18ca4ccb54a4",
+        "rev": "daa45f10955cc2207ac9c5f0206774d2f757c162",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`d2113e15`](https://github.com/nix-community/emacs-overlay/commit/d2113e151e11f32b5cc9c42e3e67a4235e818aa7) | `` Updated melpa ``        |
| [`d71d520e`](https://github.com/nix-community/emacs-overlay/commit/d71d520eb14ab918ad054d24139a609f9bb35c1b) | `` Updated elpa ``         |
| [`56f8bda7`](https://github.com/nix-community/emacs-overlay/commit/56f8bda7cc83f888339626c663c76471d1fd9497) | `` Updated nongnu ``       |
| [`7a6ff7ec`](https://github.com/nix-community/emacs-overlay/commit/7a6ff7ecebf2e089fa613b7a6a5e5be93a02224c) | `` Updated flake inputs `` |