### PR TITLE
chore(flake/nur): `0962cdde` -> `bdce6626`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -811,11 +811,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1753043887,
-        "narHash": "sha256-dFUEvylWBtClTW7K/9hPgSBDn2hkYrrg8Z1R7AI2j8k=",
+        "lastModified": 1753079654,
+        "narHash": "sha256-uSErLYSnZ+0ElDstxJsKcNn2q2mIul4MKZRi2W5+umw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0962cddec17f391830d1980d926ffb9172bda22b",
+        "rev": "bdce6626a10a914339c1285d730c19e579460d29",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bdce6626`](https://github.com/nix-community/NUR/commit/bdce6626a10a914339c1285d730c19e579460d29) | `` automatic update `` |
| [`84d952a1`](https://github.com/nix-community/NUR/commit/84d952a1ed63dede792f1a1c5e9ae5bfab38ca83) | `` automatic update `` |
| [`447d9b59`](https://github.com/nix-community/NUR/commit/447d9b591f66367891087aa4fd03d556e2191255) | `` automatic update `` |
| [`78e34d48`](https://github.com/nix-community/NUR/commit/78e34d48b48a16718ba443dad7ac85c326098e69) | `` automatic update `` |
| [`3504b321`](https://github.com/nix-community/NUR/commit/3504b3211c1109f194615f8f9b8bbac297d833da) | `` automatic update `` |
| [`e42cd043`](https://github.com/nix-community/NUR/commit/e42cd043a16d7eda7fa65cde0f60176ea68239ce) | `` automatic update `` |
| [`73f0c104`](https://github.com/nix-community/NUR/commit/73f0c1049187491e2699631482577d2afd5f5463) | `` automatic update `` |
| [`6e38a3a3`](https://github.com/nix-community/NUR/commit/6e38a3a3100fcb276753fc545e66240755619f2a) | `` automatic update `` |
| [`9d6b8d12`](https://github.com/nix-community/NUR/commit/9d6b8d121eda8f69261114cd87baf3ff94bd9c5c) | `` automatic update `` |