### PR TITLE
chore(flake/nixpkgs): `08f22084` -> `4206c4cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -726,11 +726,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1750365781,
-        "narHash": "sha256-XE/lFNhz5lsriMm/yjXkvSZz5DfvKJLUjsS6pP8EC50=",
+        "lastModified": 1750506804,
+        "narHash": "sha256-VLFNc4egNjovYVxDGyBYTrvVCgDYgENp5bVi9fPTDYc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "08f22084e6085d19bcfb4be30d1ca76ecb96fe54",
+        "rev": "4206c4cb56751df534751b058295ea61357bbbaa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`a1bf4101`](https://github.com/NixOS/nixpkgs/commit/a1bf410187c62cbf70fbb0ebded9d3f6400cdb54) | `` netns-proxy: init at 0.2.1 ``                                                       |
| [`d00d3190`](https://github.com/NixOS/nixpkgs/commit/d00d3190d6ae913d32bbb2d8133da5558a5cbe07) | `` workflows/labels: fix on older PRs ``                                               |
| [`155ea15a`](https://github.com/NixOS/nixpkgs/commit/155ea15a381bd7720ad6ac13ab683fdd61f804ae) | `` workflows/pr: run in pull_request context on changed labels.yml ``                  |
| [`8e1f8692`](https://github.com/NixOS/nixpkgs/commit/8e1f8692618c82a3b5c42d46b41c75b066810e66) | `` workflows/labels: lower API calls reservoir to 500 ``                               |
| [`9581b0c5`](https://github.com/NixOS/nixpkgs/commit/9581b0c55bfab9a42fd12dc1cadfb4cdb5289308) | `` workflows/labels: fix race condition with throttling ``                             |
| [`19ce5d94`](https://github.com/NixOS/nixpkgs/commit/19ce5d94bc2b2b4f7230595a425c612ad98c992f) | `` ci/eval/compare: fix rebuild-stdenv labels ``                                       |
| [`a3c6aeef`](https://github.com/NixOS/nixpkgs/commit/a3c6aeeffeb3604008865e420fd1f02fa0f5d410) | `` ecapture: 1.1.0 -> 1.2.0 ``                                                         |
| [`151b48c1`](https://github.com/NixOS/nixpkgs/commit/151b48c1599368c3ef93d001437c4b180a4c2780) | `` jetbrains-toolbox: remove AnatolyPopov from maintainers ``                          |
| [`21dc8976`](https://github.com/NixOS/nixpkgs/commit/21dc8976a0e49f5fd454c60a9b4c7c3d826857cc) | `` yabridge: fix build error after meson update ``                                     |
| [`a0866156`](https://github.com/NixOS/nixpkgs/commit/a086615681056257053dff52e90be302ff0487b9) | `` chirp: 0.4.0-unstable-2025-06-03 -> 0.4.0-unstable-2025-06-19 ``                    |
| [`da9d9f91`](https://github.com/NixOS/nixpkgs/commit/da9d9f91eb3bb1f8363f8609d1f1a456d4faf735) | `` warp-terminal: 0.2025.06.04.08.11.stable_03 -> 0.2025.06.18.08.11.stable_03 ``      |
| [`a6955ddd`](https://github.com/NixOS/nixpkgs/commit/a6955ddd05a7a5d0100f5e909216b382f1bf5e45) | `` affine: 0.22.3 -> 0.22.4 ``                                                         |
| [`ee9ecc47`](https://github.com/NixOS/nixpkgs/commit/ee9ecc47d8240bd88dd4cd15de36266460e71ce5) | `` presenterm: refactor ``                                                             |
| [`481fe0b9`](https://github.com/NixOS/nixpkgs/commit/481fe0b915f5bf922eeda4613e1711c578bb86c9) | `` presenterm: fix linking to libsixel on darwin ``                                    |
| [`f5d07900`](https://github.com/NixOS/nixpkgs/commit/f5d07900bf66cfea46fc28c947e38d731fedf25f) | `` lib.systems.examples: Split glibc powerpc64 back into 2 ABI options ``              |
| [`d818fc47`](https://github.com/NixOS/nixpkgs/commit/d818fc4788bd8ef1514642846a4547b3fb7258f8) | `` cosmic-protocols: 0-unstable-2025-05-02 -> 0-unstable-2025-06-19 ``                 |
| [`db5fd48b`](https://github.com/NixOS/nixpkgs/commit/db5fd48bc86a1816127358996153902f4902fd45) | `` josm: 19396 → 19412 ``                                                              |
| [`ed7639a5`](https://github.com/NixOS/nixpkgs/commit/ed7639a5db5d4a13d3660f94b1ca3bb5c4808310) | `` mailmanPackages: add recurseIntoAttrs ``                                            |
| [`a0f99b45`](https://github.com/NixOS/nixpkgs/commit/a0f99b458fa6dd88d168a57f31c7f75f39f96565) | `` mailmanPackages.hyperkitty: fix build with python 3.13 ``                           |
| [`984615b1`](https://github.com/NixOS/nixpkgs/commit/984615b18a1242af83b44596650635aba33d8251) | `` buildLinux: configEnv: Fix for cross ``                                             |
| [`e0b8b299`](https://github.com/NixOS/nixpkgs/commit/e0b8b299cfd713318fbfcf97b554b0fb5f8041d5) | `` thunderbird-esr: bring back patches dropped by accident ``                          |
| [`02e74dfd`](https://github.com/NixOS/nixpkgs/commit/02e74dfd6dade15eba110f0969b3f7c1896b7ca3) | `` rust-parallel: remove linux platform restriction ``                                 |
| [`f059374b`](https://github.com/NixOS/nixpkgs/commit/f059374bfcb07401c5f6f044c109f0dbebcdb8fc) | `` python3Packages.pyhomee: 1.2.9 -> 1.2.10 ``                                         |
| [`ae1f308d`](https://github.com/NixOS/nixpkgs/commit/ae1f308d4a60a96466e5fb660f90e4ecd34c69a2) | `` qlementine-icons: 1.8.1 -> 1.9.0 ``                                                 |
| [`5b502206`](https://github.com/NixOS/nixpkgs/commit/5b502206cedba317711e08f5aa621f7d107cdd60) | `` gauge-unwrapped: 1.6.17 -> 1.6.18 ``                                                |
| [`a0d86ee2`](https://github.com/NixOS/nixpkgs/commit/a0d86ee26f57d6555a3990800c82fba3e13b5b60) | `` fend: use finalAttrs ``                                                             |
| [`7edecd35`](https://github.com/NixOS/nixpkgs/commit/7edecd356925703b5af018c79a36726b1e4d555b) | `` bruno: 2.5.0 -> 2.6.1 ``                                                            |
| [`4cf7932d`](https://github.com/NixOS/nixpkgs/commit/4cf7932d5b557b27427849aaf9f361ad1b1460d2) | `` wpsoffice: Fix libxml2 abi breakage ``                                              |
| [`7b359558`](https://github.com/NixOS/nixpkgs/commit/7b3595581e232ae2e73db949bae48b0e320aacc5) | `` python3Packages.pytorch-pfn-extras: 0.8.2 -> 0.8.3 ``                               |
| [`a078f6c5`](https://github.com/NixOS/nixpkgs/commit/a078f6c5ffeb92b32264b069e947b35ca87c3dc6) | `` mslicer: 0.2.1 -> 0.2.2 ``                                                          |
| [`a6b95108`](https://github.com/NixOS/nixpkgs/commit/a6b9510866951fd872f35ba58892a415a50dee7e) | `` python3Packages.tpm2-pytss: fix build failure ``                                    |
| [`374f0333`](https://github.com/NixOS/nixpkgs/commit/374f03332bff676596cb6fde57413a1c7d08feea) | `` handbrake: fix build ``                                                             |
| [`77055540`](https://github.com/NixOS/nixpkgs/commit/77055540aeac490a3fc04e6084852045256c1a19) | `` go-musicfox: 4.6.0 -> 4.6.2 ``                                                      |
| [`25a9dddf`](https://github.com/NixOS/nixpkgs/commit/25a9dddf5f19cf7c50efe8fd28b8ab5ef591ec5c) | `` python3Packages.pyhomee: 1.2.8 -> 1.2.9 ``                                          |
| [`50b354db`](https://github.com/NixOS/nixpkgs/commit/50b354db88ed70cf031b6986a516fd5564559ea1) | `` zed-editor: 0.191.6 -> 0.191.7 ``                                                   |
| [`1303e4bc`](https://github.com/NixOS/nixpkgs/commit/1303e4bc92d178a850d0ee6b57ce4933bbcc82f6) | `` python3Packages.qutip: use standard cython ``                                       |
| [`e590755e`](https://github.com/NixOS/nixpkgs/commit/e590755e64c433209ec9cede9a76df280da55aa6) | `` python3Packages.pytorch-lightning: 2.5.1.post0 -> 2.5.2 ``                          |
| [`f1e3866e`](https://github.com/NixOS/nixpkgs/commit/f1e3866e2b4d37071503ae7b4868df7a9f245bb4) | `` tea: 0.10.0 -> 0.10.1 ``                                                            |
| [`c5db3034`](https://github.com/NixOS/nixpkgs/commit/c5db303485f55347e9a3ae4d7f8b3d89d49d974f) | `` ungoogled-chromium: 137.0.7151.103-1 -> 137.0.7151.119-1 ``                         |
| [`c88fdab9`](https://github.com/NixOS/nixpkgs/commit/c88fdab98673307910dd306d5f07c322dbe2cfbb) | `` trezor-suite: 25.5.2 -> 25.6.2 ``                                                   |
| [`aa6bb509`](https://github.com/NixOS/nixpkgs/commit/aa6bb50924784e3c508a98bf39ab380b6149daca) | `` vscode-extensions.hashicorp.terraform: 2.34.4 -> 2.34.5 ``                          |
| [`b3ed4126`](https://github.com/NixOS/nixpkgs/commit/b3ed412650f6365603d8dbf871754f6ac9b92a21) | `` dvdauthor: fix build ``                                                             |
| [`f65e98ef`](https://github.com/NixOS/nixpkgs/commit/f65e98efc0028c7a9e647e03bd7906366b4de6ab) | `` immich: 1.135.0 -> 1.135.3 ``                                                       |
| [`b1aea57b`](https://github.com/NixOS/nixpkgs/commit/b1aea57b15e3ddebd9f1cd9aa6fa576058554515) | `` csdp: fix pkgsStatic build ``                                                       |
| [`1e353550`](https://github.com/NixOS/nixpkgs/commit/1e3535506d35d3de250780aeb2e473522c7b0c26) | `` python3Packages.marko: 2.1.3 -> 2.1.4 ``                                            |
| [`3d96edd9`](https://github.com/NixOS/nixpkgs/commit/3d96edd9e890cae5a976581f929161ca41c15f94) | `` filesender: 2.54 -> 2.56 ``                                                         |
| [`9f5971b6`](https://github.com/NixOS/nixpkgs/commit/9f5971b6e696c715d1aa34cec6b338f9abae550f) | `` karmor: 1.4.2 -> 1.4.3 ``                                                           |
| [`fbdd930c`](https://github.com/NixOS/nixpkgs/commit/fbdd930cef5a43ab95372828864e378bc82621f5) | `` mark: 14.0.4 -> 14.1.0 ``                                                           |
| [`51e4bf74`](https://github.com/NixOS/nixpkgs/commit/51e4bf74fe96afc697081c7346de38cd216a15c3) | `` python313Packages.flask-security: remove pony ``                                    |
| [`878b4cbb`](https://github.com/NixOS/nixpkgs/commit/878b4cbbd067cc522110515741990518f09ff2df) | `` spacectl: 1.14.2 -> 1.14.3 ``                                                       |
| [`92e2572f`](https://github.com/NixOS/nixpkgs/commit/92e2572f9be7adf8af48a98e8544058fef182ae6) | `` ocamlPackages.scfg: init at 0.5 ``                                                  |
| [`f8ea9ce8`](https://github.com/NixOS/nixpkgs/commit/f8ea9ce81c256935c3b7047b5d06b45f4dd6a5e0) | `` mdns-scanner: init at 0.12.1 ``                                                     |
| [`e45a97c0`](https://github.com/NixOS/nixpkgs/commit/e45a97c0c5d7ee07d12fc873073c7659911c30e1) | `` btcpayserver: 2.1.4 -> 2.1.5 ``                                                     |
| [`effa0caf`](https://github.com/NixOS/nixpkgs/commit/effa0caffa20d3ed8a41cc99a7ec4578b0530680) | `` hut: 0.6.0 -> 0.7.0 ``                                                              |
| [`226e613f`](https://github.com/NixOS/nixpkgs/commit/226e613fe09da35d0e7898af48c03ee540aedaaf) | `` orchard: 0.33.3 -> 0.34.0 ``                                                        |
| [`22ef1186`](https://github.com/NixOS/nixpkgs/commit/22ef1186a9bccfc11423d982fc734f5f444c6f5a) | `` python3Packages.gbinder-python: 1.1.1 -> 1.1.2 ``                                   |
| [`abf1d0e1`](https://github.com/NixOS/nixpkgs/commit/abf1d0e1f77df6481cd06812c32571351f728c00) | `` lutgen: 0.12.0 -> 0.12.1 ``                                                         |
| [`7afd6383`](https://github.com/NixOS/nixpkgs/commit/7afd638334b1a8dd9e16d9404abf63e30fe32a8b) | `` tio: fix Bash completion ``                                                         |
| [`62ccedfe`](https://github.com/NixOS/nixpkgs/commit/62ccedfe0c6a7093fa9f21ab76e8a1a84245ec86) | `` lunasvg: 3.2.1 -> 3.3.0 ``                                                          |
| [`b06f5569`](https://github.com/NixOS/nixpkgs/commit/b06f55695f3c4032685dc5fb5246bdf7188dec55) | `` astal.tray: unbreak ``                                                              |
| [`9ac1c988`](https://github.com/NixOS/nixpkgs/commit/9ac1c98810b333d19b3fa7883244ac153a2ef2ae) | `` appmenu-glib-translator: init at 25.04 ``                                           |
| [`ca370837`](https://github.com/NixOS/nixpkgs/commit/ca370837a91fd9857ee95c83e0fb7b104859cea9) | `` firefox-beta-unwrapped: 140.0b7 -> 140.0b9 ``                                       |
| [`f819e270`](https://github.com/NixOS/nixpkgs/commit/f819e2709af0bf7a6492850f1bc5e94c28ce2c92) | `` zgrviewer: 0.9.0 -> 0.10.0 ``                                                       |
| [`189af990`](https://github.com/NixOS/nixpkgs/commit/189af990394df40c4260b4648182fc08f8232d95) | `` vscodium: 1.101.03933 -> 1.101.14098 ``                                             |
| [`a30735b4`](https://github.com/NixOS/nixpkgs/commit/a30735b455e65c5d3e7f17a0bf0ec0a95b494182) | `` vimPlugins.avante-nvim: 0.0.24-unstable-2025-06-12 -> 0.0.25-unstable-2025-06-20 `` |
| [`ee52555c`](https://github.com/NixOS/nixpkgs/commit/ee52555ca7c6b63f09a0db298a1806fdc4929382) | `` hardinfo2: 2.2.10 -> 2.2.13 ``                                                      |
| [`2415427a`](https://github.com/NixOS/nixpkgs/commit/2415427a38964755cfae663724be8bece4c2ff35) | `` rsyncy: init at 0.2.0 ``                                                            |
| [`ee9679e3`](https://github.com/NixOS/nixpkgs/commit/ee9679e3cfe6780faccd56de34b0b2732d44d54f) | `` Add meta.mainProgram to crane/go-containerregistry ``                               |
| [`e2406c53`](https://github.com/NixOS/nixpkgs/commit/e2406c53f0ae3b40df3c0255b9b826535a0ccfc0) | `` linux/hardened/patches/6.6: v6.6.92-hardened1 -> v6.6.94-hardened1 ``               |
| [`1129db78`](https://github.com/NixOS/nixpkgs/commit/1129db78d66354e8138e54cba3c6ad5292cff3cc) | `` linux/hardened/patches/6.14: v6.14.8-hardened1 -> v6.14.11-hardened1 ``             |
| [`e65abef2`](https://github.com/NixOS/nixpkgs/commit/e65abef29c98e9e9020f43e6013c18350ce8390f) | `` linux/hardened/patches/6.12: v6.12.30-hardened1 -> v6.12.34-hardened1 ``            |
| [`2d4890b5`](https://github.com/NixOS/nixpkgs/commit/2d4890b53e5a505ea5fea10fa400cfcaf8f1e462) | `` linux/hardened/patches/6.1: v6.1.140-hardened1 -> v6.1.141-hardened1 ``             |
| [`f0d18ebb`](https://github.com/NixOS/nixpkgs/commit/f0d18ebb969c0f7fcc3c972562eccf38426b244b) | `` linux/hardened/patches/5.4: v5.4.293-hardened1 -> v5.4.294-hardened1 ``             |
| [`df5e52b7`](https://github.com/NixOS/nixpkgs/commit/df5e52b738f2ec9d7b35a4703ae219a58d9ac690) | `` linux/hardened/patches/5.15: v5.15.184-hardened1 -> v5.15.185-hardened1 ``          |
| [`89192423`](https://github.com/NixOS/nixpkgs/commit/89192423b4b954fcaf5fe36b2a605cabec57846b) | `` linux/hardened/patches/5.10: v5.10.237-hardened1 -> v5.10.238-hardened1 ``          |
| [`abc8eb2b`](https://github.com/NixOS/nixpkgs/commit/abc8eb2b78869076f8acd4842ad176a502f7aa76) | `` liburing: 2.10 -> 2.11 ``                                                           |
| [`63b6e30d`](https://github.com/NixOS/nixpkgs/commit/63b6e30d3622c28f1180abf7e1d0a93ecf00a34a) | `` signal-desktop: 7.56.1 -> 7.58.0 ``                                                 |
| [`53156aa1`](https://github.com/NixOS/nixpkgs/commit/53156aa1f89bf6e2a4702dda3063654cd87b5382) | `` delsum: init at 1.0.0 ``                                                            |
| [`c0f52c28`](https://github.com/NixOS/nixpkgs/commit/c0f52c28cd3551ca5df9b574ff27e05dc6c40d7a) | `` fedimint: 0.5.1 -> 0.7.1 ``                                                         |
| [`493b7040`](https://github.com/NixOS/nixpkgs/commit/493b704080cf302bce6567ed1ece90884dda0f10) | `` gtklock-powerbar-module: Fix systemctl command paths ``                             |
| [`1f29a455`](https://github.com/NixOS/nixpkgs/commit/1f29a455325a28199be01fa3b0d45b3d8b6b0ebf) | `` rustc-unwrapped: Add mainProgram ``                                                 |
| [`1d1faeb6`](https://github.com/NixOS/nixpkgs/commit/1d1faeb638eed5f6fe6a1f4d20a9d42dafd5dc51) | `` decklink: fix build for kernel 6.15 ``                                              |
| [`d096ae26`](https://github.com/NixOS/nixpkgs/commit/d096ae2640dc577d73d0f519e583c9bf5fd9b91b) | `` gnucash: remove me from maintainers ``                                              |
| [`d1da9cce`](https://github.com/NixOS/nixpkgs/commit/d1da9cce7caa1aa1336a7d41395060f585935901) | `` spire: move to finalAttrs pattern and enable tests ``                               |
| [`88f129f5`](https://github.com/NixOS/nixpkgs/commit/88f129f5d168b0d00cdac112f1d5fe08db501881) | `` rclone: 1.70.0 -> 1.70.1 ``                                                         |
| [`f5177f3d`](https://github.com/NixOS/nixpkgs/commit/f5177f3d1eec2d3608a438fe84a6235ce7be99cc) | `` rocmPackages.llvm.rocmcxx: rm bootstrap compiler references ``                      |
| [`51d4495a`](https://github.com/NixOS/nixpkgs/commit/51d4495ae763e99fede1a09cfc268e9cf1e248fa) | `` xfce.xfburn: 0.7.2 -> 0.8.0 ``                                                      |
| [`22077431`](https://github.com/NixOS/nixpkgs/commit/220774315930ec5b4979ddce90916dc44ddcf60f) | `` slipshow: init at 0.2.0 ``                                                          |
| [`ef9b886b`](https://github.com/NixOS/nixpkgs/commit/ef9b886b02fb3fa8f6dd3b7d4fc586c1dc43e286) | `` python313Packages.flask-sqlalchemy-lite: fix py13 compat ``                         |
| [`c1ee60f7`](https://github.com/NixOS/nixpkgs/commit/c1ee60f76939728866bd7ed66dd8043972990201) | `` python3Packages.fpylll: fix standalone usage ``                                     |