### PR TITLE
chore(flake/catppuccin): `fe78fa55` -> `4e95eaf8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1750013871,
-        "narHash": "sha256-UQx3rC3QDjD/sIen51+5Juk1rqN3y/sTeMY1WinmhqQ=",
+        "lastModified": 1750153510,
+        "narHash": "sha256-NYHXXJZ9m4fJpKk9tKn/EExX87SqcBcRINOGF7hKRLI=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "fe78fa558d6603481c03eb03a946eadb970d1801",
+        "rev": "4e95eaf8a351956d75cc400318579967ca2b6d0f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                            |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`4e95eaf8`](https://github.com/catppuccin/nix/commit/4e95eaf8a351956d75cc400318579967ca2b6d0f) | `` fix(gitea): controlled by enable #588 (#589) `` |