### PR TITLE
chore(flake/minimal-emacs-d): `9eade3da` -> `37e2bd44`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -434,11 +434,11 @@
     "minimal-emacs-d": {
       "flake": false,
       "locked": {
-        "lastModified": 1755274743,
-        "narHash": "sha256-5N5hZTlekl5kaoI9WgvbPvGWZ2Rh5dezV+nr49NRpcU=",
+        "lastModified": 1755389600,
+        "narHash": "sha256-xg3FVSrrO2FDBg9J68++Bg9DqHVBk9xwdQ4/I0C8LoM=",
         "owner": "jamescherti",
         "repo": "minimal-emacs.d",
-        "rev": "9eade3da59042fcda88c33f0ccfe76a6f7dc82f6",
+        "rev": "37e2bd448f952e6af0a0bcdb4cacec258a702a31",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                               |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
| [`37e2bd44`](https://github.com/jamescherti/minimal-emacs.d/commit/37e2bd448f952e6af0a0bcdb4cacec258a702a31) | `` Remove native-comp-async-report-warnings-errors `` |