### PR TITLE
chore(flake/nur): `dd4cad69` -> `eb10594c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -811,11 +811,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1754132989,
-        "narHash": "sha256-wOCYEwSknCri0+Rp77VNTUqdfiKDO9W6P0iG5vmIB8o=",
+        "lastModified": 1754164015,
+        "narHash": "sha256-Zf0t03UIDmlozEwP6v/brzJ3BE4XLmoNSIb2SrBuuv8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dd4cad690f1ada34910930d9f8786f67db2d534d",
+        "rev": "eb10594c0da5cb09f3ad687461d1979e5f054c6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`eb10594c`](https://github.com/nix-community/NUR/commit/eb10594c0da5cb09f3ad687461d1979e5f054c6c) | `` automatic update `` |
| [`0b030e85`](https://github.com/nix-community/NUR/commit/0b030e85aa15ae9e0236cc1799a0d644ccc14a11) | `` automatic update `` |
| [`c2eb35aa`](https://github.com/nix-community/NUR/commit/c2eb35aafdd6e61f37728bce5f64d76148646f70) | `` automatic update `` |
| [`d0d88edc`](https://github.com/nix-community/NUR/commit/d0d88edcefcb823d4de2343814d6004f428b5db8) | `` automatic update `` |
| [`993ed205`](https://github.com/nix-community/NUR/commit/993ed205326b2180c8d4967018cd0ceed807d372) | `` automatic update `` |
| [`ca0cf0af`](https://github.com/nix-community/NUR/commit/ca0cf0af08e03a609607974e226a36d09d88e299) | `` automatic update `` |
| [`621a7cbd`](https://github.com/nix-community/NUR/commit/621a7cbd7b44f418f539e00d79f7aab91f8e5fdf) | `` automatic update `` |
| [`46103880`](https://github.com/nix-community/NUR/commit/46103880eb8597fc262062e790f6e4959c07f9a5) | `` automatic update `` |
| [`bae772f3`](https://github.com/nix-community/NUR/commit/bae772f319b57b76ca819c4b599cdb4c075466ce) | `` automatic update `` |
| [`28de4c84`](https://github.com/nix-community/NUR/commit/28de4c8457d178e18de85f4b4ba647fbd3fc123d) | `` automatic update `` |