### PR TITLE
chore(flake/nur): `681256fe` -> `70a5f614`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1751212059,
-        "narHash": "sha256-NANTtqmoCFVhzedyDUApuiOZZTJDNScNPRGHrQTn5oM=",
+        "lastModified": 1751227229,
+        "narHash": "sha256-RofzHM7pRUcDmxjRhFo/hevtaZmo5BB53LWZBU5m7m0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "681256fe323fa55ebc7214653b30aedab51a74a7",
+        "rev": "70a5f61483bedf8d2e7ad41175c7d2f9042c4477",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                         |
| -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`70a5f614`](https://github.com/nix-community/NUR/commit/70a5f61483bedf8d2e7ad41175c7d2f9042c4477) | `` automatic update ``                                          |
| [`cb1f4a0a`](https://github.com/nix-community/NUR/commit/cb1f4a0ae01cbae9c6c3406f80f27068b6992d04) | `` automatic update ``                                          |
| [`e83fc7e1`](https://github.com/nix-community/NUR/commit/e83fc7e1640e74898740da71f4fca211a4153cbc) | `` automatic update ``                                          |
| [`873e573a`](https://github.com/nix-community/NUR/commit/873e573a93300046272a0b3dec82b0f9e732458f) | `` automatic update ``                                          |
| [`1809d267`](https://github.com/nix-community/NUR/commit/1809d2679f5dcfb912020b3fec6223f4a69c4b74) | `` automatic update ``                                          |
| [`124ffb8b`](https://github.com/nix-community/NUR/commit/124ffb8b10b43973bc8756ba1005f03f608effd0) | `` use builtin fetchers to prevent importing from derivation `` |
| [`8f1f3d25`](https://github.com/nix-community/NUR/commit/8f1f3d25ea8eb1b037896240e099016f62997a35) | `` add cameronyule repository ``                                |
| [`c42d7b97`](https://github.com/nix-community/NUR/commit/c42d7b97c78fc038a994fa73b4f4c5fcf9e26079) | `` RossSmyth: init nux repo ``                                  |
| [`5dbc773f`](https://github.com/nix-community/NUR/commit/5dbc773ff9d9b771324829fd26b17ca66b5c0402) | `` automatic update ``                                          |