### PR TITLE
chore(flake/srvos): `f7c9ea72` -> `4f59ec08`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -945,11 +945,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753924140,
-        "narHash": "sha256-eZ+71f1rflReoA3EtIlUVV11ar2wQJ577jLHWHZWWdE=",
+        "lastModified": 1754120295,
+        "narHash": "sha256-6cKGUOm2VVuPToZig/Kl3NOrGP+Rir0jHqHd32s5pVU=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "f7c9ea726dcaeb7954091bf51c73611b9f2781c6",
+        "rev": "4f59ec08568d142514df76369e464928797802db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                             |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`4f59ec08`](https://github.com/nix-community/srvos/commit/4f59ec08568d142514df76369e464928797802db) | `` fix: allow failing ssh-ng substituters (#676) `` |