### PR TITLE
chore(flake/sops-nix): `50754dfa` -> `77c423a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -948,11 +948,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749592509,
-        "narHash": "sha256-VunQzfZFA+Y6x3wYi2UE4DEQ8qKoAZZCnZPUlSoqC+A=",
+        "lastModified": 1750119275,
+        "narHash": "sha256-Rr7Pooz9zQbhdVxux16h7URa6mA80Pb/G07T4lHvh0M=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "50754dfaa0e24e313c626900d44ef431f3210138",
+        "rev": "77c423a03b9b2b79709ea2cb63336312e78b72e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                           |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`0247855a`](https://github.com/Mic92/sops-nix/commit/0247855a0e0c8b47308a41175504d0658934153c) | `` update vendorHash ``                                           |
| [`130a655e`](https://github.com/Mic92/sops-nix/commit/130a655e052d5b42e4c50b485095da86cc793f21) | `` build(deps): bump golang.org/x/crypto from 0.38.0 to 0.39.0 `` |