### PR TITLE
chore(flake/catppuccin): `36ee702f` -> `9bdf7f5f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1754338020,
-        "narHash": "sha256-E1fGaBzVoYueb7zDZWuDDeTLcg4vct/nGqVJzXze7gY=",
+        "lastModified": 1754418797,
+        "narHash": "sha256-8UP/nu75GyNcdKW3FD/mRxhs5zWlRIpAQo8wgm9rVQE=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "36ee702f10f4d2befb55c6d6704becf140399275",
+        "rev": "9bdf7f5fb308409495523ea21bec5484b75b2492",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                            |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`9bdf7f5f`](https://github.com/catppuccin/nix/commit/9bdf7f5fb308409495523ea21bec5484b75b2492) | `` chore(vscode): update pmpm fetchDeps fetcherVersion 2 (#678) `` |