### PR TITLE
chore(flake/srvos): `cc76247e` -> `f7c9ea72`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -945,11 +945,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753665188,
-        "narHash": "sha256-EZ4FUDaZVonbTE8rGr5+SIVOki0QLQugd481cmNjisc=",
+        "lastModified": 1753924140,
+        "narHash": "sha256-eZ+71f1rflReoA3EtIlUVV11ar2wQJ577jLHWHZWWdE=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "cc76247e77c04cf2ad0bf04be10a5d47bc3da594",
+        "rev": "f7c9ea726dcaeb7954091bf51c73611b9f2781c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`f7c9ea72`](https://github.com/nix-community/srvos/commit/f7c9ea726dcaeb7954091bf51c73611b9f2781c6) | `` dev/private/flake.lock: Update `` |
| [`f3cd0d83`](https://github.com/nix-community/srvos/commit/f3cd0d836f93c3bf74d0506bf350f194264baf9a) | `` flake.lock: Update ``             |