### PR TITLE
chore(flake/emacs-overlay): `58dae564` -> `2aa171e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1753002546,
-        "narHash": "sha256-eVDmnGUaE8b3dCQc1VwOi3acpkkZ8qDKxcOlUNYMM4A=",
+        "lastModified": 1753034167,
+        "narHash": "sha256-4rlB41E+vC/d6OjF4e5w2qSwNw4zb4EA0E/r2u0yyXs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "58dae564cab8143a83cc38672dcf71a1c301443b",
+        "rev": "2aa171e1b491047b7465466e39e2e55540ccd3f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`2aa171e1`](https://github.com/nix-community/emacs-overlay/commit/2aa171e1b491047b7465466e39e2e55540ccd3f1) | `` Updated emacs ``        |
| [`81523c81`](https://github.com/nix-community/emacs-overlay/commit/81523c81b44f3a5697c04b3e0f6984a6dae2d6d5) | `` Updated melpa ``        |
| [`0685d7da`](https://github.com/nix-community/emacs-overlay/commit/0685d7da6e8054dd9f9bc9e2cd3d416289713e42) | `` Updated elpa ``         |
| [`dc7c432f`](https://github.com/nix-community/emacs-overlay/commit/dc7c432f20089264d5ac14f09e2a68c436799b50) | `` Updated nongnu ``       |
| [`f5254c7d`](https://github.com/nix-community/emacs-overlay/commit/f5254c7d813835df860a1acf7d5cb2ac18656c05) | `` Updated flake inputs `` |