### PR TITLE
chore(flake/nur): `a23ff3a0` -> `e6721151`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752850488,
-        "narHash": "sha256-UE3vzMQCr/RI+f09emPs2IXAYcPzgq+XBfZ86cywmQk=",
+        "lastModified": 1752868036,
+        "narHash": "sha256-TJMwY0bKm1SsvpSROg54sglwwpslWYtl1mYh4j+hc1E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a23ff3a09e0e8a6f03944e29c8399717b33e491f",
+        "rev": "e6721151f19a4db5099336ea1651201b1ab8023f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e6721151`](https://github.com/nix-community/NUR/commit/e6721151f19a4db5099336ea1651201b1ab8023f) | `` automatic update `` |
| [`24383064`](https://github.com/nix-community/NUR/commit/24383064c3f25e80c84dbc63ab1d64d2d6fd5b3e) | `` automatic update `` |
| [`7e7ae251`](https://github.com/nix-community/NUR/commit/7e7ae251a4d632f1278ae553a8c95f1e1c5138d4) | `` automatic update `` |
| [`fa509d10`](https://github.com/nix-community/NUR/commit/fa509d10e459de7c36829cc2850d1df61c7e2e96) | `` automatic update `` |