### PR TITLE
chore(flake/nur): `e52b1820` -> `8509a135`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -845,11 +845,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1755373390,
-        "narHash": "sha256-YUeBTlaNP+6h1jGKqUedjzQ6+Y01N9k6fBO9aaDSfKY=",
+        "lastModified": 1755441713,
+        "narHash": "sha256-bxN6mZti2vbHl4NUYLDaYdqULNay1qbkxUeVAN6DE+8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e52b18205d9b7e7920f8583c7eb6fdb0493fcfa8",
+        "rev": "8509a13591f79f1772501d1d30c48f921c2aed3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                    |
| -------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`8509a135`](https://github.com/nix-community/NUR/commit/8509a13591f79f1772501d1d30c48f921c2aed3e) | `` automatic update ``                     |
| [`3cf97a4e`](https://github.com/nix-community/NUR/commit/3cf97a4e2861712a9b36386a78e14d63ff9bc4e4) | `` automatic update ``                     |
| [`a99607be`](https://github.com/nix-community/NUR/commit/a99607beba79103eb973f4fe2b4f38f603ec7ad4) | `` automatic update ``                     |
| [`ffaa7d51`](https://github.com/nix-community/NUR/commit/ffaa7d5185910bfaeda1cfed7ad441809f7d890a) | `` automatic update ``                     |
| [`199390e7`](https://github.com/nix-community/NUR/commit/199390e7082f9307578531d389cccd9f37412156) | `` automatic update ``                     |
| [`18f6b5dd`](https://github.com/nix-community/NUR/commit/18f6b5ddf1bba18d84f94805d9dc9d567fc83ed8) | `` Add `shymega/nixfigs-nur` repository `` |
| [`9cb965e7`](https://github.com/nix-community/NUR/commit/9cb965e70913b9bceeb98bdd4bcac6d5ff8208af) | `` add theutz repo ``                      |
| [`742afc9c`](https://github.com/nix-community/NUR/commit/742afc9cde4ad99575e198d216d87fcb56550e21) | `` automatic update ``                     |
| [`c68bcdd6`](https://github.com/nix-community/NUR/commit/c68bcdd607b76ff3be2d4499fa7cef7ca217c552) | `` automatic update ``                     |
| [`56901ad1`](https://github.com/nix-community/NUR/commit/56901ad16f4ac75c3e6d41b77df7b1f28235d35b) | `` automatic update ``                     |
| [`c4bef509`](https://github.com/nix-community/NUR/commit/c4bef50946bc456245fbeb1775deabbd98f8a538) | `` automatic update ``                     |
| [`544bd042`](https://github.com/nix-community/NUR/commit/544bd04284061e2f14c6a2f9cb4e22f67ed91727) | `` automatic update ``                     |
| [`d0ab55a3`](https://github.com/nix-community/NUR/commit/d0ab55a3d643383718819f406e83fd8093d55786) | `` automatic update ``                     |
| [`6bd388b8`](https://github.com/nix-community/NUR/commit/6bd388b8785ba17e88311ca4b1f28efb9c296bda) | `` automatic update ``                     |
| [`dab12a4c`](https://github.com/nix-community/NUR/commit/dab12a4cbba10f00d9cd6310f3796ba951ec2084) | `` automatic update ``                     |
| [`70dd987d`](https://github.com/nix-community/NUR/commit/70dd987dcfdaa9fb6274dc348ead40748e10ee1b) | `` automatic update ``                     |
| [`5fe8f406`](https://github.com/nix-community/NUR/commit/5fe8f40618b14bf31ab6f05d1822d0ce6d354906) | `` automatic update ``                     |
| [`ca081f34`](https://github.com/nix-community/NUR/commit/ca081f34215acc159d309eb8420690989377486c) | `` automatic update ``                     |
| [`4c6e7f89`](https://github.com/nix-community/NUR/commit/4c6e7f89dc178869d84bd987ad7a4a6e5332d39c) | `` automatic update ``                     |
| [`3d6a3ec4`](https://github.com/nix-community/NUR/commit/3d6a3ec4742479d9538ae992f0f4db02738ab537) | `` automatic update ``                     |
| [`ade77871`](https://github.com/nix-community/NUR/commit/ade77871bd255132054d9d0be6acdf90104a7789) | `` automatic update ``                     |
| [`c9ebe16b`](https://github.com/nix-community/NUR/commit/c9ebe16bc316aa4efe7db097d32e38269d1c8f7a) | `` automatic update ``                     |
| [`7e0b9686`](https://github.com/nix-community/NUR/commit/7e0b9686cfa51eda0c2f3f4777b61f628f230586) | `` automatic update ``                     |
| [`bef2b008`](https://github.com/nix-community/NUR/commit/bef2b008f7aa305d2f4af9a1e579f55b3497be33) | `` automatic update ``                     |
| [`5d7b845c`](https://github.com/nix-community/NUR/commit/5d7b845c2199ca94d52f65e1f54ef91e910c2dc1) | `` automatic update ``                     |
| [`288b1732`](https://github.com/nix-community/NUR/commit/288b17321085d6d08d5d11b37d2eb778f0910530) | `` automatic update ``                     |
| [`13978a2f`](https://github.com/nix-community/NUR/commit/13978a2fffadb5d62b8bc5f07adb14cc10a40d8b) | `` automatic update ``                     |
| [`9705c629`](https://github.com/nix-community/NUR/commit/9705c62979bca61d5205bb0a6581dfd6810eb973) | `` automatic update ``                     |
| [`e5c56df5`](https://github.com/nix-community/NUR/commit/e5c56df534cd78204af1265210616ce903e5f458) | `` automatic update ``                     |
| [`c98d1d13`](https://github.com/nix-community/NUR/commit/c98d1d13a1a22fdbe67a1a7b2a8e1632e898fb0e) | `` automatic update ``                     |
| [`ec328b0e`](https://github.com/nix-community/NUR/commit/ec328b0ec6558e01dabd94b304c4363a405b264b) | `` automatic update ``                     |