### PR TITLE
chore(flake/nur): `06942a0a` -> `74a901e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -845,11 +845,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1755516720,
-        "narHash": "sha256-VodbisoBAKOn0yyh/Ed9aY/vdvF2yQFDJtYuD3J5w+0=",
+        "lastModified": 1755532166,
+        "narHash": "sha256-IcX1zxqzhWqv5LLMM+3BTRjWuHUYY6CgcrVRrRrJqoE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "06942a0a88bfa9b3a6f46dfa82235f8f34fb331f",
+        "rev": "74a901e7f45df791d7df5ffa2b1b5ffb34811906",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`74a901e7`](https://github.com/nix-community/NUR/commit/74a901e7f45df791d7df5ffa2b1b5ffb34811906) | `` automatic update `` |
| [`17255790`](https://github.com/nix-community/NUR/commit/17255790e7abaaaa4790d0e594f90f4744082917) | `` automatic update `` |
| [`cf1a095b`](https://github.com/nix-community/NUR/commit/cf1a095b4791925df774dee91bf9e38d80c98837) | `` automatic update `` |
| [`568092d3`](https://github.com/nix-community/NUR/commit/568092d37c240c999349e497b2320753dadb5ff2) | `` automatic update `` |
| [`0dce3df0`](https://github.com/nix-community/NUR/commit/0dce3df0087dc79c3dbe3c5cebd95bf2a801b030) | `` automatic update `` |
| [`7336a17f`](https://github.com/nix-community/NUR/commit/7336a17f80b5f9eca8cae27776eebf7f30e4fe24) | `` automatic update `` |
| [`2b8086c7`](https://github.com/nix-community/NUR/commit/2b8086c757b6ee16eebafd0f18d0a5b2eb07e01f) | `` automatic update `` |