### PR TITLE
chore(flake/emacs-overlay): `d2113e15` -> `81f55880`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1750093689,
-        "narHash": "sha256-L2QmD1sJtQXmCqcUCFJaEIpMHXqA85zesTsV2YzlngU=",
+        "lastModified": 1750126963,
+        "narHash": "sha256-0D22xrXkDM872W4ZMnUiJHsjq/uYSBsA6XumYgAkxyM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d2113e151e11f32b5cc9c42e3e67a4235e818aa7",
+        "rev": "81f55880689625e1e8cd184cb499c3fac8753790",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`81f55880`](https://github.com/nix-community/emacs-overlay/commit/81f55880689625e1e8cd184cb499c3fac8753790) | `` Updated emacs ``  |
| [`1a723b22`](https://github.com/nix-community/emacs-overlay/commit/1a723b22b7c59b6a88c3cf1752d9501a726c9e3d) | `` Updated melpa ``  |
| [`785396ba`](https://github.com/nix-community/emacs-overlay/commit/785396ba001d14e95f171a2d4dda5510ddf9b0ef) | `` Updated elpa ``   |
| [`beb6258d`](https://github.com/nix-community/emacs-overlay/commit/beb6258dbb0f0977fa8b96b19c590f7659e856e5) | `` Updated nongnu `` |