### PR TITLE
chore(flake/minimal-emacs-d): `66788d10` -> `5315bae1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -414,11 +414,11 @@
     "minimal-emacs-d": {
       "flake": false,
       "locked": {
-        "lastModified": 1751048926,
-        "narHash": "sha256-5w6UqsbtvKb334LuLPYJLot+0ouuKjWOd1u/MjGEbfE=",
+        "lastModified": 1751125818,
+        "narHash": "sha256-MSNwO3noL/JrL7a28NSZmdzPcMw1NhAMYSwV6YxhQVs=",
         "owner": "jamescherti",
         "repo": "minimal-emacs.d",
-        "rev": "66788d1045f5e728346603229f3a66480223bc8d",
+        "rev": "5315bae11cb52a00379009955470f2f894eaca97",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                         |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
| [`5315bae1`](https://github.com/jamescherti/minimal-emacs.d/commit/5315bae11cb52a00379009955470f2f894eaca97) | `` Set auto-revert-remote-files to nil ``                       |
| [`a3f21623`](https://github.com/jamescherti/minimal-emacs.d/commit/a3f2162365c17c5230e0930b08415aae2c60a6dc) | `` Add auto-revert-remote-files and dired-auto-revert-buffer `` |
| [`db5913aa`](https://github.com/jamescherti/minimal-emacs.d/commit/db5913aa4071e7df829cfa37bc53ac6fde994fec) | `` Move dired-auto-revert-buffer to README.md ``                |
| [`a2e5aac1`](https://github.com/jamescherti/minimal-emacs.d/commit/a2e5aac1406ec67ae6d53bbfaf95e22a8d24ec62) | `` dired: Group directories first ``                            |
| [`5b6af804`](https://github.com/jamescherti/minimal-emacs.d/commit/5b6af8044568904e8c605c5936e12c668a3d2a1b) | `` dired: Group directories first ``                            |