### PR TITLE
chore(flake/srvos): `59e4d887` -> `3af451e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -933,11 +933,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750641062,
-        "narHash": "sha256-BlsBuLi1YxJyYQFmSUesBZaMmPnfTzI2WbZhAbc20z8=",
+        "lastModified": 1750907330,
+        "narHash": "sha256-rXA4RdUfZxBmy3RZ8TiP9ITuGwLGBWlyP16dN6ILS6M=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "59e4d88787de0a2bdc58854566ab90419de73a06",
+        "rev": "3af451e7eb42df68fc06b689da4f4ca7198eed5e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                     |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`3af451e7`](https://github.com/nix-community/srvos/commit/3af451e7eb42df68fc06b689da4f4ca7198eed5e) | `` update-diff: add defaultText for update-diff for docs `` |
| [`9c435eb7`](https://github.com/nix-community/srvos/commit/9c435eb70e0843c58f3d7b2ca7c63b5a2fd4a7cd) | `` update-diff: option to use custom command ``             |
| [`391e6416`](https://github.com/nix-community/srvos/commit/391e64165f6f739ff0264338edff1de7ac87f678) | `` dev/private/flake.lock: Update ``                        |
| [`7982afea`](https://github.com/nix-community/srvos/commit/7982afea681a4566bb973db0e054c9d878d5a76e) | `` flake.lock: Update ``                                    |
| [`86a3af1c`](https://github.com/nix-community/srvos/commit/86a3af1cc9d0069be12ab9cccab82d486db10449) | `` add description for update-diff.text ``                  |