### PR TITLE
chore(flake/minimal-emacs-d): `bea24ca3` -> `c6f0cda3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -434,11 +434,11 @@
     "minimal-emacs-d": {
       "flake": false,
       "locked": {
-        "lastModified": 1754686478,
-        "narHash": "sha256-IWY8M/BorVT/DME+4Qw3ywmMbrS5TxhOOgvmZrDpURM=",
+        "lastModified": 1754936146,
+        "narHash": "sha256-jJ8dHtn72ym8fBVh5XOIdonqoBHw235e4AkZbENDJY0=",
         "owner": "jamescherti",
         "repo": "minimal-emacs.d",
-        "rev": "bea24ca3c26e7dea8cda23d97d215e9b885c3129",
+        "rev": "c6f0cda3186a78065c1ffc212d535a621c0382fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                 |
| ------------------------------------------------------------------------------------------------------------ | ----------------------- |
| [`c6f0cda3`](https://github.com/jamescherti/minimal-emacs.d/commit/c6f0cda3186a78065c1ffc212d535a621c0382fe) | `` Update vars order `` |
| [`d55daca0`](https://github.com/jamescherti/minimal-emacs.d/commit/d55daca02033bab4d8701455af7f8b413fb51e0c) | `` Update docstring ``  |