### PR TITLE
chore(flake/emacs-overlay): `8e4ecd7c` -> `4bf862ff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1751908357,
-        "narHash": "sha256-7JeYhMYTdfzHsFfGZRUM+t0nx4HdYa3oaMH2B/qz9MA=",
+        "lastModified": 1752226781,
+        "narHash": "sha256-tzdPce6wQGUSQ4BrnHzC/PW+c+fEXHvfjax2iPx2OP4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8e4ecd7c43c5e061dd2fc4d9d1994ec4d67cab2e",
+        "rev": "4bf862fff2ff0d2618813b698d5b2dbf9cc355cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`4bf862ff`](https://github.com/nix-community/emacs-overlay/commit/4bf862fff2ff0d2618813b698d5b2dbf9cc355cc) | `` Updated emacs ``        |
| [`11215952`](https://github.com/nix-community/emacs-overlay/commit/112159521737d020bee75bfb8702d26933eeca19) | `` Updated melpa ``        |
| [`d797bda1`](https://github.com/nix-community/emacs-overlay/commit/d797bda1908ae40e437d51a4fcd15b6dc2956195) | `` Updated melpa ``        |
| [`72553272`](https://github.com/nix-community/emacs-overlay/commit/7255327281cdb819f7e2bf959097c087d815907e) | `` Updated emacs ``        |
| [`fc31ccb4`](https://github.com/nix-community/emacs-overlay/commit/fc31ccb4f9b115e9447e57dafb0cd356841f3f5f) | `` Updated elpa ``         |
| [`ec732454`](https://github.com/nix-community/emacs-overlay/commit/ec73245421f7e82629552ad5053359bd5293ed2d) | `` Updated nongnu ``       |
| [`9972974b`](https://github.com/nix-community/emacs-overlay/commit/9972974b23747d11421187718a5039bec3b5f675) | `` Updated elpa ``         |
| [`1bd26960`](https://github.com/nix-community/emacs-overlay/commit/1bd269600d7264dfe397f57222a8dd8221ded020) | `` Updated nongnu ``       |
| [`febfa20b`](https://github.com/nix-community/emacs-overlay/commit/febfa20b8cf0e03b474fa6029fe75dfa2cabc97f) | `` Updated melpa ``        |
| [`cff6620e`](https://github.com/nix-community/emacs-overlay/commit/cff6620e9c8030f47dd76c2f6575cf20a4c66768) | `` Updated emacs ``        |
| [`5c75507a`](https://github.com/nix-community/emacs-overlay/commit/5c75507a03c0ee10985b9124a344fd457a219c63) | `` Updated elpa ``         |
| [`8f91ee19`](https://github.com/nix-community/emacs-overlay/commit/8f91ee1966747aadcaa12c7ec1351216889c4869) | `` Updated nongnu ``       |
| [`f038fa72`](https://github.com/nix-community/emacs-overlay/commit/f038fa723daa69b6c0e6bb479163a4093a5af4d9) | `` Updated emacs ``        |
| [`6c6d3785`](https://github.com/nix-community/emacs-overlay/commit/6c6d3785428bc4c739ca8c27b58267428ec2fa00) | `` Updated melpa ``        |
| [`6770bb9f`](https://github.com/nix-community/emacs-overlay/commit/6770bb9f9c937921d14c3da94d03717e3a6a0fed) | `` Updated elpa ``         |
| [`8bd29457`](https://github.com/nix-community/emacs-overlay/commit/8bd294574bb1a71be550ba970708fdc46fea9614) | `` Updated nongnu ``       |
| [`eb09bd12`](https://github.com/nix-community/emacs-overlay/commit/eb09bd1221dddece1b7f45c57ef902b2c6815bb2) | `` Updated flake inputs `` |
| [`5a64a848`](https://github.com/nix-community/emacs-overlay/commit/5a64a848253e773d14dffe72e95bf302932e6d02) | `` Updated melpa ``        |
| [`73c5d354`](https://github.com/nix-community/emacs-overlay/commit/73c5d354a7af9cf692e6cc5f044e06349d411884) | `` Updated elpa ``         |
| [`b30dc844`](https://github.com/nix-community/emacs-overlay/commit/b30dc844217930d65fb76b757eb34d188a9ad8ca) | `` Updated nongnu ``       |
| [`82937ee6`](https://github.com/nix-community/emacs-overlay/commit/82937ee6d83abf5a9a5a8ae05329c37c0e9380cf) | `` Updated melpa ``        |
| [`cd307021`](https://github.com/nix-community/emacs-overlay/commit/cd3070218132ac6cbd71b180fda5b51a8348fb20) | `` Updated emacs ``        |
| [`49d5fcc7`](https://github.com/nix-community/emacs-overlay/commit/49d5fcc70ce467bee03500e0ebc147e95f78c652) | `` Updated elpa ``         |
| [`867dab2a`](https://github.com/nix-community/emacs-overlay/commit/867dab2adb75e75dcc2521dc9e30f40973febc40) | `` Updated nongnu ``       |