### PR TITLE
chore(flake/nur): `ba60d758` -> `417f3e47`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -811,11 +811,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1753444108,
-        "narHash": "sha256-u212YtHffB7X3+IPg/WJSyE8mhgY1JwwFkhZpKx0i6E=",
+        "lastModified": 1753459131,
+        "narHash": "sha256-ud158xxudPEtZIfzR0rHSX2t+pvX8aQj1rlAEzbrNGs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ba60d758bb3d1ca5a2eb4dd03b5cddfdc48c3246",
+        "rev": "417f3e47584d537d68ca8b96d061c95485188efb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                      |
| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`417f3e47`](https://github.com/nix-community/NUR/commit/417f3e47584d537d68ca8b96d061c95485188efb) | `` automatic update ``                                       |
| [`fb5be73a`](https://github.com/nix-community/NUR/commit/fb5be73a6c5b02b55c867df8068a7694c06bd766) | `` add rogreat repository ``                                 |
| [`624e4092`](https://github.com/nix-community/NUR/commit/624e4092aecca08fa361716232952dc0b6e30582) | `` rename cyberleagueaustria -> nodezeroat ``                |
| [`f5d2cc05`](https://github.com/nix-community/NUR/commit/f5d2cc05a61222419f73eb86293beee9ec4ed007) | `` add lxl66566/NUR repository ``                            |
| [`29da3a04`](https://github.com/nix-community/NUR/commit/29da3a04f142a3cf449c6bf57070e7256f92b134) | `` Add Red-Flake repository ``                               |
| [`e8e3798f`](https://github.com/nix-community/NUR/commit/e8e3798f14add0eb8469348fd11cecfbb991f9f8) | `` Add bloodhound-ce-desktop with electron_36-bin overlay `` |
| [`5d2ec507`](https://github.com/nix-community/NUR/commit/5d2ec507162b53b1a947ca6e71bba25458d43756) | `` automatic update ``                                       |