### PR TITLE
chore(flake/nix-index-database): `ad29e296` -> `deff7a9a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -485,11 +485,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752305182,
-        "narHash": "sha256-6i4Q68G7wzNq1m2+l3lJUYgGZ9PwULvSVJpRSTTC46o=",
+        "lastModified": 1752346111,
+        "narHash": "sha256-SVxCIYnbED0rNYSpm3QQoOhqxYRp1GuE9FkyM5Y2afs=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "ad29e2961dd0d58372384563bf00d510fc9f2e15",
+        "rev": "deff7a9a0aa98a08d8c7839fe2658199ce9828f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                     |
| ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`e7745792`](https://github.com/nix-community/nix-index-database/commit/e77457923021afe202eec6be1e681ab08fbfd8bd) | `` print warning message when hmModules is used ``          |
| [`e12a2236`](https://github.com/nix-community/nix-index-database/commit/e12a223611ef4a4e0e9f0920c9b0faa8900d65ed) | `` use the official output name for home-manager modules `` |