### PR TITLE
chore(flake/emacs-overlay): `fe84d9de` -> `2d6e5536`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1753520949,
-        "narHash": "sha256-00xm0AKqat+lxWeWpqe7cuCigNm4y8jlNC69HaQqwSI=",
+        "lastModified": 1753583672,
+        "narHash": "sha256-SlOXkY41SGXC+SHgtCoF9UQPGezBrwbdnYkHyE4SDYU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fe84d9de435663c7f191cf2cd4920dde2bd1b629",
+        "rev": "2d6e5536a0cd507c089234e0a87ff6eba6b327b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`2d6e5536`](https://github.com/nix-community/emacs-overlay/commit/2d6e5536a0cd507c089234e0a87ff6eba6b327b0) | `` Updated melpa ``  |
| [`c7165384`](https://github.com/nix-community/emacs-overlay/commit/c7165384a3567db171650e19a61fe47403ec59a1) | `` Updated emacs ``  |
| [`7565f308`](https://github.com/nix-community/emacs-overlay/commit/7565f308f547bf50984aec1b8730e323d727dd97) | `` Updated elpa ``   |
| [`983dc5da`](https://github.com/nix-community/emacs-overlay/commit/983dc5dacc3654f92e9c914c10d678ff32f5ca13) | `` Updated melpa ``  |
| [`b6df7296`](https://github.com/nix-community/emacs-overlay/commit/b6df7296a9a5ddaefacf7c1d2e08492c4b2dddc7) | `` Updated emacs ``  |
| [`c465e235`](https://github.com/nix-community/emacs-overlay/commit/c465e235cdb8947f81e1dd65f2bf7052435cce28) | `` Updated nongnu `` |