### PR TITLE
chore(flake/treefmt-nix): `c9d477b5` -> `0043b95d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -964,11 +964,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752055615,
-        "narHash": "sha256-19m7P4O/Aw/6+CzncWMAJu89JaKeMh3aMle1CNQSIwM=",
+        "lastModified": 1752909129,
+        "narHash": "sha256-Eh8FkMvGRaY71BU/oyZTTzt9RsBIq2E6j0r3eLZ/2kY=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "c9d477b5d5bd7f26adddd3f96cfd6a904768d4f9",
+        "rev": "0043b95d80b5bf6d61e84d237e2007727f4dd38d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                            |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`0043b95d`](https://github.com/numtide/treefmt-nix/commit/0043b95d80b5bf6d61e84d237e2007727f4dd38d) | `` bugfix: biome default organizeImports (#382) `` |