### PR TITLE
chore(flake/emacs-overlay): `a63bd8d2` -> `7ee9a6e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1754125773,
-        "narHash": "sha256-3Yy6ZAPMt+Er3MMWPk6M3Tr2ibQGpm2Ci/VQ/vWl5iI=",
+        "lastModified": 1754154724,
+        "narHash": "sha256-qfPc9EO3u4n2a3P2czmhMmnmjHGPu1FnYZV6v+As1Vc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a63bd8d267777776bb1ddb5eed3419210b8d768a",
+        "rev": "7ee9a6e8993ebf33e56cd02aab0ec80cfe16df64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`7ee9a6e8`](https://github.com/nix-community/emacs-overlay/commit/7ee9a6e8993ebf33e56cd02aab0ec80cfe16df64) | `` Updated emacs `` |
| [`e5c1eb0d`](https://github.com/nix-community/emacs-overlay/commit/e5c1eb0df9c698c9356da00fcc01001bc2421806) | `` Updated melpa `` |
| [`eae92963`](https://github.com/nix-community/emacs-overlay/commit/eae92963de9d6cc715993a479bf7d9c097110264) | `` Updated elpa ``  |