### PR TITLE
chore(flake/catppuccin): `9bdf7f5f` -> `7b55c494`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1754418797,
-        "narHash": "sha256-8UP/nu75GyNcdKW3FD/mRxhs5zWlRIpAQo8wgm9rVQE=",
+        "lastModified": 1754727511,
+        "narHash": "sha256-iRqRCeeXEQ5HSB6zI6Wja7ZfY0PPRx5yelgjtoX2iMo=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "9bdf7f5fb308409495523ea21bec5484b75b2492",
+        "rev": "7b55c4947c02f79dfd249432ccb0ada2726c29e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                         |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`7b55c494`](https://github.com/catppuccin/nix/commit/7b55c4947c02f79dfd249432ccb0ada2726c29e2) | `` fix(home-manager/mako): remove ifd (#684) `` |