### PR TITLE
chore(flake/emacs-overlay): `07c08ea0` -> `37b552ff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1753460825,
-        "narHash": "sha256-MNu9l5nukxFpT5LzsT7Q83BqmO36EByn6/o/xA7hu7I=",
+        "lastModified": 1753496625,
+        "narHash": "sha256-IEf1cwrA/Nxd6koE96IfyD3+jDCSvRQWHw3TuZeI6wg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "07c08ea0037b2fd7e0b5416361586d4552ac8255",
+        "rev": "37b552ff889582192ebfcfb23d1baaf4f7f44673",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`37b552ff`](https://github.com/nix-community/emacs-overlay/commit/37b552ff889582192ebfcfb23d1baaf4f7f44673) | `` Updated melpa ``  |
| [`2011b60e`](https://github.com/nix-community/emacs-overlay/commit/2011b60e519c66ee1a9473051217dcf93de5b0ee) | `` Updated emacs ``  |
| [`55f920eb`](https://github.com/nix-community/emacs-overlay/commit/55f920ebcef4357786f00d367a913e4a2819b8c3) | `` Updated elpa ``   |
| [`234d7cac`](https://github.com/nix-community/emacs-overlay/commit/234d7cacd38e056b51bed1c619ababee1629e697) | `` Updated nongnu `` |