### PR TITLE
chore(flake/nur): `5f01257d` -> `bf5f19d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -843,11 +843,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1754474936,
-        "narHash": "sha256-5isFM/P8BUOJvHnloh3WNg9HEJKUdNVyIjmCAzaanQY=",
+        "lastModified": 1754553115,
+        "narHash": "sha256-EM7M+5OA1Jdl10/t0X83uqN1PeFs0NOjckqYShwy6f0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5f01257d6fa49cde9d57e7992b9872136a283c5c",
+        "rev": "bf5f19d67bc2eb7ef0429734f8f9fdc84ca277f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                      |
| -------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`bf5f19d6`](https://github.com/nix-community/NUR/commit/bf5f19d67bc2eb7ef0429734f8f9fdc84ca277f4) | `` automatic update ``       |
| [`deaefede`](https://github.com/nix-community/NUR/commit/deaefedef12f15f59f503f38c36dec8956df9fbc) | `` automatic update ``       |
| [`1f267a20`](https://github.com/nix-community/NUR/commit/1f267a20b62924a4e45878b1bf631a4a541a2a3b) | `` automatic update ``       |
| [`13fdbbd9`](https://github.com/nix-community/NUR/commit/13fdbbd92ecc6ce8f3957aa1b32965d3b48bbd79) | `` automatic update ``       |
| [`965610b6`](https://github.com/nix-community/NUR/commit/965610b676073fc87afe259b5c20f82cdeb07f8c) | `` automatic update ``       |
| [`ad772d1e`](https://github.com/nix-community/NUR/commit/ad772d1e5ebea99e741f0e61a73655928bc53bfa) | `` automatic update ``       |
| [`0d75abff`](https://github.com/nix-community/NUR/commit/0d75abff8343adaa20cd89b79e1f58d334101534) | `` automatic update ``       |
| [`e17e7704`](https://github.com/nix-community/NUR/commit/e17e7704458de0ed07a36e2e029ebee6cd4fa081) | `` automatic update ``       |
| [`3463ebe8`](https://github.com/nix-community/NUR/commit/3463ebe88afbcbb490332e9a4966f5add3279aeb) | `` automatic update ``       |
| [`aa0b0703`](https://github.com/nix-community/NUR/commit/aa0b07033c3d738d673d21c2400bc5e3394a17fa) | `` automatic update ``       |
| [`d257e6c2`](https://github.com/nix-community/NUR/commit/d257e6c27509be6edfae3e376bcf07123b05cf62) | `` automatic update ``       |
| [`146053d7`](https://github.com/nix-community/NUR/commit/146053d72b83164afc79775f0e461607a732c621) | `` automatic update ``       |
| [`a376e915`](https://github.com/nix-community/NUR/commit/a376e91594de596a6e525badc1dfa79181a1f4d4) | `` automatic update ``       |
| [`d643396e`](https://github.com/nix-community/NUR/commit/d643396e0b0e4f68b4e8d1a38b79cedfba08bf0a) | `` automatic update ``       |
| [`6c12c709`](https://github.com/nix-community/NUR/commit/6c12c7092fde8a8e3a199f74e9450ad38e3ac2ba) | `` automatic update ``       |
| [`fb620512`](https://github.com/nix-community/NUR/commit/fb6205120dbfef5d3598ba9ee4568b76ab76f0d7) | `` automatic update ``       |
| [`126694fe`](https://github.com/nix-community/NUR/commit/126694fe3fc2b1995aced12abb459b6077a7d189) | `` automatic update ``       |
| [`50a639c3`](https://github.com/nix-community/NUR/commit/50a639c37fb26fe2b1a457810599eb2956799221) | `` add mikidep repository `` |
| [`62515019`](https://github.com/nix-community/NUR/commit/62515019716a9c221d25a7940eefeffd720934e0) | `` automatic update ``       |
| [`fbf653ef`](https://github.com/nix-community/NUR/commit/fbf653ef4523239db9ce115bf20b6214e2e77cf3) | `` automatic update ``       |
| [`f0b15c62`](https://github.com/nix-community/NUR/commit/f0b15c62ef4ee07662feb1ced9c226e578a8772a) | `` automatic update ``       |