### PR TITLE
chore(flake/nur): `c37c980d` -> `f24675cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -753,11 +753,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1753694789,
-        "narHash": "sha256-cKgvtz6fKuK1Xr5LQW/zOUiAC0oSQoA9nOISB0pJZqM=",
+        "lastModified": 1753939845,
+        "narHash": "sha256-K2ViRJfdVGE8tpJejs8Qpvvejks1+A4GQej/lBk5y7I=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dc9637876d0dcc8c9e5e22986b857632effeb727",
+        "rev": "94def634a20494ee057c76998843c015909d6311",
         "type": "github"
       },
       "original": {
@@ -811,11 +811,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1754034173,
-        "narHash": "sha256-xDWz5lENkW99MnchhceAyeUewyHOngRLtgXCijphgZY=",
+        "lastModified": 1754044146,
+        "narHash": "sha256-0hTNz395ODc7zQOW3Y4u2cTwUFY00YoKlPq9Segvum4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c37c980dae86cf07ec2b54559fcd87aeaca94913",
+        "rev": "f24675cbfdb6a67275dd25201ee7df36081805a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f24675cb`](https://github.com/nix-community/NUR/commit/f24675cbfdb6a67275dd25201ee7df36081805a3) | `` automatic update `` |
| [`8e92971c`](https://github.com/nix-community/NUR/commit/8e92971cc1a6a1083d93a992a4b77dec45686ccb) | `` automatic update `` |
| [`79df6931`](https://github.com/nix-community/NUR/commit/79df6931da61e94e235c2f37445b4819338a211a) | `` automatic update `` |
| [`dfb7cbaf`](https://github.com/nix-community/NUR/commit/dfb7cbaff97f38cf48b338cf621208a3d967deb2) | `` automatic update `` |
| [`712704e1`](https://github.com/nix-community/NUR/commit/712704e1ec1eb928c5340b210d4cef1988dd2451) | `` automatic update `` |