### PR TITLE
chore(flake/nix-index-database): `fafdcb50` -> `f0736b09`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -505,11 +505,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752985182,
-        "narHash": "sha256-sX8Neff8lp3TCHai6QmgLr5AD8MdsQQX3b52C1DVXR8=",
+        "lastModified": 1753589988,
+        "narHash": "sha256-y1JlcMB2dKFkrr6g+Ucmj8L//IY09BtSKTH/A7OU7mU=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "fafdcb505ba605157ff7a7eeea452bc6d6cbc23c",
+        "rev": "f0736b09c43028fd726fb70c3eb3d1f0795454cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`f0736b09`](https://github.com/nix-community/nix-index-database/commit/f0736b09c43028fd726fb70c3eb3d1f0795454cf) | `` update generated.nix to release 2025-07-27-040015 `` |
| [`a4e1c3ba`](https://github.com/nix-community/nix-index-database/commit/a4e1c3bac560b098e71542ae5f262ceb68502a74) | `` flake.lock: Update ``                                |