### PR TITLE
chore(flake/nur): `eab5295b` -> `f8a833f0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752349530,
-        "narHash": "sha256-LJsKDaLdXQpF7ivp9UydPqz2gqGRKT5E7J/ZR5hwd/w=",
+        "lastModified": 1752392529,
+        "narHash": "sha256-mS5L/pKdb3CKN+gEHH+F7vv7YPq7241aFqS6SwFLm34=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eab5295b680baadac2ad617952d1f70119b35e3c",
+        "rev": "f8a833f0b9edb2c9e1ce684e392abc89ed4a7d36",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f8a833f0`](https://github.com/nix-community/NUR/commit/f8a833f0b9edb2c9e1ce684e392abc89ed4a7d36) | `` automatic update `` |
| [`0a73ad66`](https://github.com/nix-community/NUR/commit/0a73ad666efdd985777761322c739e9e3e68b928) | `` automatic update `` |
| [`1fb2d243`](https://github.com/nix-community/NUR/commit/1fb2d2437fc2d8f0e96b4ddf75164ecf0a6f7d51) | `` automatic update `` |
| [`2151a762`](https://github.com/nix-community/NUR/commit/2151a762d85d26fc38f402edc678957b807e5679) | `` automatic update `` |
| [`fd4a34fd`](https://github.com/nix-community/NUR/commit/fd4a34fd1e5b9b09de49990a945ed9b0b5a42089) | `` automatic update `` |
| [`d15c17c6`](https://github.com/nix-community/NUR/commit/d15c17c643cbef982fd5e0960f51ed2a586e7489) | `` automatic update `` |
| [`196696a1`](https://github.com/nix-community/NUR/commit/196696a12a1087ce8dd11708d2e7e652c5c666ed) | `` automatic update `` |
| [`11604015`](https://github.com/nix-community/NUR/commit/11604015df92f70dc14c55dbaccf786358d23fc8) | `` automatic update `` |
| [`b2350b4a`](https://github.com/nix-community/NUR/commit/b2350b4af69a7c9799cad80f28b32d9bbee37139) | `` automatic update `` |