### PR TITLE
chore(flake/emacs-overlay): `2dd8d2a4` -> `acdb3607`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1751533870,
-        "narHash": "sha256-QrYtdbXjFjawI89+jQt9ASoUwGy8UAae/yLLFO9JxI4=",
+        "lastModified": 1751595285,
+        "narHash": "sha256-xYgWEszsCxwYT0I2irXq+OIxuWakBjM4SE5EevbU0C8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2dd8d2a429c834a0f85066f5313d38c5661bf5e0",
+        "rev": "acdb3607deb5a42163249378da3513ba1a8ada05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`acdb3607`](https://github.com/nix-community/emacs-overlay/commit/acdb3607deb5a42163249378da3513ba1a8ada05) | `` Updated melpa `` |
| [`90da85c2`](https://github.com/nix-community/emacs-overlay/commit/90da85c2423f60e0a1ce9018784c84e0493f8b7e) | `` Updated emacs `` |
| [`fe62bd67`](https://github.com/nix-community/emacs-overlay/commit/fe62bd676b51946027f48c80a5e07fc57492afe1) | `` Updated elpa ``  |
| [`bb79080f`](https://github.com/nix-community/emacs-overlay/commit/bb79080f5f1f9ce1cd29617d3e6bad6dc8f815fb) | `` Updated melpa `` |
| [`2d56fcf9`](https://github.com/nix-community/emacs-overlay/commit/2d56fcf92235c019306b6f763bceac51d6e4a177) | `` Updated emacs `` |
| [`47e4d553`](https://github.com/nix-community/emacs-overlay/commit/47e4d553bed49a63a3bff54c90e9781127628b52) | `` Updated elpa ``  |