### PR TITLE
chore(flake/nur): `9de96ce8` -> `00ca4731`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1750859945,
-        "narHash": "sha256-gdBJcDACiN4mJhLNe7IgBlisxzayK3rHFXU0T4rsn74=",
+        "lastModified": 1750880745,
+        "narHash": "sha256-ryJ/tjeahYqoW+aGiQdRaeF1PLXUAn0C2aMfZsp5lu4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9de96ce8882bfd20dd6aa3a183bcb7bba1ca281c",
+        "rev": "00ca473157cf7b9cf9b19e8e0bd0c509b5ec391a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`00ca4731`](https://github.com/nix-community/NUR/commit/00ca473157cf7b9cf9b19e8e0bd0c509b5ec391a) | `` automatic update `` |
| [`82688d18`](https://github.com/nix-community/NUR/commit/82688d18898c7f521cdaa8c4b6d182f34a2a1acd) | `` automatic update `` |
| [`ddfa37e1`](https://github.com/nix-community/NUR/commit/ddfa37e12f5e6a587273ce4202430bb75fe2d699) | `` automatic update `` |