### PR TITLE
chore(flake/nur): `1c920036` -> `36341520`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752752944,
-        "narHash": "sha256-Tjdl6UwwlnpPfO/W+u6lNMCIY1X2hH3wYjwiMj48GjQ=",
+        "lastModified": 1752796200,
+        "narHash": "sha256-iGf4ka0ZYzRmEdSfWBVzwgRKXDQujDSs1mdc6CQXFAA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1c920036e31c0d5db9d0bb9bd317a2590e7773b6",
+        "rev": "36341520a844d7b7fba073c924fdc53bf4a49981",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                       |
| -------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`36341520`](https://github.com/nix-community/NUR/commit/36341520a844d7b7fba073c924fdc53bf4a49981) | `` automatic update ``        |
| [`2382167c`](https://github.com/nix-community/NUR/commit/2382167cb946364581adf48dc2cabbf601bbf602) | `` automatic update ``        |
| [`992e1f2b`](https://github.com/nix-community/NUR/commit/992e1f2bcd76f86b20e71fddfb8529cf2161474f) | `` automatic update ``        |
| [`3c776e8a`](https://github.com/nix-community/NUR/commit/3c776e8afa33406dfe24292fb70d4e259d4dd40e) | `` automatic update ``        |
| [`12d87205`](https://github.com/nix-community/NUR/commit/12d87205784d8600ad091054f2d8458721e362ed) | `` automatic update ``        |
| [`6c2d1262`](https://github.com/nix-community/NUR/commit/6c2d1262ca090b10e07a076d9b73a5694f08a62b) | `` automatic update ``        |
| [`290ad20d`](https://github.com/nix-community/NUR/commit/290ad20d36a3ea1f4ada4964355783890d014608) | `` automatic update ``        |
| [`abc31ffd`](https://github.com/nix-community/NUR/commit/abc31ffdbf2a85922a7e7c807eee09907a87af07) | `` automatic update ``        |
| [`a354aa8b`](https://github.com/nix-community/NUR/commit/a354aa8bcab5191c01acba64b4fdc81ede297757) | `` automatic update ``        |
| [`12e4cdf8`](https://github.com/nix-community/NUR/commit/12e4cdf84bcb1d491e16500a312be91c4558a434) | `` automatic update ``        |
| [`5a15dae5`](https://github.com/nix-community/NUR/commit/5a15dae5e8fb90ed3ee549260a1beaa76790697f) | `` add vieb-nix repository `` |
| [`4f3e206c`](https://github.com/nix-community/NUR/commit/4f3e206ceec9fa428abbee370a7ada2a08d972fc) | `` automatic update ``        |