### PR TITLE
chore(flake/emacs-overlay): `23f01b93` -> `b8c12697`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1752513173,
-        "narHash": "sha256-sqyKxh/s9eQse5vhThpXqF/b5YHNEXxUxzc1VqQ5dfY=",
+        "lastModified": 1752599451,
+        "narHash": "sha256-ab+fuXVq18iZ2D4uVoo3UtHX6OvPESN1LecSrSbSrtM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "23f01b932e0f2f8c7a3f877da0add697cedda30c",
+        "rev": "b8c1269741faa8b59cb4635569e16e12bf47e664",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`b8c12697`](https://github.com/nix-community/emacs-overlay/commit/b8c1269741faa8b59cb4635569e16e12bf47e664) | `` Updated melpa ``        |
| [`95e3e2dc`](https://github.com/nix-community/emacs-overlay/commit/95e3e2dc0f22191f0cd61b6cecbd83c7e1724f51) | `` Updated emacs ``        |
| [`6512601b`](https://github.com/nix-community/emacs-overlay/commit/6512601b23450a49e84d749bac0026fb94fa5456) | `` Updated elpa ``         |
| [`0d512bc7`](https://github.com/nix-community/emacs-overlay/commit/0d512bc7b5222c91a5e450dd645e9ac26c4537f4) | `` Updated nongnu ``       |
| [`56c61d31`](https://github.com/nix-community/emacs-overlay/commit/56c61d31e73662ef2ed2bbb60ec862b9f7694d54) | `` Updated melpa ``        |
| [`f3eb21a2`](https://github.com/nix-community/emacs-overlay/commit/f3eb21a25e66cf4eaab7986f7688994565492aba) | `` Updated flake inputs `` |
| [`39514385`](https://github.com/nix-community/emacs-overlay/commit/39514385b3c81dbd20bebcf6ee64cd452ca2fce8) | `` Updated melpa ``        |
| [`78c231d9`](https://github.com/nix-community/emacs-overlay/commit/78c231d9dc3d8d7ddf75abe2acdb43da29367445) | `` Updated emacs ``        |
| [`126f2a16`](https://github.com/nix-community/emacs-overlay/commit/126f2a1659dbe936f5c744654fb4d61f821be109) | `` Updated elpa ``         |
| [`d846dd46`](https://github.com/nix-community/emacs-overlay/commit/d846dd4691d42b6f68e86c7cf5dbeffe80dec5cf) | `` Updated nongnu ``       |