### PR TITLE
chore(flake/nix-index-database): `839e02de` -> `fafdcb50`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -505,11 +505,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752441837,
-        "narHash": "sha256-FMH1OSSJp8Cx8MZHXz6KckxJGbCnVMotZNAH3v2WneU=",
+        "lastModified": 1752985182,
+        "narHash": "sha256-sX8Neff8lp3TCHai6QmgLr5AD8MdsQQX3b52C1DVXR8=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "839e02dece5845be3a322e507a79712b73a96ba2",
+        "rev": "fafdcb505ba605157ff7a7eeea452bc6d6cbc23c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`fafdcb50`](https://github.com/nix-community/nix-index-database/commit/fafdcb505ba605157ff7a7eeea452bc6d6cbc23c) | `` update generated.nix to release 2025-07-20-035855 `` |
| [`57d85475`](https://github.com/nix-community/nix-index-database/commit/57d8547540d3abb18922e8d1edbaac70dc486b7f) | `` flake.lock: Update ``                                |