### PR TITLE
chore(flake/nur): `ccb6cee3` -> `bbfdb776`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -843,11 +843,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1754996709,
-        "narHash": "sha256-IOFqbuRuumZFG9s/c8pablo4AL4jzXdjr86OvMxINkE=",
+        "lastModified": 1755010404,
+        "narHash": "sha256-ardoTycniITw5EwWNwNdqsMbeDUIZiGEVNvoB4ah7os=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ccb6cee3ff1f3b002d95144230d3908bcdf1b4d8",
+        "rev": "bbfdb7764fd1045e525703449e7e29f957e28c0d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bbfdb776`](https://github.com/nix-community/NUR/commit/bbfdb7764fd1045e525703449e7e29f957e28c0d) | `` automatic update `` |
| [`310ee225`](https://github.com/nix-community/NUR/commit/310ee225d78767abda1f86de23444e8172c777cb) | `` automatic update `` |
| [`6115fd9a`](https://github.com/nix-community/NUR/commit/6115fd9a51192a8c4c402a81ee657491e3661f9e) | `` automatic update `` |
| [`d0dab324`](https://github.com/nix-community/NUR/commit/d0dab3248adc17eff8827ae2629c677deab3ed40) | `` automatic update `` |
| [`9294efad`](https://github.com/nix-community/NUR/commit/9294efadde942795fc1fd075617a53db9de3c285) | `` automatic update `` |
| [`7e5bf47a`](https://github.com/nix-community/NUR/commit/7e5bf47a4a5ed066ae47e6f421eb8b0d5c48ec8a) | `` automatic update `` |