### PR TITLE
chore(flake/nur): `ff6e470d` -> `5d8566b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -741,11 +741,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1751271578,
-        "narHash": "sha256-P/SQmKDu06x8yv7i0s8bvnnuJYkxVGBWLWHaU+tt4YY=",
+        "lastModified": 1751637120,
+        "narHash": "sha256-xVNy/XopSfIG9c46nRmPaKfH1Gn/56vQ8++xWA8itO4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3016b4b15d13f3089db8a41ef937b13a9e33a8df",
+        "rev": "5c724ed1388e53cc231ed98330a60eb2f7be4be3",
         "type": "github"
       },
       "original": {
@@ -799,11 +799,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1751729623,
-        "narHash": "sha256-iq5PwAP7HFJ5I9942RvaJwU/F0vBjuORC8U2Yf6qMUw=",
+        "lastModified": 1751744760,
+        "narHash": "sha256-z0wQX4GQYOxwCZ94+aU3Z4NnJHPoaPIsrOgw91lWa8w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ff6e470d2e26b173e6e3ec18ad80cc5c667a51f7",
+        "rev": "5d8566b7031d3d1134cc31dfd4b212b2e0df870f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5d8566b7`](https://github.com/nix-community/NUR/commit/5d8566b7031d3d1134cc31dfd4b212b2e0df870f) | `` automatic update `` |
| [`d7ad850e`](https://github.com/nix-community/NUR/commit/d7ad850e64098032b6f4d86b034cc9e1c5215417) | `` automatic update `` |
| [`30c04fd2`](https://github.com/nix-community/NUR/commit/30c04fd2215b3f5faf9cdeefccdce30dd5a435e1) | `` automatic update `` |
| [`da2136f6`](https://github.com/nix-community/NUR/commit/da2136f67780b4a2a50263d221204934306c00de) | `` automatic update `` |
| [`53b28242`](https://github.com/nix-community/NUR/commit/53b28242d904d71f0a15e596015f42880eb438f9) | `` automatic update `` |
| [`e1057363`](https://github.com/nix-community/NUR/commit/e105736348b97b9600e469465d6d691e55868c38) | `` automatic update `` |
| [`179e95cd`](https://github.com/nix-community/NUR/commit/179e95cda1a895ed05b22e8eba14fc61ce28ac2f) | `` automatic update `` |
| [`553a11e4`](https://github.com/nix-community/NUR/commit/553a11e46f96b1633fc0aede9d43a3178d6e3272) | `` automatic update `` |