### PR TITLE
chore(flake/nixos-hardware): `26ed7a0d` -> `3dac8a87`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -598,11 +598,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1754564048,
-        "narHash": "sha256-dz303vGuzWjzOPOaYkS9xSW+B93PSAJxvBd6CambXVA=",
+        "lastModified": 1755330281,
+        "narHash": "sha256-aJHFJWP9AuI8jUGzI77LYcSlkA9wJnOIg4ZqftwNGXA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "26ed7a0d4b8741fe1ef1ee6fa64453ca056ce113",
+        "rev": "3dac8a872557e0ca8c083cdcfc2f218d18e113b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                      |
| ----------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`c006c5a5`](https://github.com/NixOS/nixos-hardware/commit/c006c5a59b9f844ca5e835e0bb1aed85a9bf4284) | `` formatting ``             |
| [`7dd36b62`](https://github.com/NixOS/nixos-hardware/commit/7dd36b62fc1316dc33d63d4ada114f52b5300d8d) | `` fix typo casuing error `` |