### PR TITLE
chore(flake/nur): `e61ae01d` -> `9228c936`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -833,11 +833,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1750132687,
-        "narHash": "sha256-hju3e9uKS3oTV/6qbQGF+C69rL/wm8NUMC1ODI9YfA0=",
+        "lastModified": 1750161457,
+        "narHash": "sha256-ZGAWe2cvPRc4IwlOHddIygKsT/dsCRbj8bZ7e0l3efs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e61ae01d458228ff47306a7067d29c90995841ef",
+        "rev": "9228c93645192cfa04c0819ffe6802afdfd1907e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9228c936`](https://github.com/nix-community/NUR/commit/9228c93645192cfa04c0819ffe6802afdfd1907e) | `` automatic update `` |
| [`d7f328ab`](https://github.com/nix-community/NUR/commit/d7f328abcf9c578dac35009f3832d195b51cc068) | `` automatic update `` |
| [`aaf2ba0f`](https://github.com/nix-community/NUR/commit/aaf2ba0fd3f94589cb13158a88164cd8c0b58acd) | `` automatic update `` |
| [`fddd9116`](https://github.com/nix-community/NUR/commit/fddd911662911456fa9f41d6527504363d3a33a4) | `` automatic update `` |
| [`f5ef0df5`](https://github.com/nix-community/NUR/commit/f5ef0df55e29b4001f691b238b6aeea90d55f800) | `` automatic update `` |
| [`6dd304c3`](https://github.com/nix-community/NUR/commit/6dd304c3ea73089978f85fd7e0e6ef0dcaeecb25) | `` automatic update `` |
| [`ad98c506`](https://github.com/nix-community/NUR/commit/ad98c506def8096a521e1c70badff8b358a34604) | `` automatic update `` |
| [`dddf6ee8`](https://github.com/nix-community/NUR/commit/dddf6ee8c6a0dfc79b242c38e37ed13b2c325755) | `` automatic update `` |
| [`be8fafc7`](https://github.com/nix-community/NUR/commit/be8fafc7b7641c56beee2f6506003d00488ebcf5) | `` automatic update `` |
| [`1adb45f8`](https://github.com/nix-community/NUR/commit/1adb45f8f3a4ad705f944925fc5e586e66ac6ec0) | `` automatic update `` |