### PR TITLE
chore(flake/home-manager): `402333d5` -> `f117b383`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -352,11 +352,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751580393,
-        "narHash": "sha256-oRipTA4/JGeDGI31GNNVGFx0uhuR7h/R9SvkR4K8Axc=",
+        "lastModified": 1751729568,
+        "narHash": "sha256-ay7O1jjalUxkL23QWLv9C2s8rdVGs3hUOPZClIbUHKs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "402333d5ec2f9eed0f2584555936361f39d2f93e",
+        "rev": "f117b383dd591fd579bce5ee7bac07a3fdc1d050",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                             |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`f117b383`](https://github.com/nix-community/home-manager/commit/f117b383dd591fd579bce5ee7bac07a3fdc1d050) | `` numbat: Allow specifying a path for initFile ``                                  |
| [`26d405da`](https://github.com/nix-community/home-manager/commit/26d405da4179c7dafc0a84e611edfa2f5ddf7faa) | `` numbat: Add initFile option ``                                                   |
| [`d75a5474`](https://github.com/nix-community/home-manager/commit/d75a547415f08a52a1e8fc84a1bef9e48bba4c5c) | `` programs.msmtp: merge extraConfig and extraAccount into configContent (#7385) `` |
| [`36c57c6a`](https://github.com/nix-community/home-manager/commit/36c57c6a1d03a5efbf5e23c04dbe21259d25f992) | `` lib/deprecations: add ignore parameter to remapAttrsRecursive ``                 |
| [`650a38eb`](https://github.com/nix-community/home-manager/commit/650a38ebe819d439ece41b5a1c510b3244896265) | `` ashell: support yaml and toml config ``                                          |
| [`f62e9a81`](https://github.com/nix-community/home-manager/commit/f62e9a8114bc181ae160c9a1d7ce8205fa5619b0) | `` lib/strings: add extra string matching predicates ``                             |
| [`19f0ba9c`](https://github.com/nix-community/home-manager/commit/19f0ba9c52f30c1a26e816a05bddf6b4aa9e327d) | `` lib/deprecations: add remapAttrsRecursive ``                                     |
| [`a4fc77c6`](https://github.com/nix-community/home-manager/commit/a4fc77c63d41b74f156f25fb34be905527865028) | `` ashell: new ashell 0.5.0 config standards ``                                     |
| [`e8da7372`](https://github.com/nix-community/home-manager/commit/e8da7372fd1f0da3fe3874af3aa9ddd78662d8ae) | `` anki: add module (#7274) ``                                                      |
| [`57d1027e`](https://github.com/nix-community/home-manager/commit/57d1027e1eaf1220342248ff18d34f42b0beea7b) | `` aerc: allow config sections to be lines (#7280) ``                               |
| [`7d9e3c35`](https://github.com/nix-community/home-manager/commit/7d9e3c35f0d46f82bac791d76260f15f53d83529) | `` all-maintainers: regenerate with latest changes ``                               |
| [`412c545b`](https://github.com/nix-community/home-manager/commit/412c545bb6df640c795177b02f79831087132267) | `` extract-maintainers-meta: simplify ``                                            |
| [`f6d11046`](https://github.com/nix-community/home-manager/commit/f6d11046657ea7e22a70be602f1b05ea61684056) | `` extract-maintainers-meta: include non module system files ``                     |
| [`b8bb556c`](https://github.com/nix-community/home-manager/commit/b8bb556ce5abe5bbc10acb7508ef273b053f647d) | `` maintainers: remove duplicate HM entries ``                                      |
| [`18e1f7fb`](https://github.com/nix-community/home-manager/commit/18e1f7fbce644f9fe44cf38faad137f2d0bfa1af) | `` ci: validate maintainers also checks for duplicate maintainers ``                |
| [`31242bdf`](https://github.com/nix-community/home-manager/commit/31242bdf8f5fff430a23bc167dd8e0fb2fce4c35) | `` polybar: fix meta.maintainer position ``                                         |
| [`83f97881`](https://github.com/nix-community/home-manager/commit/83f978812c37511ef2ffaf75ffa72160483f738a) | `` podman: support mounts configuration (#7377) ``                                  |