### PR TITLE
chore(flake/nixpkgs): `9807714d` -> `62e0f05e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -702,11 +702,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1751984180,
-        "narHash": "sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X+xgOL0=",
+        "lastModified": 1752480373,
+        "narHash": "sha256-JHQbm+OcGp32wAsXTE/FLYGNpb+4GLi5oTvCxwSoBOA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9807714d6944a957c2e036f84b0ff8caf9930bc0",
+        "rev": "62e0f05ede1da0d54515d4ea8ce9c733f12d9f08",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                       |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`089a8d87`](https://github.com/NixOS/nixpkgs/commit/089a8d87cb089fc91f10adf9d559959886893506) | `` home-assistant-custom-lovelace-modules.restriction-card: init at 1.2.19 ``                 |
| [`e084a24b`](https://github.com/NixOS/nixpkgs/commit/e084a24b594fa6b947ea4ba5ca46668788ef4eda) | `` plasma5Packages.kimageformats: temporarily disable libavif support ``                      |
| [`5d82cd9e`](https://github.com/NixOS/nixpkgs/commit/5d82cd9e7c6892569de0fda68920b7ab276001de) | `` home-assistant-custom-lovelace-modules.advanced-camera-card: 7.14.1 -> 7.14.2 (#424967) `` |
| [`ab1ab3e6`](https://github.com/NixOS/nixpkgs/commit/ab1ab3e6d85cd71b60e259e5a3a964c80983adf5) | `` python3Packages.robotframework: 7.3.1 -> 7.3.2 ``                                          |
| [`3ebec4d8`](https://github.com/NixOS/nixpkgs/commit/3ebec4d8ca7f14392db8fad958ae0a77aeb8fd3c) | `` hydra: disable nixpkgs-update ``                                                           |
| [`aa1d7dfa`](https://github.com/NixOS/nixpkgs/commit/aa1d7dfa3e8ce340dcbdd8a3acde8b76b69c42d9) | `` claude-code: 1.0.48 -> 1.0.51 ``                                                           |
| [`1d3d5613`](https://github.com/NixOS/nixpkgs/commit/1d3d561383edab5cc5639b89386cb10d820689df) | `` ctrtool: enable darwin platform ``                                                         |
| [`96372e5f`](https://github.com/NixOS/nixpkgs/commit/96372e5fd265b5928a20fdc2f55f038a37a75c21) | `` pgroll: 0.14.0 -> 0.14.1 ``                                                                |
| [`b0e8a55e`](https://github.com/NixOS/nixpkgs/commit/b0e8a55ed3c6f812284e0b8fa3ec45b03862b371) | `` go-jsonnet: remove aaronjheng from maintainers ``                                          |
| [`99dc34dc`](https://github.com/NixOS/nixpkgs/commit/99dc34dc531010293bb2830af2e1341eae6240b3) | `` dust: remove aaronjheng from maintainers ``                                                |
| [`4077be17`](https://github.com/NixOS/nixpkgs/commit/4077be17563597eeaf6fdf04eb6117ab495e0df5) | `` buf: remove aaronjheng from maintainers ``                                                 |
| [`03586dab`](https://github.com/NixOS/nixpkgs/commit/03586dab2ae9e791c7739295e3377712d00151eb) | `` deltachat-desktop: 1.58.2 -> 1.60.1 ``                                                     |
| [`98ce7414`](https://github.com/NixOS/nixpkgs/commit/98ce741417c7cc368b51099505e1e125ab1c1617) | `` python3Packages.xsdata: 25.4 -> 25.7 ``                                                    |
| [`5a794e9a`](https://github.com/NixOS/nixpkgs/commit/5a794e9af7ba6a6ed998814b75313f95e69f2560) | `` vscode-extensions.amazonwebservices.amazon-q-vscode: 1.81.0 -> 1.83.0 ``                   |
| [`3a0cd56b`](https://github.com/NixOS/nixpkgs/commit/3a0cd56be2cab7e487c3c3e6c8d486c62da632db) | `` vscode-extensions.ms-windows-ai-studio.windows-ai-studio: 0.16.0 -> 0.16.1 ``              |
| [`f8b73979`](https://github.com/NixOS/nixpkgs/commit/f8b739792063713425e4af73b6820d8c5bcf1e9b) | `` github-mcp-server: 0.6.0 -> 0.7.0 ``                                                       |
| [`40b74fd2`](https://github.com/NixOS/nixpkgs/commit/40b74fd2cffcf1d4d14d1e906491eff32569ae13) | `` python3Packages.sagemaker-core: 1.0.41 -> 1.0.42 ``                                        |
| [`25b52347`](https://github.com/NixOS/nixpkgs/commit/25b523479235e52df12e836ef3e5c465380691ae) | `` rmapi: 0.0.30 -> 0.0.31 ``                                                                 |
| [`3c118bcb`](https://github.com/NixOS/nixpkgs/commit/3c118bcb879b97fadb020bfc475152d469268268) | `` necesse-server: 0.32.1-18336931 -> 0.33.0-19201409 ``                                      |
| [`30ffb1e7`](https://github.com/NixOS/nixpkgs/commit/30ffb1e7c883ee704aeb98e3635af5316af1cd07) | `` rehex: 0.63.0 -> 0.63.2 ``                                                                 |
| [`3bdcb37b`](https://github.com/NixOS/nixpkgs/commit/3bdcb37ba7f7c218f1a0c93d28320c2e083cac11) | `` devcontainer: 0.78.0 -> 0.80.0 ``                                                          |
| [`ed791975`](https://github.com/NixOS/nixpkgs/commit/ed79197505eb7c1f43c66c16e34a892e04c7f9ac) | `` gpxsee: 13.44 -> 13.45 ``                                                                  |
| [`5a87a15e`](https://github.com/NixOS/nixpkgs/commit/5a87a15e738c5602487582fc9d85900c099290e5) | `` linuxKernel.kernels.linux_lqx: 6.15.4 -> 6.15.6 ``                                         |
| [`e9e1be0d`](https://github.com/NixOS/nixpkgs/commit/e9e1be0d97319d30c8f272a48b10b5657b3c8a62) | `` home-assistant-custom-components.lednetwf_ble: 0.0.14.2 -> 0.0.15 ``                       |
| [`71f3d238`](https://github.com/NixOS/nixpkgs/commit/71f3d2389e7baf7c84e72bea5fa97a701bedbfc9) | `` sslscan: 2.1.6 -> 2.2.0 ``                                                                 |
| [`d1be3afb`](https://github.com/NixOS/nixpkgs/commit/d1be3afb6146fc3a6ae4f4ac6fc2c79e324b9aee) | `` cosmic-applets: backport upstream bugfix ``                                                |
| [`c0e0c035`](https://github.com/NixOS/nixpkgs/commit/c0e0c0351bbbc06b114b34cd015cceec51fa75ef) | `` lightdm: use regular gettext to fix build ``                                               |
| [`7ed1c991`](https://github.com/NixOS/nixpkgs/commit/7ed1c991f11b15762da41ed337ab4dd5e0adbc11) | `` ldmud: 3.6.7 -> 3.6.8 ``                                                                   |
| [`468fd1dd`](https://github.com/NixOS/nixpkgs/commit/468fd1ddba67abf549c9ac9cc8d5facb970dd9cb) | `` ldmud: fix MacOS iconv link time errors ``                                                 |
| [`12de190b`](https://github.com/NixOS/nixpkgs/commit/12de190b5fc98502a6cc89bc9e646de71167800d) | `` gale: add maintainer notohh ``                                                             |
| [`19928598`](https://github.com/NixOS/nixpkgs/commit/19928598c4d5baec81ba0e6b55b90416e139c604) | `` maintainers: add notohh ``                                                                 |
| [`cdeba33c`](https://github.com/NixOS/nixpkgs/commit/cdeba33c9de3f7ac2f254d8938e3a244c2fe72ff) | `` mpc-qt: migrate to by-name ``                                                              |
| [`91e3ba27`](https://github.com/NixOS/nixpkgs/commit/91e3ba27452ed34757807bf714d0e00f5ecf336c) | `` morewaita-icon-theme: 48.3 -> 48.3.1 ``                                                    |
| [`22074851`](https://github.com/NixOS/nixpkgs/commit/22074851eb3ccbb26d2988626c37e766d74284a4) | `` vcluster: remove berryp from maintainers ``                                                |
| [`91fa9215`](https://github.com/NixOS/nixpkgs/commit/91fa92153788a48d0e6550bc30e0a78f25183aa5) | `` redlib: Use the unstable git updater ``                                                    |
| [`0b5d0cd3`](https://github.com/NixOS/nixpkgs/commit/0b5d0cd3487fa5beaa62646426144a82f62d631f) | `` php8{1-4}Extensions.spx: 0.4.18 -> 0.4.20 ``                                               |
| [`cd06a259`](https://github.com/NixOS/nixpkgs/commit/cd06a25980e5f5274cf5352b1a67d9b388fdb78d) | `` gale: 1.7.1 -> 1.8.6, switch to pnpm,  add updateScript ``                                 |
| [`1840d4db`](https://github.com/NixOS/nixpkgs/commit/1840d4dbf07face79ee2fad40ae7759b54f9d978) | `` gccNGPackages: Rework threading model patch based on feedback on IRC ``                    |
| [`aa715282`](https://github.com/NixOS/nixpkgs/commit/aa71528276f6e97368237c8043eb14b66cd16008) | `` phpPackages.castor: 0.25.0 -> 0.26.0 ``                                                    |
| [`cfe95170`](https://github.com/NixOS/nixpkgs/commit/cfe95170f10473a188f4126e684d7c9408256e48) | `` nixos/fw-fanctrl: init ``                                                                  |
| [`43b1db71`](https://github.com/NixOS/nixpkgs/commit/43b1db710b28935597507cf94e57c35efe261e9a) | `` fw-fanctrl: init at 1.0.3 ``                                                               |
| [`d068251f`](https://github.com/NixOS/nixpkgs/commit/d068251fc8180a579f697367e28e91fbf8b7e08c) | `` repomix: 1.0.0 -> 1.1.0 ``                                                                 |
| [`3bdd0c11`](https://github.com/NixOS/nixpkgs/commit/3bdd0c1181549fa55a33ee4a3dde449452501abe) | `` nixos/klipper: support extra settings (#378998) ``                                         |
| [`65a03038`](https://github.com/NixOS/nixpkgs/commit/65a03038b93d8fa95461042889361c29bcc2e9e4) | `` vte: 0.80.2 → 0.80.3 ``                                                                    |
| [`d670c427`](https://github.com/NixOS/nixpkgs/commit/d670c4274622751f5216d702dd79fce0e5253432) | `` nautilus: 48.2 → 48.3 ``                                                                   |
| [`ea74420a`](https://github.com/NixOS/nixpkgs/commit/ea74420a54b2a097b294abcf64483a706408b8b4) | `` mutter: 48.3.1 → 48.4 ``                                                                   |
| [`859ada39`](https://github.com/NixOS/nixpkgs/commit/859ada395b46198514d55b46f097dca46fb47de3) | `` libdex: 0.10.0 → 0.10.1 ``                                                                 |
| [`f1ad3fdb`](https://github.com/NixOS/nixpkgs/commit/f1ad3fdb48995bc8c8b40fa2c8b5c47cbc262437) | `` gnome-user-share: 48.0 → 48.1 ``                                                           |
| [`4fed923d`](https://github.com/NixOS/nixpkgs/commit/4fed923d2138ee4669ea9aa91f7b407edd28d930) | `` gnome-software: 48.2 → 48.3 ``                                                             |
| [`5d868ede`](https://github.com/NixOS/nixpkgs/commit/5d868eded8f553bc1b487eb6be3c5cf503f99875) | `` gnome-shell-extensions: 48.2 → 48.3 ``                                                     |
| [`22426591`](https://github.com/NixOS/nixpkgs/commit/2242659119d02f3b2a6661f48fa3dae9b40b769c) | `` gnome-shell: 48.2 → 48.3 ``                                                                |
| [`25650729`](https://github.com/NixOS/nixpkgs/commit/256507292313907c711151c823d2b35ba011c43a) | `` gnome-online-accounts: 3.54.3 → 3.54.4 ``                                                  |
| [`8391b82e`](https://github.com/NixOS/nixpkgs/commit/8391b82ee0d0c6df668030af257517f186098d02) | `` gnome-builder: 48.0 → 48.2 ``                                                              |
| [`2aebae62`](https://github.com/NixOS/nixpkgs/commit/2aebae6243aceff4e28d7cd0437f0a5175289d8c) | `` libglycin: 1.2.1 → 1.2.2 ``                                                                |
| [`d877c9b3`](https://github.com/NixOS/nixpkgs/commit/d877c9b3e3c202041f0b947b11c42f4f7c920349) | `` libglycin: Handle cargoDeps hash in update script ``                                       |
| [`a9b38466`](https://github.com/NixOS/nixpkgs/commit/a9b384668b8d5b0dad6d1d2317fb3e78130d7b76) | `` ldmud: apply some small modernizations ``                                                  |
| [`2e4d17bf`](https://github.com/NixOS/nixpkgs/commit/2e4d17bfe7f7b9f7e995d362f2619395f54d9b91) | `` home-assistant-custom-components.waste_collection_schedule: 2.8.0 -> 2.9.0 ``              |
| [`e6a07d71`](https://github.com/NixOS/nixpkgs/commit/e6a07d71580ac60690eaf195f0d7a05ffa48ebb4) | `` php81Extensions.meminfo: unstable-2022-03-25 -> 1.1.1-unstable-2022-03-25 ``               |
| [`321ff26f`](https://github.com/NixOS/nixpkgs/commit/321ff26fb4321b15bd1a9a3d87c63f9479a94730) | `` glycin-loaders: 1.2.1 → 1.2.2 ``                                                           |
| [`bceb8e6b`](https://github.com/NixOS/nixpkgs/commit/bceb8e6b7012ac831a27c85bf6e2a98d4c3c96bb) | `` evince: 48.0 → 48.1 ``                                                                     |
| [`3f6d337b`](https://github.com/NixOS/nixpkgs/commit/3f6d337be6743edbda8f1457072d8b8591ae88d3) | `` pkgs/by-name/{u,v,w,x,y,z}*: migrate to pyproject = true ``                                |
| [`e128f4f3`](https://github.com/NixOS/nixpkgs/commit/e128f4f301bef2a8d69d18d500e76f08744f7113) | `` lunar-client: 3.4.3 -> 3.4.4 ``                                                            |
| [`f391cba8`](https://github.com/NixOS/nixpkgs/commit/f391cba8413982d1e033e85d47b282caefef7e4f) | `` nixosTests.vscodium: handleTest -> runTest ``                                              |
| [`8acc71bb`](https://github.com/NixOS/nixpkgs/commit/8acc71bb6f9be7d75b973bbb24f8548b859e3c1f) | `` aporetic-bin: 1.1.0 -> 1.2.0 ``                                                            |
| [`d806a8e1`](https://github.com/NixOS/nixpkgs/commit/d806a8e152f683fe3e40a16e8e288d4db52e19dd) | `` swaynotificationcenter: 0.11.0 -> 0.12.0 ``                                                |
| [`2d13df39`](https://github.com/NixOS/nixpkgs/commit/2d13df39826e66f040eebe997d96b1b4ffff3da7) | `` hyprwayland-scanner: 0.4.4 -> 0.4.5 ``                                                     |
| [`7d571a93`](https://github.com/NixOS/nixpkgs/commit/7d571a936cfc366539901f402c4379b187d27e1a) | `` pkgs/by-name/{r,s,t}*: migrate to pyproject = true ``                                      |
| [`82eb03f6`](https://github.com/NixOS/nixpkgs/commit/82eb03f698402ec02e9feb81449d2cd2b7c4f8c9) | `` argo-workflows: remove unused staticfiles ``                                               |
| [`3724418d`](https://github.com/NixOS/nixpkgs/commit/3724418d031b5cfc800212cd7c9b1f94a36307f0) | `` _1oom: 1.11.6 -> 1.11.7 ``                                                                 |
| [`0cbdae41`](https://github.com/NixOS/nixpkgs/commit/0cbdae412405a9cccf7209931e7f882c19cf1a26) | `` nixos-rebuild-ng: error if --upgrade/--upgrade-all is called without --sudo/root ``        |
| [`e8f0519b`](https://github.com/NixOS/nixpkgs/commit/e8f0519b49f0568a7830068505e66dbc013b90c6) | `` python3Packages.textual: 3.7.1 -> 4.0.0 ``                                                 |
| [`b586af0a`](https://github.com/NixOS/nixpkgs/commit/b586af0af73cac5a210b19cb8aa7ce9a394e01ef) | `` arcan: disable tracy by default ``                                                         |
| [`e72ba488`](https://github.com/NixOS/nixpkgs/commit/e72ba488f1ef68e34e0ed59663a29c6d6a1f72c3) | `` python3Packages.ale-py: 0.11.1 -> 0.11.2 ``                                                |
| [`a1a21104`](https://github.com/NixOS/nixpkgs/commit/a1a2110485f49000acb2e3cd59b85ef3130d8a1f) | `` libretro.pcsx2: 0-unstable-2025-07-03 -> 0-unstable-2025-07-11 ``                          |
| [`5a39beac`](https://github.com/NixOS/nixpkgs/commit/5a39beace1d05a48b7a4dff170fa7bca08d2f04b) | `` python3Packages.torchrl: 0.8.1 -> 0.9.1 ``                                                 |
| [`ee4541be`](https://github.com/NixOS/nixpkgs/commit/ee4541be494587ed6fcb4e051a4cb11118eb36cb) | `` mergiraf: do not install "mgf_dev" ``                                                      |
| [`543beeb9`](https://github.com/NixOS/nixpkgs/commit/543beeb98b8c0fd84687755421554237f8405eec) | `` python3Packages.zigpy: disable failing tests ``                                            |
| [`d75ba2e8`](https://github.com/NixOS/nixpkgs/commit/d75ba2e8f04a0f80bb9a5eb344235b1a25a3b4e9) | `` nixos-rebuild-ng: run upgrade_channels with sudo ``                                        |
| [`89dc88bf`](https://github.com/NixOS/nixpkgs/commit/89dc88bf09a22319ca845d1fbf0e99018d4438a7) | `` roddhjav-apparmor-rules: 0-unstable-2025-06-21 -> 0-unstable-2025-07-12 ``                 |
| [`0f506f21`](https://github.com/NixOS/nixpkgs/commit/0f506f219157bd37dc809698bcb44bd5622fc356) | `` python3Packages.uiprotect: 7.14.1 -> 7.14.2 (#424736) ``                                   |
| [`7a0af8fd`](https://github.com/NixOS/nixpkgs/commit/7a0af8fd4a944e55fe9407537c0f5ae55740170c) | `` dbus-test-runner: use regular gettext to fix build ``                                      |
| [`fab364e8`](https://github.com/NixOS/nixpkgs/commit/fab364e89b845735ef7f4d27420ede07c8e433a2) | `` nixos/invidious-router: Add systemd dependency on `network-online.target` ``               |
| [`f685a226`](https://github.com/NixOS/nixpkgs/commit/f685a226649044b3016bc4726974bf114fae3ea6) | `` treewide: remove `paveloom` as maintainer ``                                               |
| [`a6c6fe33`](https://github.com/NixOS/nixpkgs/commit/a6c6fe3394a3bc3ef6bbffdb78ef6a6a218ccc61) | `` gojq: remove aaronjheng from maintainers ``                                                |
| [`ea5785e8`](https://github.com/NixOS/nixpkgs/commit/ea5785e8c4793b2b289c2a1bbacb06f9c03437c1) | `` edk2: re-vendor OpenSSL ``                                                                 |
| [`cc52a08c`](https://github.com/NixOS/nixpkgs/commit/cc52a08c42fa450a6b38458a772ff68607d04e08) | `` xh: remove aaronjheng from maintainers ``                                                  |
| [`bbe3f31c`](https://github.com/NixOS/nixpkgs/commit/bbe3f31cf8480edeb8477bdba1e0e78910dbc112) | `` temporal-cli: 1.3.0 -> 1.4.0 ``                                                            |
| [`90ada24a`](https://github.com/NixOS/nixpkgs/commit/90ada24a99cc3f944d58d64ea1e9022aac265099) | `` edk2: pin to openssl_3 ``                                                                  |
| [`bc79c820`](https://github.com/NixOS/nixpkgs/commit/bc79c820216b96b2408cf613fe0321a38a837f41) | `` duf: modernize ``                                                                          |
| [`2f0a9075`](https://github.com/NixOS/nixpkgs/commit/2f0a9075f6fee22aca84e6276665091c6c94b750) | `` electron_36-bin: update hashes ``                                                          |
| [`11c800de`](https://github.com/NixOS/nixpkgs/commit/11c800de0272c04f4f78341ec5abc97588e6f1d7) | `` xdg-user-dirs: hack-fix build on darwin ``                                                 |
| [`af33502b`](https://github.com/NixOS/nixpkgs/commit/af33502badc3b1cd0f39b3c10ec5d7f00b7e0547) | `` fpc: fix on x86_64-darwin by downgrading Clang ``                                          |
| [`cfad37c4`](https://github.com/NixOS/nixpkgs/commit/cfad37c45971010b30b0547acad9e9e3ff142a4c) | `` redpanda-client: 25.1.6 -> 25.1.7 ``                                                       |
| [`46d070c6`](https://github.com/NixOS/nixpkgs/commit/46d070c6b44182816b2f5bcc64d8daa03bf21fd1) | `` libretro.play: 0-unstable-2025-07-01 -> 0-unstable-2025-07-09 ``                           |
| [`ef25b852`](https://github.com/NixOS/nixpkgs/commit/ef25b85211192479082a07add97d07cc2a55d3c9) | `` traefik: 3.4.3 -> 3.4.4 ``                                                                 |
| [`25d00647`](https://github.com/NixOS/nixpkgs/commit/25d00647a441aa26cb347baff53fa0b2d762eb4a) | `` phpunit: 12.2.5 -> 12.2.7 ``                                                               |
| [`115dc338`](https://github.com/NixOS/nixpkgs/commit/115dc338f4ffd719ebf6e253448258db285d9367) | `` ghostfolio: 2.176.0 -> 2.181.0 ``                                                          |
| [`8b5a33db`](https://github.com/NixOS/nixpkgs/commit/8b5a33db695f57c449062f303a8112a8166928fc) | `` fiddler-everywhere: 6.6.0 -> 7.0.0 ``                                                      |
| [`66048acc`](https://github.com/NixOS/nixpkgs/commit/66048acc1ea8f686a30b68fe4f031b1a0e8f549d) | `` luau: 0.681 -> 0.682 ``                                                                    |
| [`b0b6c223`](https://github.com/NixOS/nixpkgs/commit/b0b6c2231296e37830e016380a764c91ff3d1e18) | `` python3Packages.snakemake-interface-report-plugins: 1.1.0 -> 1.1.1 ``                      |
| [`d3274f6f`](https://github.com/NixOS/nixpkgs/commit/d3274f6f233a8da2d468f4bc9a09dfcd323c9dcd) | `` fehlstart: unstable-2016-05-23 -> 0.5-unstable-2025-01-12 ``                               |
| [`ecc88adb`](https://github.com/NixOS/nixpkgs/commit/ecc88adb5178c7392e054bc81cd25641816220e9) | `` xlockmore: 5.83 -> 5.84 ``                                                                 |