### PR TITLE
chore(flake/nur): `e6721151` -> `d68ea61b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752868036,
-        "narHash": "sha256-TJMwY0bKm1SsvpSROg54sglwwpslWYtl1mYh4j+hc1E=",
+        "lastModified": 1752895120,
+        "narHash": "sha256-kzJ85DF2QSSDA34Pw6mh2Y2WQM1RWBjRVMD0/I3Iejg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e6721151f19a4db5099336ea1651201b1ab8023f",
+        "rev": "d68ea61b416a6a14c036889652a4abe2024c3359",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d68ea61b`](https://github.com/nix-community/NUR/commit/d68ea61b416a6a14c036889652a4abe2024c3359) | `` automatic update `` |
| [`07894f22`](https://github.com/nix-community/NUR/commit/07894f220a5381d082c485bdb1c80e28db186327) | `` automatic update `` |
| [`f5cc05d2`](https://github.com/nix-community/NUR/commit/f5cc05d2fc9806e7d9cf823194e03e1e0627185e) | `` automatic update `` |
| [`b057614b`](https://github.com/nix-community/NUR/commit/b057614bd0d482887c5c04674413943b0581d2df) | `` automatic update `` |
| [`0adc5f69`](https://github.com/nix-community/NUR/commit/0adc5f69f2f38e79ae6e377ddcf770ef9404776a) | `` automatic update `` |
| [`51f87c40`](https://github.com/nix-community/NUR/commit/51f87c401a6c2f22674c82db95fcd467b27a330c) | `` automatic update `` |
| [`2092b876`](https://github.com/nix-community/NUR/commit/2092b8768748b1dc80eb60889129b0f707faaf04) | `` automatic update `` |
| [`eaaad845`](https://github.com/nix-community/NUR/commit/eaaad84552156a70e9bcd2111a3d65a38af5f22d) | `` automatic update `` |
| [`65d2b785`](https://github.com/nix-community/NUR/commit/65d2b785f19daebabbf6642b33cd46f35181acd4) | `` automatic update `` |