### PR TITLE
chore(flake/nur): `dd57571e` -> `b2374914`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -811,11 +811,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1753385110,
-        "narHash": "sha256-WeJgB0dbgUJxFcUeLmdSf88DyKB7kviQsZZDIyi/9+4=",
+        "lastModified": 1753402599,
+        "narHash": "sha256-YO0qW0AyVNHFupyI9sf+4QOw+jtilAxQ5fQE+i+dxDE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dd57571e894e7c9a4dd776a056e411e71db0e8b9",
+        "rev": "b2374914949adf2f30a70cffcbbf9ed0f6ed7517",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b2374914`](https://github.com/nix-community/NUR/commit/b2374914949adf2f30a70cffcbbf9ed0f6ed7517) | `` automatic update `` |
| [`aa86568f`](https://github.com/nix-community/NUR/commit/aa86568fa2f9f3c99e7d5c747a32b4a254d6f46c) | `` automatic update `` |
| [`1e547513`](https://github.com/nix-community/NUR/commit/1e547513562298260bf14591c8912cc07c2776aa) | `` automatic update `` |
| [`daea7014`](https://github.com/nix-community/NUR/commit/daea701438ff45b791e7c5ac382b320bd6aacb97) | `` automatic update `` |