### PR TITLE
chore(flake/nur): `5e9436fe` -> `45c3f5ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752725122,
-        "narHash": "sha256-08SkItJ+wiNyysKajOUGX4vdfQLC5Uq2qkBDww6wEEc=",
+        "lastModified": 1752738196,
+        "narHash": "sha256-nqifp7SP0aO1B4TCYR9AGrPy0udYWOrLGh7wlcOehJI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5e9436fe80cdfe5bcbb73f675da1a41d013fe321",
+        "rev": "45c3f5ac0cb9b9c17cd7d49c6e795c7160ec91f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`45c3f5ac`](https://github.com/nix-community/NUR/commit/45c3f5ac0cb9b9c17cd7d49c6e795c7160ec91f7) | `` automatic update `` |
| [`5229ec61`](https://github.com/nix-community/NUR/commit/5229ec61691c7b03c73fbef23fda4b3e645039a5) | `` automatic update `` |
| [`8a5248cd`](https://github.com/nix-community/NUR/commit/8a5248cdace82b87c933f7d484f30eb604b76534) | `` automatic update `` |