### PR TITLE
chore(flake/emacs-overlay): `614abf79` -> `487c33cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1752856079,
-        "narHash": "sha256-9IJ4jH4uv1SeK47rsfN3guz6slmUbs0/7pN38b2KQQ4=",
+        "lastModified": 1752916765,
+        "narHash": "sha256-G5gKbbomP7eTvUJNAmXd8DP/q9i6rP+8ZoSbk59+HOg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "614abf799bbc623abdd197cc47222161781dbaf7",
+        "rev": "487c33cc9c100af127f363393cacc170e42d3b61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`487c33cc`](https://github.com/nix-community/emacs-overlay/commit/487c33cc9c100af127f363393cacc170e42d3b61) | `` Updated emacs ``  |
| [`8abc4be5`](https://github.com/nix-community/emacs-overlay/commit/8abc4be5a46f043d17fb82b1f053ac227752598c) | `` Updated melpa ``  |
| [`ff6e9d75`](https://github.com/nix-community/emacs-overlay/commit/ff6e9d75622b02d35076d7fd9ae118bac480d9f5) | `` Updated elpa ``   |
| [`52c2c670`](https://github.com/nix-community/emacs-overlay/commit/52c2c6707d5c22e72363cc0460f86cc0bce818fb) | `` Updated nongnu `` |