### PR TITLE
chore(flake/nur): `93d91108` -> `964490c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -800,11 +800,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1751355827,
-        "narHash": "sha256-w0dc97DRw+dJ1EKnFBZrvsipQq7BGH7iW6MqiSA2Hmc=",
+        "lastModified": 1751453621,
+        "narHash": "sha256-F9dHpFuw1r/XIUKCmHlpVqH1E1WHOEQwwaDDSU3ghnk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "93d91108dd5ca22a3d470b376c7b5c44e1d6d2bb",
+        "rev": "964490c85745dd28927fd8b2c6eeaa60182ac0a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                                  |
| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`964490c8`](https://github.com/nix-community/NUR/commit/964490c85745dd28927fd8b2c6eeaa60182ac0a2) | `` automatic update ``                                                   |
| [`8a2ffa94`](https://github.com/nix-community/NUR/commit/8a2ffa949d3a0214b1584b8d862472f0a6268955) | `` automatic update ``                                                   |
| [`e7c5647e`](https://github.com/nix-community/NUR/commit/e7c5647eb2f4cd3281373e7a6a05ad0f8a3aef2a) | `` automatic update ``                                                   |
| [`f05f7fc6`](https://github.com/nix-community/NUR/commit/f05f7fc6ae626bfae96d3d5d8751dabb9db8d06f) | `` automatic update ``                                                   |
| [`5365d082`](https://github.com/nix-community/NUR/commit/5365d082abff136302afd81bace38ce1e2f04f1a) | `` automatic update ``                                                   |
| [`60e5ae17`](https://github.com/nix-community/NUR/commit/60e5ae173b5eb3e3658e26accf367abf9040815d) | `` automatic update ``                                                   |
| [`d85cc10f`](https://github.com/nix-community/NUR/commit/d85cc10fefc34eba875021edc6a99bd777075319) | `` automatic update ``                                                   |
| [`79a68394`](https://github.com/nix-community/NUR/commit/79a683948ad499bdb12a6c46a824fe35c5e8da02) | `` automatic update ``                                                   |
| [`18423f02`](https://github.com/nix-community/NUR/commit/18423f0232f1b2aee3070195be4ff0afb78c3f90) | `` automatic update ``                                                   |
| [`15e95254`](https://github.com/nix-community/NUR/commit/15e95254dfb9d728742892e0088ad37a37378d56) | `` automatic update ``                                                   |
| [`77ac3873`](https://github.com/nix-community/NUR/commit/77ac3873be8e611fcfc49866d8c9426a0ff07921) | `` automatic update ``                                                   |
| [`1c565d9e`](https://github.com/nix-community/NUR/commit/1c565d9e2a5ea9e93b67fc783e132fb64c84d565) | `` automatic update ``                                                   |
| [`5d59a804`](https://github.com/nix-community/NUR/commit/5d59a804e2611c157d62d219a3d010a29d30403b) | `` automatic update ``                                                   |
| [`fea869d1`](https://github.com/nix-community/NUR/commit/fea869d1991122d940c718105cce6e96f6d08678) | `` automatic update ``                                                   |
| [`7613d3eb`](https://github.com/nix-community/NUR/commit/7613d3ebaf028c30235863581d944f2412a6bcb3) | `` automatic update ``                                                   |
| [`bd158002`](https://github.com/nix-community/NUR/commit/bd158002f0761cec6c4523a5e906e633c663cc13) | `` automatic update ``                                                   |
| [`52c5b77a`](https://github.com/nix-community/NUR/commit/52c5b77a638fd5604bb7c476e38538e90eca313a) | `` automatic update ``                                                   |
| [`854a99c9`](https://github.com/nix-community/NUR/commit/854a99c90daebea47d6ea04121f31056a4de3543) | `` automatic update ``                                                   |
| [`3fa17657`](https://github.com/nix-community/NUR/commit/3fa176577b655ede19f3a1425a775e5ec0985c3c) | `` Revert "use builtin fetchers to prevent importing from derivation" `` |
| [`f7a8234d`](https://github.com/nix-community/NUR/commit/f7a8234d0483f4657eb7503af0741d1fa666cdd1) | `` automatic update ``                                                   |
| [`326860af`](https://github.com/nix-community/NUR/commit/326860af7a41ac4d1ab8055bf88fdc8e79b82acf) | `` automatic update ``                                                   |
| [`2c6cfcbc`](https://github.com/nix-community/NUR/commit/2c6cfcbc51fa99fbf662d71d4e736c9a45b08ea1) | `` automatic update ``                                                   |
| [`a81d7350`](https://github.com/nix-community/NUR/commit/a81d7350797bacc43e16ec758923bf7ca2e3e058) | `` automatic update ``                                                   |
| [`a09cd9a7`](https://github.com/nix-community/NUR/commit/a09cd9a7c2cbb8b0e2f699a823a31f80963db43f) | `` automatic update ``                                                   |
| [`fa33ff99`](https://github.com/nix-community/NUR/commit/fa33ff993d2de7c64552cf20db249290aaabe00f) | `` automatic update ``                                                   |
| [`9900a768`](https://github.com/nix-community/NUR/commit/9900a7687e801aa2561f8bcea821ef116a67c638) | `` automatic update ``                                                   |
| [`98f1c94a`](https://github.com/nix-community/NUR/commit/98f1c94ac4b1a28aae27d61895ecb5a1a0cdd37f) | `` automatic update ``                                                   |
| [`efe71f28`](https://github.com/nix-community/NUR/commit/efe71f285c504678cdca4f596b47e5012fda182a) | `` automatic update ``                                                   |
| [`05d7d80e`](https://github.com/nix-community/NUR/commit/05d7d80e5173b396cbeba75fb2d66514414e8dd8) | `` automatic update ``                                                   |
| [`42955cd1`](https://github.com/nix-community/NUR/commit/42955cd18e93a16ccc2d403f664b6dce95139a05) | `` automatic update ``                                                   |