### PR TITLE
chore(flake/nur): `16643788` -> `ed43806a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -799,11 +799,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752089474,
-        "narHash": "sha256-DM0VITWX1gqVVF82jeHYsihUVhRQXEh2nq0Gc1l2HVM=",
+        "lastModified": 1752100463,
+        "narHash": "sha256-wII0BUaQ2QaqZwqrxu4Fg4SBSTyR7fptQsn6wpxknKU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "16643788946b715e831548f820e98137f358536a",
+        "rev": "ed43806ae56b0d0c9fb945e6b339fb5c40676ee8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ed43806a`](https://github.com/nix-community/NUR/commit/ed43806ae56b0d0c9fb945e6b339fb5c40676ee8) | `` automatic update `` |
| [`00fb900a`](https://github.com/nix-community/NUR/commit/00fb900a250797fa11f84190b40ca0e4115f7e22) | `` automatic update `` |
| [`f75d6541`](https://github.com/nix-community/NUR/commit/f75d6541afb65affb1f7c733782c2ff619ca55fd) | `` automatic update `` |
| [`5f4fb1a1`](https://github.com/nix-community/NUR/commit/5f4fb1a1a861afb6ce7cba14d4ee9531a03f6872) | `` automatic update `` |