### PR TITLE
chore(flake/emacs-overlay): `4bf862ff` -> `561dcd2c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1752226781,
-        "narHash": "sha256-tzdPce6wQGUSQ4BrnHzC/PW+c+fEXHvfjax2iPx2OP4=",
+        "lastModified": 1752284554,
+        "narHash": "sha256-RYLdS0ZNbmUwvJncCQ3QwSzwxXdGtsBeWozHZXmgb9o=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4bf862fff2ff0d2618813b698d5b2dbf9cc355cc",
+        "rev": "561dcd2c7a0f8cb2f869d51a16cda65d3612dce7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`561dcd2c`](https://github.com/nix-community/emacs-overlay/commit/561dcd2c7a0f8cb2f869d51a16cda65d3612dce7) | `` Updated elpa ``   |
| [`b8713c1b`](https://github.com/nix-community/emacs-overlay/commit/b8713c1b9d142fd2331a442b6bb4448e2db0e47d) | `` Updated nongnu `` |
| [`fcd9c1b4`](https://github.com/nix-community/emacs-overlay/commit/fcd9c1b4bded92ec89abe7b41cb2fdb1dd1dd370) | `` Updated nongnu `` |