### PR TITLE
chore(flake/nur): `c8045035` -> `bf268ec0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -799,11 +799,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752003955,
-        "narHash": "sha256-rbFhF0F1kFRENEIKOn2GemPo6GgNRgwRRjmTlN0jlQQ=",
+        "lastModified": 1752014066,
+        "narHash": "sha256-U0YxVLcjcgGEJnbpV875tnWmqU7CS26XOylh3j//JbY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c8045035de030280406161d242fb021bf15a77fb",
+        "rev": "bf268ec0085e4df1464c819d57dc8ab42518b4ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bf268ec0`](https://github.com/nix-community/NUR/commit/bf268ec0085e4df1464c819d57dc8ab42518b4ab) | `` automatic update `` |
| [`3bf8ac35`](https://github.com/nix-community/NUR/commit/3bf8ac35206e4b0a408e89fdfaf252f364aa8b68) | `` automatic update `` |
| [`e250531a`](https://github.com/nix-community/NUR/commit/e250531a0741a33387ec822399e297d4644f16b3) | `` automatic update `` |
| [`93dcdd82`](https://github.com/nix-community/NUR/commit/93dcdd821d0b4d4557e508c28b870d5625b8e89a) | `` automatic update `` |
| [`6b591b6a`](https://github.com/nix-community/NUR/commit/6b591b6aafc08b4a6f6c8736f0eac013b546b9a7) | `` automatic update `` |
| [`c811625a`](https://github.com/nix-community/NUR/commit/c811625ae4ff86e1f70d3ad704687fcc8fc3bffd) | `` automatic update `` |
| [`a9460e59`](https://github.com/nix-community/NUR/commit/a9460e593d4fbab9e5d19000dfe33cfaa20de379) | `` automatic update `` |
| [`c997e095`](https://github.com/nix-community/NUR/commit/c997e0952b5b79e642f56cd00c2165573c2466a3) | `` automatic update `` |
| [`c48f7645`](https://github.com/nix-community/NUR/commit/c48f7645e19cb663793f5a8669f8658593b56d98) | `` automatic update `` |
| [`a2570fb4`](https://github.com/nix-community/NUR/commit/a2570fb4d0699fd34ebbbd52e2a763722601f6c6) | `` automatic update `` |