### PR TITLE
chore(flake/srvos): `8e7d3c69` -> `0fd4b65a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -979,11 +979,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754273897,
-        "narHash": "sha256-l7epHqAcg8Qktu8vO2ZfjSH1wcai01XQOKQA9ADHIk4=",
+        "lastModified": 1754876635,
+        "narHash": "sha256-eU+DxKxVGNC7wjsfxdjDJQcDPx+V+K2qz8YbtSQIuG4=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "8e7d3c690975ee6790926bdfd1258016c967d163",
+        "rev": "0fd4b65ae4649ce65a83e00fd39747fe64c5076f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                           |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`0fd4b65a`](https://github.com/nix-community/srvos/commit/0fd4b65ae4649ce65a83e00fd39747fe64c5076f) | `` nixos/server: fix evaluation on old commits `` |