### PR TITLE
chore(flake/emacs-overlay): `c5aea461` -> `9dffdb70`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1754705618,
-        "narHash": "sha256-JYwLLpnzJz0+ihJrwZUTAodx2+iBPWfnmfhJy3lpSw4=",
+        "lastModified": 1754730565,
+        "narHash": "sha256-ctkidU9Z40fXP+VbSwxPaGXfgBvNeu6X7G5Aof8ZXZs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c5aea4616a2c482eb3f1765f90de9771ba1d134a",
+        "rev": "9dffdb70d5a10e15a9d65f9bb038926a25e8839b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`9dffdb70`](https://github.com/nix-community/emacs-overlay/commit/9dffdb70d5a10e15a9d65f9bb038926a25e8839b) | `` Updated melpa `` |
| [`0833d9a8`](https://github.com/nix-community/emacs-overlay/commit/0833d9a869e3162bd8baede2c919f736e6b90991) | `` Updated emacs `` |