### PR TITLE
chore(flake/nur): `ec05f316` -> `c8045035`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -799,11 +799,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1751989830,
-        "narHash": "sha256-KtLrodhjVLhvq9OlrFQP3UtTqju7+1UwbgUn0Q/QDiY=",
+        "lastModified": 1752003955,
+        "narHash": "sha256-rbFhF0F1kFRENEIKOn2GemPo6GgNRgwRRjmTlN0jlQQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ec05f316038beba6b45efbf67abdfb4b805321f4",
+        "rev": "c8045035de030280406161d242fb021bf15a77fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c8045035`](https://github.com/nix-community/NUR/commit/c8045035de030280406161d242fb021bf15a77fb) | `` automatic update `` |
| [`1ddda31b`](https://github.com/nix-community/NUR/commit/1ddda31b8cbc5c4ab3068d266d0dc233f6c57473) | `` automatic update `` |
| [`dfd6cf3f`](https://github.com/nix-community/NUR/commit/dfd6cf3f475ba7bf4320b8ea2c71fb650e418917) | `` automatic update `` |
| [`8468291b`](https://github.com/nix-community/NUR/commit/8468291b2c3125fd8d70e16a0368d08e468fd282) | `` automatic update `` |
| [`80d89ceb`](https://github.com/nix-community/NUR/commit/80d89ceb7c4718fd62368e4cf30e1c62dbf912c3) | `` automatic update `` |
| [`38e697ee`](https://github.com/nix-community/NUR/commit/38e697ee2d722e60605bbed9f76cd8f312825148) | `` automatic update `` |
| [`ff9d31be`](https://github.com/nix-community/NUR/commit/ff9d31be2b3f3f09d9a90acce176ea3ad10a4582) | `` automatic update `` |
| [`09f16015`](https://github.com/nix-community/NUR/commit/09f160159ff91052a6213a156d3fa84efdc49c6a) | `` automatic update `` |