### PR TITLE
chore(flake/nur): `18248611` -> `467bfd9a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -811,11 +811,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1753257080,
-        "narHash": "sha256-uz1YdUhagSMabde/wjO/e82QOCWOklogQZAWnDCz4FY=",
+        "lastModified": 1753330415,
+        "narHash": "sha256-CYK+EwmQYIP0SL5xIIfHVAoj3riUaFi1WUVpVA3r0R4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "182486117f110c88323a4c9f95b6afc7fb6f4729",
+        "rev": "467bfd9ae8648cddd5d3fccfeaf430a4cb3f596e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`467bfd9a`](https://github.com/nix-community/NUR/commit/467bfd9ae8648cddd5d3fccfeaf430a4cb3f596e) | `` automatic update `` |
| [`4bbed566`](https://github.com/nix-community/NUR/commit/4bbed566037bf6ed723ff536f0690c703fbbbe25) | `` automatic update `` |
| [`0c43bbb3`](https://github.com/nix-community/NUR/commit/0c43bbb3a82f6aab588095da089d203e4d628f15) | `` automatic update `` |
| [`4d055408`](https://github.com/nix-community/NUR/commit/4d05540811f7a58b3b827b69eff2df11b680a6bb) | `` automatic update `` |
| [`b8ee0a99`](https://github.com/nix-community/NUR/commit/b8ee0a9915b955d64983f8b25800577772e01bc8) | `` automatic update `` |
| [`e9ac0e61`](https://github.com/nix-community/NUR/commit/e9ac0e615220b10559d0a466f6eacc7e2e0ff6f0) | `` automatic update `` |
| [`d1448851`](https://github.com/nix-community/NUR/commit/d1448851ea57a673253d6aff5d2139b3097f9e00) | `` automatic update `` |
| [`11956e33`](https://github.com/nix-community/NUR/commit/11956e332ce683521772f5db136f26e5438c07ed) | `` automatic update `` |
| [`7cca5381`](https://github.com/nix-community/NUR/commit/7cca53812f04097f6647ccf5bed02aa4124b34f1) | `` automatic update `` |
| [`162eb7c4`](https://github.com/nix-community/NUR/commit/162eb7c498e5b5f7ed1fcb57fbb917c95485ac65) | `` automatic update `` |
| [`01d46045`](https://github.com/nix-community/NUR/commit/01d460452bf2e55bd01cf2c723b38417d8d40fad) | `` automatic update `` |
| [`93f6a7f8`](https://github.com/nix-community/NUR/commit/93f6a7f8cfef53eac3f0252d1603013f56464050) | `` automatic update `` |
| [`19cb19d3`](https://github.com/nix-community/NUR/commit/19cb19d35b547a0d5b111a539b4874fbba62e034) | `` automatic update `` |
| [`1c6fa248`](https://github.com/nix-community/NUR/commit/1c6fa24885e260413ac5fca27185f475f6512554) | `` automatic update `` |
| [`f35d4a8b`](https://github.com/nix-community/NUR/commit/f35d4a8bca2a593c6217f53e9af6d4c09de1bed0) | `` automatic update `` |
| [`af2f8d14`](https://github.com/nix-community/NUR/commit/af2f8d14b638eba81f2da5195e90ab4e1f4d2cef) | `` automatic update `` |
| [`4d99f848`](https://github.com/nix-community/NUR/commit/4d99f848b4551ef31245cfff7cdf6a0eb7136ed0) | `` automatic update `` |
| [`dc3ced24`](https://github.com/nix-community/NUR/commit/dc3ced24667c2f8d83fe92ae75e796b5c27e3409) | `` automatic update `` |
| [`43afa751`](https://github.com/nix-community/NUR/commit/43afa751acc5ebb38ea549eb6b9899bc18ec84a6) | `` automatic update `` |
| [`f9af5366`](https://github.com/nix-community/NUR/commit/f9af536603ca56ff734034a80d6430273bb8c305) | `` automatic update `` |
| [`252f3bce`](https://github.com/nix-community/NUR/commit/252f3bce3bef21b8151b8366913e0cc1a24e6da1) | `` automatic update `` |
| [`e288c8af`](https://github.com/nix-community/NUR/commit/e288c8af36f241f15f87c649d1bacba5b57971fa) | `` automatic update `` |