### PR TITLE
chore(flake/emacs-overlay): `b7b0edd2` -> `a63bd8d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1754015942,
-        "narHash": "sha256-a1rKs50GWP8RUI8bFXuhXPxeUgOvYiNxsk4Jf7cdzCw=",
+        "lastModified": 1754125773,
+        "narHash": "sha256-3Yy6ZAPMt+Er3MMWPk6M3Tr2ibQGpm2Ci/VQ/vWl5iI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b7b0edd24abbdd05fde75c80d59001c9fd9b5598",
+        "rev": "a63bd8d267777776bb1ddb5eed3419210b8d768a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`a63bd8d2`](https://github.com/nix-community/emacs-overlay/commit/a63bd8d267777776bb1ddb5eed3419210b8d768a) | `` Updated melpa ``        |
| [`eb9539b6`](https://github.com/nix-community/emacs-overlay/commit/eb9539b615cfe3d5871baf6d78303033e3f31b86) | `` Updated melpa ``        |
| [`ab168974`](https://github.com/nix-community/emacs-overlay/commit/ab168974831d4ef27fa4cbdc11396d2f8427abd8) | `` Updated emacs ``        |
| [`c7fdb7d6`](https://github.com/nix-community/emacs-overlay/commit/c7fdb7d668eceb3e3d96ccc7e5459f651256fd0c) | `` Updated elpa ``         |
| [`748227ef`](https://github.com/nix-community/emacs-overlay/commit/748227ef471bb95363a0e86ca04083bb98eb0627) | `` Updated nongnu ``       |
| [`a2c4e31c`](https://github.com/nix-community/emacs-overlay/commit/a2c4e31c1f77ddc72342af1ab4f90847d46e1cc6) | `` Updated emacs ``        |
| [`6c6e3715`](https://github.com/nix-community/emacs-overlay/commit/6c6e3715bc2799c2f016ab191b71066e5a1d0528) | `` Updated melpa ``        |
| [`70daf116`](https://github.com/nix-community/emacs-overlay/commit/70daf11699abf34753629cb88ffaeef1198277f8) | `` Updated nongnu ``       |
| [`c9975f40`](https://github.com/nix-community/emacs-overlay/commit/c9975f4091f29354e372e6b654d225294d214137) | `` Updated flake inputs `` |