### PR TITLE
chore(flake/nur): `9ebd6026` -> `cd4704be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -811,11 +811,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1753011846,
-        "narHash": "sha256-Njc3BIUu1wosqZXJpEs3TcIQvKRuRNkI5AKl6X1x/dM=",
+        "lastModified": 1753039389,
+        "narHash": "sha256-2DvnF9gHrOq3iXhXytE5nlZvhhJU2RrsB/jUVoTf99g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ebd6026f445b63a1442662acffeaebb5c8fad63",
+        "rev": "cd4704bef83d332226b8a030296f5f4de3552958",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cd4704be`](https://github.com/nix-community/NUR/commit/cd4704bef83d332226b8a030296f5f4de3552958) | `` automatic update `` |
| [`e7606ef6`](https://github.com/nix-community/NUR/commit/e7606ef6a268cd03fc117de249ce754a077f4402) | `` automatic update `` |
| [`0c4a05a1`](https://github.com/nix-community/NUR/commit/0c4a05a119c7185d8044d9d4c1f8af6475d8ce83) | `` automatic update `` |
| [`62ce6f99`](https://github.com/nix-community/NUR/commit/62ce6f995eee745f1ecf8d80a20dffa00ea7c278) | `` automatic update `` |
| [`15f413a0`](https://github.com/nix-community/NUR/commit/15f413a056f125f992aa0a7e507f8696b5dbf32f) | `` automatic update `` |
| [`b9ce183b`](https://github.com/nix-community/NUR/commit/b9ce183b2d3857290d95a8d2c3a1509f0502f751) | `` automatic update `` |
| [`957770b1`](https://github.com/nix-community/NUR/commit/957770b19c714ca6af2b6e9d6c8c5093fa460585) | `` automatic update `` |