### PR TITLE
chore(flake/home-manager): `67393957` -> `27a26be5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -372,11 +372,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754924470,
-        "narHash": "sha256-asI/or9AcUMydwzodCgpHGytnMSNUlciw3uaycpXm4E=",
+        "lastModified": 1754974548,
+        "narHash": "sha256-XMjUjKD/QRPcqUnmSDczSYdw46SilnG0+wkho654DFM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "67393957c27b4e4c6c48a60108a201413ced7800",
+        "rev": "27a26be51ff0162a8f67660239f9407dba68d7c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`27a26be5`](https://github.com/nix-community/home-manager/commit/27a26be51ff0162a8f67660239f9407dba68d7c5) | `` gemini-cli: init module ``           |
| [`461706d2`](https://github.com/nix-community/home-manager/commit/461706d28bd9e2ef2555756a17edc93e79612047) | `` maintainers: add rrvsh ``            |
| [`d19f3213`](https://github.com/nix-community/home-manager/commit/d19f3213e51469321835a9188adfa20391ff9371) | `` Translate using Weblate (Italian) `` |