### PR TITLE
chore(flake/minimal-emacs-d): `42929fd0` -> `afffa5ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -414,11 +414,11 @@
     "minimal-emacs-d": {
       "flake": false,
       "locked": {
-        "lastModified": 1751558993,
-        "narHash": "sha256-B4uB2M8mQr/bf4z9PTPFaVEJgcL7dwgWKWbLF7I25t8=",
+        "lastModified": 1751687881,
+        "narHash": "sha256-fVMPV1BX5nWBKJbxtiLnDLlFGWBEEWm1UdIdmGQF8NA=",
         "owner": "jamescherti",
         "repo": "minimal-emacs.d",
-        "rev": "42929fd0804c85eb7cd1f74c7047a84223984d11",
+        "rev": "afffa5bade64e6fb44ca970d0230423e60551ef6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                                           |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------- |
| [`afffa5ba`](https://github.com/jamescherti/minimal-emacs.d/commit/afffa5bade64e6fb44ca970d0230423e60551ef6) | `` Add redisplay-skip-fontification-on-input ``                                   |
| [`9e7911fa`](https://github.com/jamescherti/minimal-emacs.d/commit/9e7911fab1f90f28d0f5d363aadf20b6a8b3e93a) | `` Update README.md ``                                                            |
| [`2e5a413d`](https://github.com/jamescherti/minimal-emacs.d/commit/2e5a413d72211de4073f131d2cea5fa854d55ed6) | `` Update README.md ``                                                            |
| [`081acac5`](https://github.com/jamescherti/minimal-emacs.d/commit/081acac52c9d50a6fa5ac92c8792cdb8a3687163) | `` Fixes #67: Dired doesn't work in MacOS because of --group-directories-first `` |