### PR TITLE
chore(flake/emacs-overlay): `c78dc0e6` -> `93b4d290`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1754989922,
-        "narHash": "sha256-afY1Yx0XSQCxf69mHZ7mHumIxUl4J6KcJiv56VcdO3Q=",
+        "lastModified": 1755192048,
+        "narHash": "sha256-+B/GngvxzeLxe5JXuJkXNc3k77jLiyb0p3rwvu5hLPA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c78dc0e6f53e072f114196be4fdda2a081fb7805",
+        "rev": "93b4d290691b68c068df845463c33e9fabf640fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`93b4d290`](https://github.com/nix-community/emacs-overlay/commit/93b4d290691b68c068df845463c33e9fabf640fd) | `` Updated emacs ``        |
| [`daec74a9`](https://github.com/nix-community/emacs-overlay/commit/daec74a940365c90b9f23658a4ea54d5bbd361e8) | `` Updated melpa ``        |
| [`21dcd69f`](https://github.com/nix-community/emacs-overlay/commit/21dcd69f358b3f829b283fbfd5aa59fd4a02cc44) | `` Updated elpa ``         |
| [`fed28056`](https://github.com/nix-community/emacs-overlay/commit/fed2805613ce5968e4a175472eb86ad36e45e516) | `` Updated melpa ``        |
| [`6232e87e`](https://github.com/nix-community/emacs-overlay/commit/6232e87e90334db949b2f52667b7e6c657bcb5dd) | `` Updated emacs ``        |
| [`5125ae83`](https://github.com/nix-community/emacs-overlay/commit/5125ae83bc49f9c97ac403c568a044a06c394279) | `` Updated elpa ``         |
| [`48df22b8`](https://github.com/nix-community/emacs-overlay/commit/48df22b83ebf2645e3ca6c0c773847a1e09f316b) | `` Updated nongnu ``       |
| [`f6151862`](https://github.com/nix-community/emacs-overlay/commit/f6151862155f7bb5e21b7682bc89905a8f188da2) | `` Updated melpa ``        |
| [`f350d990`](https://github.com/nix-community/emacs-overlay/commit/f350d990a97c3ed060d028a193dde02f6ec2bc39) | `` Updated emacs ``        |
| [`5e2c1e74`](https://github.com/nix-community/emacs-overlay/commit/5e2c1e74b6433249ef8f0065b4e730f8bb7241de) | `` Updated elpa ``         |
| [`1be91d12`](https://github.com/nix-community/emacs-overlay/commit/1be91d128824aa1039fe82b79f2fc83bdd2c471e) | `` Updated nongnu ``       |
| [`7811f003`](https://github.com/nix-community/emacs-overlay/commit/7811f003d2cf575cf8f6e5b755055e73b1ac5e17) | `` Updated flake inputs `` |
| [`c939170e`](https://github.com/nix-community/emacs-overlay/commit/c939170e1c6a20912966030fb32d65740c296d39) | `` Updated melpa ``        |
| [`2376e541`](https://github.com/nix-community/emacs-overlay/commit/2376e54195ed3e9770c9943ec744fdb937977dab) | `` Updated emacs ``        |
| [`f9cda441`](https://github.com/nix-community/emacs-overlay/commit/f9cda441c7588de556bc2b4344d281a62cb25644) | `` Updated melpa ``        |
| [`7b07a44e`](https://github.com/nix-community/emacs-overlay/commit/7b07a44e1c655561cb20e64db2566dc3ba38f270) | `` Updated elpa ``         |
| [`d45009ca`](https://github.com/nix-community/emacs-overlay/commit/d45009cae1a50440b5ca2480edaa9f9450110300) | `` Updated nongnu ``       |
| [`a86865a7`](https://github.com/nix-community/emacs-overlay/commit/a86865a7014f4e91cdf045177fd57ab917972f73) | `` Updated emacs ``        |
| [`447bb49a`](https://github.com/nix-community/emacs-overlay/commit/447bb49a7d70e3e8a601239ec3f790eb9a0bc08f) | `` Updated melpa ``        |
| [`fe7a7818`](https://github.com/nix-community/emacs-overlay/commit/fe7a78181e94f164b7959e409dda78e21459e681) | `` Updated elpa ``         |
| [`bbc03ad7`](https://github.com/nix-community/emacs-overlay/commit/bbc03ad73a3794daa65d77beeb762466cd336e55) | `` Updated nongnu ``       |