### PR TITLE
chore(flake/nur): `db699ccf` -> `9cbfe791`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752248434,
-        "narHash": "sha256-ud6xU5FlZSdi9RSPNIt+NWdZ3MmFGfQj4VoC7AQF+I0=",
+        "lastModified": 1752263225,
+        "narHash": "sha256-mkAJnfevRVrlJ2uiKin6cnwAj64DcXd7jYrZegA5M+0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "db699ccf4981f144e5200406f717a72e6751a0e2",
+        "rev": "9cbfe7915a97a3dc3e0bf1ddc37aadd76b4a9ee2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9cbfe791`](https://github.com/nix-community/NUR/commit/9cbfe7915a97a3dc3e0bf1ddc37aadd76b4a9ee2) | `` automatic update `` |
| [`98098362`](https://github.com/nix-community/NUR/commit/980983629098b8a3a426d0542d30d3104cffccb8) | `` automatic update `` |
| [`5007d5e7`](https://github.com/nix-community/NUR/commit/5007d5e7fddc1b0b3b023d79b47242fcb1702d3d) | `` automatic update `` |
| [`b4ecb243`](https://github.com/nix-community/NUR/commit/b4ecb24330b6bc131fe46c41317e65e41fd879d6) | `` automatic update `` |
| [`0f9cb91c`](https://github.com/nix-community/NUR/commit/0f9cb91c906d17bccb6dcd32f71aafb64b6ccf8a) | `` automatic update `` |