### PR TITLE
chore(flake/emacs-overlay): `b13d5507` -> `0cce9a01`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1750753596,
-        "narHash": "sha256-/XQ4k8fUYrYe+utV0aCSHT9wB0wyw/E2IzwHxYySvGc=",
+        "lastModified": 1750785611,
+        "narHash": "sha256-fi8N4PAlBA6A1yoXywCQsagGfCMNPHt9QL05p644jjU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b13d55077455690a9b4e25e4077012f3ac724e2c",
+        "rev": "0cce9a0141bd5d937262adb4861355d07015e715",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`0cce9a01`](https://github.com/nix-community/emacs-overlay/commit/0cce9a0141bd5d937262adb4861355d07015e715) | `` Updated emacs ``  |
| [`9f22df7d`](https://github.com/nix-community/emacs-overlay/commit/9f22df7dec870cfb961d2fa58390a4f327717427) | `` Updated melpa ``  |
| [`b1b98814`](https://github.com/nix-community/emacs-overlay/commit/b1b988141b9541453a15a90b52a0ab0896a732cd) | `` Updated elpa ``   |
| [`03f5f12e`](https://github.com/nix-community/emacs-overlay/commit/03f5f12e07ec5e71d110a97ff19c647eff21e930) | `` Updated nongnu `` |