### PR TITLE
chore(flake/nur): `c88b5101` -> `9de96ce8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1750850088,
-        "narHash": "sha256-xTt5WrELoqVjWsMIGgaiMGGOLuPqiXm3yU/S3jdZnx8=",
+        "lastModified": 1750859945,
+        "narHash": "sha256-gdBJcDACiN4mJhLNe7IgBlisxzayK3rHFXU0T4rsn74=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c88b51016199220f76068c7a1bb0e199cbdb18e5",
+        "rev": "9de96ce8882bfd20dd6aa3a183bcb7bba1ca281c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9de96ce8`](https://github.com/nix-community/NUR/commit/9de96ce8882bfd20dd6aa3a183bcb7bba1ca281c) | `` automatic update `` |
| [`a4060e6a`](https://github.com/nix-community/NUR/commit/a4060e6a07847fa3326e61a5c484a4df4336986f) | `` automatic update `` |
| [`26613f14`](https://github.com/nix-community/NUR/commit/26613f144ec6172a1ca711f47e08b89278031899) | `` automatic update `` |