### PR TITLE
chore(flake/nur): `06c508f5` -> `b268c995`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -833,11 +833,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1750344650,
-        "narHash": "sha256-YZaJeWgsz7aFRSVKSyUUGyO+reMYEABAF/hOKRKFaAY=",
+        "lastModified": 1750362320,
+        "narHash": "sha256-SO/2K/k+1Rma/8AwXREj3CGblNsCHdoP0Xp7SnvPkR4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "06c508f541ef17296026c47886b5f4f916f2100c",
+        "rev": "b268c99503bbe66ce6bca9d005e08f0308273883",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b268c995`](https://github.com/nix-community/NUR/commit/b268c99503bbe66ce6bca9d005e08f0308273883) | `` automatic update `` |
| [`c88c2e4d`](https://github.com/nix-community/NUR/commit/c88c2e4d436452120f7c8996d614cfbd439ff5ab) | `` automatic update `` |
| [`082c61d3`](https://github.com/nix-community/NUR/commit/082c61d3b9b922ce0e72b8eec478f2cbdd4eb5c1) | `` automatic update `` |
| [`915bfae0`](https://github.com/nix-community/NUR/commit/915bfae089ec83ebac112aff579c183a703da89e) | `` automatic update `` |