### PR TITLE
chore(flake/nur): `dd7b97b8` -> `294f62a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -753,11 +753,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1753250450,
-        "narHash": "sha256-i+CQV2rPmP8wHxj0aq4siYyohHwVlsh40kV89f3nw1s=",
+        "lastModified": 1753429684,
+        "narHash": "sha256-9h7+4/53cSfQ/uA3pSvCaBepmZaz/dLlLVJnbQ+SJjk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fc02ee70efb805d3b2865908a13ddd4474557ecf",
+        "rev": "7fd36ee82c0275fb545775cc5e4d30542899511d",
         "type": "github"
       },
       "original": {
@@ -811,11 +811,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1753502740,
-        "narHash": "sha256-g6D9WfAHVq9D76D1t9FahCtuBq+MfTo4dChFde0XosI=",
+        "lastModified": 1753562419,
+        "narHash": "sha256-hSutp1wLoj2DBGdhkFUCy8gJHu7YJ8Nt/OgsYrQ/O50=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dd7b97b8d11ebe7c7513d6c58e13104441862896",
+        "rev": "294f62a0da32efbda589682cc1f038e773530959",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`294f62a0`](https://github.com/nix-community/NUR/commit/294f62a0da32efbda589682cc1f038e773530959) | `` automatic update `` |
| [`3c0dd612`](https://github.com/nix-community/NUR/commit/3c0dd6127373509dd1b3877fbd820926c83ae3af) | `` automatic update `` |
| [`bc5deaa7`](https://github.com/nix-community/NUR/commit/bc5deaa73afd5c55ac6f6f427f6bab8c64919a52) | `` automatic update `` |
| [`3b0e2174`](https://github.com/nix-community/NUR/commit/3b0e21747e52ede6ac3fecb2107d2e0cfe64eba8) | `` automatic update `` |
| [`83c1dafd`](https://github.com/nix-community/NUR/commit/83c1dafd5065df0699821a3f18b9e598fe1448b0) | `` automatic update `` |
| [`0e5f33f4`](https://github.com/nix-community/NUR/commit/0e5f33f4637ade4fb614b81cfdba101099bf8b84) | `` automatic update `` |
| [`e98eaa10`](https://github.com/nix-community/NUR/commit/e98eaa10c2362b96be7f212e0e99f9b3476ddbf6) | `` automatic update `` |
| [`64ecaf16`](https://github.com/nix-community/NUR/commit/64ecaf164bc3a0f5a6c8f48cfc3e10ceac1c232b) | `` automatic update `` |
| [`4017c73b`](https://github.com/nix-community/NUR/commit/4017c73b82091a4b1dd8c171aa0de76afa4e25de) | `` automatic update `` |
| [`8c37eaf3`](https://github.com/nix-community/NUR/commit/8c37eaf318485018b37efa1006af881c5c7f5616) | `` automatic update `` |
| [`20bef157`](https://github.com/nix-community/NUR/commit/20bef1577803a8178bf908d1b3fed43e8919bc48) | `` automatic update `` |
| [`859530a4`](https://github.com/nix-community/NUR/commit/859530a4510ce406868b00ffaec1772f7c12f577) | `` automatic update `` |
| [`c0a841e3`](https://github.com/nix-community/NUR/commit/c0a841e35e73f2d6cf33b6341d67daf796925a38) | `` automatic update `` |
| [`c2c6db35`](https://github.com/nix-community/NUR/commit/c2c6db35c5ceef69d8f413de9882ec03aa9dd74b) | `` automatic update `` |
| [`be4d0cfe`](https://github.com/nix-community/NUR/commit/be4d0cfef146cb7d80a7d534585c9c913f8e8868) | `` automatic update `` |
| [`d1d1bc61`](https://github.com/nix-community/NUR/commit/d1d1bc61122f5677a364e50424286d2dcbaacdb6) | `` automatic update `` |
| [`7efa4e0a`](https://github.com/nix-community/NUR/commit/7efa4e0a689e5e251cd76bb9b65b71a7747c46fb) | `` automatic update `` |
| [`7acda5b8`](https://github.com/nix-community/NUR/commit/7acda5b8e13ed64769cc85efbb4b5552cbdd8a2c) | `` automatic update `` |
| [`797c2bf7`](https://github.com/nix-community/NUR/commit/797c2bf77f4c6b81e36d755d284fe466a3a69adc) | `` automatic update `` |
| [`226969ba`](https://github.com/nix-community/NUR/commit/226969bae6178b330436bcdc84a04e80d5e7f625) | `` automatic update `` |