### PR TITLE
chore(flake/emacs-overlay): `4b39688c` -> `b4bf921a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1750443503,
-        "narHash": "sha256-TVDR3EyVhOdgcWKhSa5tFqEKgCzRgADcfaThmimkIFw=",
+        "lastModified": 1750497756,
+        "narHash": "sha256-4UW5oR9kqzs2BnzxeDvEnoMaD1NTmHwf41Wzt8+E6ac=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4b39688c50935c3b279f1443221573cd54698240",
+        "rev": "b4bf921a1c856836190c9e61e31214aead109c80",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`b4bf921a`](https://github.com/nix-community/emacs-overlay/commit/b4bf921a1c856836190c9e61e31214aead109c80) | `` Updated emacs `` |
| [`796e80e0`](https://github.com/nix-community/emacs-overlay/commit/796e80e085ee9494a7ba122fc58db0489b1af1c5) | `` Updated melpa `` |
| [`04ed4ae8`](https://github.com/nix-community/emacs-overlay/commit/04ed4ae85a4ee5278c63e41e4aee401f401e1b5e) | `` Updated elpa ``  |