### PR TITLE
chore(flake/emacs-overlay): `931654ae` -> `4b39688c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1750414428,
-        "narHash": "sha256-p3meRJhl1qFEEVPvMZE9FAdFl0kgcsTw5DSzC1HRzjY=",
+        "lastModified": 1750443503,
+        "narHash": "sha256-TVDR3EyVhOdgcWKhSa5tFqEKgCzRgADcfaThmimkIFw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "931654aec6ae8014146b7bb03b63b6284b277e92",
+        "rev": "4b39688c50935c3b279f1443221573cd54698240",
         "type": "github"
       },
       "original": {
@@ -663,11 +663,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1750151854,
-        "narHash": "sha256-3za+1J9FifMetO7E/kwgyW+dp+8pPBNlWKfcBovnn6M=",
+        "lastModified": 1750330365,
+        "narHash": "sha256-hJ7XMNVsTnnbV2NPmStCC07gvv5l2x7+Skb7hyUzazg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ad5c70bcc5cc5178205161b7a7d61a6e80f6d244",
+        "rev": "d883b6213afa179b58ba8bace834f1419707d0ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`4b39688c`](https://github.com/nix-community/emacs-overlay/commit/4b39688c50935c3b279f1443221573cd54698240) | `` Updated emacs ``        |
| [`51a0c157`](https://github.com/nix-community/emacs-overlay/commit/51a0c157c2556ce628cbc2e4b251570dae4df0af) | `` Updated melpa ``        |
| [`0d7321aa`](https://github.com/nix-community/emacs-overlay/commit/0d7321aad9166a9431f651ecc135df2ef09dc2de) | `` Updated elpa ``         |
| [`468137d5`](https://github.com/nix-community/emacs-overlay/commit/468137d5e6ecd4be121ae0b0547fe154009c1fb2) | `` Updated nongnu ``       |
| [`370f2cdb`](https://github.com/nix-community/emacs-overlay/commit/370f2cdb87343c8d4c40e8dc7c32c0dffb1893b1) | `` Updated flake inputs `` |