### PR TITLE
chore(flake/nur): `614338ea` -> `475c1a91`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -811,11 +811,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1753789729,
-        "narHash": "sha256-YgQIXvA6GZbVxeENrEyOTxq2bn+1RMOGz5v34Z/qjIo=",
+        "lastModified": 1753818482,
+        "narHash": "sha256-knGSgHl/ypOI7f/lMv73xrCEj8SCNfzROfM2wtq1dZ0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "614338ea0479e8f1d80a72db80e8f229b3647f07",
+        "rev": "475c1a91ec2b0ae0d074373819f781a0a9bf7787",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`475c1a91`](https://github.com/nix-community/NUR/commit/475c1a91ec2b0ae0d074373819f781a0a9bf7787) | `` automatic update `` |
| [`c0e68958`](https://github.com/nix-community/NUR/commit/c0e689580b807867cef9b3a301f49e627ddc5dcf) | `` automatic update `` |
| [`bb7b19a4`](https://github.com/nix-community/NUR/commit/bb7b19a47c6f6d378f3233ad0e5d70cbe5d6a3f3) | `` automatic update `` |
| [`14a3f0eb`](https://github.com/nix-community/NUR/commit/14a3f0eb404c02012fc177425994569c7957d5f2) | `` automatic update `` |
| [`747e4328`](https://github.com/nix-community/NUR/commit/747e4328a05cab81908b783e236e696ed49c0a27) | `` automatic update `` |
| [`40f39973`](https://github.com/nix-community/NUR/commit/40f39973837ac9be188c95b179d0764b55a61e6c) | `` automatic update `` |
| [`89fa7691`](https://github.com/nix-community/NUR/commit/89fa7691153caa384bce5e2935519083967f6bc5) | `` automatic update `` |
| [`1c2d775c`](https://github.com/nix-community/NUR/commit/1c2d775cf4c82dec70bfcb5143d8bc5e2a100ee3) | `` automatic update `` |
| [`320a245a`](https://github.com/nix-community/NUR/commit/320a245a59c255642604509539a2e0a94aec5a68) | `` automatic update `` |
| [`dad44483`](https://github.com/nix-community/NUR/commit/dad44483eb16c470b1392aa2e88075a1bb16a9e2) | `` automatic update `` |
| [`1c5a8980`](https://github.com/nix-community/NUR/commit/1c5a89805afb646146ab35d7712b4df212b0ff76) | `` automatic update `` |
| [`87afc3af`](https://github.com/nix-community/NUR/commit/87afc3af6ef82de1d6b35bc02a45e2e5a7675fc2) | `` automatic update `` |