### PR TITLE
chore(flake/disko): `79264292` -> `d5ad4485`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -131,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752113600,
-        "narHash": "sha256-7LYDxKxZgBQ8LZUuolAQ8UkIB+jb4A2UmiR+kzY9CLI=",
+        "lastModified": 1752718651,
+        "narHash": "sha256-PkaR0qmyP9q/MDN3uYa+RLeBA0PjvEQiM0rTDDBXkL8=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "79264292b7e3482e5702932949de9cbb69fedf6d",
+        "rev": "d5ad4485e6f2edcc06751df65c5e16572877db88",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                    |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`d5ad4485`](https://github.com/nix-community/disko/commit/d5ad4485e6f2edcc06751df65c5e16572877db88) | `` flake.lock: Update ``                                                   |
| [`2bf3421f`](https://github.com/nix-community/disko/commit/2bf3421f7fed5c84d9392b62dcb9d76ef09796a7) | `` build(deps): bump DeterminateSystems/update-flake-lock from 25 to 26 `` |