### PR TITLE
chore(flake/treefmt-nix): `6b9214ff` -> `58bd4da4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1001,11 +1001,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753772294,
-        "narHash": "sha256-8rkd13WfClfZUBIYpX5dvG3O9V9w3K9FPQ9rY14VtBE=",
+        "lastModified": 1754061284,
+        "narHash": "sha256-ONcNxdSiPyJ9qavMPJYAXDNBzYobHRxw0WbT38lKbwU=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "6b9214fffbcf3f1e608efa15044431651635ca83",
+        "rev": "58bd4da459f0a39e506847109a2a5cfceb837796",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                          |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`58bd4da4`](https://github.com/numtide/treefmt-nix/commit/58bd4da459f0a39e506847109a2a5cfceb837796) | `` fix: biome config extension missing (#393) `` |