### PR TITLE
chore(flake/nur): `950343d9` -> `93d91108`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1751342987,
-        "narHash": "sha256-iVVxFRroXRu9cRaKvbiJLX1zvm8vo+yQDVCL2OzeZhM=",
+        "lastModified": 1751355827,
+        "narHash": "sha256-w0dc97DRw+dJ1EKnFBZrvsipQq7BGH7iW6MqiSA2Hmc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "950343d94d45e702a4db6ad529fba103c9db90fb",
+        "rev": "93d91108dd5ca22a3d470b376c7b5c44e1d6d2bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`93d91108`](https://github.com/nix-community/NUR/commit/93d91108dd5ca22a3d470b376c7b5c44e1d6d2bb) | `` automatic update `` |
| [`c41210bd`](https://github.com/nix-community/NUR/commit/c41210bd9aea6b7cd8fea393385bef84ee1355e8) | `` automatic update `` |
| [`50fd93fb`](https://github.com/nix-community/NUR/commit/50fd93fb7d46e97b5dc30909754f597c2b703a29) | `` automatic update `` |
| [`12f95832`](https://github.com/nix-community/NUR/commit/12f95832c8080cb7f6a336cfe38633e7de45660e) | `` automatic update `` |