### PR TITLE
chore(flake/disko): `8246829f` -> `4073ff2f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -131,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754971456,
-        "narHash": "sha256-p04ZnIBGzerSyiY2dNGmookCldhldWAu03y0s3P8CB0=",
+        "lastModified": 1755519972,
+        "narHash": "sha256-bU4nqi3IpsUZJeyS8Jk85ytlX61i4b0KCxXX9YcOgVc=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "8246829f2e675a46919718f9a64b71afe3bfb22d",
+        "rev": "4073ff2f481f9ef3501678ff479ed81402caae6d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                             |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`4073ff2f`](https://github.com/nix-community/disko/commit/4073ff2f481f9ef3501678ff479ed81402caae6d) | `` types.luks: fix password check ``                                |
| [`f64ab152`](https://github.com/nix-community/disko/commit/f64ab1525b34d5d9202f5801db36f364075abde1) | `` docs: add recursive method for fetching flake input out paths `` |