### PR TITLE
chore(flake/emacs-overlay): `7ee9a6e8` -> `e2605be2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1754154724,
-        "narHash": "sha256-qfPc9EO3u4n2a3P2czmhMmnmjHGPu1FnYZV6v+As1Vc=",
+        "lastModified": 1754185988,
+        "narHash": "sha256-eyMAmcuCoJ33Z4gZNPuEjk7mjkb1vWidUUNpF1LGGx8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7ee9a6e8993ebf33e56cd02aab0ec80cfe16df64",
+        "rev": "e2605be20a68d8d72e6879c8b0522ee16fad0acf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`e2605be2`](https://github.com/nix-community/emacs-overlay/commit/e2605be20a68d8d72e6879c8b0522ee16fad0acf) | `` Updated elpa ``   |
| [`541f4e57`](https://github.com/nix-community/emacs-overlay/commit/541f4e57412ef5faa7dbc9d3312ce104cd616034) | `` Updated nongnu `` |