### PR TITLE
chore(flake/emacs-overlay): `acdb3607` -> `00d4d098`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1751595285,
-        "narHash": "sha256-xYgWEszsCxwYT0I2irXq+OIxuWakBjM4SE5EevbU0C8=",
+        "lastModified": 1751646329,
+        "narHash": "sha256-CtelQKKRcMlH41PSm3kLpZZzVpjaV+WtNx64y6q1fp4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "acdb3607deb5a42163249378da3513ba1a8ada05",
+        "rev": "00d4d09883863ae7456f86c8bb2f3c03719e3c02",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`00d4d098`](https://github.com/nix-community/emacs-overlay/commit/00d4d09883863ae7456f86c8bb2f3c03719e3c02) | `` Updated elpa ``   |
| [`02aa49bb`](https://github.com/nix-community/emacs-overlay/commit/02aa49bbe8e37acfd6dffab70e085c1af3b1876a) | `` Updated nongnu `` |