### PR TITLE
chore(flake/srvos): `83f86669` -> `278214ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -979,11 +979,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754976577,
-        "narHash": "sha256-F6h97bTJfEgFoWkACsuOolUmxa4ByXdQ8KfdYMkDQ2Q=",
+        "lastModified": 1755133551,
+        "narHash": "sha256-WMwREoEq9pBSwoCmv7SNOb3eHNfO8QYc3z7wyprjGHQ=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "83f8666976107a0d84ddc7a3c835d46ffdf83d97",
+        "rev": "278214ace1f3b099badb7e78e13384f3e0892d9d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`278214ac`](https://github.com/nix-community/srvos/commit/278214ace1f3b099badb7e78e13384f3e0892d9d) | `` dev/private/flake.lock: Update `` |
| [`67117d25`](https://github.com/nix-community/srvos/commit/67117d253e6fa07a413b5a7f7054f3f04459d287) | `` flake.lock: Update ``             |