### PR TITLE
chore(flake/emacs-overlay): `562e5da8` -> `9e06201e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1751216990,
-        "narHash": "sha256-KMcGSznyttkf3C2Gv4LNCPYOfvjj7Qk/Mu2Og2yCsbk=",
+        "lastModified": 1751274822,
+        "narHash": "sha256-N5Kl10TFWL7mWZWR/SYiYA3+bnH2HfuB/qCFGco2HOo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "562e5da816da90627ed5775d4ba6f968bde0ff57",
+        "rev": "9e06201e3703da9d83c608ad31c5bb44ad0753b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`9e06201e`](https://github.com/nix-community/emacs-overlay/commit/9e06201e3703da9d83c608ad31c5bb44ad0753b6) | `` Updated melpa ``  |
| [`bb77ed68`](https://github.com/nix-community/emacs-overlay/commit/bb77ed684cae2381c23040593ed17bf114a8a103) | `` Updated emacs ``  |
| [`28a7010a`](https://github.com/nix-community/emacs-overlay/commit/28a7010a46ee17016c9b37be86f4ce4796c47a71) | `` Updated melpa ``  |
| [`9f73a610`](https://github.com/nix-community/emacs-overlay/commit/9f73a610203b810152591e4e2f20bd474c52bcb1) | `` Updated emacs ``  |
| [`33602303`](https://github.com/nix-community/emacs-overlay/commit/33602303ab14a817c510384630baa93d8bc3350d) | `` Updated elpa ``   |
| [`74e80365`](https://github.com/nix-community/emacs-overlay/commit/74e80365df20a25050875512c20402abea441240) | `` Updated nongnu `` |