### PR TITLE
chore(flake/emacs-overlay): `d04f1a9d` -> `a9a66708`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1754272381,
-        "narHash": "sha256-IVt8JTUe2ZmeAqXZ2QyTsvbRPTwG5aCnVlz0OxR0h9Y=",
+        "lastModified": 1754361940,
+        "narHash": "sha256-2KROQdENN8Ix5kiBZRM8FQP1KiJDikKPTiaaExYdVAY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d04f1a9d416694d2227c06ee12e2fb8d0260fd0a",
+        "rev": "a9a667084c0cf89081842d3002aef7b4829980aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`a9a66708`](https://github.com/nix-community/emacs-overlay/commit/a9a667084c0cf89081842d3002aef7b4829980aa) | `` Updated emacs ``        |
| [`46465925`](https://github.com/nix-community/emacs-overlay/commit/46465925bd5c40ec2c64151736d94bae305ffb49) | `` Updated melpa ``        |
| [`ba878501`](https://github.com/nix-community/emacs-overlay/commit/ba8785013fa36610f4559343cdbf42122ba3c91e) | `` Updated elpa ``         |
| [`bf5f6ffc`](https://github.com/nix-community/emacs-overlay/commit/bf5f6ffceac1e758ea096c0a036555f322606367) | `` Updated nongnu ``       |
| [`ea37d730`](https://github.com/nix-community/emacs-overlay/commit/ea37d7305404538ce26f1dbf26c32f32678a9e7c) | `` Updated melpa ``        |
| [`a8c18a3f`](https://github.com/nix-community/emacs-overlay/commit/a8c18a3f130ec05774b741318d47caa375b34ad1) | `` Updated emacs ``        |
| [`a195eb43`](https://github.com/nix-community/emacs-overlay/commit/a195eb43aaa011e264b8df0d450c36b4ca5c8cd2) | `` Updated elpa ``         |
| [`d55830b9`](https://github.com/nix-community/emacs-overlay/commit/d55830b972dfbbb6e1a01a5e886abb8bceb7c4bf) | `` Updated nongnu ``       |
| [`8aebf2a9`](https://github.com/nix-community/emacs-overlay/commit/8aebf2a959f8cd1bff7489e002de5565c83f8307) | `` Updated flake inputs `` |
| [`dc8f6950`](https://github.com/nix-community/emacs-overlay/commit/dc8f6950b1d59a7275b7ab3a275ca43cf8632a2e) | `` Updated melpa ``        |
| [`ecd03e89`](https://github.com/nix-community/emacs-overlay/commit/ecd03e89863c0cfa994355905ee2e7497a06ef3c) | `` Updated emacs ``        |
| [`b7a1ede5`](https://github.com/nix-community/emacs-overlay/commit/b7a1ede556c97d41c9d028f48b7de35580c07e59) | `` Updated elpa ``         |