### PR TITLE
chore(flake/minimal-emacs-d): `fd753d9d` -> `8b93ebc6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -414,11 +414,11 @@
     "minimal-emacs-d": {
       "flake": false,
       "locked": {
-        "lastModified": 1750267944,
-        "narHash": "sha256-4ijdUWsPGx5UnXyX1yi+NGchdH4qic0YIc8dGB6mExE=",
+        "lastModified": 1750956774,
+        "narHash": "sha256-HysIrAeuEUlORqPPHz5e9QJi5+rS+gTsTURhGLr/IV4=",
         "owner": "jamescherti",
         "repo": "minimal-emacs.d",
-        "rev": "fd753d9d17b24eef61e26bca0e8a0cf3005887cd",
+        "rev": "8b93ebc6c3c2f5c0ea3625b13aea4da2bd1459a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                          |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
| [`8b93ebc6`](https://github.com/jamescherti/minimal-emacs.d/commit/8b93ebc6c3c2f5c0ea3625b13aea4da2bd1459a6) | `` Add next-line-add-newlines and pgtk-wait-for-event-timeout `` |
| [`691a293e`](https://github.com/jamescherti/minimal-emacs.d/commit/691a293e58e380e25fd388d86a0113ed8d4930ea) | `` Add imenu-auto-rescan and imenu-max-item-length ``            |
| [`32902df6`](https://github.com/jamescherti/minimal-emacs.d/commit/32902df61a58d409e0768bb93fcbdb4b3dbc8a4a) | `` Update ibuffer-formats ``                                     |
| [`2b931b13`](https://github.com/jamescherti/minimal-emacs.d/commit/2b931b134cbab91c765c608911ec598165f30ac5) | `` Add electric-indent-chars ``                                  |
| [`c833048e`](https://github.com/jamescherti/minimal-emacs.d/commit/c833048e696d33e4b7d0c796d4373daa5a1fc55c) | `` Update tab-first-completion and tab-always-indent ``          |