### PR TITLE
chore(flake/emacs-overlay): `d88b4b41` -> `7117741b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1751852591,
-        "narHash": "sha256-5+eH9k3QpgxijkCWF12Iq73oqyr9LPkLfAsKS9GDsLU=",
+        "lastModified": 1751879680,
+        "narHash": "sha256-Ds+BCEUMgMBLaZRURHh8uVLVb0J6EVBxU5jtvXOldGM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d88b4b41d40b012ca06bbeb465871cd66b8b9d27",
+        "rev": "7117741b454cf1aa6c6d47f1a8d213e62ab0bb84",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`7117741b`](https://github.com/nix-community/emacs-overlay/commit/7117741b454cf1aa6c6d47f1a8d213e62ab0bb84) | `` Updated melpa ``        |
| [`81d9dcf0`](https://github.com/nix-community/emacs-overlay/commit/81d9dcf0fc065bb7d89761dde4f2fed0c8e443eb) | `` Updated emacs ``        |
| [`20946dca`](https://github.com/nix-community/emacs-overlay/commit/20946dca55a61b69a5f0edf1eac8bf3c46ec258f) | `` Updated flake inputs `` |