### PR TITLE
chore(flake/home-manager): `fab659b3` -> `1e548375`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -352,11 +352,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752202894,
-        "narHash": "sha256-knafgng4gCjZIUMyAEWjxxdols6n/swkYnbWr+oF+1w=",
+        "lastModified": 1752467539,
+        "narHash": "sha256-4kaR+xmng9YPASckfvIgl5flF/1nAZOplM+Wp9I5SMI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fab659b346c0d4252208434c3c4b3983a4b38fec",
+        "rev": "1e54837569e0b80797c47be4720fab19e0db1616",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                        |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`1e548375`](https://github.com/nix-community/home-manager/commit/1e54837569e0b80797c47be4720fab19e0db1616) | `` ci: extract-maintainers handle non-existent files (#7469) ``                |
| [`1a4d8ffd`](https://github.com/nix-community/home-manager/commit/1a4d8ffd320c2393b72e7ebc5b647122d5703056) | `` gurk-rs: fix missing s in home.packages (#7467) ``                          |
| [`7969ed8b`](https://github.com/nix-community/home-manager/commit/7969ed8baac8363b32775c5f55e132668bab8123) | `` gurk-rs: add module (#7466) ``                                              |
| [`bf893ad4`](https://github.com/nix-community/home-manager/commit/bf893ad4cbf46610dd1b620c974f824e266cd1df) | `` tests: re-add module argument ``                                            |
| [`fc253984`](https://github.com/nix-community/home-manager/commit/fc25398450cdab61af9654928dfef9d101f51140) | `` zellij: add keybind examples (#7447) ``                                     |
| [`2a8220dd`](https://github.com/nix-community/home-manager/commit/2a8220dd923f5b4a06a8c8abc11d75e17b11e599) | `` ci: fix tag-maintainers (#7448) ``                                          |
| [`908200d6`](https://github.com/nix-community/home-manager/commit/908200d6808bf961718ae96c5aad7ae6b0f8bda9) | `` tests/zellij: add zellij layout test ``                                     |
| [`78d93389`](https://github.com/nix-community/home-manager/commit/78d9338934a6c9485d9804df6f1a0917b6797180) | `` zellij: add support for layouts generation ``                               |
| [`f2795aa0`](https://github.com/nix-community/home-manager/commit/f2795aa053ef11f958fba49aef15a5c4d9734c02) | `` ci: tag-maintainers further refactoring (#7446) ``                          |
| [`ea24675e`](https://github.com/nix-community/home-manager/commit/ea24675e4f4f4c494ccb04f6645db2a394d348ee) | `` lib: Improve KDL generator (#7429) ``                                       |
| [`ae62fd8a`](https://github.com/nix-community/home-manager/commit/ae62fd8ad8347e6bb5b615057f39f33d595a1c47) | `` tests/zsh: add zprof test ``                                                |
| [`196487c5`](https://github.com/nix-community/home-manager/commit/196487c54f58f237fade6b85dfd57f097c8b5581) | `` zsh: group plugins in a separate directory ``                               |
| [`26b987cf`](https://github.com/nix-community/home-manager/commit/26b987cf8840e74b89bf3fe42d48fdf84af108b3) | `` zsh: move deprecated options to separate file ``                            |
| [`80a07bc6`](https://github.com/nix-community/home-manager/commit/80a07bc6f7f062d78c7dbc91ae8863eca0cabb2a) | `` zsh: move history to separate file ``                                       |
| [`3d95ab3c`](https://github.com/nix-community/home-manager/commit/3d95ab3cdca4e931b062e4dff39dea5563cbc2e3) | `` zsh: move zprof to separate file ``                                         |
| [`9b76feaf`](https://github.com/nix-community/home-manager/commit/9b76feafd02c84935ca3dea671057ca28b08131f) | `` zsh: move oh-my-zsh to separate file ``                                     |
| [`392ddb64`](https://github.com/nix-community/home-manager/commit/392ddb642abec771d63688c49fa7bcbb9d2a5717) | `` home-manager: add flake support for repl command (#7439) ``                 |
| [`7c6f7377`](https://github.com/nix-community/home-manager/commit/7c6f7377ccca88c45a28875e7755c38b604c5ff3) | `` vscode: enable defining `mcp.json` separate from `settings.json` (#7441) `` |
| [`3976e050`](https://github.com/nix-community/home-manager/commit/3976e0507edc9a5f332cb2be93fa20e646d22374) | `` test/wpaperd: add test for empty settings ``                                |
| [`a3f4b998`](https://github.com/nix-community/home-manager/commit/a3f4b998ecaa9cf87f1a6244a49e5ed96a81f03e) | `` wpaperd: handle empty settings properly ``                                  |
| [`6d8ed2b4`](https://github.com/nix-community/home-manager/commit/6d8ed2b4fc2aaba8c87f44b1cf4931e22b683583) | `` ci: tag-maintainer workflow refactor (#7436) ``                             |
| [`03bf1bd8`](https://github.com/nix-community/home-manager/commit/03bf1bd8d6bad7521ce1c69dbe9b953156ca1148) | `` gtk2: fix missing force option (#7437) ``                                   |
| [`b8b7e5ec`](https://github.com/nix-community/home-manager/commit/b8b7e5ec3570eb003d55f4947dd39af15c3ca98d) | `` ci: extract-maintainers-meta tweaks (#7434) ``                              |
| [`9d343f08`](https://github.com/nix-community/home-manager/commit/9d343f08806148605e61af532e36d80ed47cef3e) | `` ci: update-maintainers cleanup / tweaks (#7433) ``                          |
| [`f5b36e5e`](https://github.com/nix-community/home-manager/commit/f5b36e5ecea60542d6f39797974cc6324a834e5e) | `` gtk: add khaneliman maintainer ``                                           |
| [`a9594d34`](https://github.com/nix-community/home-manager/commit/a9594d34a28201b93f3ca63b4ac65cd2280420cb) | `` gtk: remove long removed option removal assertion ``                        |
| [`fa7d5101`](https://github.com/nix-community/home-manager/commit/fa7d51011f4607a3c44f549d656b27d810b1d885) | `` gtk: refactor and break up to improve readability ``                        |
| [`47443585`](https://github.com/nix-community/home-manager/commit/47443585fe686a283626c27c5fb936883b7666e9) | `` tests/gtk: refactor and organize ``                                         |
| [`18ff4e1e`](https://github.com/nix-community/home-manager/commit/18ff4e1e11b4a42576a30bd260250059c2bfd989) | `` tests/gtk: expand testing for new customization ``                          |
| [`d9915499`](https://github.com/nix-community/home-manager/commit/d9915499e3080fe2afe1f717acabeb697dd21709) | `` gtk: refactor to support more modular customization ``                      |
| [`e90b2896`](https://github.com/nix-community/home-manager/commit/e90b28967cacc64de7fb8742314ed0d7d12f47c6) | `` wayfire: allow path in settings (#7427) ``                                  |
| [`ce150018`](https://github.com/nix-community/home-manager/commit/ce15001862e43130b347cb93bed9b4bd4dac990d) | `` cliphist: use lib.getExe (#7431) ``                                         |