### PR TITLE
chore(flake/nur): `7f781545` -> `0ca9aba7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -811,11 +811,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1753644335,
-        "narHash": "sha256-25dFBB7jn3HaQWEmWcqD3Qlh0y3tCMf/0c/G0nKJnHo=",
+        "lastModified": 1753686169,
+        "narHash": "sha256-OEqqcfz+Dny+IWxTg/gGyf4Pr21TevNHFKxuVVo4NLs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7f781545337bdb84957b87c84c355ffb1b3a1e22",
+        "rev": "0ca9aba7c440a77873111b7a52913cfaac5ddb08",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0ca9aba7`](https://github.com/nix-community/NUR/commit/0ca9aba7c440a77873111b7a52913cfaac5ddb08) | `` automatic update `` |
| [`d52b2535`](https://github.com/nix-community/NUR/commit/d52b253583c0465af73319bf1103af4fe108ae35) | `` automatic update `` |
| [`aa97a3e1`](https://github.com/nix-community/NUR/commit/aa97a3e15b8bd008194d28d4e3f86ad9dcabbbf9) | `` automatic update `` |
| [`857227d2`](https://github.com/nix-community/NUR/commit/857227d26ebb8a1fbabf9f04dc3724c01042167b) | `` automatic update `` |
| [`b8743080`](https://github.com/nix-community/NUR/commit/b8743080fb38c18386c840f820cc795c29a4d4ec) | `` automatic update `` |
| [`627e93b2`](https://github.com/nix-community/NUR/commit/627e93b2f3148a7ef4f392bcee9cdc43cef55ccd) | `` automatic update `` |
| [`66ba7f23`](https://github.com/nix-community/NUR/commit/66ba7f231ed5195a2e3fd6f8d97af35ca84f269d) | `` automatic update `` |
| [`8393299f`](https://github.com/nix-community/NUR/commit/8393299ffb0faa8cd73605f602001fa64b922b99) | `` automatic update `` |
| [`445dc705`](https://github.com/nix-community/NUR/commit/445dc705bfda4e2c67c19d1f6646609fa4198342) | `` automatic update `` |
| [`e0759865`](https://github.com/nix-community/NUR/commit/e0759865ed946bed60a4343add96ae6d0b20c114) | `` automatic update `` |
| [`b21122a1`](https://github.com/nix-community/NUR/commit/b21122a1d43d8972eed712976cd59dfbdd45b0d6) | `` automatic update `` |
| [`4a4880fa`](https://github.com/nix-community/NUR/commit/4a4880fafb3286f53825bfa40d861dbcae1cd076) | `` automatic update `` |
| [`17728e9b`](https://github.com/nix-community/NUR/commit/17728e9b76bb35b5a1d08dcdc30aaed536459d53) | `` automatic update `` |