### PR TITLE
chore(flake/nur): `b268c995` -> `258d603b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -833,11 +833,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1750362320,
-        "narHash": "sha256-SO/2K/k+1Rma/8AwXREj3CGblNsCHdoP0Xp7SnvPkR4=",
+        "lastModified": 1750392274,
+        "narHash": "sha256-eZPmBlEaUVS2vRlIUKfsSu/0Jj6Qqpws4QEMnZkll4A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b268c99503bbe66ce6bca9d005e08f0308273883",
+        "rev": "258d603b4fb0faf3e252a10c2125ec3457ae056b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`258d603b`](https://github.com/nix-community/NUR/commit/258d603b4fb0faf3e252a10c2125ec3457ae056b) | `` automatic update `` |
| [`bf097ee7`](https://github.com/nix-community/NUR/commit/bf097ee7678d2e4cccc681678153ae9a91da1f51) | `` automatic update `` |
| [`21d329e5`](https://github.com/nix-community/NUR/commit/21d329e5fd5404e6023a8ad855e4e34af6c788c7) | `` automatic update `` |
| [`ae007dbe`](https://github.com/nix-community/NUR/commit/ae007dbe4ee43ee7ec22665713df91a680cb1a3f) | `` automatic update `` |
| [`6b6777f0`](https://github.com/nix-community/NUR/commit/6b6777f09a843f543eb7909a561c6231f1588dae) | `` automatic update `` |