### PR TITLE
chore(flake/nur): `bce40772` -> `fb6ff10c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -801,11 +801,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1750707026,
-        "narHash": "sha256-fMQLm34QaC0EVifB6waX4UTeoY1Ivc9G7XMDG39D7+A=",
+        "lastModified": 1750715228,
+        "narHash": "sha256-ZOnRzaZQ52F7INIBcG35K3+IudC5THOs+7kN3m1hdMU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bce40772bd9314ab6d4800e0201771facc0997a0",
+        "rev": "fb6ff10c64608340413d9140d3efeba642a57316",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fb6ff10c`](https://github.com/nix-community/NUR/commit/fb6ff10c64608340413d9140d3efeba642a57316) | `` automatic update `` |
| [`d7c3820e`](https://github.com/nix-community/NUR/commit/d7c3820e3bcc86b564a42df51bcbeb003ad90588) | `` automatic update `` |