### PR TITLE
chore(flake/nur): `e2b0a54f` -> `bd7c4150`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -753,11 +753,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1754214453,
-        "narHash": "sha256-Q/I2xJn/j1wpkGhWkQnm20nShYnG7TI99foDBpXm1SY=",
+        "lastModified": 1754498491,
+        "narHash": "sha256-erbiH2agUTD0Z30xcVSFcDHzkRvkRXOQ3lb887bcVrs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5b09dc45f24cf32316283e62aec81ffee3c3e376",
+        "rev": "c2ae88e026f9525daf89587f3cbee584b92b6134",
         "type": "github"
       },
       "original": {
@@ -843,11 +843,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1754562534,
-        "narHash": "sha256-8tP2Jj1SA55zpp4SUl3bzeEDZWUiswQulGYMrOzxXpw=",
+        "lastModified": 1754581054,
+        "narHash": "sha256-Qy/KBx5uQ7fkl90UXKT7vyHnBeIpNaEijuSj3gRAMLI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e2b0a54f3538a26b983ab3fe7fa2bdbf466621cd",
+        "rev": "bd7c41503777e7066cc261cbe8f5a52df3899034",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bd7c4150`](https://github.com/nix-community/NUR/commit/bd7c41503777e7066cc261cbe8f5a52df3899034) | `` automatic update `` |
| [`45c56bf8`](https://github.com/nix-community/NUR/commit/45c56bf867424cd5f48d859ecfce5bd9be7e06c2) | `` automatic update `` |
| [`4fe4c7df`](https://github.com/nix-community/NUR/commit/4fe4c7dfc7534f3b86a5986912eaff5961fba89f) | `` automatic update `` |
| [`7cfa649d`](https://github.com/nix-community/NUR/commit/7cfa649d67be382825da31d9918b879d2c467303) | `` automatic update `` |
| [`d26ed459`](https://github.com/nix-community/NUR/commit/d26ed459d1427517284c69002e78c89d8a923757) | `` automatic update `` |