### PR TITLE
chore(flake/srvos): `1637ff53` -> `f9bc092d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -908,11 +908,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752619489,
-        "narHash": "sha256-7YKiwNoJhK4LDaFvGbxB4UeEq3FSIGjCt5capipkA4A=",
+        "lastModified": 1752660522,
+        "narHash": "sha256-Gl2Zi0bTl672DqEeb/5XiEwjGPPyX7L5QMfsjOWxOic=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "1637ff5392f9d10a5a0ecfbebef67a0e6ec7b252",
+        "rev": "f9bc092d85e8219b7a4c4e34f0efd3abab530a7d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                   |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`f9bc092d`](https://github.com/nix-community/srvos/commit/f9bc092d85e8219b7a4c4e34f0efd3abab530a7d) | `` .github/settings.yml: remove (#665) `` |