### PR TITLE
chore(flake/nixpkgs): `4b1164c3` -> `30a61f05`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -725,11 +725,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1750741721,
-        "narHash": "sha256-Z0djmTa1YmnGMfE9jEe05oO4zggjDmxOGKwt844bUhE=",
+        "lastModified": 1750776420,
+        "narHash": "sha256-/CG+w0o0oJ5itVklOoLbdn2dGB0wbZVOoDm4np6w09A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4b1164c3215f018c4442463a27689d973cffd750",
+        "rev": "30a61f056ac492e3b7cdcb69c1e6abdcf00e39cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                      |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`cafe161f`](https://github.com/NixOS/nixpkgs/commit/cafe161f051c38854b93079d71603781ae14e03a) | `` lixPackageSets.git: patch for CVE-2025-4641{5,6} ``                                       |
| [`dc090e80`](https://github.com/NixOS/nixpkgs/commit/dc090e801c261f2bb6f7593062fc6215db73c2bd) | `` lixPackageSets.lix_2_92: patch for CVE-2025-4641{5,6} ``                                  |
| [`69bd6a53`](https://github.com/NixOS/nixpkgs/commit/69bd6a53159da314523febbaa597810952131c34) | `` lixPackageSets.lix_2_93: patch for CVE-2025-4641{5,6} ``                                  |
| [`be402607`](https://github.com/NixOS/nixpkgs/commit/be4026079c96792b6cc0723bd3b40c72b8202060) | `` lixPackageSets.lix_2_91: patch for CVE-2025-4641{5,6} ``                                  |
| [`c2da8de4`](https://github.com/NixOS/nixpkgs/commit/c2da8de4d1d618e830b0a18e09626e2fbdf6560b) | `` lixPackageSets.lix_2_90: mark as vulnerable ``                                            |
| [`923146e9`](https://github.com/NixOS/nixpkgs/commit/923146e9275bd0a4331669c1c9f800fe59253b23) | `` nixComponents_2_29: add patch for GHSA-g948-229j-48j3 ``                                  |
| [`a1eacc0a`](https://github.com/NixOS/nixpkgs/commit/a1eacc0a2ce4a4de3c7fd523ddb26c2d95a01fd1) | `` nix_2_28: add patch for GHSA-g948-229j-48j3 ``                                            |
| [`639ad310`](https://github.com/NixOS/nixpkgs/commit/639ad310605baa85093cdb0692759aedaaa02780) | `` nix_2_26: add patch for GHSA-g948-229j-48j3 ``                                            |
| [`3d27c5f2`](https://github.com/NixOS/nixpkgs/commit/3d27c5f2485588fd7f61eb2e0ead168d2b94addc) | `` nix_2_24: add patch for GHSA-g948-229j-48j3 ``                                            |
| [`c366efa6`](https://github.com/NixOS/nixpkgs/commit/c366efa6e2816c2cb48b3018fe00ceb8ca6cbc81) | `` Revert "workflows/labels: manage stale & merge conflict labels" ``                        |
| [`dd3ce1ee`](https://github.com/NixOS/nixpkgs/commit/dd3ce1ee90f7eccd802be74a49c13b03e8fdcaa8) | `` weblate: 5.12.1 -> 5.12.2 ``                                                              |
| [`e1d83e3c`](https://github.com/NixOS/nixpkgs/commit/e1d83e3cee69a59ed9b9df80d1441bb607b24f91) | `` waydroid: adopt ``                                                                        |
| [`ee0937ff`](https://github.com/NixOS/nixpkgs/commit/ee0937ff0db78d87f57165c89038c0f1dfd22fa4) | `` nixos/waydroid: allow override waydroid ``                                                |
| [`36e9fe9e`](https://github.com/NixOS/nixpkgs/commit/36e9fe9e7d8537438cf5d8f3cf197921f171d154) | `` workflows/labels: manage merge-conflict label for pull requests ``                        |
| [`58dd9630`](https://github.com/NixOS/nixpkgs/commit/58dd9630c38123707c6acd97fb65f33f36c70af1) | `` workflows/labels: manage stale label for pull requests ``                                 |
| [`63b9355e`](https://github.com/NixOS/nixpkgs/commit/63b9355ed892b715a881f95e71fc3c22c67bb641) | `` workflows/labels: handle missing eval results gracefully ``                               |
| [`e55128a0`](https://github.com/NixOS/nixpkgs/commit/e55128a079e998204d0e0721cc750ee354d0ea8e) | `` workflows/labels: run on every PR eventually ``                                           |
| [`d9d97fda`](https://github.com/NixOS/nixpkgs/commit/d9d97fda59d81255aa606f1fccf04dc9f2b6240c) | `` workflows/labels: refactor to search instead of listing PRs ``                            |
| [`9438cfd2`](https://github.com/NixOS/nixpkgs/commit/9438cfd2d67afd836b6c43e29fc4f63dcf05eb06) | `` olivetin: 2025.6.6 -> 2025.6.22 ``                                                        |
| [`248f4b8d`](https://github.com/NixOS/nixpkgs/commit/248f4b8deb76ab68a8351868465ac31fc2898d6b) | `` bruijn: init at 0-unstable-2025-06-23 ``                                                  |
| [`8b510155`](https://github.com/NixOS/nixpkgs/commit/8b5101554abc12b9fdf6be4095f11b1d0b1e2892) | `` workflows/labels: save an API request when running in pull_request context ``             |
| [`f394b274`](https://github.com/NixOS/nixpkgs/commit/f394b2741ed5fe11e79fc926a7547ec174e219e2) | `` workflows/labels: refactor moving cutoff downwards ``                                     |
| [`042a2fd6`](https://github.com/NixOS/nixpkgs/commit/042a2fd6d6834366b142c74e518fd2674de69725) | `` workflows/labels: refactor into handle() function ``                                      |
| [`a5539704`](https://github.com/NixOS/nixpkgs/commit/a5539704d765b6ff487839cbc10728d139074a20) | `` luaPackages.lrexlib-oniguruma: init at 2.9.2-1 ``                                         |
| [`902aeaeb`](https://github.com/NixOS/nixpkgs/commit/902aeaeb8529c5475b21db5a98972d07456c1270) | `` kdePackages.drkonqi: provide eu-unstrip ``                                                |
| [`ac9539cd`](https://github.com/NixOS/nixpkgs/commit/ac9539cd82b477082f13dcc79943774f7b07ad2c) | `` kdePackages: Plasma 6.4.0 -> 6.4.1 ``                                                     |
| [`8bb91f9a`](https://github.com/NixOS/nixpkgs/commit/8bb91f9a07d688880253d1c1f446a5e4af7471d6) | `` vscode-extensions.amazonwebservices.amazon-q-vscode: 1.75.0 -> 1.78.0 ``                  |
| [`b48485fd`](https://github.com/NixOS/nixpkgs/commit/b48485fd372114c510e2b50a223d803df595a56d) | `` home-assistant.python.pkgs.pytest-homeassistant-custom-component: 0.13.251 -> 0.13.253 `` |
| [`068d936b`](https://github.com/NixOS/nixpkgs/commit/068d936b01123930afef3f388cececf739a4ae31) | `` python3Packages.homeassistant-stubs: 2025.6.1 -> 2025.6.2 ``                              |
| [`c51f10d7`](https://github.com/NixOS/nixpkgs/commit/c51f10d7cf647ebba79740c889788a5fbd85f513) | `` vscode-extensions.ms-windows-ai-studio.windows-ai-studio: 0.14.3 -> 0.14.4 ``             |
| [`5b0ed1ea`](https://github.com/NixOS/nixpkgs/commit/5b0ed1eac9ccb1e21ad3a4c9fd5beb8fdc68e76e) | `` nixos/gitea/mailer: update example configuration ``                                       |
| [`f5c5dc5f`](https://github.com/NixOS/nixpkgs/commit/f5c5dc5f5beea769427924e839ae7b18eb507404) | `` nixos/gitea/mailer: fix using sendmail ``                                                 |
| [`80cec4fc`](https://github.com/NixOS/nixpkgs/commit/80cec4fc92ef19d522a17b7ad500d65573aaf299) | `` python3Packages.sagemaker-core: 1.0.37 -> 1.0.40 ``                                       |
| [`f9bd91aa`](https://github.com/NixOS/nixpkgs/commit/f9bd91aa07c30359540aeec8613a29f0b742f540) | `` nixos/bcachefs: include poly1305 and chacha20 kernel modules for kernel < 6.15 ``         |
| [`33ce0ba4`](https://github.com/NixOS/nixpkgs/commit/33ce0ba4f9b590748289ad6b172b375f3736f389) | `` kdePackages.kdepim-runtime: backport patch recommended by upstream ``                     |
| [`2aa9f0db`](https://github.com/NixOS/nixpkgs/commit/2aa9f0db329a5de14556d9c357f3ae9c7513c90b) | `` kdePackages.kirigami: backport patch recommended by upstream ``                           |
| [`0531394d`](https://github.com/NixOS/nixpkgs/commit/0531394d882e9f142fe334b9e741a953a38c95cb) | `` mdbook-d2: 0.3.4 -> 0.3.5 ``                                                              |
| [`00f33e63`](https://github.com/NixOS/nixpkgs/commit/00f33e6316283f98ae54b6890aeacd00a3511190) | `` python313Packages.lib4package: fix description typo ``                                    |
| [`4fe7209f`](https://github.com/NixOS/nixpkgs/commit/4fe7209f36a2e9d9cb987b9cc6544e1d46cdc41e) | `` lstr: 0.2.0 -> 0.2.1 ``                                                                   |
| [`4b083a7d`](https://github.com/NixOS/nixpkgs/commit/4b083a7db8bd55fad5acb8a794f3944e5f27472f) | `` linuxKernel.kernels.linux_lqx: 6.15.2 -> 6.15.3 ``                                        |
| [`37a725b5`](https://github.com/NixOS/nixpkgs/commit/37a725b5ef2ec49e3fb8dc89b409fe2327abeb26) | `` python3Packages.lib4package: 0.3.2 -> 0.3.3 ``                                            |
| [`9c2c54e3`](https://github.com/NixOS/nixpkgs/commit/9c2c54e34bc0bc163f869ac1e51d1bdff8125d09) | `` symfony-cli: 5.11.0 -> 5.12.0 ``                                                          |
| [`24e7e47c`](https://github.com/NixOS/nixpkgs/commit/24e7e47c91afc7e1c264c14c723a7f57e5241dee) | `` workflows/labels: dynamically adjust reservoir to remaining rate limit ``                 |
| [`8976f8ad`](https://github.com/NixOS/nixpkgs/commit/8976f8ad3ba71ea5eaa3ca0dfd39e5b9e1500484) | `` wiringpi: remove `with lib`, add ryand56 as maintainer ``                                 |
| [`a6e88390`](https://github.com/NixOS/nixpkgs/commit/a6e883907839ef0543d7b870a5d7346584a45889) | `` wiringpi: 3.10 -> 3.16 ``                                                                 |
| [`9079857a`](https://github.com/NixOS/nixpkgs/commit/9079857aba0efeaca48dfddcc72fd4fe2b2803c8) | `` auto-editor: 28.0.1 -> 28.0.2 ``                                                          |
| [`083009d8`](https://github.com/NixOS/nixpkgs/commit/083009d87284ebc4d90672534356fb7d66c9cff5) | `` maintainers/team-list: jetbrains add jamesward ``                                         |
| [`fd751b2c`](https://github.com/NixOS/nixpkgs/commit/fd751b2cae7edc93d8f4bf11916169aae84964aa) | `` vscode: expose vscodeVersion as a passthru attribute ``                                   |
| [`3515e24a`](https://github.com/NixOS/nixpkgs/commit/3515e24a18155120d39a82b8844b3bf67bc7cf9e) | `` roddhjav-apparmor-rules: 0-unstable-2025-06-12 -> 0-unstable-2025-06-21 ``                |
| [`ef105f44`](https://github.com/NixOS/nixpkgs/commit/ef105f441abeced5abb65ceca7f9daed94371485) | `` nelm: 1.6.0 -> 1.7.0 ``                                                                   |
| [`c50af17f`](https://github.com/NixOS/nixpkgs/commit/c50af17f7852ce82d8d3984d659ce34820e1fed8) | `` wezterm: fix app bundle on darwin ``                                                      |
| [`864a6fdd`](https://github.com/NixOS/nixpkgs/commit/864a6fdd7f577e2cab3c44866017b2f5ce84b5d8) | `` uv: 0.7.13 -> 0.7.14 ``                                                                   |
| [`3b5c14a2`](https://github.com/NixOS/nixpkgs/commit/3b5c14a2c70c086effd0da24f7365924f8fbf2a4) | `` gitqlient: move to by-name ``                                                             |
| [`e8783077`](https://github.com/NixOS/nixpkgs/commit/e878307708630955e5f774caea9b24916adc9c06) | `` gitqlient: modernize ``                                                                   |
| [`f4881e44`](https://github.com/NixOS/nixpkgs/commit/f4881e4427bd14a31b41427d122c278c79735f66) | `` osslsigncode: 2.9 -> 2.10 ``                                                              |
| [`0cde186e`](https://github.com/NixOS/nixpkgs/commit/0cde186e047281c5d84a1cf3897be181e9a378c7) | `` guacamole-client: 1.5.5 -> 1.6.0 ``                                                       |
| [`e2908c53`](https://github.com/NixOS/nixpkgs/commit/e2908c536e25c722d2984ef4a3fd08bbb2c71df6) | `` firefox-esr-128-unwrapped: fix build on darwin ``                                         |
| [`bed3f503`](https://github.com/NixOS/nixpkgs/commit/bed3f503627c224c6999284f98efba17791721b8) | `` xtensor-blas: init at 0.22.0 ``                                                           |
| [`42271f3d`](https://github.com/NixOS/nixpkgs/commit/42271f3d95ddd75ac76088dbae63e7f651939fb0) | `` tana: 1.0.32 -> 1.0.36 ``                                                                 |
| [`7891319c`](https://github.com/NixOS/nixpkgs/commit/7891319ca81736c66ebd56d1d95a6941f74c5096) | `` victoriametrics: 1.119.0 -> 1.120.0 ``                                                    |
| [`65a6d709`](https://github.com/NixOS/nixpkgs/commit/65a6d7099057b013a65b6563585ffb1b500281e7) | `` fluxcd-operator-mcp: 0.22.0 -> 0.23.0 ``                                                  |
| [`1b7c6b61`](https://github.com/NixOS/nixpkgs/commit/1b7c6b61801ad5f2ebff2a2676cd0176d3418463) | `` home-assistant: 2025.6.1 -> 2025.6.2 ``                                                   |
| [`ab398693`](https://github.com/NixOS/nixpkgs/commit/ab39869328248d4dae26cee94e7c0c8b9390adf3) | `` python3Packages.zha: 0.0.59 -> 0.0.60 ``                                                  |
| [`624c2247`](https://github.com/NixOS/nixpkgs/commit/624c224795906207ba12de0a9c748ae8375a70f0) | `` python3Packages.zigpy-znp: 0.14.0 -> 0.14.1 ``                                            |
| [`24b54378`](https://github.com/NixOS/nixpkgs/commit/24b5437818010d3fa52902f353815d950bd12b03) | `` python3Packages.zigpy-zigate: 0.13.2 -> 0.13.3 ``                                         |
| [`8798c7d0`](https://github.com/NixOS/nixpkgs/commit/8798c7d006ff932da93782f8dfd2dd1572f7e9d4) | `` python3Packages.homematicip: 2.0.5 -> 2.0.6 ``                                            |
| [`b3ea1252`](https://github.com/NixOS/nixpkgs/commit/b3ea12521f362a9201da2c4b506225ed743ad593) | `` python3Packages.deebot-client: 13.3.0 -> 13.4.0 ``                                        |
| [`9ffbe82e`](https://github.com/NixOS/nixpkgs/commit/9ffbe82e18e641abe85c7e5570f42c71dbf1f1b3) | `` python3Packages.bthome-ble: 3.13.0 -> 3.13.1 (#416937) ``                                 |
| [`9844427d`](https://github.com/NixOS/nixpkgs/commit/9844427d4f9a5601d6a6353ca19547478213a541) | `` python3Packages.aioesphomeapi: 32.2.1 -> 33.1.1 ``                                        |
| [`a081327e`](https://github.com/NixOS/nixpkgs/commit/a081327e235368cfc04c6cf0689dec625cdad68d) | `` python3Packages.aioamazondevices: 3.1.12 -> 3.1.14 ``                                     |
| [`9f7948fb`](https://github.com/NixOS/nixpkgs/commit/9f7948fbecd670768e1372773a301d21916c6bb0) | `` nixosTests.nipap: init nipap test ``                                                      |
| [`a013d925`](https://github.com/NixOS/nixpkgs/commit/a013d9258c510d8660e64aaf1200946864959d6a) | `` nixos/nipap: init ``                                                                      |
| [`1da9c9a3`](https://github.com/NixOS/nixpkgs/commit/1da9c9a39ac6cb9b662be922b2ebd84624c0a144) | `` maintainers: add jherland ``                                                              |
| [`0c84d34f`](https://github.com/NixOS/nixpkgs/commit/0c84d34f95dbd0dd15eb47a93d2464a799f0cfb1) | `` factorPackages.buildFactorVocab: fix find directory typo ``                               |
| [`55fbc4c0`](https://github.com/NixOS/nixpkgs/commit/55fbc4c0e05a476550743c164744bea79cbec43e) | `` firefox-esr-128-unwrapped: 128.11.0esr -> 128.12.0esr ``                                  |
| [`e0ece258`](https://github.com/NixOS/nixpkgs/commit/e0ece2582646de63907926af098e2cfeafb239c6) | `` firefox-bin-unwrapped: 139.0.4 -> 140.0 ``                                                |
| [`e8c80f28`](https://github.com/NixOS/nixpkgs/commit/e8c80f28fa6b7aed905e3d2059287dacaf9295cf) | `` firefox-unwrapped: 139.0.4 -> 140.0 ``                                                    |
| [`a69fe005`](https://github.com/NixOS/nixpkgs/commit/a69fe005dcd475f5418dbd44866e89c561d888a6) | `` nss_latest: 3.112 -> 3.113 ``                                                             |
| [`bca445dd`](https://github.com/NixOS/nixpkgs/commit/bca445dd9f00912abc779cb37f849264e8ef6ac8) | `` zmate: init at 0.3.1 ``                                                                   |
| [`acc1c0ae`](https://github.com/NixOS/nixpkgs/commit/acc1c0ae59106180ec63f11503d0f4bd090436c4) | `` workflows/labels: run with app token ``                                                   |
| [`6ab23cbe`](https://github.com/NixOS/nixpkgs/commit/6ab23cbe035d0920efdf8b6a9407344ceb2cd1eb) | `` moonlight: 1.3.19 -> 1.3.21 ``                                                            |
| [`650d9f6c`](https://github.com/NixOS/nixpkgs/commit/650d9f6c249947a6c68cf445cb482a6418f886a4) | `` makejinja: 2.7.2 -> 2.8.0 ``                                                              |
| [`3dd6e750`](https://github.com/NixOS/nixpkgs/commit/3dd6e7500a1127f0e09e05d39124a443d1db1993) | `` quickemu: correctly handle version 10.0.0 of QEMU ``                                      |
| [`5a0374e2`](https://github.com/NixOS/nixpkgs/commit/5a0374e20e3377e95725c15eb304fe073ba72349) | `` postgresqlPackages.ip4r: init at 2.4.2 ``                                                 |
| [`9c9c3642`](https://github.com/NixOS/nixpkgs/commit/9c9c3642f0c96aa81319e620b7233d84ba9da746) | `` nipap-www: init at 0.32.7 ``                                                              |
| [`4abad970`](https://github.com/NixOS/nixpkgs/commit/4abad970d7d207d04dddc8e648503e082ca22c6b) | `` nipap-cli: init at 0.32.7 ``                                                              |
| [`8071d341`](https://github.com/NixOS/nixpkgs/commit/8071d341875c47d1eeb5d8cd08600a2fdd98373a) | `` pynipap: init at 0.32.7 ``                                                                |
| [`39b9409d`](https://github.com/NixOS/nixpkgs/commit/39b9409d1a178a68fa844c6b80c48d8bf4c14354) | `` nipap: init at v0.32.7 ``                                                                 |
| [`bed132b2`](https://github.com/NixOS/nixpkgs/commit/bed132b2edf544eddd12111a4332415def230e73) | `` flask-xml-rpc-re: init at v0.2.0 ``                                                       |
| [`221364e6`](https://github.com/NixOS/nixpkgs/commit/221364e65c4d288fe7828a3dea24e8a4124c45d1) | `` libdeltachat: 1.159.5 -> 1.160.0 ``                                                       |
| [`41cc14c5`](https://github.com/NixOS/nixpkgs/commit/41cc14c5267cf614eabf22ba6de1d161fa32dc35) | `` vulkan-validation-layers: fix Darwin build by enabling robin-hood-hashing ``              |
| [`5e3aab16`](https://github.com/NixOS/nixpkgs/commit/5e3aab16040afe6fed8d31aa9d08441992126889) | `` clamav: fix tests on sandboxed Darwin ``                                                  |
| [`ace78c7d`](https://github.com/NixOS/nixpkgs/commit/ace78c7d30d96f37f1480ede7ba6afa0d3cb41d9) | `` gitea: 1.24.0 -> 1.24.2 ``                                                                |
| [`f6f3549d`](https://github.com/NixOS/nixpkgs/commit/f6f3549df6dc19f7b2e4587960e53f95f40d3d6a) | `` python3Packages.wadler-lindig: 0.1.6 -> 0.1.7 ``                                          |
| [`d40a78e1`](https://github.com/NixOS/nixpkgs/commit/d40a78e1297e3e4859ddce137ba7dff0f66522c3) | `` ledfx: 2.0.108 -> 2.0.109 ``                                                              |
| [`fd636882`](https://github.com/NixOS/nixpkgs/commit/fd636882374cdce4c1e042b088b4eeaa18bbdb69) | `` python3Packages.warp-lang: init at 1.7.2.post1 ``                                         |
| [`fe3e7c9e`](https://github.com/NixOS/nixpkgs/commit/fe3e7c9efd64810ec1a29d475ea9984b51f1a204) | `` python3Packages.orbax-checkpoint: 0.11.15 -> 0.11.16 ``                                   |
| [`02ec1658`](https://github.com/NixOS/nixpkgs/commit/02ec16588d0fc6eb00f6856dc8060ebc2bf5bfec) | `` lianad: 11.0 -> 11.1 ``                                                                   |
| [`219a846e`](https://github.com/NixOS/nixpkgs/commit/219a846ea46777a05274cdd109cf8e17c733e042) | `` liana: 11.0 -> 11.1 ``                                                                    |
| [`5034dd73`](https://github.com/NixOS/nixpkgs/commit/5034dd73846be1264d9f44114da5b6a88494e2fc) | `` nixos/wastebin: update default POST size to match upstream ``                             |
| [`78a7cd35`](https://github.com/NixOS/nixpkgs/commit/78a7cd352e5b92fdcd7c4487e37745c84b281005) | `` wavebox: 10.137.9-2 -> 10.137.11-2 ``                                                     |
| [`e0ec68ae`](https://github.com/NixOS/nixpkgs/commit/e0ec68aee570cc84a402ad9ed66327ac51c0438f) | `` nickel: 1.11.0 -> 1.12.0 ``                                                               |
| [`1713262d`](https://github.com/NixOS/nixpkgs/commit/1713262d28c814f3f01bb461718d1534fbdc82c3) | `` nickel: disable nix feature by default ``                                                 |
| [`c7082db8`](https://github.com/NixOS/nixpkgs/commit/c7082db884a50d425c1c07bf871fef6a07a12d87) | `` nickel: add yannham to maintainers ``                                                     |
| [`00eae402`](https://github.com/NixOS/nixpkgs/commit/00eae402c32eb23a7be320a9bbb40d2021befd82) | `` Add yannham to the maintainer list ``                                                     |