### PR TITLE
chore(flake/nur): `d5221bc9` -> `bbe25d5b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752565432,
-        "narHash": "sha256-F19/GfIJ34mJRoE2rQ/saS4281RMrLiS6O45gJcuhgE=",
+        "lastModified": 1752608029,
+        "narHash": "sha256-TYxLdlXnfVcipQ0z4VNF3ecJSq+WieQSRZx1/N6BENY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d5221bc958f3a8e5ab5edb33a4745da90c709049",
+        "rev": "bbe25d5bee287b0358ee58c27a047b56eb64bfe2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bbe25d5b`](https://github.com/nix-community/NUR/commit/bbe25d5bee287b0358ee58c27a047b56eb64bfe2) | `` automatic update `` |
| [`23c13c78`](https://github.com/nix-community/NUR/commit/23c13c787a0870855e414a8899a1ae61229408fc) | `` automatic update `` |
| [`35a0dcad`](https://github.com/nix-community/NUR/commit/35a0dcad5616fb0973a344dc0752c68ce1289393) | `` automatic update `` |
| [`45cad2bb`](https://github.com/nix-community/NUR/commit/45cad2bbddae8c9910600858f020986cf9c07f5f) | `` automatic update `` |
| [`ba155ceb`](https://github.com/nix-community/NUR/commit/ba155ceb6957c6d362348eadd6c3504250520431) | `` automatic update `` |
| [`e3469493`](https://github.com/nix-community/NUR/commit/e3469493d26051c20036577da57a9a75e2e31564) | `` automatic update `` |
| [`1d017192`](https://github.com/nix-community/NUR/commit/1d0171928849751f177699b68ae574ec39084696) | `` automatic update `` |
| [`9e1c1224`](https://github.com/nix-community/NUR/commit/9e1c1224f720f070b660fea6f57dde93601394d3) | `` automatic update `` |
| [`e6b60c63`](https://github.com/nix-community/NUR/commit/e6b60c631f8ba6cba0ca0cd7619fb5c871be73e6) | `` automatic update `` |
| [`b4815529`](https://github.com/nix-community/NUR/commit/b4815529806b1e30a4e6c66c1091e010e0a4c2b8) | `` automatic update `` |
| [`4216e010`](https://github.com/nix-community/NUR/commit/4216e010efabb9ca3c2648dac753d815f028af72) | `` automatic update `` |
| [`03d68216`](https://github.com/nix-community/NUR/commit/03d68216ee4db72b0813d8ffc5570473dca589ed) | `` automatic update `` |
| [`7edeec8f`](https://github.com/nix-community/NUR/commit/7edeec8fbfef675524441754df94de44ebf91cce) | `` automatic update `` |