### PR TITLE
chore(flake/emacs-overlay): `91802f42` -> `b7b0edd2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1753895464,
-        "narHash": "sha256-rXKusZhSApwk4LjE2F5wkggeY/dJhesIU1myC1MN3lo=",
+        "lastModified": 1754015942,
+        "narHash": "sha256-a1rKs50GWP8RUI8bFXuhXPxeUgOvYiNxsk4Jf7cdzCw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "91802f4208e83e409f7a864c8f2ce2a5f08c23ea",
+        "rev": "b7b0edd24abbdd05fde75c80d59001c9fd9b5598",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`b7b0edd2`](https://github.com/nix-community/emacs-overlay/commit/b7b0edd24abbdd05fde75c80d59001c9fd9b5598) | `` Updated melpa ``  |
| [`728c49d9`](https://github.com/nix-community/emacs-overlay/commit/728c49d97ecd4f0af3835b09c9d60b4f20f69ca4) | `` Updated emacs ``  |
| [`4175315b`](https://github.com/nix-community/emacs-overlay/commit/4175315b099e1adb444de2610d712921446bb6da) | `` Updated elpa ``   |
| [`b48c03cf`](https://github.com/nix-community/emacs-overlay/commit/b48c03cf85580c7996ce59ee149a7bdcddcdc503) | `` Updated nongnu `` |
| [`4ed6313a`](https://github.com/nix-community/emacs-overlay/commit/4ed6313ad6f2e7ed940143096808085c44028afa) | `` Updated melpa ``  |
| [`4d717d76`](https://github.com/nix-community/emacs-overlay/commit/4d717d76e879174c0760cc697d751f8819823b15) | `` Updated emacs ``  |
| [`01a52dd7`](https://github.com/nix-community/emacs-overlay/commit/01a52dd77357a78153687f8b0ad720ec849efcdd) | `` Updated elpa ``   |
| [`2dc863f0`](https://github.com/nix-community/emacs-overlay/commit/2dc863f0ba0b72414695f5bedabeeb4a1eef0c44) | `` Updated emacs ``  |
| [`633b5e2f`](https://github.com/nix-community/emacs-overlay/commit/633b5e2f351e1c7960323d70290e4d46bc901969) | `` Updated melpa ``  |
| [`bd0f14a0`](https://github.com/nix-community/emacs-overlay/commit/bd0f14a038b52c908561ecfdb392e84e29635d67) | `` Updated melpa ``  |
| [`6ad9ec2a`](https://github.com/nix-community/emacs-overlay/commit/6ad9ec2a5a640c77530385479aca545d2033456e) | `` Updated emacs ``  |
| [`f502ded0`](https://github.com/nix-community/emacs-overlay/commit/f502ded0d175e4c4c6cf7b504a08e82651a0dafb) | `` Updated elpa ``   |
| [`5e3853d8`](https://github.com/nix-community/emacs-overlay/commit/5e3853d8ed0cdeb40db7f05a083b6c12d1d3c47e) | `` Updated nongnu `` |