### PR TITLE
chore(flake/home-manager): `c23168ac` -> `88913c98`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -372,11 +372,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754436133,
-        "narHash": "sha256-UpcWgMSNE8sz6oMWNqzQK8NzX+rz3pXrUQ66fWCqKGA=",
+        "lastModified": 1754495836,
+        "narHash": "sha256-ON5VEr70cAUR0YOHuVgLlgq9HarBqfbWsxknlmHnM+o=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c23168acf558fc24adc8240533c4fbf9591f183e",
+        "rev": "88913c98fe674e10302bbdb71b4e173f527b69c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`88913c98`](https://github.com/nix-community/home-manager/commit/88913c98fe674e10302bbdb71b4e173f527b69c2) | `` goto: init module ``                         |
| [`ad5d2b4a`](https://github.com/nix-community/home-manager/commit/ad5d2b4aa770fdc74c80fd682fee0b00a8ad7991) | `` rescrobbled: add module ``                   |
| [`f6cc29aa`](https://github.com/nix-community/home-manager/commit/f6cc29aab07640942da39250ac8e23a69ebe0f3e) | `` flake.lock: Update ``                        |
| [`c15ffc85`](https://github.com/nix-community/home-manager/commit/c15ffc850c1f0dff20602742cd660c32bdaa1c8c) | `` news: fix duplicate news id ``               |
| [`998c2374`](https://github.com/nix-community/home-manager/commit/998c2374f0e332f46ea3100157d0acfcdcfa4e97) | `` news: cleanup invalid timestamps ``          |
| [`ac351d43`](https://github.com/nix-community/home-manager/commit/ac351d435afd1b648b30202edc3f6390497708ae) | `` tests/news: add new test for news entries `` |
| [`8f02266b`](https://github.com/nix-community/home-manager/commit/8f02266b8e49c1c6bbe122b5602e1c877e42c5be) | `` news: fix font config entry ``               |
| [`a3790776`](https://github.com/nix-community/home-manager/commit/a3790776751d1a6365aa0717f509d05adee90734) | `` sherlock: init module ``                     |
| [`f0d81a41`](https://github.com/nix-community/home-manager/commit/f0d81a415d7a8fbf57b518aec5cf7dca20576389) | `` news: add new feature entries ``             |