### PR TITLE
chore(flake/emacs-overlay): `6b8981d1` -> `c8c7ef94`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1751389846,
-        "narHash": "sha256-XUFCVZjoyDlfKA5BcC/vRPckjyYh2vbGUAan22RjHF0=",
+        "lastModified": 1751508915,
+        "narHash": "sha256-mVnjzM1VGLNrIEC8ghaQVoat68kXh4/AzBE4QPi29QI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6b8981d1d7c06ce113a467db09a24ba3bb815351",
+        "rev": "c8c7ef94b6600add651b3d3aea1db5665b1b92eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`c8c7ef94`](https://github.com/nix-community/emacs-overlay/commit/c8c7ef94b6600add651b3d3aea1db5665b1b92eb) | `` Updated melpa ``  |
| [`345ee27d`](https://github.com/nix-community/emacs-overlay/commit/345ee27dfa367ce181e29e410f57ee8322f6a537) | `` Updated elpa ``   |
| [`2f69b6f4`](https://github.com/nix-community/emacs-overlay/commit/2f69b6f471d881d3aecb69148863f78e83a68a48) | `` Updated nongnu `` |
| [`8e6e0124`](https://github.com/nix-community/emacs-overlay/commit/8e6e01245f40b1f8a1f548db553bc9061e4ef412) | `` Updated melpa ``  |
| [`1de278e4`](https://github.com/nix-community/emacs-overlay/commit/1de278e46115d49a11ee9b01bfca5b74432e6074) | `` Updated elpa ``   |
| [`85362161`](https://github.com/nix-community/emacs-overlay/commit/853621610af3735d6f12e08b1975b8ba9b7dca12) | `` Updated nongnu `` |
| [`6b5c9e8d`](https://github.com/nix-community/emacs-overlay/commit/6b5c9e8d4cfe157a398aedf877ad6fbb71c6bca6) | `` Updated melpa ``  |
| [`6f4540bf`](https://github.com/nix-community/emacs-overlay/commit/6f4540bf073014dca1ea1b12a79ad23ad0ba47ce) | `` Updated emacs ``  |
| [`90efeb9a`](https://github.com/nix-community/emacs-overlay/commit/90efeb9a2880c3d0af37e5cec028be58581bbea7) | `` Updated elpa ``   |
| [`7eb0169a`](https://github.com/nix-community/emacs-overlay/commit/7eb0169a5ed29130421732641069e69b77461e99) | `` Updated nongnu `` |