### PR TITLE
chore(flake/emacs-overlay): `9ef65f39` -> `d88b4b41`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1751821693,
-        "narHash": "sha256-N9vSw5nENL0YHddiLRIMh3EXwD60SjhypqSCt4xnD9k=",
+        "lastModified": 1751852591,
+        "narHash": "sha256-5+eH9k3QpgxijkCWF12Iq73oqyr9LPkLfAsKS9GDsLU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9ef65f3921dab451acc52c96daad68fecd6ea2e1",
+        "rev": "d88b4b41d40b012ca06bbeb465871cd66b8b9d27",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`d88b4b41`](https://github.com/nix-community/emacs-overlay/commit/d88b4b41d40b012ca06bbeb465871cd66b8b9d27) | `` Updated elpa ``   |
| [`80a24045`](https://github.com/nix-community/emacs-overlay/commit/80a240454472243430b763ab2bdcb37c8149a388) | `` Updated nongnu `` |