### PR TITLE
chore(flake/nixos-facter-modules): `58ad9691` -> `14df13c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -585,11 +585,11 @@
     },
     "nixos-facter-modules": {
       "locked": {
-        "lastModified": 1743671943,
-        "narHash": "sha256-7sYig0+RcrR3sOL5M+2spbpFUHyEP7cnUvCaqFOBjyU=",
+        "lastModified": 1750412875,
+        "narHash": "sha256-uP9Xxw5XcFwjX9lNoYRpybOnIIe1BHfZu5vJnnPg3Jc=",
         "owner": "nix-community",
         "repo": "nixos-facter-modules",
-        "rev": "58ad9691670d293a15221d4a78818e0088d2e086",
+        "rev": "14df13c84552a7d1f33c1cd18336128fbc43f920",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                              | Message                                       |
| ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`eda4e0bd`](https://github.com/nix-community/nixos-facter-modules/commit/eda4e0bd35cf164b655d308d17e761c7f2bdb8b7) | `` README: change numtide to nix-community `` |