### PR TITLE
chore(flake/nur): `bafc355b` -> `5e9436fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752705337,
-        "narHash": "sha256-402Buiz6l3GmyhYRaQ69HCsvEwrU1up3T71RDeAdmX0=",
+        "lastModified": 1752725122,
+        "narHash": "sha256-08SkItJ+wiNyysKajOUGX4vdfQLC5Uq2qkBDww6wEEc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bafc355bff627bc38b3ca14c93e755f7aff5f5d4",
+        "rev": "5e9436fe80cdfe5bcbb73f675da1a41d013fe321",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5e9436fe`](https://github.com/nix-community/NUR/commit/5e9436fe80cdfe5bcbb73f675da1a41d013fe321) | `` automatic update `` |
| [`c8c76d38`](https://github.com/nix-community/NUR/commit/c8c76d3821f8fc78aee1c290027e1268a9af8de3) | `` automatic update `` |
| [`911438b2`](https://github.com/nix-community/NUR/commit/911438b2bff9b38313bfd0e9d4d18b6a0867b9ca) | `` automatic update `` |
| [`71dfcdc7`](https://github.com/nix-community/NUR/commit/71dfcdc7eadb04b9a57d3229ed1d8ad0ede83996) | `` automatic update `` |
| [`5bcfa130`](https://github.com/nix-community/NUR/commit/5bcfa130e4724d2fd7d8f241806d67acbc5ea0e1) | `` automatic update `` |
| [`8de606fa`](https://github.com/nix-community/NUR/commit/8de606fab97195c8ddb2e87f44302ad8abbab82d) | `` automatic update `` |