### PR TITLE
chore(flake/emacs-overlay): `00d4d098` -> `9ef65f39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1751646329,
-        "narHash": "sha256-CtelQKKRcMlH41PSm3kLpZZzVpjaV+WtNx64y6q1fp4=",
+        "lastModified": 1751821693,
+        "narHash": "sha256-N9vSw5nENL0YHddiLRIMh3EXwD60SjhypqSCt4xnD9k=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "00d4d09883863ae7456f86c8bb2f3c03719e3c02",
+        "rev": "9ef65f3921dab451acc52c96daad68fecd6ea2e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`9ef65f39`](https://github.com/nix-community/emacs-overlay/commit/9ef65f3921dab451acc52c96daad68fecd6ea2e1) | `` Updated melpa ``        |
| [`4f520d47`](https://github.com/nix-community/emacs-overlay/commit/4f520d4784a7039db9eb0d6c5bbf46c1578fafc0) | `` Updated emacs ``        |
| [`b36094ff`](https://github.com/nix-community/emacs-overlay/commit/b36094ff60e3b8e3d8cda96f2824bd57bbf32d93) | `` Updated elpa ``         |
| [`374852af`](https://github.com/nix-community/emacs-overlay/commit/374852af1b33829dab1734c890e41ceb2a75828c) | `` Updated nongnu ``       |
| [`9b4124eb`](https://github.com/nix-community/emacs-overlay/commit/9b4124ebcf6b1387e61761f5b46e940f91f18d5a) | `` Updated melpa ``        |
| [`ea29925b`](https://github.com/nix-community/emacs-overlay/commit/ea29925b983074e1f1482b884e4cb9aa9b9e02de) | `` Updated emacs ``        |
| [`2447869c`](https://github.com/nix-community/emacs-overlay/commit/2447869cbd64a802a72d9c94122dede36d51a335) | `` Updated melpa ``        |
| [`77a1d284`](https://github.com/nix-community/emacs-overlay/commit/77a1d284c248dc84412cc329150a02f08657aaab) | `` Updated emacs ``        |
| [`35e4150b`](https://github.com/nix-community/emacs-overlay/commit/35e4150b360528360680a0b75e142396c6fbd484) | `` Updated elpa ``         |
| [`03292e30`](https://github.com/nix-community/emacs-overlay/commit/03292e302b78321eaba835d0126a35aca0f8bafc) | `` Updated nongnu ``       |
| [`78145636`](https://github.com/nix-community/emacs-overlay/commit/7814563653df513416099284cb1d95c2bf96f95f) | `` Updated flake inputs `` |
| [`ab81896f`](https://github.com/nix-community/emacs-overlay/commit/ab81896fac2f4238718d42248af2cba678050963) | `` Updated melpa ``        |
| [`0442e156`](https://github.com/nix-community/emacs-overlay/commit/0442e15621c2474483d513dd29ab0f78ae8302ac) | `` Updated emacs ``        |
| [`57d1fbfd`](https://github.com/nix-community/emacs-overlay/commit/57d1fbfd7ad6bbc3c4ff0b6e8fd8dde33620d52b) | `` Updated nongnu ``       |
| [`c444de8a`](https://github.com/nix-community/emacs-overlay/commit/c444de8aed68439fa788b7d3740b98f3c1bdef6b) | `` Updated melpa ``        |
| [`80b1e931`](https://github.com/nix-community/emacs-overlay/commit/80b1e9317e0a571db079e99efa135a345e9d1889) | `` Updated emacs ``        |
| [`5ccdea94`](https://github.com/nix-community/emacs-overlay/commit/5ccdea942b6d6483c626a82a5a2eb856afb4a96e) | `` Updated melpa ``        |
| [`96f9656c`](https://github.com/nix-community/emacs-overlay/commit/96f9656c86d4190ced26c529907efed49de0726f) | `` Updated emacs ``        |
| [`ad9f3477`](https://github.com/nix-community/emacs-overlay/commit/ad9f347739b80f42f517dbba401a8bfb0cea30b2) | `` Updated nongnu ``       |