### PR TITLE
chore(flake/emacs-overlay): `2aa171e1` -> `2a54b26b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1753034167,
-        "narHash": "sha256-4rlB41E+vC/d6OjF4e5w2qSwNw4zb4EA0E/r2u0yyXs=",
+        "lastModified": 1753089309,
+        "narHash": "sha256-ewCHpdXkEF5kXRA04qPJUmrTBkIPblvulFbpexNlXjQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2aa171e1b491047b7465466e39e2e55540ccd3f1",
+        "rev": "2a54b26bae8366c15757f417d5f92c4c2a759481",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`2a54b26b`](https://github.com/nix-community/emacs-overlay/commit/2a54b26bae8366c15757f417d5f92c4c2a759481) | `` Updated melpa ``  |
| [`6b85b21d`](https://github.com/nix-community/emacs-overlay/commit/6b85b21dcbee3bbc11a2260b920bbd0001d63ff9) | `` Updated emacs ``  |
| [`6db77842`](https://github.com/nix-community/emacs-overlay/commit/6db77842d89c5a343722b5f5fa6bcb18c875548a) | `` Updated elpa ``   |
| [`a4098718`](https://github.com/nix-community/emacs-overlay/commit/a4098718f27d13c7252f1d9f7634b6693c814bc3) | `` Updated nongnu `` |