### PR TITLE
chore(flake/git-hooks): `fae816c5` -> `16ec914f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -294,11 +294,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750684550,
-        "narHash": "sha256-uLtw0iF9mQ94L831NOlQLPX9wm0qzd5yim3rcwACEoM=",
+        "lastModified": 1750779888,
+        "narHash": "sha256-wibppH3g/E2lxU43ZQHC5yA/7kIKLGxVEnsnVK1BtRg=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "fae816c55a75675f30d18c9cbdecc13b970d95d4",
+        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                  |
| ----------------------------------------------------------------------------------------------------- | ------------------------ |
| [`b8c7eb0c`](https://github.com/cachix/git-hooks.nix/commit/b8c7eb0c7e0817c78804947921b419ca50a509f0) | `` feat: add uv hooks `` |