### PR TITLE
chore(flake/nur): `a559bd9b` -> `650ca827`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -811,11 +811,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1752954367,
-        "narHash": "sha256-ZXJWqnmlrBVZ7STr3LOryfhsiAuDpfPA9RC1+TDxEwg=",
+        "lastModified": 1752958249,
+        "narHash": "sha256-yIgIUORVWZzvN61H8JbDYt3kGisy+OiG/Ro8mpg8uAE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a559bd9b53591ba1d7e30e661d34bd4519c955d0",
+        "rev": "650ca8274beb7dc230dc251d677d0b99d4951199",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`650ca827`](https://github.com/nix-community/NUR/commit/650ca8274beb7dc230dc251d677d0b99d4951199) | `` automatic update `` |
| [`41fa1a25`](https://github.com/nix-community/NUR/commit/41fa1a2534912bfd6e6277aef86470d94cd7e5e0) | `` automatic update `` |