### PR TITLE
chore(flake/srvos): `3af451e7` -> `c877dc6f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -933,11 +933,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750907330,
-        "narHash": "sha256-rXA4RdUfZxBmy3RZ8TiP9ITuGwLGBWlyP16dN6ILS6M=",
+        "lastModified": 1751245728,
+        "narHash": "sha256-0UHOzDW5yRgNL0AyHgN0r0B6XehzLFKZ00HBSjX8BWM=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "3af451e7eb42df68fc06b689da4f4ca7198eed5e",
+        "rev": "c877dc6f7920b373e5943f77377e6ef816f4dc30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`c877dc6f`](https://github.com/nix-community/srvos/commit/c877dc6f7920b373e5943f77377e6ef816f4dc30) | `` dev/private/flake.lock: Update `` |
| [`d56954b8`](https://github.com/nix-community/srvos/commit/d56954b8f21e4ff423b34c084e0f83c3597f065c) | `` flake.lock: Update ``             |