### PR TITLE
chore(flake/nixos-avf): `130a0512` -> `103c8435`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -545,11 +545,11 @@
     },
     "nixos-avf": {
       "locked": {
-        "lastModified": 1755286110,
-        "narHash": "sha256-flrut+s91QwYg3/zy5GTGOAls8FWMXOUzpVAzNiteSw=",
+        "lastModified": 1755348447,
+        "narHash": "sha256-5fEyConJDWFXVlzursUcetzurjow0fVRWVK+99zVxho=",
         "owner": "bbigras",
         "repo": "nixos-avf",
-        "rev": "130a05120221961c1655cc1d83e2df4fbcd60106",
+        "rev": "103c84359e5310c40d2ff14b28ff4866af3ebd3d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                              |
| -------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`103c8435`](https://github.com/bbigras/nixos-avf/commit/103c84359e5310c40d2ff14b28ff4866af3ebd3d) | `` extraStructuredConfig -> structuredExtraConfig `` |
| [`dd9e8e99`](https://github.com/bbigras/nixos-avf/commit/dd9e8e99dc14aac5bff4a4d5337c8d306e8f3985) | `` ci: fix ``                                        |
| [`1a2b7730`](https://github.com/bbigras/nixos-avf/commit/1a2b773008ea07a33b54ba793e073f82f6c1510f) | `` ci: disable fail fast ``                          |
| [`b8db9ae1`](https://github.com/bbigras/nixos-avf/commit/b8db9ae14398a5f42a6240938c5a6fa065acab86) | `` ci: add pr ci ``                                  |