### PR TITLE
chore(flake/nixpkgs): `6e987485` -> `c87b95e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -737,11 +737,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1752687322,
-        "narHash": "sha256-RKwfXA4OZROjBTQAl9WOZQFm7L8Bo93FQwSJpAiSRvo=",
+        "lastModified": 1752950548,
+        "narHash": "sha256-NS6BLD0lxOrnCiEOcvQCDVPXafX1/ek1dfJHX1nUIzc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6e987485eb2c77e5dcc5af4e3c70843711ef9251",
+        "rev": "c87b95e25065c028d31a94f06a62927d18763fdf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                     |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
| [`75ae0280`](https://github.com/NixOS/nixpkgs/commit/75ae028029f36bc280369c6c6ad5411560693900) | `` python3Packages.datadog: 0.51.0 -> 0.52.0 ``                                                             |
| [`4a85363a`](https://github.com/NixOS/nixpkgs/commit/4a85363afd76703c5d4098a3c66589d4f4214f10) | `` opendrop: migrate package definitions ``                                                                 |
| [`24320d9a`](https://github.com/NixOS/nixpkgs/commit/24320d9a7a65d812166f4d5fe0419b14b087cbec) | `` opendrop: migrate to by-name ``                                                                          |
| [`33e9d4f3`](https://github.com/NixOS/nixpkgs/commit/33e9d4f3c0d9839248e057967df248794a901191) | `` libunwind: fix dangling symlink errors ``                                                                |
| [`162f2a88`](https://github.com/NixOS/nixpkgs/commit/162f2a883a1288bdcb926af68859f94f0773a915) | `` lux-cli: 0.8.2 -> 0.9.1 ``                                                                               |
| [`12c49aca`](https://github.com/NixOS/nixpkgs/commit/12c49aca94d40c6008d1c78592d8f2c04331fd97) | `` postgresqlPackages: remove top-level aliases ``                                                          |
| [`652ce1f9`](https://github.com/NixOS/nixpkgs/commit/652ce1f95b1142108814536dfee721b949cec4f9) | `` strawberry: remove libgpod depedency/feature ``                                                          |
| [`1d348e88`](https://github.com/NixOS/nixpkgs/commit/1d348e88e024c8f4d1af6904cee37a727dec9d69) | `` jellyfin-ffmpeg: add to release-cuda ``                                                                  |
| [`2e2ff832`](https://github.com/NixOS/nixpkgs/commit/2e2ff832914937e3ecc783245b552a6e6e12a2e6) | `` tscli: 0.0.12 -> 0.0.13 ``                                                                               |
| [`839f8681`](https://github.com/NixOS/nixpkgs/commit/839f8681812ba4b905ca12959779bc85fe2d3b43) | `` helix: 25.07 -> 25.07.1 ``                                                                               |
| [`13dc8d57`](https://github.com/NixOS/nixpkgs/commit/13dc8d57c307a22a152282438935f5a6ef0b619a) | `` rat-king-adventure: 2.2.0 -> 2.2.2 ``                                                                    |
| [`a0b153c1`](https://github.com/NixOS/nixpkgs/commit/a0b153c14854fb58ca22d9f287930344ffcd49f9) | `` ft2-clone: 1.96 -> 1.97 ``                                                                               |
| [`68f8de61`](https://github.com/NixOS/nixpkgs/commit/68f8de6113802135de59e20afd4c96526faa9824) | `` cargo-pgrx: prevent update of pinned versions ``                                                         |
| [`5bd538ca`](https://github.com/NixOS/nixpkgs/commit/5bd538caf1063829431df122b4053d817a758348) | `` comma: 2.1.0 -> 2.2.0 ``                                                                                 |
| [`2f6d65c5`](https://github.com/NixOS/nixpkgs/commit/2f6d65c578225bc0ccdb56bbfd56a09d73cf6caa) | `` keybinder3: unpin autotools ``                                                                           |
| [`e6de7124`](https://github.com/NixOS/nixpkgs/commit/e6de71245006ec7a59ac4de6dcf55ac2cd937dc4) | `` keybinder: unpin autotools ``                                                                            |
| [`8d3a6d5a`](https://github.com/NixOS/nixpkgs/commit/8d3a6d5a6728e8f3f0162d4e879a642057b66636) | `` linux_xanmod_latest: 6.15.6 -> 6.15.7 ``                                                                 |
| [`94522dde`](https://github.com/NixOS/nixpkgs/commit/94522dde2dfb6cbe0a2d0cba7346153e7debc654) | `` linux_xanmod: 6.12.37 -> 6.12.39 ``                                                                      |
| [`c75ae074`](https://github.com/NixOS/nixpkgs/commit/c75ae07474065cb55bbbc61eb8d0d8b1d1e3fb54) | `` elixir_1_{14,15,16}: fix build with erlang 26 ``                                                         |
| [`46a4c640`](https://github.com/NixOS/nixpkgs/commit/46a4c640f05eb5f26e7951e11e5e7d9d425dfde1) | `` ocamlformat_0_26_2: build with OCaml 5.2 ``                                                              |
| [`f12ceef3`](https://github.com/NixOS/nixpkgs/commit/f12ceef33f4fc6623d9cf19302175fe3377a81c0) | `` proton-ge-bin: GE-Proton10-9 -> GE-Proton10-10 ``                                                        |
| [`266eab05`](https://github.com/NixOS/nixpkgs/commit/266eab0547186335b92fca0a97fb80f9751de5d9) | `` opencode: remove "models-dev-data" from updateScript subpackages ``                                      |
| [`2a1e8246`](https://github.com/NixOS/nixpkgs/commit/2a1e82461b6ee6c9b82ee56720e52473ec582026) | `` nixosTests.lemurs*: init ``                                                                              |
| [`140a6b45`](https://github.com/NixOS/nixpkgs/commit/140a6b4522f396cabf7d91b1ea2a11f063d02126) | `` nixos/lemurs: init ``                                                                                    |
| [`242e80f3`](https://github.com/NixOS/nixpkgs/commit/242e80f393307d6d79f3e24ff378448bf6271c37) | `` opencode: 0.2.33 -> 0.3.22 ``                                                                            |
| [`b2179199`](https://github.com/NixOS/nixpkgs/commit/b21791994debd066e520ca58a6e77cc4c9c61a48) | `` flood: fix build failure ``                                                                              |
| [`1910563b`](https://github.com/NixOS/nixpkgs/commit/1910563bb3c0a76aae035d578a8c094c5646baa7) | `` python313Packages.pybind11-protobuf: downgrade abseil-cpp to fix build ``                                |
| [`cf0661c6`](https://github.com/NixOS/nixpkgs/commit/cf0661c6f3ce5310e77413a9d5725a95621e761b) | `` postgresql_18: turn off NUMA support in 18beta2 as well ``                                               |
| [`7f75ff0d`](https://github.com/NixOS/nixpkgs/commit/7f75ff0da259ffaa91c2864bbcdbcdc08cef5663) | `` hdr10plus: decouple the src from hdr10plus_tool ``                                                       |
| [`b81199d9`](https://github.com/NixOS/nixpkgs/commit/b81199d926493e87552634ac1865c3ae4805f8ef) | `` hdr10plus_tool: 1.7.0 -> 1.7.1 ``                                                                        |
| [`595e2e95`](https://github.com/NixOS/nixpkgs/commit/595e2e9581b660f9dd37f7e7983e9298b0986fb4) | `` glab: enable `versionCheckHook` ``                                                                       |
| [`123a65a9`](https://github.com/NixOS/nixpkgs/commit/123a65a90cd4a60d1e07a10880a2a1df047b90a5) | `` nvc: 1.16.2 -> 1.17.0 ``                                                                                 |
| [`f1bc9b03`](https://github.com/NixOS/nixpkgs/commit/f1bc9b03bf604ed55dfeb869b0aceb48c996f555) | `` postgresqlPackages.pg-gvm: 22.6.9 -> 22.6.10 ``                                                          |
| [`a4eba7d7`](https://github.com/NixOS/nixpkgs/commit/a4eba7d754fec19c16f3a32443c0547a7826ad8e) | `` docling: downgrade to 2.38.1 to unblock docling-parse test failure ``                                    |
| [`b1e1ba7b`](https://github.com/NixOS/nixpkgs/commit/b1e1ba7b45250d9d4525bc6e0d7658357e6f5c43) | `` ruffle: 0-nightly-2025-07-10 -> 0-nightly-2025-07-19 ``                                                  |
| [`7189c196`](https://github.com/NixOS/nixpkgs/commit/7189c1969baec665146299def1fccdd61ccaf19b) | `` python3Packages.docling-serve: 0.14.0 -> 1.0.0 ``                                                        |
| [`3bdd515c`](https://github.com/NixOS/nixpkgs/commit/3bdd515c4ed20b2f345926971c85e2f90a9db7a7) | `` kopia-ui: 0.20.1 -> 0.21.0 ``                                                                            |
| [`389e30e4`](https://github.com/NixOS/nixpkgs/commit/389e30e4fd9af3a51eeb4b3c4a84d074b0885b01) | `` home-assistant: update component packages ``                                                             |
| [`ab3c1690`](https://github.com/NixOS/nixpkgs/commit/ab3c1690d0b519a24ac54b309b4319f9931a5a11) | `` python313Packages.iperf3: init at 0.1.11 ``                                                              |
| [`02a66e0d`](https://github.com/NixOS/nixpkgs/commit/02a66e0dec1726a448f11524ae96c05563bef3e4) | `` ty: 0.0.1-alpha.14 -> 0.0.1-alpha.15 ``                                                                  |
| [`da7f5f7a`](https://github.com/NixOS/nixpkgs/commit/da7f5f7a82d84cdaa15e73f6dda69649cf8c269c) | `` home-assistant: update component packages ``                                                             |
| [`727688de`](https://github.com/NixOS/nixpkgs/commit/727688de015a0b7638e5087a3e85f6e154f857cf) | `` python313Packages.freesms: init at 0.3.0 ``                                                              |
| [`3613281c`](https://github.com/NixOS/nixpkgs/commit/3613281ca03f67ee0434a7f5af58d64cc81d15ae) | `` python3Packages.logassert: 8.4 -> 8.5 ``                                                                 |
| [`7dbbf570`](https://github.com/NixOS/nixpkgs/commit/7dbbf570e78d4102096e4e7c33579e2ac55c5e14) | `` albert: 0.30.0 -> 0.30.1 ``                                                                              |
| [`862e6b7c`](https://github.com/NixOS/nixpkgs/commit/862e6b7c205d053182db475f53031b14a2e33461) | `` home-assistant: update component packages ``                                                             |
| [`b4fd6df3`](https://github.com/NixOS/nixpkgs/commit/b4fd6df395c13f86f0050632f6e118431ed399e9) | `` python313Packages.lacrosse-view: init at 1.1.1 ``                                                        |
| [`04f9dec8`](https://github.com/NixOS/nixpkgs/commit/04f9dec8cbd1f0450ce3759c03e4a4ea3146b146) | `` home-assistant: update component packages ``                                                             |
| [`08c5b11d`](https://github.com/NixOS/nixpkgs/commit/08c5b11d444d8b144edd440d272138e72157f4f2) | `` python313Packages.pyw215: init at 0.8.0 ``                                                               |
| [`107ca9a3`](https://github.com/NixOS/nixpkgs/commit/107ca9a330900b22a88bd585c48accc96273b783) | `` python3Packages.craft-platforms: 0.9.0 -> 0.10.0 ``                                                      |
| [`7d75c0bd`](https://github.com/NixOS/nixpkgs/commit/7d75c0bd0958322e1349bca09ea9bebbc9ba207c) | `` tofu-ls: 0.0.8 -> 0.0.9 ``                                                                               |
| [`14159577`](https://github.com/NixOS/nixpkgs/commit/1415957799721c1cf37c5788de13204050e12f40) | `` planify: 4.12.2 -> 4.13.0 ``                                                                             |
| [`aa030ff8`](https://github.com/NixOS/nixpkgs/commit/aa030ff8678c65967b09472893bab8f35c643d15) | `` terraform-providers.ibm: 1.79.2 -> 1.80.4 ``                                                             |
| [`258bd021`](https://github.com/NixOS/nixpkgs/commit/258bd021d47354ce9ab9dd23a595f9bda6715a74) | `` terraform-providers.baiducloud: 1.21.16 -> 1.22.8 ``                                                     |
| [`3add063f`](https://github.com/NixOS/nixpkgs/commit/3add063fbf69bf1ead4954ca53c6738d56dd7074) | `` terraform-providers.gitlab: 18.0.0 -> 18.1.1 ``                                                          |
| [`68859aa3`](https://github.com/NixOS/nixpkgs/commit/68859aa35d3750fa48b71a49bb6068846587abe9) | `` terraform-providers.azurerm: 4.32.0 -> 4.37.0 ``                                                         |
| [`2319e923`](https://github.com/NixOS/nixpkgs/commit/2319e923eaee4234864621f768c96c40d15a7e6b) | `` mcontrolcenter: 0.5.0 -> 0.5.1 ``                                                                        |
| [`b5a4beba`](https://github.com/NixOS/nixpkgs/commit/b5a4bebab20371a4199f45fd8b2965f229079345) | `` python3Packages.formulaic: 1.1.1 -> 1.2.0 ``                                                             |
| [`74b3c0e3`](https://github.com/NixOS/nixpkgs/commit/74b3c0e35013fda4063f6c134b3076e61283c18b) | `` gitolite: 3.6.13 -> 3.6.14 ``                                                                            |
| [`6e1b757b`](https://github.com/NixOS/nixpkgs/commit/6e1b757bf75bb4c2fba2087d7076390ea339b57e) | `` esphome: 2025.7.1 -> 2025.7.2 ``                                                                         |
| [`35eee85f`](https://github.com/NixOS/nixpkgs/commit/35eee85f37a9131efa5f2e6ae034514462235d81) | `` hoppscotch: 25.6.0-0 -> 25.6.1-0 ``                                                                      |
| [`3e402f4f`](https://github.com/NixOS/nixpkgs/commit/3e402f4f21d0551698228820d95578f54714073d) | `` gdevelop: 5.5.236 -> 5.5.237 ``                                                                          |
| [`b2315084`](https://github.com/NixOS/nixpkgs/commit/b23150849557b034c7f1e5ed15ed1ad9617f3efe) | `` python313Packages.colcon: fixed spellchecking test ``                                                    |
| [`b927f514`](https://github.com/NixOS/nixpkgs/commit/b927f514a6120549fdfd33611b06c06146aa6e89) | `` trezor-suite: 25.6.3 -> 25.7.4 ``                                                                        |
| [`6f71d58f`](https://github.com/NixOS/nixpkgs/commit/6f71d58f5514dbf51783c126a24132d720b85557) | `` fastfetch: 2.48.0 -> 2.48.1 ``                                                                           |
| [`8f649179`](https://github.com/NixOS/nixpkgs/commit/8f64917951c2c87d8b19165f1b7e553378f3c7ea) | `` obs-studio-plugins.obs-vertical canvas: fix build ``                                                     |
| [`34eec3a4`](https://github.com/NixOS/nixpkgs/commit/34eec3a4bde9c2f8a56f107f1f433b44b5d61d9f) | `` obs-studio-plugins.obs-aitum-multistream: fix build ``                                                   |
| [`57a3cd9c`](https://github.com/NixOS/nixpkgs/commit/57a3cd9cd3c4895c6d6e51c346123ccbbb638c8a) | `` ungoogled-chromium: 138.0.7204.100-1 -> 138.0.7204.157-1 ``                                              |
| [`de9abc26`](https://github.com/NixOS/nixpkgs/commit/de9abc266d4c0f7b7a7146d648381d7d61788aa4) | `` gale: define pnpm fetcherVersion ``                                                                      |
| [`5d5599f7`](https://github.com/NixOS/nixpkgs/commit/5d5599f720409725ff8025657d0bb406d7d38eb1) | `` pkgs/top-level/stage.nix: fix allowVariants with variants set ``                                         |
| [`b3f6d66b`](https://github.com/NixOS/nixpkgs/commit/b3f6d66b504a62093086ef32a55d19f917e25a6c) | `` glab: 1.61.0 -> 1.62.0 ``                                                                                |
| [`bdb5a8b0`](https://github.com/NixOS/nixpkgs/commit/bdb5a8b07ab35609df534ed7a3874b8e20e8d25e) | `` glab: disable update check and telemetry by default ``                                                   |
| [`f83b14cd`](https://github.com/NixOS/nixpkgs/commit/f83b14cd30748101e274b0f76315e237dac7ecac) | `` prometheus: disable failing test on aarch64 ``                                                           |
| [`bbe778f5`](https://github.com/NixOS/nixpkgs/commit/bbe778f5d8fe9357446f9af1b896f232412c50ce) | `` glab: fix checkPhase, missing `git` ``                                                                   |
| [`7a8d5a2d`](https://github.com/NixOS/nixpkgs/commit/7a8d5a2d55ddde24be721d826d84a0054af24737) | `` zed-editor: 0.195.4 -> 0.195.5 ``                                                                        |
| [`3fbea50a`](https://github.com/NixOS/nixpkgs/commit/3fbea50a3ca4f7f4f9521284d63959c647711592) | `` python3Packages.willow: 1.9.0 -> 1.11.0, with lib refactor, adopt, remove old test skips and depRelax `` |
| [`5deeec2a`](https://github.com/NixOS/nixpkgs/commit/5deeec2a14e776e6f26081eeba102657c3a87b74) | `` glab: show short commit id when doing `glab version` ``                                                  |
| [`ff3b61a2`](https://github.com/NixOS/nixpkgs/commit/ff3b61a24bd63af784003f4faa9f4d52b83c0d35) | `` libretro.fbneo: 0-unstable-2025-07-09 -> 0-unstable-2025-07-18 ``                                        |
| [`29ced933`](https://github.com/NixOS/nixpkgs/commit/29ced933689e67d3244a6269d2632e7ed4cf5229) | `` libretro.mame: 0-unstable-2025-07-03 -> 0-unstable-2025-07-12 ``                                         |