### PR TITLE
chore(flake/srvos): `4f59ec08` -> `8e7d3c69`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -945,11 +945,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754120295,
-        "narHash": "sha256-6cKGUOm2VVuPToZig/Kl3NOrGP+Rir0jHqHd32s5pVU=",
+        "lastModified": 1754273897,
+        "narHash": "sha256-l7epHqAcg8Qktu8vO2ZfjSH1wcai01XQOKQA9ADHIk4=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "4f59ec08568d142514df76369e464928797802db",
+        "rev": "8e7d3c690975ee6790926bdfd1258016c967d163",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                          |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`8e7d3c69`](https://github.com/nix-community/srvos/commit/8e7d3c690975ee6790926bdfd1258016c967d163) | `` nixos/server: systemd.watchdog -> systemd.settings.Manager `` |
| [`7842f3c9`](https://github.com/nix-community/srvos/commit/7842f3c94fb0d9416acb6493de325c911c439e9c) | `` dev/private/flake.lock: Update ``                             |
| [`60daf41d`](https://github.com/nix-community/srvos/commit/60daf41d05017ec4778ee70fb1c0edb67cc5086f) | `` flake.lock: Update ``                                         |