### PR TITLE
chore(flake/nur): `2667d0ce` -> `f55ffbd1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -843,11 +843,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1754909811,
-        "narHash": "sha256-KpwnRJNAY6VnOO1eh8/O0rj5eSGbNlZvqYoCm8kZn3I=",
+        "lastModified": 1754957232,
+        "narHash": "sha256-ZjVh7iSd5aCczOah+zVRnhGzkTb/v7XuYnHY0slWmVU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2667d0ce65470d926631400f82406d278be255e0",
+        "rev": "f55ffbd1fafeccb1a6bea996ce9a3c746c31a5fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                           |
| -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`f55ffbd1`](https://github.com/nix-community/NUR/commit/f55ffbd1fafeccb1a6bea996ce9a3c746c31a5fa) | `` automatic update ``                                            |
| [`3bccbcfb`](https://github.com/nix-community/NUR/commit/3bccbcfb6827e976fd8a25c7a35e962311e5df49) | `` automatic update ``                                            |
| [`c8eb4ac3`](https://github.com/nix-community/NUR/commit/c8eb4ac3ef8f4da2f3be3a15258ce252bdfcaee5) | `` automatic update ``                                            |
| [`12edbcb1`](https://github.com/nix-community/NUR/commit/12edbcb1f2a857fff3892469ff1d3cbfc4f6f9a6) | `` automatic update ``                                            |
| [`449660f1`](https://github.com/nix-community/NUR/commit/449660f1a9060f54576981ff3b36379e1cb2ee8c) | `` automatic update ``                                            |
| [`459a8cdd`](https://github.com/nix-community/NUR/commit/459a8cdd1c44b52e0e454015a1f44fb85c188bd7) | `` automatic update ``                                            |
| [`ab485680`](https://github.com/nix-community/NUR/commit/ab485680208dfe0ac1cd928c97f2b2e4df5a5236) | `` add thk repository ``                                          |
| [`e9f07460`](https://github.com/nix-community/NUR/commit/e9f0746030e4740cc1ac0d52a896828129079107) | `` docs: nur.overlay has been replaced by nur.overlays.default `` |
| [`dda1653e`](https://github.com/nix-community/NUR/commit/dda1653ebac900f4fde762c5bc68ae0f014ad304) | `` automatic update ``                                            |
| [`09232cbf`](https://github.com/nix-community/NUR/commit/09232cbf5744686dcfcbc15493f709acb3150e36) | `` automatic update ``                                            |
| [`bdd763a5`](https://github.com/nix-community/NUR/commit/bdd763a5cefcde814548ce99516b71169ea10a5d) | `` automatic update ``                                            |
| [`ac764b34`](https://github.com/nix-community/NUR/commit/ac764b3412faeed1a37c7d21f30bc0fbe547f773) | `` automatic update ``                                            |
| [`ebb2bbd6`](https://github.com/nix-community/NUR/commit/ebb2bbd65bec6297aab1ddfa171e691a69406530) | `` automatic update ``                                            |
| [`d22a1e6f`](https://github.com/nix-community/NUR/commit/d22a1e6fd730b61f083caddc71a3430952117d2e) | `` automatic update ``                                            |
| [`562c625b`](https://github.com/nix-community/NUR/commit/562c625b7d509e75a150849b0e9738d5e7d64aa7) | `` automatic update ``                                            |
| [`dacefaca`](https://github.com/nix-community/NUR/commit/dacefaca6d7c2ae8fea96a103705c78bd5919133) | `` automatic update ``                                            |
| [`5fbe3ee1`](https://github.com/nix-community/NUR/commit/5fbe3ee172c39acc867caca644f879faef7900a7) | `` add hexadecimalDinosaur repository ``                          |
| [`6ab440d1`](https://github.com/nix-community/NUR/commit/6ab440d1cb938616cf798984f8f48ec0b43939ad) | `` automatic update ``                                            |
| [`aad77791`](https://github.com/nix-community/NUR/commit/aad77791922ff82a61a40daf047e41878e82ab2e) | `` automatic update ``                                            |