### PR TITLE
chore(flake/emacs-overlay): `9dffdb70` -> `d2307906`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1754730565,
-        "narHash": "sha256-ctkidU9Z40fXP+VbSwxPaGXfgBvNeu6X7G5Aof8ZXZs=",
+        "lastModified": 1754759269,
+        "narHash": "sha256-pBinP8BzBYkEZ7+c1ZHgJIvZre4uvga0edme9QN4pBU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9dffdb70d5a10e15a9d65f9bb038926a25e8839b",
+        "rev": "d23079069762b731ba233d5ab2f72ab1bfa179e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`d2307906`](https://github.com/nix-community/emacs-overlay/commit/d23079069762b731ba233d5ab2f72ab1bfa179e3) | `` Updated melpa ``  |
| [`ed671f0a`](https://github.com/nix-community/emacs-overlay/commit/ed671f0ab0ff0c782cf391a4a7c9515d7fbd4d7e) | `` Updated emacs ``  |
| [`edf36b81`](https://github.com/nix-community/emacs-overlay/commit/edf36b816e5e0a209727ffc402f0501264ada1bb) | `` Updated elpa ``   |
| [`538d8c3c`](https://github.com/nix-community/emacs-overlay/commit/538d8c3c8f58aaf0b843496f54ee569113466ad3) | `` Updated nongnu `` |