### PR TITLE
chore(flake/nur): `e92965e6` -> `c6508c49`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -755,11 +755,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1755186698,
-        "narHash": "sha256-wNO3+Ks2jZJ4nTHMuks+cxAiVBGNuEBXsT29Bz6HASo=",
+        "lastModified": 1755615617,
+        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fbcf476f790d8a217c3eab4e12033dc4a0f6d23c",
+        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
         "type": "github"
       },
       "original": {
@@ -845,11 +845,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1755599037,
-        "narHash": "sha256-wyQzSgNokEMaC1wrIbiHIqatbikrvimrTV8a47RlJ8k=",
+        "lastModified": 1755729137,
+        "narHash": "sha256-eON36fTYYgAL1J/31FZfSyJzt+T9TFOn5p6P8ddyyqA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e92965e6bad1a44445803a8567400e5c6ad9cbe6",
+        "rev": "c6508c49a36f20ea2d28920d1b5d55a48d072a4a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c6508c49`](https://github.com/nix-community/NUR/commit/c6508c49a36f20ea2d28920d1b5d55a48d072a4a) | `` automatic update `` |
| [`4a013d0e`](https://github.com/nix-community/NUR/commit/4a013d0ea53aff0c936d90a68cd134390305b66e) | `` automatic update `` |
| [`22f05c84`](https://github.com/nix-community/NUR/commit/22f05c844cd7f8d08063c6dc89448343171ad323) | `` automatic update `` |
| [`a363a91a`](https://github.com/nix-community/NUR/commit/a363a91a8246cfc461b64100a9a30944c3907137) | `` automatic update `` |
| [`46b7cd00`](https://github.com/nix-community/NUR/commit/46b7cd00b85b084dd7ebeb5b2e41c31372736adb) | `` automatic update `` |
| [`84b4210a`](https://github.com/nix-community/NUR/commit/84b4210adcb4080a750c4f7e33f6a93901b8a056) | `` automatic update `` |
| [`eb48ffa9`](https://github.com/nix-community/NUR/commit/eb48ffa9d2177188e7ed22f850e95e7fabef88a9) | `` automatic update `` |
| [`0ec4400d`](https://github.com/nix-community/NUR/commit/0ec4400d0b5115b6b046a570b13b2c4cb207db65) | `` automatic update `` |
| [`5d84b155`](https://github.com/nix-community/NUR/commit/5d84b1553a37fcbbac4cfcd9dc89db7fa1bcf158) | `` automatic update `` |
| [`6668c290`](https://github.com/nix-community/NUR/commit/6668c2909e75e8398235b0e4d614b8efd69abda7) | `` automatic update `` |
| [`8a25063a`](https://github.com/nix-community/NUR/commit/8a25063a8e1556fe62700423607719575a6ce300) | `` automatic update `` |
| [`aaeb1973`](https://github.com/nix-community/NUR/commit/aaeb19738b45aa60d35d5c1457dd82c327d2798e) | `` automatic update `` |
| [`a8f48b04`](https://github.com/nix-community/NUR/commit/a8f48b041f9464ae0dd10f61b325a5a13221d8ff) | `` automatic update `` |
| [`02bfe0b4`](https://github.com/nix-community/NUR/commit/02bfe0b4b62a2f172129b7c60fd20599e0a73091) | `` automatic update `` |
| [`1c5b78dc`](https://github.com/nix-community/NUR/commit/1c5b78dc2716783f8301f621080b328f9e102342) | `` automatic update `` |
| [`356a2e67`](https://github.com/nix-community/NUR/commit/356a2e676aeb68754bf5602998df44ca931904c8) | `` automatic update `` |
| [`56396d69`](https://github.com/nix-community/NUR/commit/56396d69a38d68bb568f6ed3a266b5c2cd3106ca) | `` automatic update `` |
| [`79dac39b`](https://github.com/nix-community/NUR/commit/79dac39b32b18a66975332918b0b5e7cf8061c92) | `` automatic update `` |
| [`ac0182ca`](https://github.com/nix-community/NUR/commit/ac0182ca4dd752bf92fd3dc7433c8eb04eb414cd) | `` automatic update `` |
| [`d8aaa570`](https://github.com/nix-community/NUR/commit/d8aaa57084bb4632800da93c99236be6b121e6b9) | `` automatic update `` |
| [`11c1645c`](https://github.com/nix-community/NUR/commit/11c1645c73372d014091a1eadd791a4e0b58e67c) | `` automatic update `` |
| [`a0372431`](https://github.com/nix-community/NUR/commit/a037243103e9aee912ad3b5c73d76371fe2a5983) | `` automatic update `` |
| [`53448dd8`](https://github.com/nix-community/NUR/commit/53448dd855b6fd4e320380f5b283f29ce4a2e0dd) | `` automatic update `` |
| [`9dfde72c`](https://github.com/nix-community/NUR/commit/9dfde72c128369eea89f370d8b46ce1fd14d8f8e) | `` automatic update `` |
| [`61336c89`](https://github.com/nix-community/NUR/commit/61336c89afcd2d1dc0f0c587bef0feb667c7918d) | `` automatic update `` |
| [`d76df8db`](https://github.com/nix-community/NUR/commit/d76df8db296746d1f155c9c1b93ce6d8891a0535) | `` automatic update `` |
| [`3e82dc5d`](https://github.com/nix-community/NUR/commit/3e82dc5daac83381ac7dd68f1af6602e92b6ae35) | `` automatic update `` |
| [`37aecf9f`](https://github.com/nix-community/NUR/commit/37aecf9f94568bff35e45ae3e9d0812a1b1c9b21) | `` automatic update `` |
| [`348e15eb`](https://github.com/nix-community/NUR/commit/348e15ebd175b7881c4b3a7e4d4ca1dda9eb40f3) | `` automatic update `` |
| [`c7b87380`](https://github.com/nix-community/NUR/commit/c7b87380a48999a9a7cb5d0da035fd69ed06832f) | `` automatic update `` |
| [`366bf47e`](https://github.com/nix-community/NUR/commit/366bf47eeda86edef3fdb437f4c7d7fbb36853d5) | `` automatic update `` |
| [`da0127fe`](https://github.com/nix-community/NUR/commit/da0127fe69456adfee373d5671401e16f502ff00) | `` automatic update `` |
| [`03f3f029`](https://github.com/nix-community/NUR/commit/03f3f029e496e5e7456f2870557d5f2e5509022b) | `` automatic update `` |
| [`78a3c535`](https://github.com/nix-community/NUR/commit/78a3c5354ece1099e134f33c495032a93693f160) | `` automatic update `` |
| [`d39e13e7`](https://github.com/nix-community/NUR/commit/d39e13e798dc26f65256c7738a2a501845d21f4d) | `` automatic update `` |