### PR TITLE
chore(flake/nur): `abc834b7` -> `8c49a5f3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -811,11 +811,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1753977181,
-        "narHash": "sha256-EuegSRTdpd1MlhNJcQ4c90u4IPr8sLlrb2LE/q0VF1w=",
+        "lastModified": 1753992079,
+        "narHash": "sha256-keY0t3d/8gJus3mG70wIzND6oLarc/fkmHlyhrWrWcw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "abc834b73015130e14ffc5b3185f5b98580e88dc",
+        "rev": "8c49a5f3656cbe25957ba121c4afddd5cc94acf5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8c49a5f3`](https://github.com/nix-community/NUR/commit/8c49a5f3656cbe25957ba121c4afddd5cc94acf5) | `` automatic update `` |
| [`9a6ef0fe`](https://github.com/nix-community/NUR/commit/9a6ef0feae02e2135a5ba894a81c1e49cbc591e8) | `` automatic update `` |
| [`64e23dea`](https://github.com/nix-community/NUR/commit/64e23deaeb3f9049669a989b4d2da423995383f6) | `` automatic update `` |
| [`adf586cf`](https://github.com/nix-community/NUR/commit/adf586cf293cbf9b4ed3265058192e2659be362b) | `` automatic update `` |
| [`66237f88`](https://github.com/nix-community/NUR/commit/66237f8810310083feddb7dfa7af2fa45e581f2a) | `` automatic update `` |