### PR TITLE
chore(flake/nur): `2bf61e69` -> `9fbbb1c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752466333,
-        "narHash": "sha256-VFvp/AuQLIWD6cFau3MHv4fC77hFP0UpdowTTuBe+X0=",
+        "lastModified": 1752491421,
+        "narHash": "sha256-kNk+utcYZfxBc8XAv+zWxhBtyefxazzma2stgAf7lZA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2bf61e69e42c4fb7ace92e80b2201268272a9399",
+        "rev": "9fbbb1c0f423b0c9606156ce4b3d230b34a65a7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9fbbb1c0`](https://github.com/nix-community/NUR/commit/9fbbb1c0f423b0c9606156ce4b3d230b34a65a7f) | `` automatic update `` |
| [`6e3de609`](https://github.com/nix-community/NUR/commit/6e3de6093a24744f2608840cef9d376e3e946743) | `` automatic update `` |
| [`5b1910b8`](https://github.com/nix-community/NUR/commit/5b1910b8032e7adc6137e2f1a1e230e25e42ddce) | `` automatic update `` |
| [`e73ef793`](https://github.com/nix-community/NUR/commit/e73ef793ac91b183505a7a5122e12ce86da2fe63) | `` automatic update `` |
| [`f40018bd`](https://github.com/nix-community/NUR/commit/f40018bd38c57722957584a2392f165bb807c9ea) | `` automatic update `` |
| [`358b888d`](https://github.com/nix-community/NUR/commit/358b888dec29b0357c78c539e0599ef2d444e200) | `` automatic update `` |
| [`6d1c35e1`](https://github.com/nix-community/NUR/commit/6d1c35e15a7ed961527582f644c37b0452bfe138) | `` automatic update `` |
| [`7121adb2`](https://github.com/nix-community/NUR/commit/7121adb2ce1495143c4f3e5db007f128fe04648f) | `` automatic update `` |
| [`1e81d7d3`](https://github.com/nix-community/NUR/commit/1e81d7d378dc4b421bef5684819f00083f3abb13) | `` automatic update `` |