### PR TITLE
chore(flake/nur): `b185dda4` -> `2667d0ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -843,11 +843,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1754811630,
-        "narHash": "sha256-w1UJglsLntxUrniQekiF5h09TUEoUgrius1eSsJk498=",
+        "lastModified": 1754909811,
+        "narHash": "sha256-KpwnRJNAY6VnOO1eh8/O0rj5eSGbNlZvqYoCm8kZn3I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b185dda47d8a32c711c4f91d77108c8900fd49c2",
+        "rev": "2667d0ce65470d926631400f82406d278be255e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                   |
| -------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`2667d0ce`](https://github.com/nix-community/NUR/commit/2667d0ce65470d926631400f82406d278be255e0) | `` automatic update ``                    |
| [`45735eca`](https://github.com/nix-community/NUR/commit/45735eca11abd2575aac2a252bb4935dc32b57d9) | `` automatic update ``                    |
| [`8b7bc4e2`](https://github.com/nix-community/NUR/commit/8b7bc4e294888ffe1ab16d554be7f6b205453915) | `` automatic update ``                    |
| [`aab204f3`](https://github.com/nix-community/NUR/commit/aab204f335aa2456797a3ef3fca6ccdbdc9a129b) | `` automatic update ``                    |
| [`1d9e1938`](https://github.com/nix-community/NUR/commit/1d9e19387612b1fe685386e34aec28992d8d4b88) | `` automatic update ``                    |
| [`3141b19c`](https://github.com/nix-community/NUR/commit/3141b19c94536d4024845ca8d30e2dd08dbaeb45) | `` automatic update ``                    |
| [`d7fa4271`](https://github.com/nix-community/NUR/commit/d7fa4271e67a1004ab00f811e043ff58aee2b1ce) | `` automatic update ``                    |
| [`cd71f0ec`](https://github.com/nix-community/NUR/commit/cd71f0ecdec74d6fdfeaaf1196901247bdd2ba5b) | `` automatic update ``                    |
| [`9d09b338`](https://github.com/nix-community/NUR/commit/9d09b338ff7ca6739f59554161c9824356ad0ba2) | `` automatic update ``                    |
| [`f657c382`](https://github.com/nix-community/NUR/commit/f657c3820a06481f3a037ffba0e69d01f2cedfb2) | `` automatic update ``                    |
| [`edc5f74d`](https://github.com/nix-community/NUR/commit/edc5f74d1ae09ae61dfa83f24a91670d0192d7af) | `` automatic update ``                    |
| [`befb50ef`](https://github.com/nix-community/NUR/commit/befb50efa1b9bd139ba332a0ddebd166f6f8bb10) | `` automatic update ``                    |
| [`db39211c`](https://github.com/nix-community/NUR/commit/db39211c5c11eb70fb6aa1ef7635d96103a681d7) | `` automatic update ``                    |
| [`cbe6acaf`](https://github.com/nix-community/NUR/commit/cbe6acaf9d4328c133507a8c4ec0029b554596a4) | `` add LucasFA/nur-packages repository `` |
| [`a32ca4ad`](https://github.com/nix-community/NUR/commit/a32ca4ad6d505ec706049fea838479e6c3b22d5c) | `` automatic update ``                    |
| [`58e27e7d`](https://github.com/nix-community/NUR/commit/58e27e7d3650598b5ccf0c9c1828e65b999678da) | `` automatic update ``                    |
| [`a89cd86e`](https://github.com/nix-community/NUR/commit/a89cd86e9fbde50758b9febf2ecd3cb237cb398b) | `` automatic update ``                    |
| [`7527c3e2`](https://github.com/nix-community/NUR/commit/7527c3e2c2e7dbb2c6003f6664f6d0207b964c30) | `` automatic update ``                    |
| [`9c6f4286`](https://github.com/nix-community/NUR/commit/9c6f428670762cad26ca74b3cc0f4f18c38ffa5c) | `` automatic update ``                    |
| [`a286e74a`](https://github.com/nix-community/NUR/commit/a286e74a15884d69db0f339edcec52ca9cc4a7aa) | `` automatic update ``                    |
| [`7caea3a0`](https://github.com/nix-community/NUR/commit/7caea3a004ebf4311a6aee5e760aa002e12f9d53) | `` automatic update ``                    |
| [`9bdc8a9b`](https://github.com/nix-community/NUR/commit/9bdc8a9b23a1e444109ff6a214e2dc139837f777) | `` automatic update ``                    |
| [`dc2e9ee0`](https://github.com/nix-community/NUR/commit/dc2e9ee0ca7834444303d46c0fa071319fdf34b4) | `` automatic update ``                    |
| [`f8b74fe8`](https://github.com/nix-community/NUR/commit/f8b74fe8a3e9090cd6ddcfe3e1ed645d8f0ca4b6) | `` automatic update ``                    |
| [`428f3150`](https://github.com/nix-community/NUR/commit/428f3150049ea479555ed3a5925a76671ceee519) | `` automatic update ``                    |
| [`577219c8`](https://github.com/nix-community/NUR/commit/577219c836de74f7939766bbf5cb214331adff3b) | `` automatic update ``                    |
| [`259f2d13`](https://github.com/nix-community/NUR/commit/259f2d13d745251fa6ccee322b6a2cb954360d19) | `` automatic update ``                    |
| [`2559394a`](https://github.com/nix-community/NUR/commit/2559394a006926626578c0a79cac0108e35792a9) | `` automatic update ``                    |
| [`a6083f3b`](https://github.com/nix-community/NUR/commit/a6083f3bfa03f6a51f31ea88bf2ff8df9631716d) | `` automatic update ``                    |