### PR TITLE
chore(flake/emacs-overlay): `2d6e5536` -> `16fb7a40`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1753583672,
-        "narHash": "sha256-SlOXkY41SGXC+SHgtCoF9UQPGezBrwbdnYkHyE4SDYU=",
+        "lastModified": 1753607314,
+        "narHash": "sha256-ysqWvsGYM6lrNL4qU3iK8A1IQfNOlFAcyLkZF6u6OHg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2d6e5536a0cd507c089234e0a87ff6eba6b327b0",
+        "rev": "16fb7a40da305fd43b679b2a8b987aa21f1203de",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`16fb7a40`](https://github.com/nix-community/emacs-overlay/commit/16fb7a40da305fd43b679b2a8b987aa21f1203de) | `` Updated melpa `` |
| [`edf5550d`](https://github.com/nix-community/emacs-overlay/commit/edf5550df669e12f402aec6411409d2a1ecc28e9) | `` Updated emacs `` |