### PR TITLE
chore(flake/nixos-avf): `7f8d2b87` -> `fde5c1a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -549,11 +549,11 @@
     },
     "nixos-avf": {
       "locked": {
-        "lastModified": 1747400219,
-        "narHash": "sha256-MuBMdJiGPqZ9+mB6ppML5hbEhDvMFDNXtVxv2wkhpNg=",
+        "lastModified": 1750484961,
+        "narHash": "sha256-qP8RgqOcllpsxcLCOngJ0Emr7ggwtuZ3yHwnqbIUcAs=",
         "owner": "nix-community",
         "repo": "nixos-avf",
-        "rev": "7f8d2b87877ed851db8060220eec92b180961977",
+        "rev": "fde5c1a6ef94e9da6710eee0b8e92587927447ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                        |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`fde5c1a6`](https://github.com/nix-community/nixos-avf/commit/fde5c1a6ef94e9da6710eee0b8e92587927447ed) | `` fix: use protobuf without version number `` |
| [`6d2f3529`](https://github.com/nix-community/nixos-avf/commit/6d2f352993a9555d926ccf8bea596d80e47a3c98) | `` chore: upgrade Virtualization module ``     |
| [`b5ff2cec`](https://github.com/nix-community/nixos-avf/commit/b5ff2cec3be8c7b56acd6f52db9382b3e65b1c9f) | `` fix: use protobuf 30 on newer nixos ``      |
| [`ae004595`](https://github.com/nix-community/nixos-avf/commit/ae0045955be48db79b71d22384cce8796182515d) | `` ci: upgrade ``                              |
| [`84f5d172`](https://github.com/nix-community/nixos-avf/commit/84f5d172fcdb22fc90add11a6c6f509b4fd2e59c) | `` fix: upgrade protobuf ``                    |