### PR TITLE
chore(flake/nur): `3a675e8f` -> `91c6ddfb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -843,11 +843,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1755080806,
-        "narHash": "sha256-P94SMIPWhpSX5tvX4ccFDEC1pm0SsddKNouM49Dz5Oo=",
+        "lastModified": 1755099934,
+        "narHash": "sha256-cHGFxjawa0TKzMBGGMcbvfo9tjcy2quyT9UIBaZSi1k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3a675e8f6015cb8ea14138b0c69722b2a0e09dee",
+        "rev": "91c6ddfbb2f60ba7d7c3b0ffa65d7f46c3910a56",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                         |
| -------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`91c6ddfb`](https://github.com/nix-community/NUR/commit/91c6ddfbb2f60ba7d7c3b0ffa65d7f46c3910a56) | `` automatic update ``          |
| [`13ab153a`](https://github.com/nix-community/NUR/commit/13ab153a293ec447f34a706ed4017d7159d50b88) | `` automatic update ``          |
| [`bfde2fa7`](https://github.com/nix-community/NUR/commit/bfde2fa7f9006dd51de160f26d46fcbc5dfe1956) | `` add lmdevv repo ``           |
| [`0125fb52`](https://github.com/nix-community/NUR/commit/0125fb522b83065470de30bbbac660208ca593aa) | `` automatic update ``          |
| [`2c7b4bfa`](https://github.com/nix-community/NUR/commit/2c7b4bfad3493d29b149b85ed32d6f3f44b69746) | `` automatic update ``          |
| [`7c189360`](https://github.com/nix-community/NUR/commit/7c1893603af477b96de2bfec0209d4fbbb875e64) | `` Add akinokaede repository `` |
| [`826f7ebf`](https://github.com/nix-community/NUR/commit/826f7ebf8e8ee6cbe1a20792b3caf9c2e1ead7bc) | `` automatic update ``          |