### PR TITLE
chore(flake/emacs-overlay): `2a54b26b` -> `45e27e29`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1753089309,
-        "narHash": "sha256-ewCHpdXkEF5kXRA04qPJUmrTBkIPblvulFbpexNlXjQ=",
+        "lastModified": 1753117833,
+        "narHash": "sha256-1qVZxRJrqK11CkDbxItPWR7Kpg+GXqAaQbdolwSLVN0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2a54b26bae8366c15757f417d5f92c4c2a759481",
+        "rev": "45e27e2994de2b559a4bc9ac17f0447a67cd89b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`45e27e29`](https://github.com/nix-community/emacs-overlay/commit/45e27e2994de2b559a4bc9ac17f0447a67cd89b2) | `` Updated melpa ``  |
| [`85e2ea41`](https://github.com/nix-community/emacs-overlay/commit/85e2ea411a339424a30a7d7ae23d3e8fff5f8913) | `` Updated emacs ``  |
| [`6c37ac5a`](https://github.com/nix-community/emacs-overlay/commit/6c37ac5a2e87e04321857e6e106676448ef8fc29) | `` Updated elpa ``   |
| [`5217e36c`](https://github.com/nix-community/emacs-overlay/commit/5217e36c603d4cac440eda6224cba5749b218b23) | `` Updated nongnu `` |