### PR TITLE
chore(flake/emacs-overlay): `b8c12697` -> `79c5920e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1752599451,
-        "narHash": "sha256-ab+fuXVq18iZ2D4uVoo3UtHX6OvPESN1LecSrSbSrtM=",
+        "lastModified": 1752769629,
+        "narHash": "sha256-sA2mQ258a+AeiVCmpvgjeK+bWnwGyl99HGdXKVg6BoA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b8c1269741faa8b59cb4635569e16e12bf47e664",
+        "rev": "79c5920ec4af99639c653215ffcb3d8f1dff6982",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`79c5920e`](https://github.com/nix-community/emacs-overlay/commit/79c5920ec4af99639c653215ffcb3d8f1dff6982) | `` Updated nongnu `` |
| [`bdb0c5ba`](https://github.com/nix-community/emacs-overlay/commit/bdb0c5ba7a493bf064de0d065a55ea4d0300ef67) | `` Updated melpa ``  |
| [`d9c000fc`](https://github.com/nix-community/emacs-overlay/commit/d9c000fcee032fbf262ff0d5f09b1c5b2165ff63) | `` Updated emacs ``  |
| [`4a99bb63`](https://github.com/nix-community/emacs-overlay/commit/4a99bb63260c70441613eea081818526c9f4c6fe) | `` Updated elpa ``   |
| [`68bbd4bb`](https://github.com/nix-community/emacs-overlay/commit/68bbd4bb06b2e38c760ef457422019d870b30efa) | `` Updated nongnu `` |
| [`5d67c0f1`](https://github.com/nix-community/emacs-overlay/commit/5d67c0f1c6115d723b187a6f00832b15e346c8b5) | `` Updated emacs ``  |
| [`24cd4475`](https://github.com/nix-community/emacs-overlay/commit/24cd4475147293d112e9df15fc2f3bc8bb02eaa7) | `` Updated melpa ``  |
| [`43160550`](https://github.com/nix-community/emacs-overlay/commit/4316055067738a21c925415821890e15e976ee76) | `` Updated elpa ``   |
| [`0b93a6b3`](https://github.com/nix-community/emacs-overlay/commit/0b93a6b35b4ac0c45e4ea09932c5d8447f4afa14) | `` Updated nongnu `` |
| [`3573872d`](https://github.com/nix-community/emacs-overlay/commit/3573872da6a5aad4cfa25410eebcb619cfdea9c1) | `` Updated emacs ``  |
| [`48ba7a60`](https://github.com/nix-community/emacs-overlay/commit/48ba7a600813e14a21d4181bd3d07ce94b8c1102) | `` Updated melpa ``  |
| [`1f8b8772`](https://github.com/nix-community/emacs-overlay/commit/1f8b8772b192c6b5f88417d7b452ed8cf737c326) | `` Updated elpa ``   |
| [`2e02805c`](https://github.com/nix-community/emacs-overlay/commit/2e02805c22d28483e68c212e980804dcbdce3c39) | `` Updated nongnu `` |