### PR TITLE
chore(flake/treefmt-nix): `0043b95d` -> `421b5631`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1001,11 +1001,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752909129,
-        "narHash": "sha256-Eh8FkMvGRaY71BU/oyZTTzt9RsBIq2E6j0r3eLZ/2kY=",
+        "lastModified": 1753006367,
+        "narHash": "sha256-tzbhc4XttkyEhswByk5R38l+ztN9UDbnj0cTcP6Hp9A=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "0043b95d80b5bf6d61e84d237e2007727f4dd38d",
+        "rev": "421b56313c65a0815a52b424777f55acf0b56ddf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                   |
| ---------------------------------------------------------------------------------------------------- | ------------------------- |
| [`421b5631`](https://github.com/numtide/treefmt-nix/commit/421b56313c65a0815a52b424777f55acf0b56ddf) | `` remove nufmt (#386) `` |