### PR TITLE
chore(flake/home-manager): `7c455533` -> `25f003f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -352,11 +352,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751469941,
-        "narHash": "sha256-ZIUkH4Djh1NUFQ0GnWCsw9HZBDcVgjvJASiTplMXEzc=",
+        "lastModified": 1751485527,
+        "narHash": "sha256-E2AtD5UUeU50xco4gmgsCOs7tnBNsVi7+CdCZ4yQUrA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7c455533409411b4053bb6d7db71eb35e0544254",
+        "rev": "25f003f8a9eae31a11938d53cb23e0b4a3c08d3a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                        |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`25f003f8`](https://github.com/nix-community/home-manager/commit/25f003f8a9eae31a11938d53cb23e0b4a3c08d3a) | `` ci: tag maintainers automatically for PR reviews (#6921) `` |
| [`9347c61b`](https://github.com/nix-community/home-manager/commit/9347c61bc0cbed0d2062b930144c2cbd557f9189) | `` ci: use GITHUB_TOKEN when app config missing (#7374) ``     |
| [`a7820832`](https://github.com/nix-community/home-manager/commit/a7820832c68180b612587a23f46f1b94a28b3407) | `` ci: fix update-maintainers indentation (#7372) ``           |
| [`bafcf336`](https://github.com/nix-community/home-manager/commit/bafcf336870c9daca80df1c4a09ef926fc497016) | `` ci: use env in update-maintainers changes summary ``        |
| [`be8f7e10`](https://github.com/nix-community/home-manager/commit/be8f7e100f285167793f7ff77ce8e5b60ab48e26) | `` ci: move update-maintainers commit/pr to env ``             |
| [`7241b18a`](https://github.com/nix-community/home-manager/commit/7241b18a7bdaec265b26a7951557a1a1e367d4f8) | `` ci: make update-maintainers check-changes multiline ``      |