### PR TITLE
chore(flake/nixos-avf): `fde5c1a6` -> `30840907`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -549,11 +549,11 @@
     },
     "nixos-avf": {
       "locked": {
-        "lastModified": 1750484961,
-        "narHash": "sha256-qP8RgqOcllpsxcLCOngJ0Emr7ggwtuZ3yHwnqbIUcAs=",
+        "lastModified": 1750534406,
+        "narHash": "sha256-j779gJoRf08Ejoh4/oMrcnSxW/JKyeDJwtSbLZJPNNI=",
         "owner": "nix-community",
         "repo": "nixos-avf",
-        "rev": "fde5c1a6ef94e9da6710eee0b8e92587927447ed",
+        "rev": "3084090727dfdce21a733b995facda7b57f50f5e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                              |
| -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`30840907`](https://github.com/nix-community/nixos-avf/commit/3084090727dfdce21a733b995facda7b57f50f5e) | `` fix: don't restart essential services on switch to avoid crash `` |