### PR TITLE
chore(flake/emacs-overlay): `a1a215bb` -> `19243a23`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1754643505,
-        "narHash": "sha256-73pnCc9w5Gr1op2zP+HKzWv8FiyIbEfot2yJBQX4HDU=",
+        "lastModified": 1754673064,
+        "narHash": "sha256-W088aHqP1rch8CR8DJqGaziCXrKjzyFiu2RLMGHdz0w=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a1a215bb6e346786dce58b6296bfd8a0eb2dc26f",
+        "rev": "19243a2335c4df92a2c7cc34bef8a1a3e1210c1b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`19243a23`](https://github.com/nix-community/emacs-overlay/commit/19243a2335c4df92a2c7cc34bef8a1a3e1210c1b) | `` Updated melpa ``  |
| [`fd7af51d`](https://github.com/nix-community/emacs-overlay/commit/fd7af51d5a242bcea9ac1c8b0a4d57e0e8089893) | `` Updated emacs ``  |
| [`1675a48a`](https://github.com/nix-community/emacs-overlay/commit/1675a48a03a89688d1ba72d4d2faea6d30f17f57) | `` Updated elpa ``   |
| [`1fa76891`](https://github.com/nix-community/emacs-overlay/commit/1fa7689126b0d1f2182f673e91bdb8ad332b670d) | `` Updated nongnu `` |