### PR TITLE
chore(flake/minimal-emacs-d): `e1b96e84` -> `7b78ad5f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -434,11 +434,11 @@
     "minimal-emacs-d": {
       "flake": false,
       "locked": {
-        "lastModified": 1753111504,
-        "narHash": "sha256-j+C/qZVYH2XnJRjS59m3tA4onyHug/FwLUQOH2avgPc=",
+        "lastModified": 1753312678,
+        "narHash": "sha256-y93cLfSuJlHRIeXBUPEyUhMSYVhCnbEnoG7eLazOAdU=",
         "owner": "jamescherti",
         "repo": "minimal-emacs.d",
-        "rev": "e1b96e84b0ef91f574d2bdca1d95e64744b365c4",
+        "rev": "7b78ad5fcc0b0ebd58995648104c5a0cb0c7e19b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                    |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
| [`7b78ad5f`](https://github.com/jamescherti/minimal-emacs.d/commit/7b78ad5fcc0b0ebd58995648104c5a0cb0c7e19b) | `` Update README.md ``                                     |
| [`d0029622`](https://github.com/jamescherti/minimal-emacs.d/commit/d0029622d8a7c2ce27ee925594d74e4216108576) | `` Update README.md ``                                     |
| [`12703b20`](https://github.com/jamescherti/minimal-emacs.d/commit/12703b20a039e9f2462d783f6e5ab19fcb61e9d1) | `` Update README.md ``                                     |
| [`b5bea68a`](https://github.com/jamescherti/minimal-emacs.d/commit/b5bea68a67627ed6d2a8658e9dad0965b3c4d0aa) | `` Update README.md ``                                     |
| [`641d3c33`](https://github.com/jamescherti/minimal-emacs.d/commit/641d3c33e56ddffb335bed01b6c8118273d37ea5) | `` Update README.md ``                                     |
| [`6b2c03a9`](https://github.com/jamescherti/minimal-emacs.d/commit/6b2c03a9186cb9b095edc13e0979b01ffcf03648) | `` Update vc-git-diff-switches ``                          |
| [`cb359641`](https://github.com/jamescherti/minimal-emacs.d/commit/cb359641da7ffc84bcfd72585291205d8f900271) | `` vc-git-diff-switches: Ensure git drivers are invoked `` |