### PR TITLE
chore(flake/nur): `1db122e7` -> `49501595`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -799,11 +799,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1751961421,
-        "narHash": "sha256-d60ujNh5LZHb4zpdfZHsEm/09WahoT04b2IZNkzcbnY=",
+        "lastModified": 1751975278,
+        "narHash": "sha256-2QAc1QeD+4vdN2Vl3QGS1EdEDc0hz5O6/voOosJVZkA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1db122e728c1ac7deb45e6750a19d705d7e6273e",
+        "rev": "49501595a7e41983f30fc3ba0821a08ccfc7fd72",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`49501595`](https://github.com/nix-community/NUR/commit/49501595a7e41983f30fc3ba0821a08ccfc7fd72) | `` automatic update `` |
| [`ba54ff83`](https://github.com/nix-community/NUR/commit/ba54ff832df087e89d6244c0e42aef958a18cd3d) | `` automatic update `` |
| [`98acf149`](https://github.com/nix-community/NUR/commit/98acf149056e9976c2f27c71dcef4f17b6439960) | `` automatic update `` |
| [`2b9f4883`](https://github.com/nix-community/NUR/commit/2b9f4883a8e3feb417acaa4431033c1367a0763d) | `` automatic update `` |