### PR TITLE
chore(flake/nur): `ed43806a` -> `77175ed8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -799,11 +799,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752100463,
-        "narHash": "sha256-wII0BUaQ2QaqZwqrxu4Fg4SBSTyR7fptQsn6wpxknKU=",
+        "lastModified": 1752120367,
+        "narHash": "sha256-4pP31qcezyW4gh8F8CfDV/Tuq631WRGNmpmhnVhgD/o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ed43806ae56b0d0c9fb945e6b339fb5c40676ee8",
+        "rev": "77175ed82ff93f6066cfb5cf11461345a7061e23",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`77175ed8`](https://github.com/nix-community/NUR/commit/77175ed82ff93f6066cfb5cf11461345a7061e23) | `` automatic update `` |
| [`1a722e06`](https://github.com/nix-community/NUR/commit/1a722e06325cce8a7614a64bca1ae0a5da1647b6) | `` automatic update `` |
| [`d815dd7e`](https://github.com/nix-community/NUR/commit/d815dd7e22084222bd704396ce722a9f1b694e71) | `` automatic update `` |
| [`e2409d89`](https://github.com/nix-community/NUR/commit/e2409d8949836fa19a93e597f1f031eb48bec07b) | `` automatic update `` |
| [`bef81c13`](https://github.com/nix-community/NUR/commit/bef81c13ff962036bad7e7053b3970141103eda6) | `` automatic update `` |