### PR TITLE
chore(flake/nur): `cb4eef35` -> `df32f7f7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -833,11 +833,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1750257166,
-        "narHash": "sha256-jM1CJvXkvFVUFqsPSa/oqUs0To+kILUjk1NzDGcrcwc=",
+        "lastModified": 1750289340,
+        "narHash": "sha256-rS18MYvihSY9UybShKk5uj517k8qqlQLQ382yURsKDM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cb4eef35ae541db62163800c861b2e2231d61da4",
+        "rev": "df32f7f73ad579d135f3cb8de159446b27cdb2f5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`df32f7f7`](https://github.com/nix-community/NUR/commit/df32f7f73ad579d135f3cb8de159446b27cdb2f5) | `` automatic update `` |
| [`2f86ca7b`](https://github.com/nix-community/NUR/commit/2f86ca7b13b6a703fd6a699163f6394564399b15) | `` automatic update `` |
| [`c5ed557e`](https://github.com/nix-community/NUR/commit/c5ed557e337d520898b24761e5695ca2ce34a47f) | `` automatic update `` |
| [`23f5b51e`](https://github.com/nix-community/NUR/commit/23f5b51ee025cd51f436d76b4813aecc8e51707f) | `` automatic update `` |
| [`1e0fde59`](https://github.com/nix-community/NUR/commit/1e0fde59d6b9013451c9fe3fc12662ab8962de9c) | `` automatic update `` |
| [`c188b586`](https://github.com/nix-community/NUR/commit/c188b586fa647ecef0b673b2519af6d7e169e069) | `` automatic update `` |