### PR TITLE
chore(flake/nur): `cbde1735` -> `950343d9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -741,11 +741,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1751011381,
-        "narHash": "sha256-krGXKxvkBhnrSC/kGBmg5MyupUUT5R6IBCLEzx9jhMM=",
+        "lastModified": 1751271578,
+        "narHash": "sha256-P/SQmKDu06x8yv7i0s8bvnnuJYkxVGBWLWHaU+tt4YY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "30e2e2857ba47844aa71991daa6ed1fc678bcbb7",
+        "rev": "3016b4b15d13f3089db8a41ef937b13a9e33a8df",
         "type": "github"
       },
       "original": {
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1751320053,
-        "narHash": "sha256-3m6RMw0FbbaUUa01PNaMLoO7D99aBClmY5ed9V3vz+0=",
+        "lastModified": 1751342987,
+        "narHash": "sha256-iVVxFRroXRu9cRaKvbiJLX1zvm8vo+yQDVCL2OzeZhM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cbde1735782f9c2bb2c63d5e05fba171a14a4670",
+        "rev": "950343d94d45e702a4db6ad529fba103c9db90fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`950343d9`](https://github.com/nix-community/NUR/commit/950343d94d45e702a4db6ad529fba103c9db90fb) | `` automatic update `` |
| [`8a3050f3`](https://github.com/nix-community/NUR/commit/8a3050f37b0032674e699a9729e61e6fbc98e6ab) | `` automatic update `` |
| [`f50353b8`](https://github.com/nix-community/NUR/commit/f50353b8ebbf5949e8487163a071aab57d1f73e4) | `` automatic update `` |
| [`b980739a`](https://github.com/nix-community/NUR/commit/b980739a62af14888207aafcf22e04c60bdbeb69) | `` automatic update `` |
| [`7f405be3`](https://github.com/nix-community/NUR/commit/7f405be3f73923c4acf0a5de2cff74af9ae89c76) | `` automatic update `` |