### PR TITLE
chore(flake/nur): `7886d96c` -> `3f1687c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -811,11 +811,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1753417681,
-        "narHash": "sha256-SFwDHCPQN6GZ35Ozaw5dKVw6w/n5VZf5JfpYknjOpUY=",
+        "lastModified": 1753429468,
+        "narHash": "sha256-yPDJZjb/WNm3RqgninTkum2Uhf6H1okDbxGnQapSn58=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7886d96cb50790ce5a44d5b495e353de164ecd71",
+        "rev": "3f1687c8ff2b49052dd4a43d266b6c71013b16eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3f1687c8`](https://github.com/nix-community/NUR/commit/3f1687c8ff2b49052dd4a43d266b6c71013b16eb) | `` automatic update `` |
| [`290c62d3`](https://github.com/nix-community/NUR/commit/290c62d34208d9f7034431bc2439f6ff06582260) | `` automatic update `` |
| [`1e165b2b`](https://github.com/nix-community/NUR/commit/1e165b2b7e247cc177129b7b085683bc1c3735ac) | `` automatic update `` |
| [`39f88cdb`](https://github.com/nix-community/NUR/commit/39f88cdba97e0384a2c69262ac4e29dd9e0c5faf) | `` automatic update `` |