### PR TITLE
chore(flake/srvos): `278214ac` -> `b2eeb751`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -981,11 +981,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755133551,
-        "narHash": "sha256-WMwREoEq9pBSwoCmv7SNOb3eHNfO8QYc3z7wyprjGHQ=",
+        "lastModified": 1755479226,
+        "narHash": "sha256-G7AVmVJhqMraf1iqMoyQ/aWuYvcFFFrMMkrMjWwVyHY=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "278214ace1f3b099badb7e78e13384f3e0892d9d",
+        "rev": "b2eeb75153c3e2c7c82991a5c335de3b6c151f51",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`b2eeb751`](https://github.com/nix-community/srvos/commit/b2eeb75153c3e2c7c82991a5c335de3b6c151f51) | `` dev/private/flake.lock: Update `` |
| [`544b60f9`](https://github.com/nix-community/srvos/commit/544b60f9bdce41fb6ba8dd950a49a4bb53f3b8fd) | `` flake.lock: Update ``             |