### PR TITLE
chore(flake/nur): `45c3f5ac` -> `1c920036`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752738196,
-        "narHash": "sha256-nqifp7SP0aO1B4TCYR9AGrPy0udYWOrLGh7wlcOehJI=",
+        "lastModified": 1752752944,
+        "narHash": "sha256-Tjdl6UwwlnpPfO/W+u6lNMCIY1X2hH3wYjwiMj48GjQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "45c3f5ac0cb9b9c17cd7d49c6e795c7160ec91f7",
+        "rev": "1c920036e31c0d5db9d0bb9bd317a2590e7773b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1c920036`](https://github.com/nix-community/NUR/commit/1c920036e31c0d5db9d0bb9bd317a2590e7773b6) | `` automatic update `` |
| [`945f926d`](https://github.com/nix-community/NUR/commit/945f926daf73c1380c8e45eaffc07904ae64195e) | `` automatic update `` |
| [`1f18f1d9`](https://github.com/nix-community/NUR/commit/1f18f1d925dd49879ce8eb629b3164efc6cf0bfd) | `` automatic update `` |
| [`89fdddca`](https://github.com/nix-community/NUR/commit/89fdddca180dba3d97ee4951ec1722c3fcda522a) | `` automatic update `` |
| [`41091098`](https://github.com/nix-community/NUR/commit/41091098b91eedb2608a4327b90e179c01ebdfac) | `` automatic update `` |