### PR TITLE
chore(flake/emacs-overlay): `ae74fa06` -> `8bf19581`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1752311385,
-        "narHash": "sha256-lXySQ0PztOdKiGFSt8zGB74lVO0EyYEGhZZHYcFmkcs=",
+        "lastModified": 1752340167,
+        "narHash": "sha256-7DAefKuQF6G8IxfWrrdnPGxquSGqCgQpu5wEOigi07g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ae74fa0656db7456569f6fd35a972ac8f9b70b74",
+        "rev": "8bf19581d2e547159929f1340ed5b65d7b6bce4e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`8bf19581`](https://github.com/nix-community/emacs-overlay/commit/8bf19581d2e547159929f1340ed5b65d7b6bce4e) | `` Updated melpa ``  |
| [`4b34db84`](https://github.com/nix-community/emacs-overlay/commit/4b34db84579acf308f72b1d7276ed30bb6436d4a) | `` Updated emacs ``  |
| [`f381dd05`](https://github.com/nix-community/emacs-overlay/commit/f381dd05cc5685a65fec42fc0a4e34ac62e81806) | `` Updated elpa ``   |
| [`ac94b8cd`](https://github.com/nix-community/emacs-overlay/commit/ac94b8cdab49de848a968971045b6c8abf3fded2) | `` Updated nongnu `` |