### PR TITLE
chore(flake/emacs-overlay): `2fab8c74` -> `6224529f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1750301575,
-        "narHash": "sha256-gNHJ34A0oK2jRD5fFkVX/Zb3iaiJ32VssnpzGaP4hPc=",
+        "lastModified": 1750352807,
+        "narHash": "sha256-jCYMcMdMqozqVcEUeSYApmgfMNgZ9+Sxh9vFYoT6SQo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2fab8c74721be21e8e06a95ab35f4e940c93a15e",
+        "rev": "6224529f64715f5bfcac0b57bce245c6ecbdb716",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`6224529f`](https://github.com/nix-community/emacs-overlay/commit/6224529f64715f5bfcac0b57bce245c6ecbdb716) | `` Updated melpa ``  |
| [`a5daf092`](https://github.com/nix-community/emacs-overlay/commit/a5daf092686fd419155ba321822b1d1457435862) | `` Updated elpa ``   |
| [`8eefaea4`](https://github.com/nix-community/emacs-overlay/commit/8eefaea426ef3a421260b6befd34b8a096f2c097) | `` Updated nongnu `` |
| [`888abc75`](https://github.com/nix-community/emacs-overlay/commit/888abc75a5686bdb999f95cb4c0106ce5c50b35d) | `` Updated emacs ``  |
| [`bedb216b`](https://github.com/nix-community/emacs-overlay/commit/bedb216b47e78a72376964f1cfeb319f16dc044b) | `` Updated melpa ``  |