### PR TITLE
chore(flake/home-manager): `88913c98` -> `62fdc8d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -372,11 +372,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754495836,
-        "narHash": "sha256-ON5VEr70cAUR0YOHuVgLlgq9HarBqfbWsxknlmHnM+o=",
+        "lastModified": 1754525296,
+        "narHash": "sha256-S6287NdqBGJ0rNbmZj+/8qv/4g7c6LreIzFarun9uQ0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "88913c98fe674e10302bbdb71b4e173f527b69c2",
+        "rev": "62fdc8d41097313e681446b46681a4f89544e51c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`62fdc8d4`](https://github.com/nix-community/home-manager/commit/62fdc8d41097313e681446b46681a4f89544e51c) | `` keepassxc: add autostart option ``                |
| [`cb8cfa0e`](https://github.com/nix-community/home-manager/commit/cb8cfa0eb9a7f2ab2edaaf934f5e413b91800c31) | `` keepassxc: add maintainer bmrips ``               |
| [`13c5c2fb`](https://github.com/nix-community/home-manager/commit/13c5c2fb4cbed19ee40552a29a1b0fac8839a2dd) | `` Translate using Weblate (Ukrainian) ``            |
| [`13461dec`](https://github.com/nix-community/home-manager/commit/13461dec40bf03d9196ff79d1abe48408268cc35) | `` git-credential-keepassxc: fix eval ``             |
| [`2a299689`](https://github.com/nix-community/home-manager/commit/2a29968912815e825a8cae73e2535a94424a9d1b) | `` git-credential-keepassxc: init module ``          |
| [`53bf4fab`](https://github.com/nix-community/home-manager/commit/53bf4fab3013c9c200593a45c95469dba12c5315) | `` docs: add tests command documentation ``          |
| [`bf2dc7eb`](https://github.com/nix-community/home-manager/commit/bf2dc7ebd8e3fd10f24cfe0a8acfd3d2676666c7) | `` tests: add tests package to search / run tests `` |