### PR TITLE
chore(flake/emacs-overlay): `16fb7a40` -> `a460ed2b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1753607314,
-        "narHash": "sha256-ysqWvsGYM6lrNL4qU3iK8A1IQfNOlFAcyLkZF6u6OHg=",
+        "lastModified": 1753720133,
+        "narHash": "sha256-08Z+2zNrOApkbmJmDS9YIc4OEKrkelBC8VtlTibx+6k=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "16fb7a40da305fd43b679b2a8b987aa21f1203de",
+        "rev": "a460ed2bc3383fcb691f8b88c254145d237b4283",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`a460ed2b`](https://github.com/nix-community/emacs-overlay/commit/a460ed2bc3383fcb691f8b88c254145d237b4283) | `` Updated elpa ``         |
| [`8b4613ee`](https://github.com/nix-community/emacs-overlay/commit/8b4613ee78a3f1ec2a58e71ed6c8a8ea93e7dd40) | `` Updated nongnu ``       |
| [`570d679b`](https://github.com/nix-community/emacs-overlay/commit/570d679bdf08d80e3864541b417fc94ba2a5da7e) | `` Updated emacs ``        |
| [`100807ee`](https://github.com/nix-community/emacs-overlay/commit/100807ee8983b230b41e5f15e3a6f1a666abf2b9) | `` Updated melpa ``        |
| [`d07a07a9`](https://github.com/nix-community/emacs-overlay/commit/d07a07a9e47610a49781ecef915e8cd97fb6516c) | `` Updated flake inputs `` |
| [`7ff67f2f`](https://github.com/nix-community/emacs-overlay/commit/7ff67f2fe892122aaa0fb28af341171d526173fe) | `` Updated melpa ``        |
| [`d897508e`](https://github.com/nix-community/emacs-overlay/commit/d897508eb2803d712e5b1da3434ad92194716515) | `` Updated emacs ``        |
| [`05e1028f`](https://github.com/nix-community/emacs-overlay/commit/05e1028fc46c7c76554e4e5ff67526d4c39d1ca6) | `` Updated elpa ``         |
| [`3ccb8d0c`](https://github.com/nix-community/emacs-overlay/commit/3ccb8d0c9393d2fbda69b83f37eb17b097a9d3a6) | `` Updated nongnu ``       |
| [`06e3e3be`](https://github.com/nix-community/emacs-overlay/commit/06e3e3be8aff792547dfd0825c7e5dc0c65bd4db) | `` Updated melpa ``        |
| [`62be4100`](https://github.com/nix-community/emacs-overlay/commit/62be41004cbfe8eca0dbf272c8fd4e66831569cc) | `` Updated emacs ``        |
| [`b798ba95`](https://github.com/nix-community/emacs-overlay/commit/b798ba95dcec69337712d76c68ee6698c48c215a) | `` Updated elpa ``         |
| [`4c71a9bc`](https://github.com/nix-community/emacs-overlay/commit/4c71a9bcac6d1d528520263c1f8718753074a267) | `` Updated nongnu ``       |