### PR TITLE
chore(flake/home-manager): `19f94a3e` -> `e102920c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -372,11 +372,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754060289,
-        "narHash": "sha256-rWc9WUHtDCnHhnKEbiyLwBmvsXxHgBf56jvmmHPMUCk=",
+        "lastModified": 1754085240,
+        "narHash": "sha256-kVHCrTWEe8B1thAhFag1bk4QPY0ZP45V9vPbrwPHoNo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "19f94a3e0e6c8573ea58dac685e96c36e2526cfa",
+        "rev": "e102920c1becb114645c6f92fe14edc0b05cc229",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`e102920c`](https://github.com/nix-community/home-manager/commit/e102920c1becb114645c6f92fe14edc0b05cc229) | `` zoxide: move zsh priority (#7593) `` |