### PR TITLE
chore(flake/emacs-overlay): `fa76f53c` -> `10f086fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1751101700,
-        "narHash": "sha256-2/oxAYeKzs7gl1WD5ST/wNvAKNOCM41vJL3eww7miH4=",
+        "lastModified": 1751164253,
+        "narHash": "sha256-hJmYTh/cS3TWI+JF1AniGpw/HXycruk4HV4xIZjMipo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fa76f53c1911cd3b56b1c6378226ec49fb3c2c98",
+        "rev": "10f086fb8668f0e3d08cd2a01180abccc43f6552",
         "type": "github"
       },
       "original": {
@@ -662,11 +662,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1750646418,
-        "narHash": "sha256-4UAN+W0Lp4xnUiHYXUXAPX18t+bn6c4Btry2RqM9JHY=",
+        "lastModified": 1750877742,
+        "narHash": "sha256-OrCy70x59VaBHxPZnm6A1wvQSdJvTz4i8Ngx40UeApI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1f426f65ac4e6bf808923eb6f8b8c2bfba3d18c5",
+        "rev": "f25c1bd2a6b33a4b1aa7aff56a94e0daab3773f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`10f086fb`](https://github.com/nix-community/emacs-overlay/commit/10f086fb8668f0e3d08cd2a01180abccc43f6552) | `` Updated melpa ``        |
| [`b4121782`](https://github.com/nix-community/emacs-overlay/commit/b412178267bd815c3cd48676a61952440c677845) | `` Updated emacs ``        |
| [`e8b584a5`](https://github.com/nix-community/emacs-overlay/commit/e8b584a552ccd5c6bab96e6e733a0c44a45a9b48) | `` Updated elpa ``         |
| [`8fa8153c`](https://github.com/nix-community/emacs-overlay/commit/8fa8153cfb6a64e6fa26fc9066a41f910bea3372) | `` Updated nongnu ``       |
| [`4676f012`](https://github.com/nix-community/emacs-overlay/commit/4676f012096addf78c814af22153fe4659604524) | `` Updated flake inputs `` |
| [`c5cc6bc8`](https://github.com/nix-community/emacs-overlay/commit/c5cc6bc833e686b5477e1a7054c5a0ee3039d413) | `` Updated elpa ``         |
| [`b4946a46`](https://github.com/nix-community/emacs-overlay/commit/b4946a46832d62520d5febcedbaebb03a5d14a9f) | `` Updated nongnu ``       |
| [`efb26d91`](https://github.com/nix-community/emacs-overlay/commit/efb26d917bcc5e7b4ec8d24efae4472c08244ed6) | `` Updated flake inputs `` |