### PR TITLE
chore(flake/nur): `294f62a0` -> `25a74a74`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -811,11 +811,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1753562419,
-        "narHash": "sha256-hSutp1wLoj2DBGdhkFUCy8gJHu7YJ8Nt/OgsYrQ/O50=",
+        "lastModified": 1753602108,
+        "narHash": "sha256-1wtWdPv2hr28ovGDO5MjWIORwEp/W/GqBSMmOjdjJ88=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "294f62a0da32efbda589682cc1f038e773530959",
+        "rev": "25a74a74a42011433753edc4970e9b8ca58994ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`25a74a74`](https://github.com/nix-community/NUR/commit/25a74a74a42011433753edc4970e9b8ca58994ec) | `` automatic update `` |
| [`d03223e3`](https://github.com/nix-community/NUR/commit/d03223e3a1523e9492deccb8c4ec7f696f661577) | `` automatic update `` |
| [`c7ab5a22`](https://github.com/nix-community/NUR/commit/c7ab5a22466bcedd5413edf953ab04e3db16d250) | `` automatic update `` |
| [`606960f2`](https://github.com/nix-community/NUR/commit/606960f2cac49ae9db05b39031119559c26c936c) | `` automatic update `` |
| [`d7edb73d`](https://github.com/nix-community/NUR/commit/d7edb73d9eef46a9ac08b36f9bdcf257566fb569) | `` automatic update `` |
| [`792db219`](https://github.com/nix-community/NUR/commit/792db2193bad9df261da0a6522d84854e0a9b206) | `` automatic update `` |
| [`8d21c9ef`](https://github.com/nix-community/NUR/commit/8d21c9ef1fa0285ee2ce0f278348b0f3d0bb9d78) | `` automatic update `` |
| [`a8e11af8`](https://github.com/nix-community/NUR/commit/a8e11af8d5ceddce852eb02750a40458132a2467) | `` automatic update `` |
| [`58c5066c`](https://github.com/nix-community/NUR/commit/58c5066ca19e98b299e352253288e76b6f4f8a69) | `` automatic update `` |