### PR TITLE
chore(flake/nixos-hardware): `cc66fddc` -> `9368056b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -596,11 +596,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1753122741,
-        "narHash": "sha256-nFxE8lk9JvGelxClCmwuJYftbHqwnc01dRN4DVLUroM=",
+        "lastModified": 1754316476,
+        "narHash": "sha256-Ry1gd1BQrNVJJfT11cpVP0FY8XFMx4DJV2IDp01CH9w=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "cc66fddc6cb04ab479a1bb062f4d4da27c936a22",
+        "rev": "9368056b73efb46eb14fd4667b99e0f81b805f28",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                      |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`547c96d7`](https://github.com/NixOS/nixos-hardware/commit/547c96d797da1c0cd1ca737d66f2d18c7de91618) | `` framework-amd-ai-300-series: mkDefault boot.kernelPackages ``             |
| [`d99ca4e5`](https://github.com/NixOS/nixos-hardware/commit/d99ca4e5f4d5dbbe3c8107e2fd2c778edeb37851) | `` framework-amd-ai-300-series: bump kernel to latest for suspend support `` |