### PR TITLE
chore(flake/nur): `21c03034` -> `abc834b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -811,11 +811,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1753947955,
-        "narHash": "sha256-rIyxCtYu/KTBGV99q82BHObKcK4fSz1HKfZ/HQYL8kU=",
+        "lastModified": 1753977181,
+        "narHash": "sha256-EuegSRTdpd1MlhNJcQ4c90u4IPr8sLlrb2LE/q0VF1w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "21c030341c7dea3a07754817041f9e91e9cdbd9f",
+        "rev": "abc834b73015130e14ffc5b3185f5b98580e88dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`abc834b7`](https://github.com/nix-community/NUR/commit/abc834b73015130e14ffc5b3185f5b98580e88dc) | `` automatic update `` |
| [`25d8fe6f`](https://github.com/nix-community/NUR/commit/25d8fe6fc69aed861c45bd8455d3dd55c9b720a5) | `` automatic update `` |
| [`9e5d1613`](https://github.com/nix-community/NUR/commit/9e5d1613a2d568f65195d581496efbf6264dcbeb) | `` automatic update `` |
| [`301cbf32`](https://github.com/nix-community/NUR/commit/301cbf3214b14360e9c55830a89b4bf2f0cd8a7a) | `` automatic update `` |
| [`7e2ac4d7`](https://github.com/nix-community/NUR/commit/7e2ac4d714497dbf91ef2a314a298804787c7574) | `` automatic update `` |
| [`2c3a2e0f`](https://github.com/nix-community/NUR/commit/2c3a2e0fc2d313ad3cad7dcb01451e9bbeb5a758) | `` automatic update `` |
| [`ed75d453`](https://github.com/nix-community/NUR/commit/ed75d453618e8848e287586a5e9aa5dc89393990) | `` automatic update `` |
| [`5a7fced6`](https://github.com/nix-community/NUR/commit/5a7fced6f906ae57afd81c0475e21320f386eed7) | `` automatic update `` |
| [`d190f2fc`](https://github.com/nix-community/NUR/commit/d190f2fc76a5817a4665865df8259912c92d18c2) | `` automatic update `` |