### PR TITLE
chore(flake/nixos-facter-modules): `14df13c8` -> `7641b72e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -581,11 +581,11 @@
     },
     "nixos-facter-modules": {
       "locked": {
-        "lastModified": 1750412875,
-        "narHash": "sha256-uP9Xxw5XcFwjX9lNoYRpybOnIIe1BHfZu5vJnnPg3Jc=",
+        "lastModified": 1755092700,
+        "narHash": "sha256-knQiR+/3d9RQR6rIDUORO6ZBITleDKDqS4r/pl327WU=",
         "owner": "nix-community",
         "repo": "nixos-facter-modules",
-        "rev": "14df13c84552a7d1f33c1cd18336128fbc43f920",
+        "rev": "7641b72e58c59ebb3c753fc36ff8ee3506ae8e05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                              | Message                                                            |
| ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`71ea1849`](https://github.com/nix-community/nixos-facter-modules/commit/71ea1849e259b26f5a47c280fb68a9f5cec29eb6) | `` chore: remove dead code in lib ``                               |
| [`1e5cbd11`](https://github.com/nix-community/nixos-facter-modules/commit/1e5cbd110b862885262617cc911d89a82ca6b0e9) | `` facter: allow partially overriding fields in `facter.report` `` |