### PR TITLE
chore(flake/emacs-overlay): `2881db6b` -> `df1e0259`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1755566801,
-        "narHash": "sha256-Hn5P2hIPJ4uzpUmz01YFTnFUVnPI4IhvmPnp1z1m0mA=",
+        "lastModified": 1755623837,
+        "narHash": "sha256-AfoT3hg31jFThBInuymwAffgOOe78zLC7CL8zmcCSfk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2881db6b1f9da926de98637cc821e3ca7c28dcfc",
+        "rev": "df1e0259cd03c65ba9f08a8173106c49cc7b98fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`df1e0259`](https://github.com/nix-community/emacs-overlay/commit/df1e0259cd03c65ba9f08a8173106c49cc7b98fe) | `` Updated emacs `` |
| [`c4161142`](https://github.com/nix-community/emacs-overlay/commit/c4161142c743857dc0df81e62c91d11e8d9378e8) | `` Updated melpa `` |
| [`d464f257`](https://github.com/nix-community/emacs-overlay/commit/d464f257f66ebcd24aa286eb54b9a90d4775a1e0) | `` Updated elpa ``  |
| [`c67dd16b`](https://github.com/nix-community/emacs-overlay/commit/c67dd16b807bc8089f5bacc9480c97ea89f973b3) | `` Updated melpa `` |
| [`fb702bca`](https://github.com/nix-community/emacs-overlay/commit/fb702bca614129012bab74a1621cead9d4d5faf4) | `` Updated emacs `` |
| [`c0104f37`](https://github.com/nix-community/emacs-overlay/commit/c0104f3788064e999c4b3a60516f98126164fc1a) | `` Updated elpa ``  |