### PR TITLE
chore(flake/emacs-ultra-scroll): `b447044b` -> `4ca8cf0c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
     "emacs-ultra-scroll": {
       "flake": false,
       "locked": {
-        "lastModified": 1749501373,
-        "narHash": "sha256-GnAn6LjxrfzrNZP2bYSsWuDifKuIbSgKe4ES7906Ig4=",
+        "lastModified": 1750175156,
+        "narHash": "sha256-pkYqfRwFa/+L3m1s8cxTWQSicH+oMGPATB5n0QJullc=",
         "owner": "jdtsmith",
         "repo": "ultra-scroll",
-        "rev": "b447044b9de68068139da9ab367126e973a6a0b0",
+        "rev": "4ca8cf0cff4209886fe841c3e62f8f12c3be89ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                     |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------- |
| [`4ca8cf0c`](https://github.com/jdtsmith/ultra-scroll/commit/4ca8cf0cff4209886fe841c3e62f8f12c3be89ff) | `` Update README.md ``                      |
| [`727fecd6`](https://github.com/jdtsmith/ultra-scroll/commit/727fecd66c2549465aa6d95a3d84ed8945137ac4) | `` README.md: more in display bugs fixed `` |
| [`81675621`](https://github.com/jdtsmith/ultra-scroll/commit/81675621ba5cf33e43312caf80a22884ac5102f9) | `` Update README.md ``                      |