### PR TITLE
chore(flake/nur): `19e40b40` -> `a559bd9b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752920818,
-        "narHash": "sha256-lMn1Qf9PhDU93r+bXS3+om4b3XKVO4h6gKu26hE/E/g=",
+        "lastModified": 1752954367,
+        "narHash": "sha256-ZXJWqnmlrBVZ7STr3LOryfhsiAuDpfPA9RC1+TDxEwg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "19e40b40406587208be688a07b0311a6d017c8e1",
+        "rev": "a559bd9b53591ba1d7e30e661d34bd4519c955d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a559bd9b`](https://github.com/nix-community/NUR/commit/a559bd9b53591ba1d7e30e661d34bd4519c955d0) | `` automatic update `` |
| [`295e3f56`](https://github.com/nix-community/NUR/commit/295e3f56766568fa17e09087ef53d7251434b9a8) | `` automatic update `` |
| [`12143c8c`](https://github.com/nix-community/NUR/commit/12143c8cd2d109a301e9c59b257148d8b9c75baf) | `` automatic update `` |
| [`75c876ab`](https://github.com/nix-community/NUR/commit/75c876ab5f168d722f2cfe36c5fd1c01ceb6e29d) | `` automatic update `` |
| [`c17fb1b4`](https://github.com/nix-community/NUR/commit/c17fb1b4c067eaabe77997762e01e5819f06d5be) | `` automatic update `` |