### PR TITLE
chore(flake/home-manager): `f117b383` -> `fd9e55f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -352,11 +352,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751729568,
-        "narHash": "sha256-ay7O1jjalUxkL23QWLv9C2s8rdVGs3hUOPZClIbUHKs=",
+        "lastModified": 1751824240,
+        "narHash": "sha256-aDDC0CHTlL7QDKWWhdbEgVPK6KwWt+ca0QkmHYZxMzI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f117b383dd591fd579bce5ee7bac07a3fdc1d050",
+        "rev": "fd9e55f5fac45a26f6169310afca64d56b681935",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                  |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`fd9e55f5`](https://github.com/nix-community/home-manager/commit/fd9e55f5fac45a26f6169310afca64d56b681935) | `` tests/firefox: add bookmark policy to profile bookmarks test ``                       |
| [`753ea0b3`](https://github.com/nix-community/home-manager/commit/753ea0b3240ae3d64923dc77e33aa5c1be06b62f) | `` librewolf: allow bookmark configuration ``                                            |
| [`dbac1fbc`](https://github.com/nix-community/home-manager/commit/dbac1fbcd675c7e7149a35309269c37aef6223ee) | `` mkFirefoxModule: set `NoDefaultBookmarks` when a profile has bookmarks are enabled `` |
| [`9d21f998`](https://github.com/nix-community/home-manager/commit/9d21f9985e279bb5d35dbf03a25644ed6e954d8c) | `` i3-sway/lib: modifier accepts any string (#7398) ``                                   |
| [`b4486ff4`](https://github.com/nix-community/home-manager/commit/b4486ff44addd453a64fd8c176ab2fd7ad3f6eb3) | `` mkFirefoxModule: add extension settings example to policies (#7397) ``                |
| [`153e680c`](https://github.com/nix-community/home-manager/commit/153e680c4263fbd8fa416ef5b8ef13397e02fd2f) | `` firefox: add release option (#6784) ``                                                |
| [`502d9b7d`](https://github.com/nix-community/home-manager/commit/502d9b7d30a1f5940ecdb786b4f71ebf57b1ac13) | `` codex: starting with v0.2.0 codex uses a TOML configuration file (#7388) ``           |
| [`cc740783`](https://github.com/nix-community/home-manager/commit/cc7407839d09cef4838c9980ee3a390c28085951) | `` flake.lock: Update (#7395) ``                                                         |
| [`8b0180dd`](https://github.com/nix-community/home-manager/commit/8b0180dde1d6f4cf632e046309e8f963924dfbd0) | `` maintainers: update all-maintainers.nix (#7392) ``                                    |
| [`af8a8841`](https://github.com/nix-community/home-manager/commit/af8a884164bb50ad34c09719bdbdb2a1b01b917c) | `` kubeswitch: add module ``                                                             |
| [`92db5be8`](https://github.com/nix-community/home-manager/commit/92db5be8e17c5150c46a2ca8f55a85d20df75643) | `` maintainers: add m0nsterrr ``                                                         |
| [`5a49fe44`](https://github.com/nix-community/home-manager/commit/5a49fe448e81ee05ab48ed3189109b322237ddbf) | `` opencode: init (#7320) ``                                                             |