### PR TITLE
chore(flake/nur): `e333f9e7` -> `cbde1735`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1751296990,
-        "narHash": "sha256-54F5eBuzlT2N9WO+mEGBVE32R9LPy7cwDGh9t9HaPco=",
+        "lastModified": 1751320053,
+        "narHash": "sha256-3m6RMw0FbbaUUa01PNaMLoO7D99aBClmY5ed9V3vz+0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e333f9e754e0ed95a8dd56f36813a5e08b03ccb8",
+        "rev": "cbde1735782f9c2bb2c63d5e05fba171a14a4670",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                   |
| -------------------------------------------------------------------------------------------------- | ------------------------- |
| [`cbde1735`](https://github.com/nix-community/NUR/commit/cbde1735782f9c2bb2c63d5e05fba171a14a4670) | `` automatic update ``    |
| [`f223023a`](https://github.com/nix-community/NUR/commit/f223023aadabe1a987860652542eb99d387fe999) | `` automatic update ``    |
| [`3e7075c9`](https://github.com/nix-community/NUR/commit/3e7075c950257a47271fc06f947765f6aa33f3b4) | `` automatic update ``    |
| [`a6b96deb`](https://github.com/nix-community/NUR/commit/a6b96deb16413840dbec8d84d6a6eb9357c0cc71) | `` automatic update ``    |
| [`29d56936`](https://github.com/nix-community/NUR/commit/29d56936b1b3ffd310e070f7ea85de4169effd3e) | `` add trev repository `` |
| [`22dc2c17`](https://github.com/nix-community/NUR/commit/22dc2c17300e15b13e425092803ab34869656240) | `` automatic update ``    |
| [`927b8693`](https://github.com/nix-community/NUR/commit/927b869393fe2da80339ff8689d12f8681b86d8a) | `` automatic update ``    |