### PR TITLE
chore(flake/nur): `3f1687c8` -> `ba60d758`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -811,11 +811,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1753429468,
-        "narHash": "sha256-yPDJZjb/WNm3RqgninTkum2Uhf6H1okDbxGnQapSn58=",
+        "lastModified": 1753444108,
+        "narHash": "sha256-u212YtHffB7X3+IPg/WJSyE8mhgY1JwwFkhZpKx0i6E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3f1687c8ff2b49052dd4a43d266b6c71013b16eb",
+        "rev": "ba60d758bb3d1ca5a2eb4dd03b5cddfdc48c3246",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ba60d758`](https://github.com/nix-community/NUR/commit/ba60d758bb3d1ca5a2eb4dd03b5cddfdc48c3246) | `` automatic update `` |
| [`bd271565`](https://github.com/nix-community/NUR/commit/bd271565c4d5c4d12ec920ed8ec83ecb0263e6c9) | `` automatic update `` |
| [`9f502600`](https://github.com/nix-community/NUR/commit/9f502600f91add8cb24f9a70c4849d0e7bf11f0c) | `` automatic update `` |