### PR TITLE
chore(flake/nur): `91fda70a` -> `18248611`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -811,11 +811,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1753243423,
-        "narHash": "sha256-MZMl+fkSqB3I7QmmUYbCvkdhtwDL4PuvjbOKnYHzCIM=",
+        "lastModified": 1753257080,
+        "narHash": "sha256-uz1YdUhagSMabde/wjO/e82QOCWOklogQZAWnDCz4FY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "91fda70ae953822e93fd8488845563439c649ed8",
+        "rev": "182486117f110c88323a4c9f95b6afc7fb6f4729",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`18248611`](https://github.com/nix-community/NUR/commit/182486117f110c88323a4c9f95b6afc7fb6f4729) | `` automatic update `` |
| [`565fc37a`](https://github.com/nix-community/NUR/commit/565fc37afa084d3b8f9b2602a09a9dd2602ca337) | `` automatic update `` |
| [`ec8e1c67`](https://github.com/nix-community/NUR/commit/ec8e1c679047de6036c9f9c845f0ae5ff6bb8c49) | `` automatic update `` |
| [`f2581f6f`](https://github.com/nix-community/NUR/commit/f2581f6f6f2aef96cacaaf231d8fa3654069a9ca) | `` automatic update `` |
| [`931351a5`](https://github.com/nix-community/NUR/commit/931351a551878e56df3328a38ec03cb0b5a5fc15) | `` automatic update `` |
| [`87ca375e`](https://github.com/nix-community/NUR/commit/87ca375ec314afae7b60cd3d620b1272a554625d) | `` automatic update `` |
| [`dacb3b72`](https://github.com/nix-community/NUR/commit/dacb3b72b25895b09874491c0e871544a263c380) | `` automatic update `` |
| [`c17e7eb4`](https://github.com/nix-community/NUR/commit/c17e7eb4b071e2882b8aa5440a1b668bb9bb590d) | `` automatic update `` |