### PR TITLE
chore(flake/treefmt-nix): `2673921c` -> `6b9214ff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1001,11 +1001,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753439394,
-        "narHash": "sha256-Bv9h1AJegLI8uAhiJ1sZ4XAndYxhgf38tMgCQwiEpmc=",
+        "lastModified": 1753772294,
+        "narHash": "sha256-8rkd13WfClfZUBIYpX5dvG3O9V9w3K9FPQ9rY14VtBE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "2673921c03d6e75fdf4aa93e025772608d1482cf",
+        "rev": "6b9214fffbcf3f1e608efa15044431651635ca83",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                        |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`6b9214ff`](https://github.com/numtide/treefmt-nix/commit/6b9214fffbcf3f1e608efa15044431651635ca83) | `` feat: use json schema for biome (#391) ``                   |
| [`9166786f`](https://github.com/numtide/treefmt-nix/commit/9166786ff800bd2b1e2cae8db7407b488ab8fed2) | `` README: update systems handling in flakes example (#392) `` |