### PR TITLE
chore(flake/nix-index-database): `f0736b09` -> `b7fcd4e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -505,11 +505,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753589988,
-        "narHash": "sha256-y1JlcMB2dKFkrr6g+Ucmj8L//IY09BtSKTH/A7OU7mU=",
+        "lastModified": 1754195341,
+        "narHash": "sha256-YL71IEf2OugH3gmAsxQox6BJI0KOcHKtW2QqT/+s2SA=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "f0736b09c43028fd726fb70c3eb3d1f0795454cf",
+        "rev": "b7fcd4e26d67fca48e77de9b0d0f954b18ae9562",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`b7fcd4e2`](https://github.com/nix-community/nix-index-database/commit/b7fcd4e26d67fca48e77de9b0d0f954b18ae9562) | `` update generated.nix to release 2025-08-03-040401 `` |
| [`b9f618a0`](https://github.com/nix-community/nix-index-database/commit/b9f618a0b22d2c58a620afb7e2dec93582980057) | `` flake.lock: Update ``                                |