### PR TITLE
chore(flake/nur): `64185b16` -> `16643788`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -741,11 +741,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1751792365,
-        "narHash": "sha256-J1kI6oAj25IG4EdVlg2hQz8NZTBNYvIS0l4wpr9KcUo=",
+        "lastModified": 1751984180,
+        "narHash": "sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X+xgOL0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1fd8bada0b6117e6c7eb54aad5813023eed37ccb",
+        "rev": "9807714d6944a957c2e036f84b0ff8caf9930bc0",
         "type": "github"
       },
       "original": {
@@ -799,11 +799,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752047019,
-        "narHash": "sha256-cquBxPthNijnDaoX6Pj5V0jQ5BhoqJOJ/DdGzeJ0xyg=",
+        "lastModified": 1752089474,
+        "narHash": "sha256-DM0VITWX1gqVVF82jeHYsihUVhRQXEh2nq0Gc1l2HVM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "64185b1642f23c6340e3ebd52eabccfadfb78cfb",
+        "rev": "16643788946b715e831548f820e98137f358536a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`16643788`](https://github.com/nix-community/NUR/commit/16643788946b715e831548f820e98137f358536a) | `` automatic update `` |
| [`5b1c797b`](https://github.com/nix-community/NUR/commit/5b1c797b03cfc35caa2040e76bf7895ff182601d) | `` automatic update `` |
| [`2fa54e17`](https://github.com/nix-community/NUR/commit/2fa54e17e204843a56ee6167c60b2eae183c9678) | `` automatic update `` |
| [`175afa73`](https://github.com/nix-community/NUR/commit/175afa73deabad5f57f5a2bd860ca676993a13d3) | `` automatic update `` |
| [`ad65272c`](https://github.com/nix-community/NUR/commit/ad65272ca97c686dda0caa70326af6e527cb56b6) | `` automatic update `` |
| [`65a6e8d8`](https://github.com/nix-community/NUR/commit/65a6e8d85d96ac8f7edc2f8cd9cf245e19fe73db) | `` automatic update `` |
| [`f8e62e41`](https://github.com/nix-community/NUR/commit/f8e62e4174138d0b3079cfcc52cbdc0837339de4) | `` automatic update `` |
| [`31638a11`](https://github.com/nix-community/NUR/commit/31638a11a8dd61ff4a040251b9663419485edf96) | `` automatic update `` |
| [`808c7777`](https://github.com/nix-community/NUR/commit/808c777775781626a946e86c6e34f3e16af5bff6) | `` automatic update `` |
| [`9db2aa1b`](https://github.com/nix-community/NUR/commit/9db2aa1b8673461fef354c788abe40e0973b0427) | `` automatic update `` |