### PR TITLE
chore(flake/nur): `01014de0` -> `4c291ad1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -799,11 +799,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1751927684,
-        "narHash": "sha256-79NL65Sw4vB75Bd2y3D+NFOCgQqxG39xrqdBhKqJMZo=",
+        "lastModified": 1751947506,
+        "narHash": "sha256-tiBuGh6cxTlurZNOWqOfMKswSzcWhc8coimunsnl4Yw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "01014de008dea8982bb4732089b8569424bbef46",
+        "rev": "4c291ad1b6086223b6e257cbe734501a6a9d3fb6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4c291ad1`](https://github.com/nix-community/NUR/commit/4c291ad1b6086223b6e257cbe734501a6a9d3fb6) | `` automatic update `` |
| [`18e229e9`](https://github.com/nix-community/NUR/commit/18e229e91df7956d114c266d2e472de87951a34d) | `` automatic update `` |
| [`3c46cb58`](https://github.com/nix-community/NUR/commit/3c46cb5879c43b40aabdfe82877eee683b5ebb30) | `` automatic update `` |
| [`be1a7678`](https://github.com/nix-community/NUR/commit/be1a7678a9e0f86295a0facdd3961e8e7e94eb41) | `` automatic update `` |
| [`9c2c8f73`](https://github.com/nix-community/NUR/commit/9c2c8f73346951214528ee6332bceab7f0fbc624) | `` automatic update `` |