### PR TITLE
chore(flake/srvos): `0fd4b65a` -> `83f86669`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -979,11 +979,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754876635,
-        "narHash": "sha256-eU+DxKxVGNC7wjsfxdjDJQcDPx+V+K2qz8YbtSQIuG4=",
+        "lastModified": 1754976577,
+        "narHash": "sha256-F6h97bTJfEgFoWkACsuOolUmxa4ByXdQ8KfdYMkDQ2Q=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "0fd4b65ae4649ce65a83e00fd39747fe64c5076f",
+        "rev": "83f8666976107a0d84ddc7a3c835d46ffdf83d97",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                              |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`83f86669`](https://github.com/nix-community/srvos/commit/83f8666976107a0d84ddc7a3c835d46ffdf83d97) | `` build(deps): bump actions/checkout from 4 to 5 `` |