### PR TITLE
chore(flake/nur): `f166dc14` -> `db699ccf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752207112,
-        "narHash": "sha256-dnVoQSGQqEGJQzS6iHAG95c0oFrezzBinwu1bDLj9J4=",
+        "lastModified": 1752248434,
+        "narHash": "sha256-ud6xU5FlZSdi9RSPNIt+NWdZ3MmFGfQj4VoC7AQF+I0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f166dc14862dfec043f9545e8291cc4402f8b866",
+        "rev": "db699ccf4981f144e5200406f717a72e6751a0e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`db699ccf`](https://github.com/nix-community/NUR/commit/db699ccf4981f144e5200406f717a72e6751a0e2) | `` automatic update `` |
| [`9e311ede`](https://github.com/nix-community/NUR/commit/9e311ede9a39b9ec3a7e37be8411056a4c4e9711) | `` automatic update `` |
| [`45385f28`](https://github.com/nix-community/NUR/commit/45385f283008d8a89ec55041c259f8795dd08958) | `` automatic update `` |
| [`b814b0f9`](https://github.com/nix-community/NUR/commit/b814b0f9755b2d58ecd69303cb438d0776ee49a5) | `` automatic update `` |
| [`cffbd3a7`](https://github.com/nix-community/NUR/commit/cffbd3a78f5d806f88371d0f13b8251a56442126) | `` automatic update `` |
| [`2fd681fd`](https://github.com/nix-community/NUR/commit/2fd681fd0fada7c462559289abe45861e381b60f) | `` automatic update `` |
| [`891a063f`](https://github.com/nix-community/NUR/commit/891a063f11cdf9e138b4661fa127cacdf7d022f0) | `` automatic update `` |
| [`e923ea67`](https://github.com/nix-community/NUR/commit/e923ea6743892d44f3b3ff174cf6f665012aeb8a) | `` automatic update `` |
| [`9a3fcbfb`](https://github.com/nix-community/NUR/commit/9a3fcbfb753f7e7e390d20da062c74df1cebbf16) | `` automatic update `` |
| [`cd66b5af`](https://github.com/nix-community/NUR/commit/cd66b5af8765535c4fe4daa62f4f2e2182f8999c) | `` automatic update `` |
| [`52eaf4f8`](https://github.com/nix-community/NUR/commit/52eaf4f800c08763c48fe4bf674a53c1c2ca10b4) | `` automatic update `` |
| [`4f583c55`](https://github.com/nix-community/NUR/commit/4f583c552574665c157f451bf081debb0b5e4e45) | `` automatic update `` |
| [`037e8630`](https://github.com/nix-community/NUR/commit/037e86308aae72615419332a8964c73b43c7062d) | `` automatic update `` |