### PR TITLE
chore(flake/emacs-overlay): `d94f174b` -> `c605ab6f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1755224130,
-        "narHash": "sha256-1FlP85b5RAnqjlRn7YeXKhDPkoByxcCyQD8NiY72RCE=",
+        "lastModified": 1755278563,
+        "narHash": "sha256-c6+8it5/lU5Ed/yCe9cFDL2WwDzUy2LQinIOPxEwuuc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d94f174b22b302c90f25e572fb187f4e2b877a17",
+        "rev": "c605ab6f57a308ab7d8cc1c29ca9ca63d9a11edf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`c605ab6f`](https://github.com/nix-community/emacs-overlay/commit/c605ab6f57a308ab7d8cc1c29ca9ca63d9a11edf) | `` Updated emacs ``        |
| [`f5cc754a`](https://github.com/nix-community/emacs-overlay/commit/f5cc754af9a1857366a10171a05b208fab5b46e0) | `` Updated melpa ``        |
| [`417a856b`](https://github.com/nix-community/emacs-overlay/commit/417a856bfc786852f30897c5fb4bf46c34a458b1) | `` Updated elpa ``         |
| [`cc462418`](https://github.com/nix-community/emacs-overlay/commit/cc462418110f6f2464a783a1abc44ccc02539e95) | `` Updated nongnu ``       |
| [`55068c4e`](https://github.com/nix-community/emacs-overlay/commit/55068c4e5545a8a9ab810ecb03a9452e1859a5ae) | `` Updated flake inputs `` |
| [`696652cd`](https://github.com/nix-community/emacs-overlay/commit/696652cd29de0dbcdc55e61c37d4381a7de51b09) | `` Updated melpa ``        |