### PR TITLE
chore(flake/catppuccin): `0b48d7ff` -> `719bb50c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1751584101,
-        "narHash": "sha256-+22eT7KEfA3gLYljZqUb/Of+ZB2j0zH94AyALBysgyk=",
+        "lastModified": 1751705516,
+        "narHash": "sha256-Y099OGYWYHtpYFP4offuV6rldBnpUv4CYk+HwuaQwLU=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "0b48d7ff0b8b6e614a013db0c384b1aeac694e32",
+        "rev": "719bb50ca2c99bc9c077669a48bfd9815493a11d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                               |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`719bb50c`](https://github.com/catppuccin/nix/commit/719bb50ca2c99bc9c077669a48bfd9815493a11d) | `` chore(lazygit): remove IFD (#604) ``                                               |
| [`f07078de`](https://github.com/catppuccin/nix/commit/f07078deae3c9f896ed3aa8bd4b114d9ab59dce8) | `` Revert "feat(home-manager/firefox): enable 'default' profile by default" (#603) `` |
| [`09e2be24`](https://github.com/catppuccin/nix/commit/09e2be240370f27312a44633d852732b66cb8f01) | `` feat(home-manager): add support for mangohud (#599) ``                             |
| [`c4c3df65`](https://github.com/catppuccin/nix/commit/c4c3df651082217710617a631d826a3c3d1ba075) | `` feat(fctix5): add enableRounded option (#600) ``                                   |
| [`423c448b`](https://github.com/catppuccin/nix/commit/423c448b6823cb6d0c284116d3829b16120ef0d9) | `` feat(home-manager/firefox): enable 'default' profile by default (#597) ``          |
| [`194881dd`](https://github.com/catppuccin/nix/commit/194881dd2ad6303bc2d49f9ce484d127372d7465) | `` feat(home-manager/vscode): Add support for per-profile config (#595) ``            |