### PR TITLE
chore(flake/nur): `d8313c7a` -> `21c03034`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -811,11 +811,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1753903622,
-        "narHash": "sha256-42JkRLlLO28HoqytDNc5TTjlVIouGAw+lXOzAwV/ltQ=",
+        "lastModified": 1753947955,
+        "narHash": "sha256-rIyxCtYu/KTBGV99q82BHObKcK4fSz1HKfZ/HQYL8kU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d8313c7ab00d25070aa1e83a2de239a3e27e66c2",
+        "rev": "21c030341c7dea3a07754817041f9e91e9cdbd9f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`21c03034`](https://github.com/nix-community/NUR/commit/21c030341c7dea3a07754817041f9e91e9cdbd9f) | `` automatic update `` |
| [`448277e4`](https://github.com/nix-community/NUR/commit/448277e46c96f6b29c386b00510082dd86165548) | `` automatic update `` |
| [`fcab7393`](https://github.com/nix-community/NUR/commit/fcab7393172a4a8821d70fe1df23b93fb3217ef7) | `` automatic update `` |
| [`51e45c57`](https://github.com/nix-community/NUR/commit/51e45c575182c1da9a0a9ded2c51c946cb2dd217) | `` automatic update `` |
| [`d9273a26`](https://github.com/nix-community/NUR/commit/d9273a2618db7c688c3eb174a0bcfdc357006a8d) | `` automatic update `` |
| [`cbae9e54`](https://github.com/nix-community/NUR/commit/cbae9e541c5f7b6f0c74d8265a5c13ca9a884192) | `` automatic update `` |
| [`0f679349`](https://github.com/nix-community/NUR/commit/0f6793496fb2ac7e819fd6ca225f28bc37d1c2b7) | `` automatic update `` |
| [`5ce0ecb6`](https://github.com/nix-community/NUR/commit/5ce0ecb6d163463464919a477aec386e24ae74e2) | `` automatic update `` |
| [`3eae39be`](https://github.com/nix-community/NUR/commit/3eae39be921b741c2e30a9241c96b386aa9a22f2) | `` automatic update `` |
| [`921ad38e`](https://github.com/nix-community/NUR/commit/921ad38e772b716f24da3995f4a0aeb028814c97) | `` automatic update `` |