### PR TITLE
chore(flake/nur): `72cdff81` -> `a23ff3a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752821623,
-        "narHash": "sha256-weAppyAcCh745A786eQ5bzuU2R/qUVYolvTktW8dzu4=",
+        "lastModified": 1752850488,
+        "narHash": "sha256-UE3vzMQCr/RI+f09emPs2IXAYcPzgq+XBfZ86cywmQk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "72cdff817c8c1a2eb76d9aa0798247052f16d2b8",
+        "rev": "a23ff3a09e0e8a6f03944e29c8399717b33e491f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a23ff3a0`](https://github.com/nix-community/NUR/commit/a23ff3a09e0e8a6f03944e29c8399717b33e491f) | `` automatic update `` |
| [`de84295a`](https://github.com/nix-community/NUR/commit/de84295ad526240d47014560f77c58bc123bd0f7) | `` automatic update `` |
| [`e643319a`](https://github.com/nix-community/NUR/commit/e643319a340c19f99458e3ed5cd6266e1c2f4d5c) | `` automatic update `` |
| [`65784156`](https://github.com/nix-community/NUR/commit/65784156b95f1b33a175532badd5da4e48302462) | `` automatic update `` |