### PR TITLE
chore(flake/nur): `bf5f19d6` -> `e2b0a54f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -843,11 +843,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1754553115,
-        "narHash": "sha256-EM7M+5OA1Jdl10/t0X83uqN1PeFs0NOjckqYShwy6f0=",
+        "lastModified": 1754562534,
+        "narHash": "sha256-8tP2Jj1SA55zpp4SUl3bzeEDZWUiswQulGYMrOzxXpw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bf5f19d67bc2eb7ef0429734f8f9fdc84ca277f4",
+        "rev": "e2b0a54f3538a26b983ab3fe7fa2bdbf466621cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e2b0a54f`](https://github.com/nix-community/NUR/commit/e2b0a54f3538a26b983ab3fe7fa2bdbf466621cd) | `` automatic update `` |
| [`af3bd79a`](https://github.com/nix-community/NUR/commit/af3bd79a8d016d6ddabae0bc754f8b3ee446fed2) | `` automatic update `` |
| [`c931e7ac`](https://github.com/nix-community/NUR/commit/c931e7accbf28f50bc147e2e88e7d5963cd9e777) | `` automatic update `` |
| [`a2e5a13b`](https://github.com/nix-community/NUR/commit/a2e5a13b547bb9cc88887949fe9a0958ad59f3da) | `` automatic update `` |