### PR TITLE
chore(flake/nixos-cosmic): `78b86e37` -> `fef2d0c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -569,11 +569,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1751281697,
-        "narHash": "sha256-abHhTXGEGYhCKOc9vQbqHFG7dxwJ6AudIy1h4MUsjm0=",
+        "lastModified": 1751591814,
+        "narHash": "sha256-A4lgvuj4v+Pr8MniXz1FBG0DXOygi8tTECR+j53FMhM=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "78b86e37713a1111d9e37c62b242d60be3013bd1",
+        "rev": "fef2d0c78c4e4d6c600a88795af193131ff51bdc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                                     |
| ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`fef2d0c7`](https://github.com/lilyinstarlight/nixos-cosmic/commit/fef2d0c78c4e4d6c600a88795af193131ff51bdc) | `` ci: bump DeterminateSystems/nix-installer-action from 17 to 18 (#856) `` |
| [`35314547`](https://github.com/lilyinstarlight/nixos-cosmic/commit/35314547bc06031925dc3fdf69eebdd655986349) | `` ci: bump DeterminateSystems/update-flake-lock from 25 to 26 (#857) ``    |