### PR TITLE
chore(flake/sops-nix): `2c8def62` -> `49021900`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -925,11 +925,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752544651,
-        "narHash": "sha256-GllP7cmQu7zLZTs9z0J2gIL42IZHa9CBEXwBY9szT0U=",
+        "lastModified": 1754328224,
+        "narHash": "sha256-glPK8DF329/dXtosV7YSzRlF4n35WDjaVwdOMEoEXHA=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "2c8def626f54708a9c38a5861866660395bb3461",
+        "rev": "49021900e69812ba7ddb9e40f9170218a7eca9f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                |
| ----------------------------------------------------------------------------------------------- | ---------------------- |
| [`49021900`](https://github.com/Mic92/sops-nix/commit/49021900e69812ba7ddb9e40f9170218a7eca9f4) | `` Resolve old TODO `` |