### PR TITLE
chore(flake/nur): `d68ea61b` -> `19e40b40`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752895120,
-        "narHash": "sha256-kzJ85DF2QSSDA34Pw6mh2Y2WQM1RWBjRVMD0/I3Iejg=",
+        "lastModified": 1752920818,
+        "narHash": "sha256-lMn1Qf9PhDU93r+bXS3+om4b3XKVO4h6gKu26hE/E/g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d68ea61b416a6a14c036889652a4abe2024c3359",
+        "rev": "19e40b40406587208be688a07b0311a6d017c8e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`19e40b40`](https://github.com/nix-community/NUR/commit/19e40b40406587208be688a07b0311a6d017c8e1) | `` automatic update `` |
| [`ce5f6cf6`](https://github.com/nix-community/NUR/commit/ce5f6cf69a4dba999909bc1198c3a05855cd4a3d) | `` automatic update `` |
| [`ea63ce63`](https://github.com/nix-community/NUR/commit/ea63ce63073a11274ef327c5eb7f2ebb67606ebe) | `` automatic update `` |
| [`95908c25`](https://github.com/nix-community/NUR/commit/95908c253419f4a28eae8680446067005b3786b2) | `` automatic update `` |
| [`4bd90347`](https://github.com/nix-community/NUR/commit/4bd90347fb635f3ad3233c01cfe39ace49e705ae) | `` automatic update `` |
| [`b6552f11`](https://github.com/nix-community/NUR/commit/b6552f1157702fc0904252e2e68110cca8bae4d4) | `` automatic update `` |