### PR TITLE
chore(flake/nur): `4c291ad1` -> `1db122e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -799,11 +799,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1751947506,
-        "narHash": "sha256-tiBuGh6cxTlurZNOWqOfMKswSzcWhc8coimunsnl4Yw=",
+        "lastModified": 1751961421,
+        "narHash": "sha256-d60ujNh5LZHb4zpdfZHsEm/09WahoT04b2IZNkzcbnY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4c291ad1b6086223b6e257cbe734501a6a9d3fb6",
+        "rev": "1db122e728c1ac7deb45e6750a19d705d7e6273e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1db122e7`](https://github.com/nix-community/NUR/commit/1db122e728c1ac7deb45e6750a19d705d7e6273e) | `` automatic update `` |
| [`6792473b`](https://github.com/nix-community/NUR/commit/6792473befcbcbe726e87605dc0041945e877fc0) | `` automatic update `` |
| [`11c2f689`](https://github.com/nix-community/NUR/commit/11c2f68966da9aba352cbb3983bfcf37a785ca63) | `` automatic update `` |
| [`15e3387b`](https://github.com/nix-community/NUR/commit/15e3387b3b652340d553683c4fa1b97093debec9) | `` automatic update `` |
| [`17533997`](https://github.com/nix-community/NUR/commit/17533997a207131c67a8df04855690a3630e6a1d) | `` automatic update `` |