### PR TITLE
chore(flake/nur): `9f6c15cf` -> `cb30f25b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -801,11 +801,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1750838189,
-        "narHash": "sha256-zDA6vwUfkzTgJ+gWKANayOsLuXzHZwUNjY7p+33J02M=",
+        "lastModified": 1750841861,
+        "narHash": "sha256-QFt5uE/piGHO0abX3wZLydYe9cq/jBZOoezWFJGeSYA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9f6c15cf757a2e68e84d799d1b8926d13d5c370f",
+        "rev": "cb30f25b4a8b864e1b5db2b07f508d96573ad67a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cb30f25b`](https://github.com/nix-community/NUR/commit/cb30f25b4a8b864e1b5db2b07f508d96573ad67a) | `` automatic update `` |