### PR TITLE
chore(flake/nur): `2355fe2c` -> `b2609836`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -741,11 +741,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1750776420,
-        "narHash": "sha256-/CG+w0o0oJ5itVklOoLbdn2dGB0wbZVOoDm4np6w09A=",
+        "lastModified": 1751011381,
+        "narHash": "sha256-krGXKxvkBhnrSC/kGBmg5MyupUUT5R6IBCLEzx9jhMM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "30a61f056ac492e3b7cdcb69c1e6abdcf00e39cf",
+        "rev": "30e2e2857ba47844aa71991daa6ed1fc678bcbb7",
         "type": "github"
       },
       "original": {
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1751096345,
-        "narHash": "sha256-csVZSJ94582i+G+O6t/lmTK6OwcGSaK/+NNWmi+EJOE=",
+        "lastModified": 1751114438,
+        "narHash": "sha256-tBDQTKlP3O8O0xe4GD4VJTEaPJHOeOHZ+eA/uULrIyA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2355fe2ca50b284b6f9110b31b45b89fa1a8e323",
+        "rev": "b26098366c0bb5935592b7566e99336351790c39",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b2609836`](https://github.com/nix-community/NUR/commit/b26098366c0bb5935592b7566e99336351790c39) | `` automatic update `` |
| [`00b0005d`](https://github.com/nix-community/NUR/commit/00b0005dbbb931014fdfe55d0db1f47af4f9aab5) | `` automatic update `` |
| [`19153475`](https://github.com/nix-community/NUR/commit/19153475374f8e3113774bf6246611596e3a2b61) | `` automatic update `` |
| [`df5b92d1`](https://github.com/nix-community/NUR/commit/df5b92d1904e8ab45b67abf930c166de83f77429) | `` automatic update `` |
| [`0f8f6135`](https://github.com/nix-community/NUR/commit/0f8f6135bb4f155dec4ee92ca8d9a436e9298aae) | `` automatic update `` |