### PR TITLE
chore(flake/nixGL): `310f8e49` -> `d47b0db3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -533,11 +533,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713543440,
-        "narHash": "sha256-lnzZQYG0+EXl/6NkGpyIz+FEOc/DSEG57AP1VsdeNrM=",
+        "lastModified": 1751696036,
+        "narHash": "sha256-hXq4IOgSdAAaF/9q/2U8TBDL7aXZyQmtq4wl6USZjKo=",
         "owner": "nix-community",
         "repo": "nixGL",
-        "rev": "310f8e49a149e4c9ea52f1adf70cdc768ec53f8a",
+        "rev": "d47b0db35dfa693c10f7c378043dcc6121d3f4ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                      |
| ---------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`47a76f8d`](https://github.com/nix-community/nixGL/commit/47a76f8d2d1dad9f5036e6da6b0b56014adb1272) | `` Create LICENSE (#174) ``  |
| [`d351a6b5`](https://github.com/nix-community/nixGL/commit/d351a6b5f442731b7e85458e1a2a32cb32f03e2e) | `` Update CI action ``       |
| [`966419db`](https://github.com/nix-community/nixGL/commit/966419db4c2ad1467a2b09c3061e5f05021eb6fc) | `` Update the flake input `` |