### PR TITLE
chore(flake/emacs-overlay): `a8f1ef39` -> `dd8fa902`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1754816935,
-        "narHash": "sha256-SnBESJKoVg/W9CSHEPCWM9khl1sNWnC2UCRJJYgdFng=",
+        "lastModified": 1754845713,
+        "narHash": "sha256-NpO4MFM06V/xgj1JMdoyx9cG7uDzlFvXM60AZcqaGP8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a8f1ef391d688e3287095e44589278381756bea7",
+        "rev": "dd8fa9020d078fc96ff0dd4c1a7bff14b19aee62",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`dd8fa902`](https://github.com/nix-community/emacs-overlay/commit/dd8fa9020d078fc96ff0dd4c1a7bff14b19aee62) | `` Updated melpa ``  |
| [`9db61ba5`](https://github.com/nix-community/emacs-overlay/commit/9db61ba5f807bc2fccabc4eab568ebd0c96e86b3) | `` Updated elpa ``   |
| [`e47193da`](https://github.com/nix-community/emacs-overlay/commit/e47193da5fe16bd776128200110229a4dc829caf) | `` Updated nongnu `` |