### PR TITLE
chore(flake/nur): `5406ac1e` -> `77e5f5ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -843,11 +843,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1754653755,
-        "narHash": "sha256-P2DC6dsa9ry06T9pv5YJyOuwLTJA/zWdWbJbjAmOX2c=",
+        "lastModified": 1754681400,
+        "narHash": "sha256-sXKv+qJI9RLnvFKXOt8IWE1iGUBEz1scdJYlG+j+L0s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5406ac1e32db706b9024caa7003fcb5bd93fc8a5",
+        "rev": "77e5f5ba0fe9184f2056e6bf447e47e89cfc5940",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`77e5f5ba`](https://github.com/nix-community/NUR/commit/77e5f5ba0fe9184f2056e6bf447e47e89cfc5940) | `` automatic update `` |
| [`6a116ccb`](https://github.com/nix-community/NUR/commit/6a116ccbab3e9769eb7ae88320d35d071231318a) | `` automatic update `` |
| [`a9572eb5`](https://github.com/nix-community/NUR/commit/a9572eb5959d7ba356f61093c8b210cec9bd6498) | `` automatic update `` |
| [`7e8db4e3`](https://github.com/nix-community/NUR/commit/7e8db4e3c3e10259b6ebe54247566ab2336a8429) | `` automatic update `` |
| [`143d66fa`](https://github.com/nix-community/NUR/commit/143d66fa64ce39216522213180f312658c544e1b) | `` automatic update `` |
| [`9ee0c53e`](https://github.com/nix-community/NUR/commit/9ee0c53e23da5d493ba601d8f700382d1ffdbb32) | `` automatic update `` |
| [`5bbfbb6d`](https://github.com/nix-community/NUR/commit/5bbfbb6d700d26d5cd9e8e2da4a0a6391036cd5d) | `` automatic update `` |
| [`913d4b0c`](https://github.com/nix-community/NUR/commit/913d4b0c82222afcf6da3e972641c124afc5514d) | `` automatic update `` |
| [`e7b3f7b9`](https://github.com/nix-community/NUR/commit/e7b3f7b9eb12f3636fb5fb7f4036bef74cb45a68) | `` automatic update `` |