### PR TITLE
chore(flake/emacs-overlay): `5d7b6b2d` -> `b7e25dfc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1755451755,
-        "narHash": "sha256-FNEjy32IrutBDnIs1NzFpvDNMudzmnJbFTkcoeNwDSM=",
+        "lastModified": 1755508444,
+        "narHash": "sha256-/XK2GVy6at/UEAgaw3jdDs7/ueLEaDuK2B5z++zFyNo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5d7b6b2d78415c0bcc19e3e651b0ec997a9acbad",
+        "rev": "b7e25dfc00eeaff5a7c6f2c4fd2213f9b42428ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`b7e25dfc`](https://github.com/nix-community/emacs-overlay/commit/b7e25dfc00eeaff5a7c6f2c4fd2213f9b42428ef) | `` Updated melpa ``  |
| [`1862d841`](https://github.com/nix-community/emacs-overlay/commit/1862d841acdb7425cf2ab6d0c8200bb1447dac45) | `` Updated emacs ``  |
| [`f57fabee`](https://github.com/nix-community/emacs-overlay/commit/f57fabeeef73658eaac452697d95ff00bd1f4694) | `` Updated melpa ``  |
| [`25c5b039`](https://github.com/nix-community/emacs-overlay/commit/25c5b0394805ad5fc3416afc722c23e61037abc8) | `` Updated elpa ``   |
| [`3d761ff4`](https://github.com/nix-community/emacs-overlay/commit/3d761ff45ac9c07aaf665e8a6210f0d5c3cd0779) | `` Updated nongnu `` |