### PR TITLE
chore(flake/nur): `678f454f` -> `38df7ffd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -811,11 +811,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1753746745,
-        "narHash": "sha256-1Ii4RX2gUAp5KtdQOLokBMJ0dKeqabAeiS18NirGI6o=",
+        "lastModified": 1753762693,
+        "narHash": "sha256-mSH2baMJckgO6moY5WBqIyUlVQJlpKyqWTU66ptKG0Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "678f454f7f1b884cea5a8b266937969693419acf",
+        "rev": "38df7ffdeb763629272899142fc92209776ed276",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`38df7ffd`](https://github.com/nix-community/NUR/commit/38df7ffdeb763629272899142fc92209776ed276) | `` automatic update `` |
| [`536aaf54`](https://github.com/nix-community/NUR/commit/536aaf54b4281f642060e5bfd802f3036e47aef1) | `` automatic update `` |
| [`8730e15f`](https://github.com/nix-community/NUR/commit/8730e15f1ad8e4c2247b7342683cdff1724189fa) | `` automatic update `` |
| [`e29b5eed`](https://github.com/nix-community/NUR/commit/e29b5eed785ad7552d0b419212b061ac3649d4f2) | `` automatic update `` |
| [`b369244a`](https://github.com/nix-community/NUR/commit/b369244a15fb69c89f2c4c9e09a53a0837e54fa7) | `` automatic update `` |
| [`ecfdfa16`](https://github.com/nix-community/NUR/commit/ecfdfa16661dda8d974c5413db23240d7e862cfb) | `` automatic update `` |