### PR TITLE
chore(flake/nur): `68fd386c` -> `bafc355b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752638779,
-        "narHash": "sha256-V3FOjqafp770rbWZBiSJnmDvQ1WfdFfeiQiex5AiuKw=",
+        "lastModified": 1752705337,
+        "narHash": "sha256-402Buiz6l3GmyhYRaQ69HCsvEwrU1up3T71RDeAdmX0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "68fd386c143d1d9af2099fa24066059b01fe62ba",
+        "rev": "bafc355bff627bc38b3ca14c93e755f7aff5f5d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                              |
| -------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`bafc355b`](https://github.com/nix-community/NUR/commit/bafc355bff627bc38b3ca14c93e755f7aff5f5d4) | `` automatic update ``               |
| [`4ddb1ef9`](https://github.com/nix-community/NUR/commit/4ddb1ef9ceabbe0d12324bd43c212b9e3120ffaa) | `` automatic update ``               |
| [`35929e41`](https://github.com/nix-community/NUR/commit/35929e4111192c3a0d04871b8543e9be96c7d341) | `` automatic update ``               |
| [`1c4aa209`](https://github.com/nix-community/NUR/commit/1c4aa2090cf309da055d7815575aa909ee8c3dd5) | `` automatic update ``               |
| [`20f5560a`](https://github.com/nix-community/NUR/commit/20f5560a37430f9ab2e8526ebd4cfe1d3b0af226) | `` automatic update ``               |
| [`c644c2da`](https://github.com/nix-community/NUR/commit/c644c2da1f73f43b3d40f1c445b69c45be314c09) | `` remove picokeys-nix repository `` |
| [`bd110a22`](https://github.com/nix-community/NUR/commit/bd110a223083f7be1c59433bf37a3e2e7c8d8e5d) | `` automatic update ``               |
| [`40e5c1db`](https://github.com/nix-community/NUR/commit/40e5c1dbd7034ccc21e10364fe2241c7e768522f) | `` automatic update ``               |
| [`621a94ab`](https://github.com/nix-community/NUR/commit/621a94ab1753db715a662b57ed528eedb9775812) | `` automatic update ``               |
| [`4d861130`](https://github.com/nix-community/NUR/commit/4d8611302e2973790e1546a32389ded1b7e9e164) | `` add blemouzy repository ``        |
| [`e7095916`](https://github.com/nix-community/NUR/commit/e70959167375a9a4f3147442f08c74a4e2a234d6) | `` automatic update ``               |
| [`94dad376`](https://github.com/nix-community/NUR/commit/94dad3767581f59690021eb4f459c457e3205eb6) | `` automatic update ``               |
| [`a5fc1a03`](https://github.com/nix-community/NUR/commit/a5fc1a03e50bdbc5990cb408b698aeb39a0627c3) | `` automatic update ``               |
| [`d5a9b359`](https://github.com/nix-community/NUR/commit/d5a9b359bab42d66886e2f783536d061de17092a) | `` automatic update ``               |
| [`c5750e66`](https://github.com/nix-community/NUR/commit/c5750e669e2712fed3e5e5a3b68ed8415d9ca214) | `` automatic update ``               |
| [`98444a92`](https://github.com/nix-community/NUR/commit/98444a92cfc841123572c9821b4a9b35021e712c) | `` automatic update ``               |
| [`5281c0e5`](https://github.com/nix-community/NUR/commit/5281c0e56e0a23328e7d13f8189b513927015971) | `` automatic update ``               |
| [`ab175215`](https://github.com/nix-community/NUR/commit/ab17521573e1e2b0a64f3f14045fcecab42354ba) | `` automatic update ``               |
| [`d5670e60`](https://github.com/nix-community/NUR/commit/d5670e60cc2ecfd869c50cb2114543cdf41481b1) | `` automatic update ``               |
| [`1cdee260`](https://github.com/nix-community/NUR/commit/1cdee260fb4992ba3cec5bd0d2cd31f673d21cc1) | `` automatic update ``               |
| [`5982e614`](https://github.com/nix-community/NUR/commit/5982e614be05be9b7db48c8f6d63814b66fb5a69) | `` automatic update ``               |
| [`91788ae5`](https://github.com/nix-community/NUR/commit/91788ae556922392b59b4905b4b5ae1b560d4c84) | `` automatic update ``               |
| [`9086de25`](https://github.com/nix-community/NUR/commit/9086de25b03c172fed1eaa4a758a026d9ad096c0) | `` automatic update ``               |