### PR TITLE
chore(flake/nur): `68c3ae81` -> `e52b1820`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -845,11 +845,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1755359141,
-        "narHash": "sha256-1i8xDsyjYjeJDpi9JkOkL1jQwVbbwVMXJ5msjGHUJIY=",
+        "lastModified": 1755373390,
+        "narHash": "sha256-YUeBTlaNP+6h1jGKqUedjzQ6+Y01N9k6fBO9aaDSfKY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "68c3ae81dc38e37820c4a639b95fd88f00710008",
+        "rev": "e52b18205d9b7e7920f8583c7eb6fdb0493fcfa8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e52b1820`](https://github.com/nix-community/NUR/commit/e52b18205d9b7e7920f8583c7eb6fdb0493fcfa8) | `` automatic update `` |
| [`a8625e43`](https://github.com/nix-community/NUR/commit/a8625e43058f543537ef28f88e92e408e7bf6b80) | `` automatic update `` |
| [`4595b515`](https://github.com/nix-community/NUR/commit/4595b51518052f4cae78a67ce4c20a4a4a83a3a5) | `` automatic update `` |
| [`9e89e96c`](https://github.com/nix-community/NUR/commit/9e89e96c58f3cd64fb705d7d0703796806efb454) | `` automatic update `` |
| [`a6d4c447`](https://github.com/nix-community/NUR/commit/a6d4c4476f59a45839f71b7aacc2e2132bb16bbe) | `` automatic update `` |