### PR TITLE
chore(flake/nur): `d0565cfe` -> `64185b16`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -799,11 +799,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752034072,
-        "narHash": "sha256-OfDYZIvN64hi9YV+yWTsqzmACmYKaWDKv9n4l0SeoaQ=",
+        "lastModified": 1752047019,
+        "narHash": "sha256-cquBxPthNijnDaoX6Pj5V0jQ5BhoqJOJ/DdGzeJ0xyg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d0565cfede3524c1a383261732cbdd8a08b3c728",
+        "rev": "64185b1642f23c6340e3ebd52eabccfadfb78cfb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`64185b16`](https://github.com/nix-community/NUR/commit/64185b1642f23c6340e3ebd52eabccfadfb78cfb) | `` automatic update `` |
| [`5b96f6ce`](https://github.com/nix-community/NUR/commit/5b96f6ce4300f587762f4b878de57645b7432fc6) | `` automatic update `` |
| [`3f14ebda`](https://github.com/nix-community/NUR/commit/3f14ebdacda996a28b2f656e59f90984d5bd556b) | `` automatic update `` |
| [`88641e50`](https://github.com/nix-community/NUR/commit/88641e5053c688cc305ea8e47c38ad37895187bb) | `` automatic update `` |