### PR TITLE
chore(flake/emacs-overlay): `37908db8` -> `fa76f53c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1750868813,
-        "narHash": "sha256-POfb3Sj4nfXtKwOcVwj76WbM5SbCuiC1wrsbuhaB0mY=",
+        "lastModified": 1751101700,
+        "narHash": "sha256-2/oxAYeKzs7gl1WD5ST/wNvAKNOCM41vJL3eww7miH4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "37908db8f6ce22f6db7728c4622d4d02f9ff6d70",
+        "rev": "fa76f53c1911cd3b56b1c6378226ec49fb3c2c98",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                    |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
| [`fa76f53c`](https://github.com/nix-community/emacs-overlay/commit/fa76f53c1911cd3b56b1c6378226ec49fb3c2c98) | `` Updated melpa ``                                        |
| [`bd5c3dea`](https://github.com/nix-community/emacs-overlay/commit/bd5c3deae9355c30d83e38f961458f81ce07d662) | `` Updated emacs ``                                        |
| [`9a8ce121`](https://github.com/nix-community/emacs-overlay/commit/9a8ce1212760d342c23fc8b65a71a2ad9bec1408) | `` Updated emacs ``                                        |
| [`955b80fe`](https://github.com/nix-community/emacs-overlay/commit/955b80fea64d024c62f938489902e549487e0e85) | `` Updated melpa ``                                        |
| [`88c7d876`](https://github.com/nix-community/emacs-overlay/commit/88c7d87694fb4bb3a9a8b64eb24843d7e0782b0f) | `` Remove emacs-pgtk to not shadow the one from Nixpkgs `` |
| [`7ea3160e`](https://github.com/nix-community/emacs-overlay/commit/7ea3160e4774fc4bb84cb5ea608e7aad0d9ec4a2) | `` Updated elpa ``                                         |
| [`aee6e989`](https://github.com/nix-community/emacs-overlay/commit/aee6e989a85d1ec0cb1f53f5339ee9b1077a6800) | `` Updated nongnu ``                                       |
| [`50a1de22`](https://github.com/nix-community/emacs-overlay/commit/50a1de22af011ea05433453f29c445050c4a747c) | `` Updated elpa ``                                         |
| [`2465573c`](https://github.com/nix-community/emacs-overlay/commit/2465573cdc6cef14a3b896195e1b8b5dbc66c3fd) | `` Updated nongnu ``                                       |
| [`236475c6`](https://github.com/nix-community/emacs-overlay/commit/236475c6fae1cfbf80629e019de4b79de63720ab) | `` Updated emacs ``                                        |
| [`2752b421`](https://github.com/nix-community/emacs-overlay/commit/2752b421efa08d3d7874a1fae482d5f1eb69fb34) | `` Updated melpa ``                                        |
| [`3c987c33`](https://github.com/nix-community/emacs-overlay/commit/3c987c332e45cd23b2873f9c875b00bc17e29543) | `` Updated emacs ``                                        |
| [`1e96986c`](https://github.com/nix-community/emacs-overlay/commit/1e96986c8544f5b5762ee6f369b524bb009d6e1c) | `` Updated melpa ``                                        |
| [`22ca58d6`](https://github.com/nix-community/emacs-overlay/commit/22ca58d68a10eee1f3458b704f568b853e35d467) | `` Updated nongnu ``                                       |
| [`4c310087`](https://github.com/nix-community/emacs-overlay/commit/4c310087af2403d31fc5ca355e890345c5a52503) | `` Updated emacs ``                                        |
| [`4cd3eba2`](https://github.com/nix-community/emacs-overlay/commit/4cd3eba24e3902fa4f894ae6a8fc77fd9d3b4c3b) | `` Updated melpa ``                                        |
| [`08ff3efa`](https://github.com/nix-community/emacs-overlay/commit/08ff3efae64b5e8b0e7748b655d811731cf72ea6) | `` Updated elpa ``                                         |
| [`f8043b3e`](https://github.com/nix-community/emacs-overlay/commit/f8043b3eb9e4d8271abef203256d1bc616174156) | `` Updated nongnu ``                                       |
| [`b4529390`](https://github.com/nix-community/emacs-overlay/commit/b4529390e2e53bae6bfa7a6884dcfa5583b5b858) | `` Updated emacs ``                                        |
| [`57fd36a6`](https://github.com/nix-community/emacs-overlay/commit/57fd36a674304874fd4f7d28e884721c6c9f7aef) | `` Updated melpa ``                                        |
| [`eace9de0`](https://github.com/nix-community/emacs-overlay/commit/eace9de06ccfd81c6760dadabdb9bc24cdf804b5) | `` Updated flake inputs ``                                 |
| [`a9a46545`](https://github.com/nix-community/emacs-overlay/commit/a9a46545034857dee5095930fdb0f76caf12de5a) | `` Updated emacs ``                                        |
| [`b4398511`](https://github.com/nix-community/emacs-overlay/commit/b43985117a2fbd866269fcd4cb65f88ce48d20c3) | `` Updated melpa ``                                        |
| [`4af4ec1c`](https://github.com/nix-community/emacs-overlay/commit/4af4ec1cdc2b264f3181ff9009a4410d57b8abae) | `` Updated elpa ``                                         |
| [`bf248307`](https://github.com/nix-community/emacs-overlay/commit/bf248307196f84d6d9933c9a986d702e8d15ad1c) | `` Updated nongnu ``                                       |