### PR TITLE
chore(flake/nixpkgs): `7fd36ee8` -> `17f6bd17`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -737,11 +737,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1753429684,
-        "narHash": "sha256-9h7+4/53cSfQ/uA3pSvCaBepmZaz/dLlLVJnbQ+SJjk=",
+        "lastModified": 1753549186,
+        "narHash": "sha256-Znl7rzuxKg/Mdm6AhimcKynM7V3YeNDIcLjBuoBcmNs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7fd36ee82c0275fb545775cc5e4d30542899511d",
+        "rev": "17f6bd177404d6d43017595c5264756764444ab8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`5948d9e5`](https://github.com/NixOS/nixpkgs/commit/5948d9e51e6f34d5ecf75bbef8a16ce2acf86e17) | `` vivaldi: 7.5.3735.54 -> 7.5.3735.56 ``                                   |
| [`edf39334`](https://github.com/NixOS/nixpkgs/commit/edf393346a8ca84c5de2b66058b3cc6da9436f66) | `` urn-timer: 0-unstable-2025-04-17 -> 0-unstable-2025-07-21 ``             |
| [`636a9234`](https://github.com/NixOS/nixpkgs/commit/636a92342bdff6f21ef26cbdaaf4057c5b8a24d4) | `` crosswords: 0.3.12 -> 0.3.15 ``                                          |
| [`f7e486a6`](https://github.com/NixOS/nixpkgs/commit/f7e486a6ca16b7f4fede9753b1b19ff6557e61f5) | `` libipuz: 0.4.5 -> 0.5.2 ``                                               |
| [`87f17273`](https://github.com/NixOS/nixpkgs/commit/87f17273e56eb2105a740a1831a1cdabb656fd6a) | `` Revert "libunwind: fix building with llvm" ``                            |
| [`b264aa2a`](https://github.com/NixOS/nixpkgs/commit/b264aa2a8eddabec4b7bd84b26f1b96062af10f3) | `` ubootRadxaZero3W: init ``                                                |
| [`3431dc91`](https://github.com/NixOS/nixpkgs/commit/3431dc91df992f5b84cc4cfdf0dc5702a2c3107c) | `` yosys: fetch patch to fix amaranth code compilation ``                   |
| [`f7226276`](https://github.com/NixOS/nixpkgs/commit/f7226276914392ab86d8b2e408f77b76626ca10f) | `` mdp: 1.0.17 -> 1.0.18 ``                                                 |
| [`3590a2c9`](https://github.com/NixOS/nixpkgs/commit/3590a2c92904534a4bcf7e49c26c1f963cf8e42c) | `` newsraft: remove unused CFLAG ``                                         |
| [`edbfa174`](https://github.com/NixOS/nixpkgs/commit/edbfa174ea7f9b13458cffe2f0d1f6ebd1808202) | `` mesa.llvmpipeHook: fix GLX, add GBM, add comments ``                     |
| [`b6185f4e`](https://github.com/NixOS/nixpkgs/commit/b6185f4ed58b8d79bdc5a6151a1ce985092bf996) | `` crosvm: 0-unstable-2025-07-15 -> 0-unstable-2025-07-24 ``                |
| [`c331cfe5`](https://github.com/NixOS/nixpkgs/commit/c331cfe5440c998d866aacaf5d5ded1ec15240c8) | `` cc-wrapper: don't set -fno-omit-frame-pointer on s390/x390x ``           |
| [`8e59ce1e`](https://github.com/NixOS/nixpkgs/commit/8e59ce1e26f7a77ddc9a4535b8332eaac7345a23) | `` buildRustPackage: warn on explicit useFetchCargoVendor ``                |
| [`7cf77aa6`](https://github.com/NixOS/nixpkgs/commit/7cf77aa671911c527a33f92fb0709173594dc1b0) | `` treewide: prefix unstable versions with `0-unstable` ``                  |
| [`8b79ece5`](https://github.com/NixOS/nixpkgs/commit/8b79ece5e9fdc8a897d09c5aa466842490fe9ad2) | `` khard: 0.19.1 -> 0.20.0 ``                                               |
| [`c9d7e166`](https://github.com/NixOS/nixpkgs/commit/c9d7e1665f68862538e72c8cee629483ab01fee4) | `` ansible: add jmespath by default ``                                      |
| [`ac983b70`](https://github.com/NixOS/nixpkgs/commit/ac983b702d1b0e3c732dd57e43d192355fa122cb) | `` ansible: add extraPackages option ``                                     |
| [`ddda942d`](https://github.com/NixOS/nixpkgs/commit/ddda942d70a53be0c177b36956ed48290dad04b7) | `` shogihome: 1.24.1 -> 1.24.2 ``                                           |
| [`c533809f`](https://github.com/NixOS/nixpkgs/commit/c533809fdb7d4b8c215a96ddfbfd4ded5f3d7f93) | `` firebase-tools: 14.11.0 -> 14.11.1 ``                                    |
| [`398b16e1`](https://github.com/NixOS/nixpkgs/commit/398b16e16cc688d8ffcf820d1ec50a55da44a108) | `` treewide: remove useFetchCargoVendor usages ``                           |
| [`6a342938`](https://github.com/NixOS/nixpkgs/commit/6a342938a52f70aac193c6400f6bb9a316a8db06) | `` python3Packages.pyscf: 2.9.0 -> 2.10.0 ``                                |
| [`92f69f15`](https://github.com/NixOS/nixpkgs/commit/92f69f15441b8a5d9d178ca69aae8e54d99e36f1) | `` ghostunnel: conditional systemd ``                                       |
| [`f77112d0`](https://github.com/NixOS/nixpkgs/commit/f77112d0a782420345d167c73e39161383ea9a22) | `` mods: 1.7.0 -> 1.8.1 ``                                                  |
| [`248e0cb9`](https://github.com/NixOS/nixpkgs/commit/248e0cb9933692eeb6b700ef2287cc62e4f74aa0) | `` hyprlang: 0.6.3 -> 0.6.4 ``                                              |
| [`7f23f852`](https://github.com/NixOS/nixpkgs/commit/7f23f852c79ddfdc8b756cf66f9c43515c6f2df2) | `` androidStudioPackages.canary: 2025.1.2.9 -> 2025.1.3.2 ``                |
| [`ea03f15d`](https://github.com/NixOS/nixpkgs/commit/ea03f15d3eb12860cf0ebc16188f31095d86ac61) | `` dockerfmt: init at 0.3.7 ``                                              |
| [`38e13211`](https://github.com/NixOS/nixpkgs/commit/38e13211101d789a8df8c037f9ff23d025021232) | `` hyprsunset: 0.3.0 -> 0.3.1 ``                                            |
| [`0422cbb3`](https://github.com/NixOS/nixpkgs/commit/0422cbb3798c0278c7b4297f207821d2b246fa61) | `` androidStudioPackages.beta: 2025.1.1.12 -> 2025.1.2.10 ``                |
| [`2c24ef1f`](https://github.com/NixOS/nixpkgs/commit/2c24ef1fb0e9272861ede4874b30c991a07adb48) | `` kuzu: 0.11.0 -> 0.11.1 ``                                                |
| [`c1b0e97b`](https://github.com/NixOS/nixpkgs/commit/c1b0e97bd0990677ca43b05d835b509a5af65116) | `` home-assistant-custom-lovelace-modules.hourly-weather: 6.7.0 -> 6.7.1 `` |
| [`f69d70b4`](https://github.com/NixOS/nixpkgs/commit/f69d70b4683096e1a7e6677f9464f5aee68bc573) | `` python3Packages.x-transformers: 2.3.12 -> 2.4.14 ``                      |
| [`450bd6c3`](https://github.com/NixOS/nixpkgs/commit/450bd6c3906eabbc68f85aa21bfceaa277b136aa) | `` gemini-cli: 0.1.7 -> 0.1.14 ``                                           |
| [`d24f0da4`](https://github.com/NixOS/nixpkgs/commit/d24f0da4a21cbb15b979cfdf905008807f3e98cf) | `` davfs2: pull upstream patch to fix build after neon update ``            |
| [`fcceefe3`](https://github.com/NixOS/nixpkgs/commit/fcceefe35fc71f5108b2be2a2253a9e9c00d3734) | `` factoriolab: 3.16.3 -> 3.16.4 ``                                         |
| [`fd6567c8`](https://github.com/NixOS/nixpkgs/commit/fd6567c8700787655b26332b284db1fc2bb4f32f) | `` home-assistant: update component packages ``                             |
| [`d3a4f9ba`](https://github.com/NixOS/nixpkgs/commit/d3a4f9ba08f6170519cbe76dbfbbc637a33b38dd) | `` python313Packages.asyncpysupla: init at 0.0.5 ``                         |
| [`a9f580d6`](https://github.com/NixOS/nixpkgs/commit/a9f580d6bb8f50367d5a27cf6e3265c02be2c9a4) | `` xml-tooling-c: fix finding boost ``                                      |
| [`8ee4547a`](https://github.com/NixOS/nixpkgs/commit/8ee4547a012f558a960a71d41273c11d618af2a8) | `` pdns-recursor: fix finding boost ``                                      |
| [`a8a3b4ca`](https://github.com/NixOS/nixpkgs/commit/a8a3b4ca56c96798ed457f38f1eb060bb8144d13) | `` pdns: fix finding boost ``                                               |
| [`af38c9c0`](https://github.com/NixOS/nixpkgs/commit/af38c9c0c99c03e0b50325164bce8bcfe097faba) | `` treewide: update rev to full-length commit ``                            |
| [`0e023235`](https://github.com/NixOS/nixpkgs/commit/0e023235d4a524f48eeddf6b157d4932a7fed2b4) | `` firebird: enableParallelBuilding = true ``                               |
| [`4ed18018`](https://github.com/NixOS/nixpkgs/commit/4ed1801815747b8b331b27e3bf81c10348961983) | `` firebird: fixup build ``                                                 |
| [`1d4c7179`](https://github.com/NixOS/nixpkgs/commit/1d4c717917059210864947b8aa8d279d865046f7) | `` typescript-go: 0-unstable-2025-07-17 -> 0-unstable-2025-07-25 ``         |
| [`57622305`](https://github.com/NixOS/nixpkgs/commit/5762230543fddfb46539c16194c832792c5a6dab) | `` heroic: don't depend on EOL libsoup ``                                   |
| [`04febbb7`](https://github.com/NixOS/nixpkgs/commit/04febbb75f189e5d318a48b572c793afa92caa6b) | `` kubexporter: 0.6.5 -> 0.7.0 ``                                           |
| [`57635db1`](https://github.com/NixOS/nixpkgs/commit/57635db1a553ce792a83e0bef7aca78947baac8c) | `` newsraft: 0.31 -> 0.32 ``                                                |
| [`ff894798`](https://github.com/NixOS/nixpkgs/commit/ff894798539a89ed5db31cdb85b4e207a3733a1f) | `` vscode-extensions.eamodio.gitlens: 17.3.1 -> 17.3.2 ``                   |
| [`97d8d594`](https://github.com/NixOS/nixpkgs/commit/97d8d594909f9e50889be136cc3227df2ed1dae4) | `` mangayomi: refactor ``                                                   |
| [`9c249131`](https://github.com/NixOS/nixpkgs/commit/9c249131f3a8d19af5fb2f1d555a84b3c15f3f5b) | `` md-lsp: init at 0.1.1 ``                                                 |
| [`b6628813`](https://github.com/NixOS/nixpkgs/commit/b6628813b6315a3fb28b72bf5b52b38f1460f3e7) | `` mangayomi: 0.6.25 -> 0.6.3 ``                                            |
| [`6f52c4d3`](https://github.com/NixOS/nixpkgs/commit/6f52c4d3979a23cad5794c3875b73cef66660aa8) | `` ahoy: 2.4.0 -> 2.5.0 ``                                                  |
| [`00739647`](https://github.com/NixOS/nixpkgs/commit/00739647786eca36fd4c5fa282db864827194eef) | `` bulky: 3.6 -> 3.7 ``                                                     |
| [`c577d75e`](https://github.com/NixOS/nixpkgs/commit/c577d75e0202b054ea01792688c1fb03b2be7df6) | `` gerbolyze: fix wrapper ``                                                |
| [`142e47cd`](https://github.com/NixOS/nixpkgs/commit/142e47cda72cbfb77e7b5d003ba5a532b73a128c) | `` libretro.vice-x128: 0-unstable-2025-07-14 -> 0-unstable-2025-07-19 ``    |
| [`0e13c2d6`](https://github.com/NixOS/nixpkgs/commit/0e13c2d6f8ba160ec3715ccf8433512166f15c47) | `` terminal-toys: init at 0.5.0 ``                                          |
| [`a3705733`](https://github.com/NixOS/nixpkgs/commit/a370573342456896cfb393d89e2edb510a93fb5e) | `` maintainers: add yiyu ``                                                 |
| [`77e6b5bf`](https://github.com/NixOS/nixpkgs/commit/77e6b5bfbf9b726d09d25119cc8a77d1bcc25ab5) | `` vscode-extensions.ionide.ionide-fsharp: 7.26.3 -> 7.26.5 ``              |
| [`1a8725be`](https://github.com/NixOS/nixpkgs/commit/1a8725be716509110ab56ca028acda6d0233e541) | `` nixos/minecraft-server: revert typo ``                                   |
| [`67e8b4cc`](https://github.com/NixOS/nixpkgs/commit/67e8b4cc7e65881feab8670da492d4eb0d47bebb) | `` thunderbird-128-unwrapped: 128.12.0esr -> 128.13.0esr ``                 |
| [`050b6674`](https://github.com/NixOS/nixpkgs/commit/050b66744aab804e027b1600ca300d4a2c2df65e) | `` cargo-deb: 3.2.1 -> 3.3.0 ``                                             |
| [`3681b723`](https://github.com/NixOS/nixpkgs/commit/3681b7232ba80ed63b7f335dbf60da9abb48f08b) | `` eddy: 3.7 -> 3.7.1 ``                                                    |
| [`970b0761`](https://github.com/NixOS/nixpkgs/commit/970b0761195b684457e82f4bec5a7917666bbeb4) | `` kb: 0.1.7 -> 0.1.8 ``                                                    |
| [`22fbb1a8`](https://github.com/NixOS/nixpkgs/commit/22fbb1a8d1af4f5405c10d768cf89ac59807aa26) | `` dazel: 0.0.42 -> 0.0.43 ``                                               |
| [`5ce38093`](https://github.com/NixOS/nixpkgs/commit/5ce38093b086c5bda2cd072d1bd5f21500ad184d) | `` python313Packages.sigstore: 3.6.2 -> 3.6.4 ``                            |
| [`c1a8e861`](https://github.com/NixOS/nixpkgs/commit/c1a8e86178dac6de65f27f371f75535a8090e373) | `` python313Packages.rfc3161-client: 1.0.1 -> 1.0.3 ``                      |
| [`a53b7b34`](https://github.com/NixOS/nixpkgs/commit/a53b7b346130b16444f6978b4692a8e0270e71a2) | `` phpExtensions.relay: 0.11.0 -> 0.11.1 ``                                 |
| [`79dbd8bb`](https://github.com/NixOS/nixpkgs/commit/79dbd8bb9cadefb7ecad6f27d69c62c31c791bce) | `` python313Packages.polyfactory: 2.19.0 -> 2.22.1 ``                       |
| [`175af875`](https://github.com/NixOS/nixpkgs/commit/175af875f33efdd7bc9712b78c3e46d7d4b0df94) | `` upbound-main: 0.39.0-115.gbdd4b5af -> 0.39.0-384.g0a0c8634 ``            |
| [`8856b092`](https://github.com/NixOS/nixpkgs/commit/8856b092155b082848339fa24b6561fbeead8c35) | `` papermc: 1.21.6-47 -> 1.21.8-11 ``                                       |
| [`48358dbc`](https://github.com/NixOS/nixpkgs/commit/48358dbce425145a2c0cdce782ee79badb301066) | `` warpinator: 1.8.8 -> 1.8.9 ``                                            |
| [`d3d88996`](https://github.com/NixOS/nixpkgs/commit/d3d88996a67ed14e6956427e2cee31cd89579850) | `` firefox-beta-unwrapped: 141.0b9 -> 142.0b3 ``                            |
| [`8f03c15a`](https://github.com/NixOS/nixpkgs/commit/8f03c15a3b692932f94a97ced5f908da095915ee) | `` firefox-devedition-unwrapped: 141.0b9 -> 142.0b3 ``                      |
| [`58b51304`](https://github.com/NixOS/nixpkgs/commit/58b513042ff494dd3daf30d8d39cbde0d60fe9f0) | `` firfox: limit apple sdk patch to versions below 142 ``                   |
| [`93475f1c`](https://github.com/NixOS/nixpkgs/commit/93475f1c02faec905475347e4d3286858f55e2ed) | `` python3Packages.disposable-email-domains: 0.0.126 -> 0.0.128 ``          |
| [`1e22f2e4`](https://github.com/NixOS/nixpkgs/commit/1e22f2e408ce8e3ccf9acc38dd4316d612fdd551) | `` microsoft-edge: 138.0.3351.95 -> 138.0.3351.109 ``                       |