### PR TITLE
chore(flake/srvos): `6bb452f0` -> `c1229575`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -908,11 +908,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751564530,
-        "narHash": "sha256-DybnqQMmkMEbNQhrbMGFijZCa9g5mtYIMPACVNMJ5u8=",
+        "lastModified": 1752305350,
+        "narHash": "sha256-5sUt2hme7ReKCTUgcspIMnkZg80//zy8S6Yd27fKZJQ=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "6bb452f0b31058ffe64241bcf092ebf1c7758be1",
+        "rev": "c1229575cfc15ae7ad5d9f9bfa90c8a996a23d72",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                        |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`cf90713b`](https://github.com/nix-community/srvos/commit/cf90713ba502990f28e233a8b03e9f6edbfc77ec) | `` drop mergify ``                                                             |
| [`8822e025`](https://github.com/nix-community/srvos/commit/8822e0255b5d9abd95e7d76d6f8cd241a3e4a87b) | `` Revert "prometheus: fix TelegrafDown host extraction for IPv6 addresses" `` |
| [`0b302695`](https://github.com/nix-community/srvos/commit/0b3026958df11dbd14d09b3d8923ecb9ea3f43c2) | `` prometheus: fix TelegrafDown host extraction for IPv6 addresses ``          |
| [`8898241b`](https://github.com/nix-community/srvos/commit/8898241b5a961178c52a92261d210538c5ef5263) | `` prometheus: add host label to TelegrafDown alerts ``                        |