### PR TITLE
chore(flake/nur): `b041d91c` -> `59016962`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -799,11 +799,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1751794199,
-        "narHash": "sha256-5cIwgbfXZNK3uYg1XpOlsL9DMQdef6IBppyOPA5Gv70=",
+        "lastModified": 1751847206,
+        "narHash": "sha256-PZCnajaxnCcUhcri7Q03CHtNvq4PaKSLa67t3KBV+D4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b041d91c7ce1b89c6ddcf48e426292bf2e97f8e2",
+        "rev": "590169623616e1dfce132e6f90295573ec340d69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`59016962`](https://github.com/nix-community/NUR/commit/590169623616e1dfce132e6f90295573ec340d69) | `` automatic update `` |
| [`2e9dcee6`](https://github.com/nix-community/NUR/commit/2e9dcee6eaf88c2950844dde2d72e3db51145eb2) | `` automatic update `` |
| [`10629ed6`](https://github.com/nix-community/NUR/commit/10629ed6781e52616c40b6e4b86c39e45c58c12f) | `` automatic update `` |
| [`d67eb728`](https://github.com/nix-community/NUR/commit/d67eb72822b99edd22ea4f5043d05c149aac204c) | `` automatic update `` |
| [`ee7920ac`](https://github.com/nix-community/NUR/commit/ee7920ac3e2a8a4bd1c70b4780c22180b3fdd3c8) | `` automatic update `` |
| [`e45a4911`](https://github.com/nix-community/NUR/commit/e45a49117667e8d80e025ed44bc343e5e763a22e) | `` automatic update `` |
| [`c6a24385`](https://github.com/nix-community/NUR/commit/c6a24385d1e517bb1d901d63148828c8cfdff3dd) | `` automatic update `` |
| [`a1b8b52a`](https://github.com/nix-community/NUR/commit/a1b8b52af03ff8da75e6c3d5e1ed4d3fc3fa3198) | `` automatic update `` |
| [`e74eb382`](https://github.com/nix-community/NUR/commit/e74eb3825e21c588983f337ca57c675855b3d5d4) | `` automatic update `` |
| [`6decca0a`](https://github.com/nix-community/NUR/commit/6decca0a78f44ff30f582226e7c1ed4e4b40c831) | `` automatic update `` |
| [`da253eb9`](https://github.com/nix-community/NUR/commit/da253eb95aeb8c9c6da3972eeb2828dae9df3bca) | `` automatic update `` |
| [`4993c0b4`](https://github.com/nix-community/NUR/commit/4993c0b47fb9942275d6c64a42a1061962c3358c) | `` automatic update `` |