### PR TITLE
chore(flake/nur): `bbe25d5b` -> `68fd386c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752608029,
-        "narHash": "sha256-TYxLdlXnfVcipQ0z4VNF3ecJSq+WieQSRZx1/N6BENY=",
+        "lastModified": 1752638779,
+        "narHash": "sha256-V3FOjqafp770rbWZBiSJnmDvQ1WfdFfeiQiex5AiuKw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bbe25d5bee287b0358ee58c27a047b56eb64bfe2",
+        "rev": "68fd386c143d1d9af2099fa24066059b01fe62ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`68fd386c`](https://github.com/nix-community/NUR/commit/68fd386c143d1d9af2099fa24066059b01fe62ba) | `` automatic update `` |
| [`7139df8e`](https://github.com/nix-community/NUR/commit/7139df8e79abd5724b01366fcab41c8315dbd5d4) | `` automatic update `` |
| [`97d257c9`](https://github.com/nix-community/NUR/commit/97d257c9b34d590683acc90193f6ddc067c5ad2c) | `` automatic update `` |
| [`cf946bf3`](https://github.com/nix-community/NUR/commit/cf946bf3a52faf3eb4ace9ddf5715852a09e3ea2) | `` automatic update `` |
| [`87b120b8`](https://github.com/nix-community/NUR/commit/87b120b86d2ec23dc43cac9194af95ae39c2625e) | `` automatic update `` |
| [`33cd5bcd`](https://github.com/nix-community/NUR/commit/33cd5bcd691bb8d22958afa73c2a9be3ebc2e129) | `` automatic update `` |
| [`78f9863f`](https://github.com/nix-community/NUR/commit/78f9863f72e6ac2c3652ef7af86f11a865d6859a) | `` automatic update `` |
| [`218afc34`](https://github.com/nix-community/NUR/commit/218afc3420f91b67bdb575f5e725032b37718cd6) | `` automatic update `` |
| [`3ee8559d`](https://github.com/nix-community/NUR/commit/3ee8559d856219249b42e38db7d9c359705f5b87) | `` automatic update `` |
| [`b67e205b`](https://github.com/nix-community/NUR/commit/b67e205b03f71013d56f0916d738450dd5b76e5e) | `` automatic update `` |