### PR TITLE
chore(flake/home-manager): `e6e2f43a` -> `0de18bd5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -372,11 +372,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754174776,
-        "narHash": "sha256-Sp3FRM6xNwNtGzYH/HByjzJYHSQvwsW+lDMMZNF43PQ=",
+        "lastModified": 1754225444,
+        "narHash": "sha256-mv01SQtqlhBMavc1dgNjgqJw4WfZxy+w3xBgwJU3YmU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e6e2f43a62b7dbc8aa8b1adb7101b0d8b9395445",
+        "rev": "0de18bd5c6681280d7ae017fa34ffd91bdcf0557",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`0de18bd5`](https://github.com/nix-community/home-manager/commit/0de18bd5c6681280d7ae017fa34ffd91bdcf0557) | `` flake.lock: Update ``                |
| [`2d3b2f33`](https://github.com/nix-community/home-manager/commit/2d3b2f33a70b5521f98e8ab8218f09cd1f29883b) | `` Translate using Weblate (Finnish) `` |