### PR TITLE
chore(flake/minimal-emacs-d): `591edf73` -> `cbcfdf19`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -434,11 +434,11 @@
     "minimal-emacs-d": {
       "flake": false,
       "locked": {
-        "lastModified": 1753461093,
-        "narHash": "sha256-qdqv0cAkGlcuerB3BQMwJgJjvCpLkKNOTVQ5g3T8s9w=",
+        "lastModified": 1753558538,
+        "narHash": "sha256-DCUjVR/52MY2jadDDXhIcvXT4KXHoT/zsYfqSBM00Sg=",
         "owner": "jamescherti",
         "repo": "minimal-emacs.d",
-        "rev": "591edf73144eb7851abdadd99e17db4926f5eafc",
+        "rev": "cbcfdf19a701fccc7717301799aa05455aafc49c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                        |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------- |
| [`cbcfdf19`](https://github.com/jamescherti/minimal-emacs.d/commit/cbcfdf19a701fccc7717301799aa05455aafc49c) | `` Update README.md ``                         |
| [`93548a37`](https://github.com/jamescherti/minimal-emacs.d/commit/93548a3784b3acf9419cc2d22d322864104d2bbb) | `` Update README.md: saveplace and savehist `` |
| [`fe289b6d`](https://github.com/jamescherti/minimal-emacs.d/commit/fe289b6d45e01e82cd8a5ac3fdbb1c2fd81f7de1) | `` Update README.md: autorevert ``             |
| [`a12275b3`](https://github.com/jamescherti/minimal-emacs.d/commit/a12275b3d2a5d361ae1773954c2a17c9b314c84b) | `` Update README.md ``                         |
| [`848c5a4c`](https://github.com/jamescherti/minimal-emacs.d/commit/848c5a4cd5225466eb9960674f08612dc84fff6f) | `` Update recentf config in README.md ``       |
| [`379131cd`](https://github.com/jamescherti/minimal-emacs.d/commit/379131cdc23cbdaa3908dce91247ff97e035b430) | `` Update recentf config ``                    |