### PR TITLE
chore(flake/home-manager): `96354906` -> `df122690`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -352,11 +352,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751336185,
-        "narHash": "sha256-ptnVr2x+sl7cZcTuGx/0BOE2qCAIYHTcgfA+/h60ml0=",
+        "lastModified": 1751429452,
+        "narHash": "sha256-4s5vRtaqdNhVBnbOWOzBNKrRa0ShQTLoEPjJp3joeNI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "96354906f58464605ff81d2f6c2ea23211cbf051",
+        "rev": "df12269039dcf752600b1bcc176bacf2786ec384",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                        |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`df122690`](https://github.com/nix-community/home-manager/commit/df12269039dcf752600b1bcc176bacf2786ec384) | `` maintainers: update all-maintainers.nix (#7361) ``          |
| [`29d717aa`](https://github.com/nix-community/home-manager/commit/29d717aab5189b3383d965928823ddac8a95e8f3) | `` ci: tests fetch nixpkgs from flake.lock rev ``              |
| [`212f4a4f`](https://github.com/nix-community/home-manager/commit/212f4a4fb20449d51bbc403e3d140778aab4d18a) | `` ci: update-maintainers fetch nixpkgs from flake.lock rev `` |
| [`121b430d`](https://github.com/nix-community/home-manager/commit/121b430df7b5c5eeb9d37dff2a3ba1883a9e51e1) | `` maintainers: fix incorrect entries (#7360) ``               |
| [`e96a8a32`](https://github.com/nix-community/home-manager/commit/e96a8a325cf23538a7f58b9335b4c4c0b393bacf) | `` ci: conditional test step runs (#7358) ``                   |
| [`5d2f3e3e`](https://github.com/nix-community/home-manager/commit/5d2f3e3e7fbb2cd8cab8b5f9e51526b1269645b9) | `` ci: fix update-maintainers reference location (#7357) ``    |
| [`77bb9e03`](https://github.com/nix-community/home-manager/commit/77bb9e033b500a7111cee096555d510b715a3fb3) | `` ci: add update-maintainers.yml ``                           |
| [`11db5613`](https://github.com/nix-community/home-manager/commit/11db56137d1efbf663f614c7714c9224d4dd818d) | `` all-maintainers.nix: initial creation ``                    |
| [`44a2308d`](https://github.com/nix-community/home-manager/commit/44a2308db94b063c8dcb6505f61fdd225e571041) | `` scripts/generate-all-maintainers.py: add script ``          |
| [`479f8889`](https://github.com/nix-community/home-manager/commit/479f8889675770881033878a1c114fbfc6de7a4d) | `` bash: support path in sessionVariables again (#7354) ``     |