### PR TITLE
chore(flake/emacs-ultra-scroll): `3dd35e9a` -> `17c0b23e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
     "emacs-ultra-scroll": {
       "flake": false,
       "locked": {
-        "lastModified": 1750524338,
-        "narHash": "sha256-u+KTitHqtwn0jAoseFXUzH7psv1b6D07QupdZQfhgto=",
+        "lastModified": 1752526369,
+        "narHash": "sha256-B6/Ns7HlzTIsQIwlrPfuX4tL3GJRGRTJqrOjrI8IYYU=",
         "owner": "jdtsmith",
         "repo": "ultra-scroll",
-        "rev": "3dd35e9a2aa327ddf889bd0f3341a81d3215862b",
+        "rev": "17c0b23e7692f373de4d584d6d8576c223373e02",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                 |
| ------------------------------------------------------------------------------------------------------ | ----------------------- |
| [`17c0b23e`](https://github.com/jdtsmith/ultra-scroll/commit/17c0b23e7692f373de4d584d6d8576c223373e02) | `` Fix badge link ``    |
| [`077d1e32`](https://github.com/jdtsmith/ultra-scroll/commit/077d1e32a604fc4244edbf4ff6ec0f37c738b585) | `` Release for MELPA `` |