### PR TITLE
chore(flake/sops-nix): `49021900` -> `3223c7a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -959,11 +959,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754328224,
-        "narHash": "sha256-glPK8DF329/dXtosV7YSzRlF4n35WDjaVwdOMEoEXHA=",
+        "lastModified": 1754988908,
+        "narHash": "sha256-t+voe2961vCgrzPFtZxha0/kmFSHFobzF00sT8p9h0U=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "49021900e69812ba7ddb9e40f9170218a7eca9f4",
+        "rev": "3223c7a92724b5d804e9988c6b447a0d09017d48",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                           |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`da8857f9`](https://github.com/Mic92/sops-nix/commit/da8857f91df6e79edfdd9f424e4dd7a3b9f98280) | `` build(deps): bump actions/checkout from 4 to 5 ``              |
| [`a4af079a`](https://github.com/Mic92/sops-nix/commit/a4af079af562590a2b4dd43565d732741e199e1d) | `` update vendorHash ``                                           |
| [`88aeb915`](https://github.com/Mic92/sops-nix/commit/88aeb915614a061e1fae35991a76d875cbb54807) | `` build(deps): bump golang.org/x/crypto from 0.39.0 to 0.41.0 `` |