### PR TITLE
chore(flake/srvos): `6a29375c` -> `cc76247e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -945,11 +945,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753319211,
-        "narHash": "sha256-WR9rKJhFjX5FJbqNWCg8dwQsJWUuCNgff63DpuKL39c=",
+        "lastModified": 1753665188,
+        "narHash": "sha256-EZ4FUDaZVonbTE8rGr5+SIVOki0QLQugd481cmNjisc=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "6a29375c7b8e9bb477233f66cd6609583741dadc",
+        "rev": "cc76247e77c04cf2ad0bf04be10a5d47bc3da594",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`cc76247e`](https://github.com/nix-community/srvos/commit/cc76247e77c04cf2ad0bf04be10a5d47bc3da594) | `` dev/private/flake.lock: Update `` |
| [`967aeda8`](https://github.com/nix-community/srvos/commit/967aeda8216b1b8a3e5d666d760c1be1df0f8574) | `` flake.lock: Update ``             |