### PR TITLE
chore(flake/home-manager): `a1817d1c` -> `2b73c2fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -372,11 +372,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753470191,
-        "narHash": "sha256-hOUWU5L62G9sm8NxdiLWlLIJZz9H52VuFiDllHdwmVA=",
+        "lastModified": 1753567913,
+        "narHash": "sha256-eYrqSRI1/mrnVGCGYO+zkKHUszwJQodq/qDHh+mzvkI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a1817d1c0e5eabe7dfdfe4caa46c94d9d8f3fdb6",
+        "rev": "2b73c2fcca690b6eca4f520179e54ae760f25d4e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`2b73c2fc`](https://github.com/nix-community/home-manager/commit/2b73c2fcca690b6eca4f520179e54ae760f25d4e) | `` treewide: remove config dependency on docs (#7547) ``    |
| [`37fec70b`](https://github.com/nix-community/home-manager/commit/37fec70bd5dace2fb025d3f7cbc0899a7fce6081) | `` ci: extract maintainers with single file eval (#7548) `` |