### PR TITLE
chore(flake/nur): `e09520e3` -> `681256fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1751197556,
-        "narHash": "sha256-EP7/Z1tE/hZ9pA7LbNhH1AsYngtFi4AliwjRQiPlJSM=",
+        "lastModified": 1751212059,
+        "narHash": "sha256-NANTtqmoCFVhzedyDUApuiOZZTJDNScNPRGHrQTn5oM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e09520e37a86ea686290b09107c3cf6af8dc4888",
+        "rev": "681256fe323fa55ebc7214653b30aedab51a74a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`681256fe`](https://github.com/nix-community/NUR/commit/681256fe323fa55ebc7214653b30aedab51a74a7) | `` automatic update `` |
| [`bd7c57e5`](https://github.com/nix-community/NUR/commit/bd7c57e58ad24cea8f6ddb0d078f9664529ec761) | `` automatic update `` |
| [`6ff93883`](https://github.com/nix-community/NUR/commit/6ff93883e22e462b56feeac5d3bb6f96246f8e05) | `` automatic update `` |
| [`0298d70e`](https://github.com/nix-community/NUR/commit/0298d70e02e56bb00bf487c5ddd00cacd4b653ed) | `` automatic update `` |