### PR TITLE
chore(flake/nur): `487e2c74` -> `5406ac1e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -843,11 +843,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1754626499,
-        "narHash": "sha256-ACCMqX5Td5DKW+1jA+Vczp6Box6iHplrtBx3BbPuCY8=",
+        "lastModified": 1754653755,
+        "narHash": "sha256-P2DC6dsa9ry06T9pv5YJyOuwLTJA/zWdWbJbjAmOX2c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "487e2c74682a24fbdd40615d4bbf37b63ad55112",
+        "rev": "5406ac1e32db706b9024caa7003fcb5bd93fc8a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5406ac1e`](https://github.com/nix-community/NUR/commit/5406ac1e32db706b9024caa7003fcb5bd93fc8a5) | `` automatic update `` |
| [`0aa6aef6`](https://github.com/nix-community/NUR/commit/0aa6aef650c7d0e0a420f48deb37dd504611d34a) | `` automatic update `` |
| [`5eb12df7`](https://github.com/nix-community/NUR/commit/5eb12df7acee0a88b9d099bcfe458101d9774e9a) | `` automatic update `` |
| [`899c01a6`](https://github.com/nix-community/NUR/commit/899c01a64333a9f97c3a2155fe3c812be99d308f) | `` automatic update `` |
| [`f15df3b0`](https://github.com/nix-community/NUR/commit/f15df3b0414f53fb17bd7b2418677edff21dae52) | `` automatic update `` |
| [`17f2a25d`](https://github.com/nix-community/NUR/commit/17f2a25d8e8a57863997b9befb8d1a46fce22e5e) | `` automatic update `` |
| [`7d56bd3d`](https://github.com/nix-community/NUR/commit/7d56bd3d88c61bd50b9643fa6b8c24e5e0bdc080) | `` automatic update `` |
| [`cfda0838`](https://github.com/nix-community/NUR/commit/cfda0838f4287fb523fe4457b4cc7a053ec12aad) | `` automatic update `` |
| [`c207a5af`](https://github.com/nix-community/NUR/commit/c207a5afe9d4dc7b145a59f96f075f7155727779) | `` automatic update `` |
| [`689af376`](https://github.com/nix-community/NUR/commit/689af37663937bcfeaacf78fdc5bd9844da1443a) | `` automatic update `` |