### PR TITLE
chore(flake/nur): `eb10594c` -> `0b5269c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -811,11 +811,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1754164015,
-        "narHash": "sha256-Zf0t03UIDmlozEwP6v/brzJ3BE4XLmoNSIb2SrBuuv8=",
+        "lastModified": 1754206906,
+        "narHash": "sha256-nQsb0ngn+JDDC+zY/wKcrl6hjF5iJiZPjr50cVsRvk0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eb10594c0da5cb09f3ad687461d1979e5f054c6c",
+        "rev": "0b5269c51fd7390229018b2a8d42cf09239c50e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0b5269c5`](https://github.com/nix-community/NUR/commit/0b5269c51fd7390229018b2a8d42cf09239c50e2) | `` automatic update `` |
| [`c9be8e14`](https://github.com/nix-community/NUR/commit/c9be8e142c0f9c8b4b646e680f9b149f712a9c2d) | `` automatic update `` |
| [`285e74e7`](https://github.com/nix-community/NUR/commit/285e74e783265bced277fa3a377240f356b2f921) | `` automatic update `` |
| [`c049dbec`](https://github.com/nix-community/NUR/commit/c049dbec5702da57a2fd3aae2f96b8d886359938) | `` automatic update `` |
| [`d7134c0f`](https://github.com/nix-community/NUR/commit/d7134c0f424be69b011eb26bccf2f575b300c5d1) | `` automatic update `` |
| [`dbd17f07`](https://github.com/nix-community/NUR/commit/dbd17f07b63f5fc630ff9d3b5b832636259ac8e8) | `` automatic update `` |
| [`e5bde1a7`](https://github.com/nix-community/NUR/commit/e5bde1a7291282d444412ac22b4e2f153ce73993) | `` automatic update `` |