### PR TITLE
chore(flake/nur): `9cbfe791` -> `4fd103b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752263225,
-        "narHash": "sha256-mkAJnfevRVrlJ2uiKin6cnwAj64DcXd7jYrZegA5M+0=",
+        "lastModified": 1752274809,
+        "narHash": "sha256-EIpOaZoPeC+5PSeaU2UgAqgdkQ70R53W4UkabW0c94o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9cbfe7915a97a3dc3e0bf1ddc37aadd76b4a9ee2",
+        "rev": "4fd103b49d2f1d3cd956adb3591093bc49c4b647",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4fd103b4`](https://github.com/nix-community/NUR/commit/4fd103b49d2f1d3cd956adb3591093bc49c4b647) | `` automatic update `` |
| [`76955420`](https://github.com/nix-community/NUR/commit/769554207725c89709291712d10f23fe6ff9fbbd) | `` automatic update `` |
| [`71e5fcae`](https://github.com/nix-community/NUR/commit/71e5fcae6f4782187276720bbb33bc0ecd6c21c1) | `` automatic update `` |
| [`91f4570a`](https://github.com/nix-community/NUR/commit/91f4570a78e50dd96af1c8214831db5a3059f1cc) | `` automatic update `` |
| [`516a3c57`](https://github.com/nix-community/NUR/commit/516a3c5775926cc3f47df57467a17ff44f9d78ad) | `` automatic update `` |
| [`556ac89a`](https://github.com/nix-community/NUR/commit/556ac89a1c7d9d65ecd7bd0c07e24dcaccd80293) | `` automatic update `` |