### PR TITLE
chore(flake/srvos): `403c3ef3` -> `8290c5a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -945,11 +945,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752715576,
-        "narHash": "sha256-CA8WzNOh7/bgxD7I0xZN0ZFqlsOWkfvHxlbXr+UvaQs=",
+        "lastModified": 1753061983,
+        "narHash": "sha256-D6+1c1L1fFJBk7ngRrPC0gHgI2DXgw2y7wNHlKvGXvk=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "403c3ef33457ed306a91214acb78913e47b0f093",
+        "rev": "8290c5a78a4a73baf17acdc4da7aa8e92f85b249",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`8290c5a7`](https://github.com/nix-community/srvos/commit/8290c5a78a4a73baf17acdc4da7aa8e92f85b249) | `` format tree ``                    |
| [`cc3bcb58`](https://github.com/nix-community/srvos/commit/cc3bcb586605e89f14ac28177744af7d9d05ecc8) | `` dev/private/flake.lock: Update `` |
| [`c824a773`](https://github.com/nix-community/srvos/commit/c824a77368ada4661f64825b974a65d2500effe4) | `` flake.lock: Update ``             |