### PR TITLE
chore(flake/sops-nix): `77c423a0` -> `3633fc4a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -913,11 +913,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750119275,
-        "narHash": "sha256-Rr7Pooz9zQbhdVxux16h7URa6mA80Pb/G07T4lHvh0M=",
+        "lastModified": 1751606940,
+        "narHash": "sha256-KrDPXobG7DFKTOteqdSVeL1bMVitDcy7otpVZWDE6MA=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "77c423a03b9b2b79709ea2cb63336312e78b72e2",
+        "rev": "3633fc4acf03f43b260244d94c71e9e14a2f6e0d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                               |
| ----------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`3633fc4a`](https://github.com/Mic92/sops-nix/commit/3633fc4acf03f43b260244d94c71e9e14a2f6e0d) | `` fix missing package ``             |
| [`655b3e3a`](https://github.com/Mic92/sops-nix/commit/655b3e3a45f0662e49ff13c19449b8be884ad3a8) | `` fix error with `nix flake show` `` |