### PR TITLE
chore(flake/emacs-overlay): `c605ab6f` -> `44876fb8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1755278563,
-        "narHash": "sha256-c6+8it5/lU5Ed/yCe9cFDL2WwDzUy2LQinIOPxEwuuc=",
+        "lastModified": 1755335529,
+        "narHash": "sha256-UHUnkf2puMslnba8H9cfypTB2Xh15w3EEihtQ3jYyvY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c605ab6f57a308ab7d8cc1c29ca9ca63d9a11edf",
+        "rev": "44876fb8febcbd38ca4532f1e580a8fbfbb72e46",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`44876fb8`](https://github.com/nix-community/emacs-overlay/commit/44876fb8febcbd38ca4532f1e580a8fbfbb72e46) | `` Updated emacs ``  |
| [`bc7321cd`](https://github.com/nix-community/emacs-overlay/commit/bc7321cdb9b2195f25217fdc534b893c3a96311a) | `` Updated melpa ``  |
| [`49c623d7`](https://github.com/nix-community/emacs-overlay/commit/49c623d71fbbace5ee943e60168fbc2e0b998966) | `` Updated melpa ``  |
| [`9c6bf713`](https://github.com/nix-community/emacs-overlay/commit/9c6bf7130e93a95ddc480d5efa41fd99ee69db15) | `` Updated elpa ``   |
| [`871aa612`](https://github.com/nix-community/emacs-overlay/commit/871aa612988ba3de7008c9ce9e5a651a786e36e5) | `` Updated nongnu `` |