### PR TITLE
chore(flake/nixos-facter-modules): `2d0757d6` -> `354ed498`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -583,11 +583,11 @@
     },
     "nixos-facter-modules": {
       "locked": {
-        "lastModified": 1755424785,
-        "narHash": "sha256-OSBoOi9KNOc7R2uVSW9Xmm1gdZXi2k6VQwgxzntqeKg=",
+        "lastModified": 1755504238,
+        "narHash": "sha256-mw7q5DPdmz/1au8mY0u1DztRgVyJToGJfJszxjKSNes=",
         "owner": "nix-community",
         "repo": "nixos-facter-modules",
-        "rev": "2d0757d6e392cf0da406c9f51647a0eed68ad550",
+        "rev": "354ed498c9628f32383c3bf5b6668a17cdd72a28",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                              | Message                                           |
| ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`65446e98`](https://github.com/nix-community/nixos-facter-modules/commit/65446e98bc906dcc0906517d40a729d3ae30b289) | `` drop broadcom-sta from nixos-factor-modules `` |