### PR TITLE
chore(flake/emacs-overlay): `e2605be2` -> `2df87ae7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1754185988,
-        "narHash": "sha256-eyMAmcuCoJ33Z4gZNPuEjk7mjkb1vWidUUNpF1LGGx8=",
+        "lastModified": 1754240942,
+        "narHash": "sha256-d/ADJhgx5poFnpvPCYiFS/SRSwSmNJV+d7K0luZFTgs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e2605be20a68d8d72e6879c8b0522ee16fad0acf",
+        "rev": "2df87ae7b3909cd4c3e0c8269989599f100a0f30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`2df87ae7`](https://github.com/nix-community/emacs-overlay/commit/2df87ae7b3909cd4c3e0c8269989599f100a0f30) | `` Updated melpa ``  |
| [`3a132ebe`](https://github.com/nix-community/emacs-overlay/commit/3a132ebef10f47d8bf916f1552301d7fb03816b9) | `` Updated emacs ``  |
| [`55b38132`](https://github.com/nix-community/emacs-overlay/commit/55b381328e9133c57f7ed010184471dcbd374227) | `` Updated elpa ``   |
| [`3904086a`](https://github.com/nix-community/emacs-overlay/commit/3904086aa9fd95a3329f21bf78a0ca837d9ff9ef) | `` Updated nongnu `` |
| [`2ef1f8b3`](https://github.com/nix-community/emacs-overlay/commit/2ef1f8b3080bb8753bcfca3733cc4b7219261dcd) | `` Updated melpa ``  |
| [`d9d697c8`](https://github.com/nix-community/emacs-overlay/commit/d9d697c855f533f2d523299f89d8286e87f6e5d8) | `` Updated emacs ``  |