### PR TITLE
chore(flake/home-manager): `3978bcd6` -> `fab659b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -352,11 +352,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752180332,
-        "narHash": "sha256-CCufHi/GclygJZbbsKyTvqylz5E3pH2oHFL9ycB8YMM=",
+        "lastModified": 1752202894,
+        "narHash": "sha256-knafgng4gCjZIUMyAEWjxxdols6n/swkYnbWr+oF+1w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3978bcd6961847385121db30c58dbd444d4a73df",
+        "rev": "fab659b346c0d4252208434c3c4b3983a4b38fec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                          |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`fab659b3`](https://github.com/nix-community/home-manager/commit/fab659b346c0d4252208434c3c4b3983a4b38fec) | `` trippy: add module (#7426) `` |