### PR TITLE
chore(flake/nur): `bdce6626` -> `f2a9d312`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -811,11 +811,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1753079654,
-        "narHash": "sha256-uSErLYSnZ+0ElDstxJsKcNn2q2mIul4MKZRi2W5+umw=",
+        "lastModified": 1753093654,
+        "narHash": "sha256-jMTTTZIhl6iF52sWqCh57/oM4JCUTYiLmUfMOz7JHc8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bdce6626a10a914339c1285d730c19e579460d29",
+        "rev": "f2a9d31269d762543980472a99372100289c5c43",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f2a9d312`](https://github.com/nix-community/NUR/commit/f2a9d31269d762543980472a99372100289c5c43) | `` automatic update `` |
| [`595a87d4`](https://github.com/nix-community/NUR/commit/595a87d41f26b345ec4bb42092952863b9b030ee) | `` automatic update `` |
| [`fde408f5`](https://github.com/nix-community/NUR/commit/fde408f56096fadf5fe1191ce4f2251d9fd1604b) | `` automatic update `` |
| [`7b668865`](https://github.com/nix-community/NUR/commit/7b6688650676d54c83934891cd2ace6d61bbc478) | `` automatic update `` |