### PR TITLE
chore(flake/nur): `20df1945` -> `68c3ae81`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -845,11 +845,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1755301591,
-        "narHash": "sha256-PZOXjNVa90BEi91p5dW4UtU0+JpGtrSnFbG1es4hMpM=",
+        "lastModified": 1755359141,
+        "narHash": "sha256-1i8xDsyjYjeJDpi9JkOkL1jQwVbbwVMXJ5msjGHUJIY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "20df194501e8496d3f9f215b81eac14ee2ef9424",
+        "rev": "68c3ae81dc38e37820c4a639b95fd88f00710008",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`68c3ae81`](https://github.com/nix-community/NUR/commit/68c3ae81dc38e37820c4a639b95fd88f00710008) | `` automatic update `` |
| [`5827ed08`](https://github.com/nix-community/NUR/commit/5827ed08e8024ecd5d280087e9cfb6b1d8645470) | `` automatic update `` |
| [`3cf12f4d`](https://github.com/nix-community/NUR/commit/3cf12f4d0e401bfa50965b2cd4d5b401a05d729e) | `` automatic update `` |
| [`d0a779c5`](https://github.com/nix-community/NUR/commit/d0a779c5dde9628e75f5fd6690c3c4c75d0af911) | `` automatic update `` |
| [`51eb0417`](https://github.com/nix-community/NUR/commit/51eb0417008edf85c3782243f02e847756b9460a) | `` automatic update `` |
| [`3fb4a282`](https://github.com/nix-community/NUR/commit/3fb4a2820a51e5c9ceaf1b1bfe1358254189ae30) | `` automatic update `` |
| [`4537db35`](https://github.com/nix-community/NUR/commit/4537db3534c855c2af03530de9deb044ce83ff24) | `` automatic update `` |
| [`7f95127a`](https://github.com/nix-community/NUR/commit/7f95127ac57bffc2a1677d426fa373993fa43d1e) | `` automatic update `` |
| [`1224f90a`](https://github.com/nix-community/NUR/commit/1224f90a28445655bff239ab66b515fc5a7daef1) | `` automatic update `` |
| [`cf289d75`](https://github.com/nix-community/NUR/commit/cf289d75bb9084b03dcc52f0d07ee6d5374c6566) | `` automatic update `` |
| [`9cef3fbc`](https://github.com/nix-community/NUR/commit/9cef3fbcc68638dc238e9262a43cae951e0c0d49) | `` automatic update `` |
| [`bf9b5958`](https://github.com/nix-community/NUR/commit/bf9b595884d4c3a3fff65a1589f11666faff3430) | `` automatic update `` |
| [`f8ff3365`](https://github.com/nix-community/NUR/commit/f8ff3365ef7ab8765d63a196f8dfea2a3cddcaf8) | `` automatic update `` |
| [`b067cce4`](https://github.com/nix-community/NUR/commit/b067cce420b0fc9a4ffff96b0bf2aadefc064a58) | `` automatic update `` |
| [`6d5c186e`](https://github.com/nix-community/NUR/commit/6d5c186eb64cf496fe471460db4906fdc67997ba) | `` automatic update `` |
| [`578d45ef`](https://github.com/nix-community/NUR/commit/578d45ef2e70e0512204db24e8bff9c665efbcc5) | `` automatic update `` |
| [`93331250`](https://github.com/nix-community/NUR/commit/933312509519376aba456a659d2639e1f0353744) | `` automatic update `` |
| [`e4a773d2`](https://github.com/nix-community/NUR/commit/e4a773d22df07992461034b61d3950f5ab2a1982) | `` automatic update `` |
| [`f181ac4d`](https://github.com/nix-community/NUR/commit/f181ac4d23b5ced06462af5bcc5436a20079211b) | `` automatic update `` |
| [`e961c603`](https://github.com/nix-community/NUR/commit/e961c60394008ea740a3fcc7c2ae8eb0b1c2151d) | `` automatic update `` |
| [`4271a7e5`](https://github.com/nix-community/NUR/commit/4271a7e5311afa360d85fd04194cd72577dbcbd8) | `` automatic update `` |
| [`195325f5`](https://github.com/nix-community/NUR/commit/195325f5e1e2a680ccd53c21ee87d11489b6ac75) | `` automatic update `` |
| [`160c1c1c`](https://github.com/nix-community/NUR/commit/160c1c1c8737a0e2109b6181a191779ac2e42f7f) | `` automatic update `` |
| [`20c3d870`](https://github.com/nix-community/NUR/commit/20c3d8709dae59b84cf0784f30d699b4049fe852) | `` automatic update `` |
| [`defea7ee`](https://github.com/nix-community/NUR/commit/defea7eede30fbf23100b39c5a7707d7fb0ca53f) | `` automatic update `` |
| [`7f420e3a`](https://github.com/nix-community/NUR/commit/7f420e3a078913fdc4c3892c5d7a25af089e8f51) | `` automatic update `` |
| [`43d5a0b2`](https://github.com/nix-community/NUR/commit/43d5a0b27087d0b592f985e5368ce14cb157c532) | `` automatic update `` |
| [`fdde09fb`](https://github.com/nix-community/NUR/commit/fdde09fb2356f3b4c0a10e65b909f997cd7a6203) | `` automatic update `` |