### PR TITLE
chore(flake/nur): `5c8a819a` -> `20df1945`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -845,11 +845,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1755255118,
-        "narHash": "sha256-9PP83A+ST04LyDGaIao5JT5m9FArJ4M4YHD2EIgZIa4=",
+        "lastModified": 1755301591,
+        "narHash": "sha256-PZOXjNVa90BEi91p5dW4UtU0+JpGtrSnFbG1es4hMpM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5c8a819ad59f2be3fa0b84f603e9ce637f836dcf",
+        "rev": "20df194501e8496d3f9f215b81eac14ee2ef9424",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                                  |
| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`20df1945`](https://github.com/nix-community/NUR/commit/20df194501e8496d3f9f215b81eac14ee2ef9424) | `` automatic update ``                                                   |
| [`d0f25317`](https://github.com/nix-community/NUR/commit/d0f25317524fd7aff6ec1e693f8b4576820842f4) | `` automatic update ``                                                   |
| [`5a13df47`](https://github.com/nix-community/NUR/commit/5a13df47f800631db5e637785b4d0409756e8efb) | `` automatic update ``                                                   |
| [`4c2e66a2`](https://github.com/nix-community/NUR/commit/4c2e66a2d7430c73c5280672b7826b709e0dff02) | `` automatic update ``                                                   |
| [`b6343f40`](https://github.com/nix-community/NUR/commit/b6343f40d743ce2532d45f5f11e0b705849f5328) | `` automatic update ``                                                   |
| [`cd892bd2`](https://github.com/nix-community/NUR/commit/cd892bd2c7e7c68fea06a839562109bdf8c6ab8d) | `` automatic update ``                                                   |
| [`e6d4f722`](https://github.com/nix-community/NUR/commit/e6d4f72242a95eaa05631bd3424e58e3b4902e4e) | `` automatic update ``                                                   |
| [`1be6f534`](https://github.com/nix-community/NUR/commit/1be6f53418526c0c4bd6a40075f7d2403e27707e) | `` automatic update ``                                                   |
| [`445e2a7a`](https://github.com/nix-community/NUR/commit/445e2a7a2892d98cd89bb67a49bdd5c235642e5f) | `` automatic update ``                                                   |
| [`7834b35b`](https://github.com/nix-community/NUR/commit/7834b35bc55568bd65e3cb9c8b11243b5fc66b80) | `` automatic update ``                                                   |
| [`861cbfb2`](https://github.com/nix-community/NUR/commit/861cbfb2b7ea21769ad0cedc24674f7dd0301a6b) | `` automatic update ``                                                   |
| [`fc918348`](https://github.com/nix-community/NUR/commit/fc9183488110d7f06b7167270410def3ccfd076f) | `` automatic update ``                                                   |
| [`e5b7c9a8`](https://github.com/nix-community/NUR/commit/e5b7c9a8aee7ebebd5fb60718660ec469809606c) | `` automatic update ``                                                   |
| [`e6284d52`](https://github.com/nix-community/NUR/commit/e6284d52693e29663f741f5cd65c3e70934ed061) | `` automatic update ``                                                   |
| [`178b145b`](https://github.com/nix-community/NUR/commit/178b145b2210ac79b885fb424cc40a4026960bd3) | `` automatic update ``                                                   |
| [`e14f2525`](https://github.com/nix-community/NUR/commit/e14f2525d5d9babbf4bc502a2d8c8f11e950d887) | `` fix: switch from depricated distutils copy_tree to shutil.copytree `` |
| [`f9405aa9`](https://github.com/nix-community/NUR/commit/f9405aa9ca638b2f404e3858cddc3ac2aba87e8e) | `` fix: add new reqs for buildPythonApplication ``                       |
| [`63ecfbb5`](https://github.com/nix-community/NUR/commit/63ecfbb53d0c5f60d7bddda868c8fa5ce334a056) | `` fix: update flake.lock ``                                             |