### PR TITLE
chore(flake/nur): `2a4bbc31` -> `d257dcb0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752179901,
-        "narHash": "sha256-q1+/NfIAXqaCy25+ojX/CVSaWTnHIFhKO/cvNlFvrnY=",
+        "lastModified": 1752191316,
+        "narHash": "sha256-vya1JwHqXAt0mbAcTts5UVargMlK0wfeJRrHaH71DLw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2a4bbc316af0ab4590abd9053da223e4fbe45e48",
+        "rev": "d257dcb0ec3e3091332f82df4e1e95d4196c436c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d257dcb0`](https://github.com/nix-community/NUR/commit/d257dcb0ec3e3091332f82df4e1e95d4196c436c) | `` automatic update `` |
| [`3d18c222`](https://github.com/nix-community/NUR/commit/3d18c222917ad6b1972f6b4aae5e40271b4de99f) | `` automatic update `` |
| [`baeb98e3`](https://github.com/nix-community/NUR/commit/baeb98e3f16ab735682ca218deda9334af2874f9) | `` automatic update `` |