### PR TITLE
chore(flake/nur): `d1651006` -> `d5221bc9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -718,11 +718,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1751984180,
-        "narHash": "sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X+xgOL0=",
+        "lastModified": 1752480373,
+        "narHash": "sha256-JHQbm+OcGp32wAsXTE/FLYGNpb+4GLi5oTvCxwSoBOA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9807714d6944a957c2e036f84b0ff8caf9930bc0",
+        "rev": "62e0f05ede1da0d54515d4ea8ce9c733f12d9f08",
         "type": "github"
       },
       "original": {
@@ -776,11 +776,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752525557,
-        "narHash": "sha256-FrGUPdXtLYRmn9GK5/8lWHAvKGJL1ks/dJG6yi81AuM=",
+        "lastModified": 1752565432,
+        "narHash": "sha256-F19/GfIJ34mJRoE2rQ/saS4281RMrLiS6O45gJcuhgE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d1651006402ab745bdec0f0352a37904c359b61c",
+        "rev": "d5221bc958f3a8e5ab5edb33a4745da90c709049",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d5221bc9`](https://github.com/nix-community/NUR/commit/d5221bc958f3a8e5ab5edb33a4745da90c709049) | `` automatic update `` |
| [`e14bc383`](https://github.com/nix-community/NUR/commit/e14bc383221941d9757eae25832fb5a3a29a896c) | `` automatic update `` |
| [`5dfd4f57`](https://github.com/nix-community/NUR/commit/5dfd4f5779c92e6031346e444b61ae6023239092) | `` automatic update `` |
| [`21c673bc`](https://github.com/nix-community/NUR/commit/21c673bc043c9c6b760828532b336f47c917b6c3) | `` automatic update `` |
| [`0967bf06`](https://github.com/nix-community/NUR/commit/0967bf0669b3153f5357402199e37e724fbcfd35) | `` automatic update `` |
| [`8f7689be`](https://github.com/nix-community/NUR/commit/8f7689beb20db191c8d6c3829dc31f343e14d991) | `` automatic update `` |
| [`2e97e175`](https://github.com/nix-community/NUR/commit/2e97e1753203f98d6d70e0b1ef9ad8a002670d9e) | `` automatic update `` |
| [`943d706e`](https://github.com/nix-community/NUR/commit/943d706e2f9349a8134723170ae4acbed514477c) | `` automatic update `` |
| [`37f57516`](https://github.com/nix-community/NUR/commit/37f575164cbcc08e29470a9e4b961e58b882efab) | `` automatic update `` |