### PR TITLE
chore(flake/nur): `b06ccaa9` -> `bce40772`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -801,11 +801,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1750678093,
-        "narHash": "sha256-57wjfkV6KIKCcy9XLwyQ5xOK8rAWsJ3lMXEpVR+f0WA=",
+        "lastModified": 1750707026,
+        "narHash": "sha256-fMQLm34QaC0EVifB6waX4UTeoY1Ivc9G7XMDG39D7+A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b06ccaa9dee5e69a1198c5ccda6b0eb9cf775027",
+        "rev": "bce40772bd9314ab6d4800e0201771facc0997a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bce40772`](https://github.com/nix-community/NUR/commit/bce40772bd9314ab6d4800e0201771facc0997a0) | `` automatic update `` |
| [`4276de7c`](https://github.com/nix-community/NUR/commit/4276de7c5796b2aed75fcce62706cffca6d00fe0) | `` automatic update `` |
| [`25195133`](https://github.com/nix-community/NUR/commit/25195133bfbae2c67b06d4cd0ee140ae13bfc7c4) | `` automatic update `` |
| [`b24fb341`](https://github.com/nix-community/NUR/commit/b24fb341872105f569c2d1b575c49ef5de46da61) | `` automatic update `` |
| [`4ea97a8b`](https://github.com/nix-community/NUR/commit/4ea97a8babddeb32a1971ce734681210ea53d8f9) | `` automatic update `` |
| [`b8dcdcf7`](https://github.com/nix-community/NUR/commit/b8dcdcf7c54ec3be8a51be57907182dd3d05409a) | `` automatic update `` |
| [`c5faf8a9`](https://github.com/nix-community/NUR/commit/c5faf8a9899f991483233eebba852128b06e7004) | `` automatic update `` |