### PR TITLE
chore(flake/nur): `bf268ec0` -> `d0565cfe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -799,11 +799,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752014066,
-        "narHash": "sha256-U0YxVLcjcgGEJnbpV875tnWmqU7CS26XOylh3j//JbY=",
+        "lastModified": 1752034072,
+        "narHash": "sha256-OfDYZIvN64hi9YV+yWTsqzmACmYKaWDKv9n4l0SeoaQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bf268ec0085e4df1464c819d57dc8ab42518b4ab",
+        "rev": "d0565cfede3524c1a383261732cbdd8a08b3c728",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d0565cfe`](https://github.com/nix-community/NUR/commit/d0565cfede3524c1a383261732cbdd8a08b3c728) | `` automatic update `` |
| [`7277127c`](https://github.com/nix-community/NUR/commit/7277127c9715cc3f0bdc9299476c3c0ad3aadb66) | `` automatic update `` |
| [`a487b50f`](https://github.com/nix-community/NUR/commit/a487b50f4cf3e852628e29f56798d64985e663bf) | `` automatic update `` |
| [`6ea31e05`](https://github.com/nix-community/NUR/commit/6ea31e0515809db2fb06c00528508f6b7cf37543) | `` automatic update `` |
| [`4f910a69`](https://github.com/nix-community/NUR/commit/4f910a69fdac3450db6de5e0eb31af7ba7af3d3f) | `` automatic update `` |