### PR TITLE
chore(flake/catppuccin): `f2a353b8` -> `03d6eb3f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1754271783,
-        "narHash": "sha256-FknT43lUuVjdOD0kLZUm2jkCS1ld721Sr9vLKi6b1y4=",
+        "lastModified": 1754321514,
+        "narHash": "sha256-UQaxAoIOkQ0L1jQzQ7L+BCUK53Athaxcfn7UgvIWoPQ=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "f2a353b8394e9aac739baf2f6bcc972e0a092f75",
+        "rev": "03d6eb3f85cfe4f643d2cdaa22d2838f3eb240f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                          |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`03d6eb3f`](https://github.com/catppuccin/nix/commit/03d6eb3f85cfe4f643d2cdaa22d2838f3eb240f2) | `` ci(website): add concurrency rule to deploy (#672) ``         |
| [`82505942`](https://github.com/catppuccin/nix/commit/82505942715570be4b68d4593201cfb8d48221ca) | `` feat(home-manager): add support for halloy (#669) ``          |
| [`767ce895`](https://github.com/catppuccin/nix/commit/767ce895d03b71e3c6461bcea9f8d31b5d581fdd) | `` chore(deps): update dependency typescript to v5.9.2 (#666) `` |
| [`ab8151be`](https://github.com/catppuccin/nix/commit/ab8151bea5308abee6c1ca2cad7ef53a90b2ea57) | `` chore(devshell): pin nix (#668) ``                            |
| [`06d571bc`](https://github.com/catppuccin/nix/commit/06d571bc9728d276f3a57b41a345770dafd30fcb) | `` chore(deps): update dependency astro to v5.12.8 (#664) ``     |
| [`c634dfd3`](https://github.com/catppuccin/nix/commit/c634dfd3cfdb81df41aa9618df8743a6e335a685) | `` style: format 8f37587 ``                                      |
| [`8f375870`](https://github.com/catppuccin/nix/commit/8f375870bcc1f2cc5bf9d6c82a1e0a9a52f398fe) | `` chore(deps): update pnpm to v10.14.0 (#665) ``                |
| [`b8a69f12`](https://github.com/catppuccin/nix/commit/b8a69f127543cfe171cca7784c8fa7c9dafd8f2f) | `` docs: move most content from repo to site (#667) ``           |