### PR TITLE
chore(flake/home-manager): `e9c599e4` -> `1fde6fb1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -372,11 +372,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753285357,
-        "narHash": "sha256-F1fCxnMvgCm01+oDReNLdaSwQAXhugT0+AfP+I3VCPo=",
+        "lastModified": 1753294394,
+        "narHash": "sha256-1Dfgq09lHZ8AdYB2Deu/mYP1pMNpob8CgqT5Mzo44eI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e9c599e40c8d0d754980f51e580d00ebef3f2fea",
+        "rev": "1fde6fb1be6cd5dc513dc1c287d69e4eb2de973e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                          |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`1fde6fb1`](https://github.com/nix-community/home-manager/commit/1fde6fb1be6cd5dc513dc1c287d69e4eb2de973e) | `` yofi: add module (#7528) ``                   |
| [`fe38a5e0`](https://github.com/nix-community/home-manager/commit/fe38a5e02870debe6084203bca56d750e5d67ce8) | `` pueue: enable darwin configuration (#7519) `` |
| [`3641df95`](https://github.com/nix-community/home-manager/commit/3641df95becab34d2d7a221218091c2cea2d9c2e) | `` Translate using Weblate (Basque) ``           |
| [`b8d1a792`](https://github.com/nix-community/home-manager/commit/b8d1a79235798d6397db93bc891350901117cf54) | `` Translate using Weblate (Swedish) ``          |