### PR TITLE
chore(flake/nur): `866e9b7a` -> `5b416fcf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1750978200,
-        "narHash": "sha256-/BRofV4oOI9YMCsOlHLiWkVcjw1LuY/zb1Dlt6r1rpw=",
+        "lastModified": 1751010441,
+        "narHash": "sha256-ek/XymPRWbX/85Pbicfokl6cnljapnjXiTh5otlLCSE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "866e9b7ab7d124ccf32c667d6b528781ee38193b",
+        "rev": "5b416fcfd1c236bd100f21b551ed33aa6a3bfd6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5b416fcf`](https://github.com/nix-community/NUR/commit/5b416fcfd1c236bd100f21b551ed33aa6a3bfd6c) | `` automatic update `` |
| [`efd9ca0c`](https://github.com/nix-community/NUR/commit/efd9ca0cf7976b87131c525837a422219ec86b72) | `` automatic update `` |
| [`5bf5ee86`](https://github.com/nix-community/NUR/commit/5bf5ee86083268992da58090bdc8c56f0a92ec71) | `` automatic update `` |
| [`2747e6e0`](https://github.com/nix-community/NUR/commit/2747e6e09afefd983d3c34b26469ec8969560afc) | `` automatic update `` |
| [`2696d810`](https://github.com/nix-community/NUR/commit/2696d810a211d9819cdbf39bef28d1cf9395e87b) | `` automatic update `` |
| [`f8d6a027`](https://github.com/nix-community/NUR/commit/f8d6a0275b7d234a3de73a6def06d95c019fdb18) | `` automatic update `` |
| [`3d3bbc40`](https://github.com/nix-community/NUR/commit/3d3bbc409c4ec79d94fb00ce78c9bf1845fe5add) | `` automatic update `` |
| [`c611a5c6`](https://github.com/nix-community/NUR/commit/c611a5c6d82ba30e12b5c0bac35deee386b14f72) | `` automatic update `` |
| [`047f248f`](https://github.com/nix-community/NUR/commit/047f248f6ad957e6c0df9a8157517a2d4df305a5) | `` automatic update `` |