### PR TITLE
chore(flake/emacs-overlay): `7117741b` -> `8e4ecd7c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1751879680,
-        "narHash": "sha256-Ds+BCEUMgMBLaZRURHh8uVLVb0J6EVBxU5jtvXOldGM=",
+        "lastModified": 1751908357,
+        "narHash": "sha256-7JeYhMYTdfzHsFfGZRUM+t0nx4HdYa3oaMH2B/qz9MA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7117741b454cf1aa6c6d47f1a8d213e62ab0bb84",
+        "rev": "8e4ecd7c43c5e061dd2fc4d9d1994ec4d67cab2e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`8e4ecd7c`](https://github.com/nix-community/emacs-overlay/commit/8e4ecd7c43c5e061dd2fc4d9d1994ec4d67cab2e) | `` Updated melpa ``  |
| [`adaca1ef`](https://github.com/nix-community/emacs-overlay/commit/adaca1efb09beb4adaef5b5db27e2641b8a53325) | `` Updated emacs ``  |
| [`55455e01`](https://github.com/nix-community/emacs-overlay/commit/55455e01b28a9eab4a158dd6ab07dee73c4986f9) | `` Updated elpa ``   |
| [`c02f3cc9`](https://github.com/nix-community/emacs-overlay/commit/c02f3cc9672fc13e99c717fecf94f700be4c4340) | `` Updated nongnu `` |