### PR TITLE
chore(flake/nixpkgs): `17f6bd17` -> `94def634`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -737,11 +737,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1753549186,
-        "narHash": "sha256-Znl7rzuxKg/Mdm6AhimcKynM7V3YeNDIcLjBuoBcmNs=",
+        "lastModified": 1753939845,
+        "narHash": "sha256-K2ViRJfdVGE8tpJejs8Qpvvejks1+A4GQej/lBk5y7I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "17f6bd177404d6d43017595c5264756764444ab8",
+        "rev": "94def634a20494ee057c76998843c015909d6311",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                      |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`caf5a7d2`](https://github.com/NixOS/nixpkgs/commit/caf5a7d2d10c4cc33d02cf16f540ba79d6ccd004) | `` gh: 2.76.1 -> 2.76.2 ``                                                                   |
| [`1905dad0`](https://github.com/NixOS/nixpkgs/commit/1905dad0b5d4f87cba3227b16a82fbce62f2cd8d) | `` go: add freebsd to binary bootstrap platforms ``                                          |
| [`cc255e52`](https://github.com/NixOS/nixpkgs/commit/cc255e52331a8ddf7ee3e42883ba7ff8982f7cf9) | `` hydra: 0-unstable-2025-06-15 -> 0-unstable-2025-07-17 ``                                  |
| [`87cb7095`](https://github.com/NixOS/nixpkgs/commit/87cb7095bf72d5ca444e75dc7e92278e812022f8) | `` linuxPackages.acer-wmi-battery: init at 0.1.0-unstable-2025-04-24 ``                      |
| [`ca3d8cc5`](https://github.com/NixOS/nixpkgs/commit/ca3d8cc5c4f3132f5515787507bcf91fd46cd2de) | `` mesa: 25.1.6 -> 25.1.7 ``                                                                 |
| [`d5730ec9`](https://github.com/NixOS/nixpkgs/commit/d5730ec9cbfa0d7a9d9da006ed046157cf87016a) | `` kdePackages.ktextaddons: 1.6.0 -> 1.7.0 ``                                                |
| [`dd1cd545`](https://github.com/NixOS/nixpkgs/commit/dd1cd545b92303df74cf3787b603e274d602ee83) | `` nixos/release-notes: Move display manager note to NixOS manual ``                         |
| [`beeafcaa`](https://github.com/NixOS/nixpkgs/commit/beeafcaa957887840357916daf2a78e3c1363e0e) | `` Update pkgs/os-specific/windows/msvcSdk/default.nix ``                                    |
| [`4e93287c`](https://github.com/NixOS/nixpkgs/commit/4e93287c0e9c2c4ec5d9f86720bd62b01279e956) | `` windows.sdk: init at 17.14.9+36310.24.-july.2025- ``                                      |
| [`98a5ff90`](https://github.com/NixOS/nixpkgs/commit/98a5ff90a70c044ab31e826f607d7d39f8e984d5) | `` renovate: update pnpm.fetchDeps hash (#426407) ``                                         |
| [`c9afcd63`](https://github.com/NixOS/nixpkgs/commit/c9afcd6326f71bc89927ad8ab67bf3820b16b60b) | `` models-dev: 0-unstable-2025-07-29 -> 0-unstable-2025-07-30 ``                             |
| [`faadfb7a`](https://github.com/NixOS/nixpkgs/commit/faadfb7ab834799df3e1344a475e0231c3c13424) | `` models-dev: add patch to rename hashed index file back to index.html ``                   |
| [`3ddeae37`](https://github.com/NixOS/nixpkgs/commit/3ddeae3761a6d280f9e555fbabb244afd3f37d62) | `` givaro: 4.2.0 -> 4.2.1 ``                                                                 |
| [`c31993ce`](https://github.com/NixOS/nixpkgs/commit/c31993cebe151fa69b62b590f4aa09cec3a4867c) | `` linbox: 1.7.0 -> 1.7.1 ``                                                                 |
| [`85eeb8bd`](https://github.com/NixOS/nixpkgs/commit/85eeb8bdb0b1793b2fcff6e48f0890411691dfc9) | `` electron-chromedriver_37: 37.2.2 -> 37.2.4 ``                                             |
| [`c7def8ac`](https://github.com/NixOS/nixpkgs/commit/c7def8ac3440b0b88bd09bbe2847048b2cc99934) | `` electron_37-bin: 37.2.2 -> 37.2.4 ``                                                      |
| [`5bdb6998`](https://github.com/NixOS/nixpkgs/commit/5bdb6998aa0d42fca2d335b50397fdafe87d5add) | `` electron-chromedriver_36: 36.7.1 -> 36.7.3 ``                                             |
| [`1236db93`](https://github.com/NixOS/nixpkgs/commit/1236db9342ac83ed5d711845a4abfedd7fb10cef) | `` electron_36-bin: 36.7.1 -> 36.7.3 ``                                                      |
| [`0ef311f4`](https://github.com/NixOS/nixpkgs/commit/0ef311f4ac398ce90924a0a2c9fbd99095f5f8a5) | `` electron-source.electron_37: 37.2.2 -> 37.2.4 ``                                          |
| [`f3aa141c`](https://github.com/NixOS/nixpkgs/commit/f3aa141cc156bb05892878d0ab60da3c5095b736) | `` electron-source.electron_36: 36.7.1 -> 36.7.3 ``                                          |
| [`1329d984`](https://github.com/NixOS/nixpkgs/commit/1329d9841b47188e40a8ea79ddad7cb2d536f9a1) | `` opencode: 0.3.58 -> 0.3.85 ``                                                             |
| [`498f3183`](https://github.com/NixOS/nixpkgs/commit/498f31839555db752f6bf73aaf94ad765d9f672f) | `` electron_33-bin: drop ``                                                                  |
| [`e566c996`](https://github.com/NixOS/nixpkgs/commit/e566c9968c0b84023b173da7ed6bcce02df90156) | `` electron_34-bin: drop ``                                                                  |
| [`92b504d2`](https://github.com/NixOS/nixpkgs/commit/92b504d2ff54385af14a1be2af7aedeb075bfba2) | `` nixos/garage: set LimitNOFILE (#429633) ``                                                |
| [`78a0b50b`](https://github.com/NixOS/nixpkgs/commit/78a0b50b2b2c5732e9ed0741fb82943feb70484a) | `` aws-encryption-sdk-cli: relax aws-encryption-sdk ``                                       |
| [`2438b15b`](https://github.com/NixOS/nixpkgs/commit/2438b15b0fedafb0cab487ab75aa8a20d032a74f) | `` vscode-extensions.tuttieee.emacs-mcx: 0.74.0 -> 0.82.0 ``                                 |
| [`4fe2f04e`](https://github.com/NixOS/nixpkgs/commit/4fe2f04e2e08320b630c1387d9df8012a5b7a693) | `` home-assistant-custom-components.fellow: init at 0.3.2 ``                                 |
| [`ddefab08`](https://github.com/NixOS/nixpkgs/commit/ddefab08392477ab825279c0ef8e5617cf30d73f) | `` nixos/tests/audit: init ``                                                                |
| [`f39b04f3`](https://github.com/NixOS/nixpkgs/commit/f39b04f304393ce6f92e11381335fb504f1df86c) | `` vscode-extensions.github.copilot: 1.346.0 -> 1.350.0 ``                                   |
| [`8840628c`](https://github.com/NixOS/nixpkgs/commit/8840628c466f28cce9f87a27c17274f22b0363ff) | `` vscode-extensions.vue.volar: 3.0.3 -> 3.0.4 ``                                            |
| [`50243c5d`](https://github.com/NixOS/nixpkgs/commit/50243c5d78d5a1f90cb0db0e1536eed77b20d3d1) | `` nixos/auditd: align with upstream ``                                                      |
| [`774f6ed2`](https://github.com/NixOS/nixpkgs/commit/774f6ed203420a85d09d0181deabc8c7ddaa29a2) | `` nixos/audit: add proper enable flag ``                                                    |
| [`dcaade5f`](https://github.com/NixOS/nixpkgs/commit/dcaade5faefa9dbea1f412c492c0dcb91d8ba0b4) | `` vscode-extensions.ms-dotnettools.vscode-dotnet-runtime: 2.3.6 -> 2.3.7 ``                 |
| [`6e16fe1a`](https://github.com/NixOS/nixpkgs/commit/6e16fe1a7b6d0a2bd8f4cfffdc84e0fcbf750194) | `` vscode-extensions.danielsanmedium.dscodegpt: 3.13.22 -> 3.13.40 ``                        |
| [`89e46354`](https://github.com/NixOS/nixpkgs/commit/89e46354fa8bb68cb3a99a6784723060a0f96acc) | `` vscode-extensions.foam.foam-vscode: 0.26.12 -> 0.27.2 ``                                  |
| [`90f4f870`](https://github.com/NixOS/nixpkgs/commit/90f4f870c36868f0d2cf89b08d6c2ac0093f0513) | `` vscode-extensions.wakatime.vscode-wakatime: 25.2.0 -> 25.2.2 ``                           |
| [`857f3432`](https://github.com/NixOS/nixpkgs/commit/857f3432737a760ed8be9c3d130c391f4b845cb9) | `` evcc: 0.205.0 -> 0.206.0 ``                                                               |
| [`0bfabee2`](https://github.com/NixOS/nixpkgs/commit/0bfabee2781f4ba88ee96def74a36359cf1f4dad) | `` python3Packages.sagemaker-core: 1.0.45 -> 1.0.47 ``                                       |
| [`a9238a1e`](https://github.com/NixOS/nixpkgs/commit/a9238a1e6f6613af99defa286595a8bfc83853ed) | `` iwd: get rid of readline segfault ``                                                      |
| [`b6e9736c`](https://github.com/NixOS/nixpkgs/commit/b6e9736cdba13da5fe1403b851ef2524ff9f97aa) | `` passage: fix build on darwin ``                                                           |
| [`cfb6649f`](https://github.com/NixOS/nixpkgs/commit/cfb6649fa75b8cc8a97ccbce7ca9a6b9b26f8a29) | `` llvmPackages: drop libclc attributes that error ``                                        |
| [`2fd2baff`](https://github.com/NixOS/nixpkgs/commit/2fd2baff9f001fe01e1ec1e3028624d24509bf18) | `` qemu: add valgrind support (disabled by default) ``                                       |
| [`d3cba2f0`](https://github.com/NixOS/nixpkgs/commit/d3cba2f0496cba4805589f597be2e0398e50ed10) | `` vhost-device-sound: init at 0.2.0 ``                                                      |
| [`6d8b2960`](https://github.com/NixOS/nixpkgs/commit/6d8b2960a928f1a107f2009a93e084dae70678fd) | `` olivetin: 2025.7.28 -> 2025.7.29 ``                                                       |
| [`1ee913e5`](https://github.com/NixOS/nixpkgs/commit/1ee913e5c95e87adc06246e76a3d663718b9a940) | `` linuxKernel.kernels.linux_lqx: 6.15.7 -> 6.15.8 ``                                        |
| [`3926cdca`](https://github.com/NixOS/nixpkgs/commit/3926cdcaa43b8df594fb1da0a18dfe492270676c) | `` radicle-httpd: 0.19.1 → 0.20.0 ``                                                         |
| [`dec02ea8`](https://github.com/NixOS/nixpkgs/commit/dec02ea8d53378d750259076eedda93f1422ac7c) | `` vscode-extensions.github.copilot-chat: update license ``                                  |
| [`a567b440`](https://github.com/NixOS/nixpkgs/commit/a567b440b6a9a3dcdec6f838c02109baeffe88e2) | `` melange: 0.29.1 -> 0.30.1 ``                                                              |
| [`320eb931`](https://github.com/NixOS/nixpkgs/commit/320eb931518fdf319584dceccf146d4903bd498d) | `` python3Packages.langchain-aws: 0.2.28 -> 0.2.29 ``                                        |
| [`48852fc3`](https://github.com/NixOS/nixpkgs/commit/48852fc3405a396738c3d9040f49c991eabe33b6) | `` libretro.mgba: 0-unstable-2025-05-18 -> 0-unstable-2025-07-24 ``                          |
| [`2ca61674`](https://github.com/NixOS/nixpkgs/commit/2ca6167483df074dbb514fd546af74c68c8f48e0) | `` nixos/release-small: fix eval ``                                                          |
| [`3427c6a6`](https://github.com/NixOS/nixpkgs/commit/3427c6a68870738fc6d0f0c9da7a69c4e79e0e1f) | `` pnpm.configHook: prevent hard linking on file systems without clone support ``            |
| [`fd31072d`](https://github.com/NixOS/nixpkgs/commit/fd31072dfe8607a83c7ca4d047539154de9219a0) | `` servo: 0-unstable-2025-07-21 -> 0-unstable-2025-07-30 ``                                  |
| [`4ecd4019`](https://github.com/NixOS/nixpkgs/commit/4ecd4019567a56e5875a38f242986bd73b28717b) | `` home-assistant.python.pkgs.pytest-homeassistant-custom-component: 0.13.262 -> 0.13.263 `` |
| [`0abe7264`](https://github.com/NixOS/nixpkgs/commit/0abe7264000d381430c07f791ce8db48a3b35399) | `` python3Packages.homeassistant-stubs: 2025.7.3 -> 2025.7.4 ``                              |
| [`f7be31a4`](https://github.com/NixOS/nixpkgs/commit/f7be31a421c8846dcae138b943472829851f43d1) | `` home-assistant: 2025.7.3 -> 2025.7.4 ``                                                   |
| [`1a3b943a`](https://github.com/NixOS/nixpkgs/commit/1a3b943a664165fa006c0165117eeb020e0e56fc) | `` python3Packages.pysuez: 2.0.5 -> 2.0.7 ``                                                 |
| [`47acefa3`](https://github.com/NixOS/nixpkgs/commit/47acefa3ca34367c6c9436a3f2297fa0dde570ec) | `` python3Packages.pyschlage: 2025.7.0 -> 2025.7.3 ``                                        |
| [`9dbf0441`](https://github.com/NixOS/nixpkgs/commit/9dbf044145cfd153cbc76d563de270ceddc53aa8) | `` python3Packages.habiticalib: 0.4.0 -> 0.4.1 ``                                            |
| [`15ac08c6`](https://github.com/NixOS/nixpkgs/commit/15ac08c6f5e762d3c8a982cdc864747d1140fed5) | `` python3Packages.aioamazondevices: 3.5.0 -> 3.6.0 ``                                       |
| [`f7b92a50`](https://github.com/NixOS/nixpkgs/commit/f7b92a500b9a8a0ef5bacab6b988f6e95516a9e5) | `` kube-bench: 0.11.1 -> 0.11.2 ``                                                           |
| [`ec4d9ef0`](https://github.com/NixOS/nixpkgs/commit/ec4d9ef02582105f7ab0a8541a7e5f85ac556cab) | `` kaniko: 1.25.0 -> 1.25.1 ``                                                               |
| [`82e15e2d`](https://github.com/NixOS/nixpkgs/commit/82e15e2dbac3be0039716a9790047180f77e4dab) | `` terraform-providers.baiducloud: 1.22.8 -> 1.22.9 ``                                       |
| [`e6ac83c7`](https://github.com/NixOS/nixpkgs/commit/e6ac83c7d54a9c04cede34fd278760acc719d2bf) | `` terraform-providers.launchdarkly: 2.25.2 -> 2.25.3 ``                                     |
| [`3472c1d4`](https://github.com/NixOS/nixpkgs/commit/3472c1d4ce67c122782cd85cbbf627d189e22fde) | `` terraform-providers.auth0: 1.24.0 -> 1.24.1 ``                                            |
| [`4d4583a0`](https://github.com/NixOS/nixpkgs/commit/4d4583a0808dce889f6caabe3688d857a0afc15a) | `` az-pim-cli: 1.6.1 -> 1.7.0 ``                                                             |
| [`905e644b`](https://github.com/NixOS/nixpkgs/commit/905e644bc85443ecce187f4c93678c3c3ba1bcdf) | `` repomix: 1.2.0 -> 1.2.1 ``                                                                |
| [`9e857361`](https://github.com/NixOS/nixpkgs/commit/9e85736135d6b6ca6df32f96c47e1db11cbe07d6) | `` doctl: 1.134.0 -> 1.135.0 ``                                                              |
| [`8d306d32`](https://github.com/NixOS/nixpkgs/commit/8d306d32c94865162ed2573c2ac214d42c6b86cc) | `` python3Packages.opentelemetry-instrumentation: 0.52b1 -> 55b0 ``                          |
| [`45ab1769`](https://github.com/NixOS/nixpkgs/commit/45ab17693c5e55efbecbef548fb2e832d744cc44) | `` python3Packages.opentelemetry-api: 1.31.1 -> 1.34.0 ``                                    |
| [`86fb4e9c`](https://github.com/NixOS/nixpkgs/commit/86fb4e9c92829f1de97114d55dc7e9a9e6062f50) | `` torchcrepe: 0.0.23 -> 0.0.24 ``                                                           |
| [`06d70eff`](https://github.com/NixOS/nixpkgs/commit/06d70efff7391bdb8a6a0c371425d612468abcee) | `` aws-sam-translator: 1.95.0 -> 1.98.0 ``                                                   |
| [`10534134`](https://github.com/NixOS/nixpkgs/commit/1053413420714bbbbde09aa3b97d0a7d9429f60e) | `` openvas-scanner: 23.22.0 -> 23.22.1 ``                                                    |
| [`10ceec3c`](https://github.com/NixOS/nixpkgs/commit/10ceec3c957da468566e5b77d1a85916bf2a4a4f) | `` linkerd_edge: 25.7.1 -> 25.7.4 ``                                                         |
| [`87f3f67a`](https://github.com/NixOS/nixpkgs/commit/87f3f67a7bf3f84ebe1f6154b50fbb71c4ee8f5c) | `` google-chrome: 138.0.7204.168 -> 138.0.7204.183 ``                                        |
| [`207a3e46`](https://github.com/NixOS/nixpkgs/commit/207a3e468b6e1014711f0b34fddf68d162d81426) | `` gamescope: correct executable only deps ``                                                |
| [`a0a49ea3`](https://github.com/NixOS/nixpkgs/commit/a0a49ea3b15fa7fd06c4501b9a4000aeeb0b1dc3) | `` gamescope: use pending upstream patch for unvendoring ``                                  |
| [`220fd95d`](https://github.com/NixOS/nixpkgs/commit/220fd95d2a8ad171fe02d3c18a811ffc96e692f2) | `` private-gpt: drop ``                                                                      |
| [`80661f91`](https://github.com/NixOS/nixpkgs/commit/80661f912feef10e59638c7ce6b710110edac933) | `` nixos/private-gpt: drop ``                                                                |
| [`78869048`](https://github.com/NixOS/nixpkgs/commit/788690481d2ce498c240618004b8eac0b9f40078) | `` roddhjav-apparmor-rules: 0-unstable-2025-07-20 -> 0-unstable-2025-07-29 ``                |
| [`b93f1d68`](https://github.com/NixOS/nixpkgs/commit/b93f1d684c6f78ec3b436b49be099cf9701af11d) | `` lunar-client: 3.4.6 -> 3.4.8 ``                                                           |
| [`16c35052`](https://github.com/NixOS/nixpkgs/commit/16c350528635c1497fe6b8434bf258b90ee8c6d0) | `` python3Packages.schwifty: 2025.6.0 -> 2025.7.0 ``                                         |
| [`49f695f9`](https://github.com/NixOS/nixpkgs/commit/49f695f9047d18b97ab23ecb7ae3b6475e55eb8b) | `` protoc-gen-elixir: 0.14.1 -> 0.15.0 ``                                                    |
| [`90214f06`](https://github.com/NixOS/nixpkgs/commit/90214f066c3cc535da649ef9a1808095c7ebfa1c) | `` home-assistant: update component packages ``                                              |
| [`aa1953e8`](https://github.com/NixOS/nixpkgs/commit/aa1953e8fa18928ec5b063e635496cc3a657e99e) | `` python313Packages.wirelesstagpy: init at 0.8.1 ``                                         |
| [`62857bca`](https://github.com/NixOS/nixpkgs/commit/62857bcaba4b6f4454a38b9b29a580816d117116) | `` home-assistant: update component packages ``                                              |
| [`c31f1605`](https://github.com/NixOS/nixpkgs/commit/c31f1605ab69167bf46cc6ef1face8d116ad6c3e) | `` python3Packages.nsw-fuel-api-client: init at 1.1.3 ``                                     |
| [`955754bf`](https://github.com/NixOS/nixpkgs/commit/955754bfd2b73c81e1396344ddc8acb3295532c5) | `` terraform-providers.hcloud: 1.51.0 -> 1.52.0 ``                                           |
| [`25b37a92`](https://github.com/NixOS/nixpkgs/commit/25b37a9225cece2da4b68aca8bd0998439074362) | `` verilator: 5.034 -> 5.038 ``                                                              |
| [`8cd5e531`](https://github.com/NixOS/nixpkgs/commit/8cd5e531049c2bfd8d1506d24f82c5fff64dc950) | `` python3Packages.pyexploitdb: 0.2.90 -> 0.2.91 ``                                          |
| [`04373fcd`](https://github.com/NixOS/nixpkgs/commit/04373fcda4d1cbbcfd92cd076043fd6b9184dbdb) | `` nushell: 0.105.1 -> 0.106.1 ``                                                            |
| [`5fe0f094`](https://github.com/NixOS/nixpkgs/commit/5fe0f0946c26e0261b987cad549a6861dfaf6e10) | `` backblaze-b2: 4.3.3 -> 4.4.0 ``                                                           |
| [`f7075282`](https://github.com/NixOS/nixpkgs/commit/f7075282d39b6d2bb66ee3b8c38a42ee8ca7c690) | `` lipo-go: 0.10.0 -> 0.9.4 ``                                                               |
| [`47ef9bf9`](https://github.com/NixOS/nixpkgs/commit/47ef9bf9c4d40955f2fdf0ea7ce568e4590f5a41) | `` python3Packages.cyclopts: 3.22.2 -> 3.22.3 ``                                             |
| [`bed6b40a`](https://github.com/NixOS/nixpkgs/commit/bed6b40a31fc3c20743a1152623507965a2bd7e7) | `` ansible-doctor: 7.0.9 -> 7.1.0 ``                                                         |
| [`380a7ac5`](https://github.com/NixOS/nixpkgs/commit/380a7ac5f45e53354d77edd7c95386696603ed06) | `` atlas: 0.36.0 -> 0.36.1 ``                                                                |
| [`f0828317`](https://github.com/NixOS/nixpkgs/commit/f0828317b2f209c2ab612667768c1613257d43e9) | `` zed-editor: 0.196.6 -> 0.196.7 ``                                                         |
| [`e5136f0b`](https://github.com/NixOS/nixpkgs/commit/e5136f0b26989cd04ebf31df94c657e6538845c7) | `` libmaddy-markdown: 1.5.0 -> 1.6.0 ``                                                      |
| [`710b778e`](https://github.com/NixOS/nixpkgs/commit/710b778e33f203ba05a22fee0ed21db61745f4d7) | `` biome: 2.1.2 -> 2.1.3 ``                                                                  |
| [`6ab2b06f`](https://github.com/NixOS/nixpkgs/commit/6ab2b06fca1cc688420b7f487b1818b7d5851b51) | `` datafusion-cli: 48.0.1 -> 49.0.0 ``                                                       |
| [`e06d31bc`](https://github.com/NixOS/nixpkgs/commit/e06d31bc764ed97c528bdd9967aebfe0c2967edf) | `` vectorcode: disable broken test in embedded chromadb ``                                   |
| [`0a9bcf77`](https://github.com/NixOS/nixpkgs/commit/0a9bcf77251cc0085c2e49fd72a6d554caffa28e) | `` python3Packages.chromadb: disable flaky tests ``                                          |
| [`44743bcb`](https://github.com/NixOS/nixpkgs/commit/44743bcb6dc8622eba2d4a4eff57f7f9fb443b57) | `` dprint-plugins.dprint-plugin-typescript: 0.95.8 -> 0.95.9 ``                              |
| [`d75913ae`](https://github.com/NixOS/nixpkgs/commit/d75913ae61b1600fc7ecac382f82f3d45fc0f7aa) | `` linuxPackages.xone: 0.3.4 -> 0.3.5 ``                                                     |
| [`8493db61`](https://github.com/NixOS/nixpkgs/commit/8493db6170a47e86e9ddb68377781e98b857fca9) | `` gosec: 2.22.6 -> 2.22.7 ``                                                                |
| [`dce00f43`](https://github.com/NixOS/nixpkgs/commit/dce00f43dacb2fcc7d65e19216f5e45b6191c61c) | `` ghost-cli: 1.27.1 -> 1.28.1 ``                                                            |
| [`b6bf7ab9`](https://github.com/NixOS/nixpkgs/commit/b6bf7ab952dae4687020e61c8a145951034d7c50) | `` syshud: 0-unstable-2025-03-11 -> 0-unstable-2025-07-26 ``                                 |