### PR TITLE
chore(flake/srvos): `7c93b611` -> `59e4d887`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -934,11 +934,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750295173,
-        "narHash": "sha256-W2dgraLz7VZZz/x+6LGt+hiHb94+FCjfyGfxN0TR+Qo=",
+        "lastModified": 1750641062,
+        "narHash": "sha256-BlsBuLi1YxJyYQFmSUesBZaMmPnfTzI2WbZhAbc20z8=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "7c93b611d175a62f3ce57fbda976c29261525a15",
+        "rev": "59e4d88787de0a2bdc58854566ab90419de73a06",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`59e4d887`](https://github.com/nix-community/srvos/commit/59e4d88787de0a2bdc58854566ab90419de73a06) | `` dev/private/flake.lock: Update `` |
| [`b46f587f`](https://github.com/nix-community/srvos/commit/b46f587f3c22dd52fd935ce350414d22603ce2dc) | `` flake.lock: Update ``             |