### PR TITLE
chore(flake/catppuccin): `4e95eaf8` -> `a6b0e34d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1750153510,
-        "narHash": "sha256-NYHXXJZ9m4fJpKk9tKn/EExX87SqcBcRINOGF7hKRLI=",
+        "lastModified": 1751021896,
+        "narHash": "sha256-L9u68mNPPiuW7+OV5BKbXaj/AENTiiuEx8+QnMBjRlU=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "4e95eaf8a351956d75cc400318579967ca2b6d0f",
+        "rev": "a6b0e34d083c79f08efabb1fd6ccf12b882daae6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                 |
| ----------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`a6b0e34d`](https://github.com/catppuccin/nix/commit/a6b0e34d083c79f08efabb1fd6ccf12b882daae6) | `` chore: update port sources (#585) `` |