### PR TITLE
chore(flake/srvos): `c4c51cca` -> `7c93b611`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -968,11 +968,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750036548,
-        "narHash": "sha256-ZwduydIUY0tdF1fLXPGeyNo24vYOhlR/w/r0hGp8OBs=",
+        "lastModified": 1750295173,
+        "narHash": "sha256-W2dgraLz7VZZz/x+6LGt+hiHb94+FCjfyGfxN0TR+Qo=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "c4c51cca77838d2ae0cc4cea36dde3bc3eea57e6",
+        "rev": "7c93b611d175a62f3ce57fbda976c29261525a15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`7c93b611`](https://github.com/nix-community/srvos/commit/7c93b611d175a62f3ce57fbda976c29261525a15) | `` dev/private/flake.lock: Update `` |
| [`a942cab1`](https://github.com/nix-community/srvos/commit/a942cab19b9bfbb9edd9e9fbfcd1f5f17a884aa0) | `` flake.lock: Update ``             |