### PR TITLE
chore(flake/emacs-ultra-scroll): `4ca8cf0c` -> `3dd35e9a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
     "emacs-ultra-scroll": {
       "flake": false,
       "locked": {
-        "lastModified": 1750175156,
-        "narHash": "sha256-pkYqfRwFa/+L3m1s8cxTWQSicH+oMGPATB5n0QJullc=",
+        "lastModified": 1750524338,
+        "narHash": "sha256-u+KTitHqtwn0jAoseFXUzH7psv1b6D07QupdZQfhgto=",
         "owner": "jdtsmith",
         "repo": "ultra-scroll",
-        "rev": "4ca8cf0cff4209886fe841c3e62f8f12c3be89ff",
+        "rev": "3dd35e9a2aa327ddf889bd0f3341a81d3215862b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message              |
| ------------------------------------------------------------------------------------------------------ | -------------------- |
| [`3dd35e9a`](https://github.com/jdtsmith/ultra-scroll/commit/3dd35e9a2aa327ddf889bd0f3341a81d3215862b) | `` Updated README `` |
| [`f9213ee5`](https://github.com/jdtsmith/ultra-scroll/commit/f9213ee5f329528c4245db21c119fc9a9042110f) | `` README updates `` |