### PR TITLE
chore(flake/catppuccin): `a2ef20ed` -> `ca11a19d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1755334713,
-        "narHash": "sha256-Nxq+mi6aqEbJA4R7i4TLr68ANuIgnEo2aKzJKRYd11s=",
+        "lastModified": 1755511413,
+        "narHash": "sha256-cBBF+nwGrSroN6ZewHPFaSThyCvwBxSZMdYEH8DxDx8=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "a2ef20ed6fb921073c2d1b1929447c3bd88f595e",
+        "rev": "ca11a19d4e1d2ba5e6162f40cb71288551fd51dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                        |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`ca11a19d`](https://github.com/catppuccin/nix/commit/ca11a19d4e1d2ba5e6162f40cb71288551fd51dd) | `` chore: sort module list (#698) ``                           |
| [`eef43ff8`](https://github.com/catppuccin/nix/commit/eef43ff875e3630e8237d1840422053275c71644) | `` chore(deps): update actions/checkout action to v5 (#695) `` |