### PR TITLE
chore(flake/nur): `f8a833f0` -> `2bf61e69`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752392529,
-        "narHash": "sha256-mS5L/pKdb3CKN+gEHH+F7vv7YPq7241aFqS6SwFLm34=",
+        "lastModified": 1752466333,
+        "narHash": "sha256-VFvp/AuQLIWD6cFau3MHv4fC77hFP0UpdowTTuBe+X0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f8a833f0b9edb2c9e1ce684e392abc89ed4a7d36",
+        "rev": "2bf61e69e42c4fb7ace92e80b2201268272a9399",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2bf61e69`](https://github.com/nix-community/NUR/commit/2bf61e69e42c4fb7ace92e80b2201268272a9399) | `` automatic update `` |
| [`81d1bf58`](https://github.com/nix-community/NUR/commit/81d1bf58849743f7b573ed7ac69bb4d096b1d020) | `` automatic update `` |
| [`ce121fde`](https://github.com/nix-community/NUR/commit/ce121fde1044a76807c7dc6741baac4b6e5c988c) | `` automatic update `` |
| [`b7ed3e5c`](https://github.com/nix-community/NUR/commit/b7ed3e5c74d725fdbe7baa689779caab3da6078f) | `` automatic update `` |
| [`adfccb9e`](https://github.com/nix-community/NUR/commit/adfccb9ee684b548be8dad404d8d374155847645) | `` automatic update `` |
| [`af46b0a3`](https://github.com/nix-community/NUR/commit/af46b0a3d4bc0e6ae2276bb562429d11cbd77d36) | `` automatic update `` |
| [`e91b2190`](https://github.com/nix-community/NUR/commit/e91b219026ed619a9a8f929014771513d4a08868) | `` automatic update `` |
| [`3ee0c434`](https://github.com/nix-community/NUR/commit/3ee0c434d0d747ac8cfaeb6ab3dfb49d69da4e88) | `` automatic update `` |
| [`7bbb0169`](https://github.com/nix-community/NUR/commit/7bbb0169e6d35a1e7a04973ba6ae3930dcfbe8bf) | `` automatic update `` |
| [`b97cb16b`](https://github.com/nix-community/NUR/commit/b97cb16b7933784d83a660731a6d6d833a969ebd) | `` automatic update `` |
| [`d34b5438`](https://github.com/nix-community/NUR/commit/d34b5438c2e3cbcdb99b0c1951f732bdb9d834be) | `` automatic update `` |
| [`e38a134b`](https://github.com/nix-community/NUR/commit/e38a134b32b1a9b1dc96a3e8c549467e7329024a) | `` automatic update `` |
| [`5c50bb56`](https://github.com/nix-community/NUR/commit/5c50bb5653b8c52370ca7a057eba2c5bd13d8dfe) | `` automatic update `` |
| [`601ed0cc`](https://github.com/nix-community/NUR/commit/601ed0cc9fa5613882947f3e1a8403d5f3031aa4) | `` automatic update `` |
| [`dab2f63b`](https://github.com/nix-community/NUR/commit/dab2f63b90badbc8c67121039ed40443d6312f94) | `` automatic update `` |
| [`4cf31e18`](https://github.com/nix-community/NUR/commit/4cf31e1814b9c56e7e4d963eb3a29bed04f4eee9) | `` automatic update `` |
| [`7afab208`](https://github.com/nix-community/NUR/commit/7afab208f85832fd49172afdf7746c396a7e50ca) | `` automatic update `` |
| [`b8f1b913`](https://github.com/nix-community/NUR/commit/b8f1b91334cb6ab7a5c6edd9a15068cdd6a91d04) | `` automatic update `` |
| [`0a1b008d`](https://github.com/nix-community/NUR/commit/0a1b008d41a9de3cca17a7f68a0af60ad7f50ed9) | `` automatic update `` |