### PR TITLE
chore(flake/catppuccin): `a6b0e34d` -> `a682f703`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1751021896,
-        "narHash": "sha256-L9u68mNPPiuW7+OV5BKbXaj/AENTiiuEx8+QnMBjRlU=",
+        "lastModified": 1751463132,
+        "narHash": "sha256-eKbIZwTsl+Rbkj4coSZETlcTbmVbegN1nCKJ7059p88=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "a6b0e34d083c79f08efabb1fd6ccf12b882daae6",
+        "rev": "a682f7033678ea093c42c5e361975af5988aa3de",
         "type": "github"
       },
       "original": {
@@ -599,11 +599,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744463964,
-        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
+        "lastModified": 1750776420,
+        "narHash": "sha256-/CG+w0o0oJ5itVklOoLbdn2dGB0wbZVOoDm4np6w09A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
+        "rev": "30a61f056ac492e3b7cdcb69c1e6abdcf00e39cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                       |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`a682f703`](https://github.com/catppuccin/nix/commit/a682f7033678ea093c42c5e361975af5988aa3de) | `` feat(home-manager): add support for vesktop (#566) ``                      |
| [`043a43ad`](https://github.com/catppuccin/nix/commit/043a43ad3b6ef225c19bf2894b50c705c0b6acc6) | `` feat(home-manager): add support for element-desktop (#555) ``              |
| [`6247b467`](https://github.com/catppuccin/nix/commit/6247b4677fef386765e762ce50964d1d7616233b) | `` feat(nixos): Add support for Limine (#570) ``                              |
| [`af87bceb`](https://github.com/catppuccin/nix/commit/af87bceb0134ef7b07fba619ba14bbb724ce95a8) | `` feat(home-manager): add support for xfce4-terminal (#587) ``               |
| [`c65eb816`](https://github.com/catppuccin/nix/commit/c65eb816b07c39c0075f5425c6b9d3d16d9dde3c) | `` chore: update to 25.05 (#590) ``                                           |
| [`592d6dde`](https://github.com/catppuccin/nix/commit/592d6dde3d5642e304a3b3280fbffeefdf70247e) | `` feat(home-manager): add theme support for firefox-based browsers (#592) `` |