### PR TITLE
chore(flake/emacs-overlay): `dd8fa902` -> `c9f73717`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1754845713,
-        "narHash": "sha256-NpO4MFM06V/xgj1JMdoyx9cG7uDzlFvXM60AZcqaGP8=",
+        "lastModified": 1754876903,
+        "narHash": "sha256-LOGFgg9as4+jCteUJQLSX+hApdRBM9bJYhS0DrmLmrA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "dd8fa9020d078fc96ff0dd4c1a7bff14b19aee62",
+        "rev": "c9f73717ad385de42dc6b64b5a2de6f5a9916a10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`c9f73717`](https://github.com/nix-community/emacs-overlay/commit/c9f73717ad385de42dc6b64b5a2de6f5a9916a10) | `` Updated elpa ``   |
| [`fe338276`](https://github.com/nix-community/emacs-overlay/commit/fe338276cb7724b0dc6adba92a1b8dda874ad25e) | `` Updated nongnu `` |