### PR TITLE
chore(flake/nur): `1dc9d5cc` -> `866e9b7a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1750965824,
-        "narHash": "sha256-F5XAObWynLymPQU55/ZbSwoE9TaBDEBCmD/pgd2WRiQ=",
+        "lastModified": 1750978200,
+        "narHash": "sha256-/BRofV4oOI9YMCsOlHLiWkVcjw1LuY/zb1Dlt6r1rpw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1dc9d5cc6ffb942c34f3a5b74097b1d96285e7c0",
+        "rev": "866e9b7ab7d124ccf32c667d6b528781ee38193b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`866e9b7a`](https://github.com/nix-community/NUR/commit/866e9b7ab7d124ccf32c667d6b528781ee38193b) | `` automatic update `` |
| [`9d790e38`](https://github.com/nix-community/NUR/commit/9d790e386b18cf38be83a93fb96a8c79b6f82e86) | `` automatic update `` |
| [`94052e85`](https://github.com/nix-community/NUR/commit/94052e851b5571be7dfa54bacee5a588a0f08545) | `` automatic update `` |
| [`25c9b3d9`](https://github.com/nix-community/NUR/commit/25c9b3d9c19ef61e3e70874cf70238cda410cef0) | `` automatic update `` |