### PR TITLE
chore(flake/emacs-overlay): `c9f73717` -> `8916044b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1754876903,
-        "narHash": "sha256-LOGFgg9as4+jCteUJQLSX+hApdRBM9bJYhS0DrmLmrA=",
+        "lastModified": 1754964749,
+        "narHash": "sha256-zrF376CPh/rkB1xPXFN5WbbEqsd7ClOXxGx3sLMqgng=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c9f73717ad385de42dc6b64b5a2de6f5a9916a10",
+        "rev": "8916044b55506a9b05b7c681ac864b302d867b34",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`8916044b`](https://github.com/nix-community/emacs-overlay/commit/8916044b55506a9b05b7c681ac864b302d867b34) | `` Updated melpa ``  |
| [`045d03da`](https://github.com/nix-community/emacs-overlay/commit/045d03dacf4caee93d07dd728d511aa13dd20826) | `` Updated emacs ``  |
| [`bf8458fc`](https://github.com/nix-community/emacs-overlay/commit/bf8458fce92d173ee248fa17a0b804b38ef1b861) | `` Updated elpa ``   |
| [`d32a2fb3`](https://github.com/nix-community/emacs-overlay/commit/d32a2fb3bfe51a24e0c261d402c606c99aae8a5b) | `` Updated nongnu `` |
| [`6d0695fb`](https://github.com/nix-community/emacs-overlay/commit/6d0695fbc0800c0d9073db9cf52294179ee2aa3c) | `` Updated elpa ``   |