### PR TITLE
chore(flake/nur): `49501595` -> `ec05f316`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -799,11 +799,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1751975278,
-        "narHash": "sha256-2QAc1QeD+4vdN2Vl3QGS1EdEDc0hz5O6/voOosJVZkA=",
+        "lastModified": 1751989830,
+        "narHash": "sha256-KtLrodhjVLhvq9OlrFQP3UtTqju7+1UwbgUn0Q/QDiY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "49501595a7e41983f30fc3ba0821a08ccfc7fd72",
+        "rev": "ec05f316038beba6b45efbf67abdfb4b805321f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ec05f316`](https://github.com/nix-community/NUR/commit/ec05f316038beba6b45efbf67abdfb4b805321f4) | `` automatic update `` |
| [`7bc83b2c`](https://github.com/nix-community/NUR/commit/7bc83b2caddf9044ab666be4fbbfcad1ea3d5ee2) | `` automatic update `` |
| [`adecc184`](https://github.com/nix-community/NUR/commit/adecc18435cfd38e256c0947f2c0fe74831dcaa8) | `` automatic update `` |
| [`2a80ea91`](https://github.com/nix-community/NUR/commit/2a80ea91278d9de29ec32454c1e49e5318b487de) | `` automatic update `` |
| [`2f05317d`](https://github.com/nix-community/NUR/commit/2f05317d91c5d5b0fefd18ee00df1eb3027de326) | `` automatic update `` |