### PR TITLE
chore(flake/emacs-overlay): `81f55880` -> `48efb8d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1750126963,
-        "narHash": "sha256-0D22xrXkDM872W4ZMnUiJHsjq/uYSBsA6XumYgAkxyM=",
+        "lastModified": 1750216540,
+        "narHash": "sha256-BbGRPoz7mN4djpiJr/mlNgug4XvNsvaSsL0Pa5xd/EI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "81f55880689625e1e8cd184cb499c3fac8753790",
+        "rev": "48efb8d3ac1f59a07031251ffca7affaee4f018d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`48efb8d3`](https://github.com/nix-community/emacs-overlay/commit/48efb8d3ac1f59a07031251ffca7affaee4f018d) | `` Updated emacs ``        |
| [`78302713`](https://github.com/nix-community/emacs-overlay/commit/78302713c2e102690ca9b531ed36c2c38d2794c9) | `` Updated melpa ``        |
| [`9e024bff`](https://github.com/nix-community/emacs-overlay/commit/9e024bff929e48104d61b12c398df881a5ae2371) | `` Updated elpa ``         |
| [`dde7fbce`](https://github.com/nix-community/emacs-overlay/commit/dde7fbce5954c788799277677b6fa4c5dae2aaae) | `` Updated nongnu ``       |
| [`435c4139`](https://github.com/nix-community/emacs-overlay/commit/435c4139ce44faa3eb00cbc60fa3abd0f510ae1d) | `` Updated flake inputs `` |
| [`79cb0891`](https://github.com/nix-community/emacs-overlay/commit/79cb0891f0cef9be3bd1d514edbd8d2b740e83b3) | `` Updated emacs ``        |
| [`091b6728`](https://github.com/nix-community/emacs-overlay/commit/091b672849b1dc2b750bfc95a4e8c4d33d809b1e) | `` Updated melpa ``        |
| [`3db1b619`](https://github.com/nix-community/emacs-overlay/commit/3db1b619f355ee953c009a3b9262af841bf8d0ac) | `` Updated nongnu ``       |
| [`cff16fc1`](https://github.com/nix-community/emacs-overlay/commit/cff16fc129c76889ddfb0ebb17b53b6633c77ba5) | `` Updated emacs ``        |
| [`e230be4f`](https://github.com/nix-community/emacs-overlay/commit/e230be4f6764e270c58612d9adf23f8726b8ac59) | `` Updated melpa ``        |