### PR TITLE
chore(flake/home-manager): `d2ffdedf` -> `8af2e064`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -372,11 +372,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755442500,
-        "narHash": "sha256-RHK4H6SWzkAtW/5WBHsyugaXJX25yr5y7FAZznxcBJs=",
+        "lastModified": 1755601933,
+        "narHash": "sha256-iXZeeYyfy8NdpvH/OOW9V3C2AfsXE+fzDHfrIOHBPF0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d2ffdedfc39c591367b1ddf22b4ce107f029dcc3",
+        "rev": "8af2e064f93234ee79df8b9858eeefbf84394488",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                            |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`8af2e064`](https://github.com/nix-community/home-manager/commit/8af2e064f93234ee79df8b9858eeefbf84394488) | `` satty: add satty to program modules ``                          |
| [`589efcf9`](https://github.com/nix-community/home-manager/commit/589efcf9c039db9dbc9410d53cf722d9e483dfd3) | `` maintainers: add gauthsvenkat ``                                |
| [`c613ac14`](https://github.com/nix-community/home-manager/commit/c613ac14f5600033bf84ae75c315d5ce24a0229b) | `` nh: allow absolute flake paths ``                               |
| [`e293a1a1`](https://github.com/nix-community/home-manager/commit/e293a1a12f448a6d92309daebd7cbda03e0f75c4) | `` aerospace: add test ``                                          |
| [`bbfbda4a`](https://github.com/nix-community/home-manager/commit/bbfbda4ad8ee3e94cfab012249493a8375382dd0) | `` aerospace: allow colemak on key-mapping ``                      |
| [`0d1e116e`](https://github.com/nix-community/home-manager/commit/0d1e116e4f2d9d22ff57e412a57b37b8edca3710) | `` ssh-tpm-agent: match the upstream systemd units ``              |
| [`3a5136d8`](https://github.com/nix-community/home-manager/commit/3a5136d8ddd2e264389868232abacd4c1ef846ea) | `` ssh-tpm-agent: on NixOS, check TPM accessibility ``             |
| [`f9ea660b`](https://github.com/nix-community/home-manager/commit/f9ea660b241e95577ff3ccc58351e6a84aa0c017) | `` ssh-tpm-agent: fix ssh-agent proxy ``                           |
| [`94a238f9`](https://github.com/nix-community/home-manager/commit/94a238f9c1b84dbb299b938bee2436ce9633c3ed) | `` ssh-agent: add option for the socket name ``                    |
| [`af03309c`](https://github.com/nix-community/home-manager/commit/af03309c122ac714da6ec497f74dbd61d875f3f2) | `` ssh-tpm-agent: add maintainer bmrips ``                         |
| [`ec369a58`](https://github.com/nix-community/home-manager/commit/ec369a58f9af13626cde7842b62e22e4dc36fc09) | `` ssh-agent: add maintainer bmrips ``                             |
| [`bf450a08`](https://github.com/nix-community/home-manager/commit/bf450a0844e80e6aa22652d3f3728f20cd974527) | `` maintainers: update all-maintainers.nix (#7693) ``              |
| [`0a06e46a`](https://github.com/nix-community/home-manager/commit/0a06e46a3b888123780eecd1cb81757b431dd7c4) | `` anyrun: Added `margin` config option (#7687) ``                 |
| [`f8af2cbe`](https://github.com/nix-community/home-manager/commit/f8af2cbe386f9b96dd9efa57ab15a09377f38f4d) | `` issue_template: remove git blame from issue template (#7692) `` |
| [`5ca4c81f`](https://github.com/nix-community/home-manager/commit/5ca4c81fd5a9bbe6899379ee729d6f495564ed3f) | `` ci: bump actions/checkout from 4 to 5 (#7690) ``                |