### PR TITLE
chore(flake/emacs-overlay): `a9a66708` -> `3b40bb2e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1754361940,
-        "narHash": "sha256-2KROQdENN8Ix5kiBZRM8FQP1KiJDikKPTiaaExYdVAY=",
+        "lastModified": 1754447417,
+        "narHash": "sha256-eyw7LSTRTBG4PcoG3Hf92n1fLqolRwP0Cw1RlGz08H8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a9a667084c0cf89081842d3002aef7b4829980aa",
+        "rev": "3b40bb2e104b70d8c5985bf16d1e1bf1e81371a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`3b40bb2e`](https://github.com/nix-community/emacs-overlay/commit/3b40bb2e104b70d8c5985bf16d1e1bf1e81371a4) | `` Updated melpa `` |
| [`f70ec008`](https://github.com/nix-community/emacs-overlay/commit/f70ec00832c6bbd8b0103db14f1ef0cdbccefb03) | `` Updated emacs `` |
| [`373932b6`](https://github.com/nix-community/emacs-overlay/commit/373932b6cfa1697b2c45a2cb60c41ce0e66f15b3) | `` Updated elpa ``  |
| [`8aec6211`](https://github.com/nix-community/emacs-overlay/commit/8aec6211de0ee48f1435727077e1fad5cfb9e97e) | `` Updated emacs `` |
| [`4c14abae`](https://github.com/nix-community/emacs-overlay/commit/4c14abae6235cb18ebcc4131c805d56a60fc90fc) | `` Updated melpa `` |
| [`637fc597`](https://github.com/nix-community/emacs-overlay/commit/637fc597773051bf2eaf3760009c5629a2a7449d) | `` Updated elpa ``  |