### PR TITLE
chore(flake/emacs-overlay): `aa1acbf4` -> `e4391465`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1753204266,
-        "narHash": "sha256-mZ/+5xC3UYINFglTDjUbkA3cUiPUQYp/MUmeLFlT5Vw=",
+        "lastModified": 1753227238,
+        "narHash": "sha256-0UIOMiF7/42tQH8g7Ay/gMXBdHi4EF9pPe2zTKyJmwA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "aa1acbf4633b38c014b547447d87bc634ff113c9",
+        "rev": "e43914657d9fcb7c3ad5150b18477f055090bc74",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                             |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------- |
| [`e4391465`](https://github.com/nix-community/emacs-overlay/commit/e43914657d9fcb7c3ad5150b18477f055090bc74) | `` Build emacs-lsp and commercial-emacs on hydra `` |
| [`d91e9a72`](https://github.com/nix-community/emacs-overlay/commit/d91e9a72cdf37f54a3570bc84fd8fe83ed8a07d7) | `` Update emacs-git-pgtk on hydra ``                |