### PR TITLE
chore(flake/nur): `d257dcb0` -> `f166dc14`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752191316,
-        "narHash": "sha256-vya1JwHqXAt0mbAcTts5UVargMlK0wfeJRrHaH71DLw=",
+        "lastModified": 1752207112,
+        "narHash": "sha256-dnVoQSGQqEGJQzS6iHAG95c0oFrezzBinwu1bDLj9J4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d257dcb0ec3e3091332f82df4e1e95d4196c436c",
+        "rev": "f166dc14862dfec043f9545e8291cc4402f8b866",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f166dc14`](https://github.com/nix-community/NUR/commit/f166dc14862dfec043f9545e8291cc4402f8b866) | `` automatic update `` |
| [`755a971b`](https://github.com/nix-community/NUR/commit/755a971bde7d8ea9ffe85fe93cf96055464c9bff) | `` automatic update `` |
| [`6614a617`](https://github.com/nix-community/NUR/commit/6614a61721e81bbdf27bcc0e523af81da6bacd2c) | `` automatic update `` |
| [`4f649911`](https://github.com/nix-community/NUR/commit/4f6499114fa3cf34507d7913b92904a1e7b1b02c) | `` automatic update `` |
| [`d0f13012`](https://github.com/nix-community/NUR/commit/d0f130126d774bdd7b91726cce5d84a52eed5ef3) | `` automatic update `` |