### PR TITLE
chore(flake/nur): `9fbbb1c0` -> `d1651006`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752491421,
-        "narHash": "sha256-kNk+utcYZfxBc8XAv+zWxhBtyefxazzma2stgAf7lZA=",
+        "lastModified": 1752525557,
+        "narHash": "sha256-FrGUPdXtLYRmn9GK5/8lWHAvKGJL1ks/dJG6yi81AuM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9fbbb1c0f423b0c9606156ce4b3d230b34a65a7f",
+        "rev": "d1651006402ab745bdec0f0352a37904c359b61c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d1651006`](https://github.com/nix-community/NUR/commit/d1651006402ab745bdec0f0352a37904c359b61c) | `` automatic update `` |
| [`d77a3382`](https://github.com/nix-community/NUR/commit/d77a3382d2ddc534bba6a21958442f9b88e97881) | `` automatic update `` |
| [`abb4d63f`](https://github.com/nix-community/NUR/commit/abb4d63fa3d49d99c210ac1a422e299e8982be61) | `` automatic update `` |
| [`3cc9d081`](https://github.com/nix-community/NUR/commit/3cc9d08177efc7340c91edb892444f58aea8313f) | `` automatic update `` |
| [`7b211af6`](https://github.com/nix-community/NUR/commit/7b211af6eb79bad838a3fa44484ee597ac26a5fb) | `` automatic update `` |
| [`79bb8fc3`](https://github.com/nix-community/NUR/commit/79bb8fc38dd4a37bb41a65e4ac697265947d9461) | `` automatic update `` |
| [`12d9a54a`](https://github.com/nix-community/NUR/commit/12d9a54a7812fdd5c7c32fad8b25d5623e334af5) | `` automatic update `` |
| [`5f563bac`](https://github.com/nix-community/NUR/commit/5f563bacfc85a67d4249382cb55964b479e93f59) | `` automatic update `` |
| [`87375483`](https://github.com/nix-community/NUR/commit/87375483a968fc4e7e2885c3337aa0b04f110d7e) | `` automatic update `` |
| [`d2ba0dd2`](https://github.com/nix-community/NUR/commit/d2ba0dd2d0ff4391e79c6eb61cf14fd2ecca16f7) | `` automatic update `` |
| [`e985dfa0`](https://github.com/nix-community/NUR/commit/e985dfa0f40cf405f33c82741eb3220347b31379) | `` automatic update `` |
| [`58be5694`](https://github.com/nix-community/NUR/commit/58be56944f15317b52e21982be29b81c38711d8a) | `` automatic update `` |