### PR TITLE
chore(flake/emacs-ultra-scroll): `17c0b23e` -> `8c92a177`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -184,11 +184,11 @@
     "emacs-ultra-scroll": {
       "flake": false,
       "locked": {
-        "lastModified": 1752526369,
-        "narHash": "sha256-B6/Ns7HlzTIsQIwlrPfuX4tL3GJRGRTJqrOjrI8IYYU=",
+        "lastModified": 1753465538,
+        "narHash": "sha256-UzFH+LXZ1ui9Wh9mlRYcZcpLBx0nSzNTtKGB8JI0r9Q=",
         "owner": "jdtsmith",
         "repo": "ultra-scroll",
-        "rev": "17c0b23e7692f373de4d584d6d8576c223373e02",
+        "rev": "8c92a17743af05fedc76beeb58da5eab48398035",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                           |
| ------------------------------------------------------------------------------------------------------ | --------------------------------- |
| [`8c92a177`](https://github.com/jdtsmith/ultra-scroll/commit/8c92a17743af05fedc76beeb58da5eab48398035) | `` README: display bug cleanup `` |