### PR TITLE
chore(flake/nur): `cd4704be` -> `0962cdde`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -811,11 +811,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1753039389,
-        "narHash": "sha256-2DvnF9gHrOq3iXhXytE5nlZvhhJU2RrsB/jUVoTf99g=",
+        "lastModified": 1753043887,
+        "narHash": "sha256-dFUEvylWBtClTW7K/9hPgSBDn2hkYrrg8Z1R7AI2j8k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cd4704bef83d332226b8a030296f5f4de3552958",
+        "rev": "0962cddec17f391830d1980d926ffb9172bda22b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0962cdde`](https://github.com/nix-community/NUR/commit/0962cddec17f391830d1980d926ffb9172bda22b) | `` automatic update `` |