### PR TITLE
chore(flake/nixos-facter-modules): `354ed498` -> `25122ee3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -583,11 +583,11 @@
     },
     "nixos-facter-modules": {
       "locked": {
-        "lastModified": 1755504238,
-        "narHash": "sha256-mw7q5DPdmz/1au8mY0u1DztRgVyJToGJfJszxjKSNes=",
+        "lastModified": 1755678220,
+        "narHash": "sha256-Yvmm03o7Z7gTAOfCnIetHomaDDJVBdLBPHD9dZ5kUcc=",
         "owner": "nix-community",
         "repo": "nixos-facter-modules",
-        "rev": "354ed498c9628f32383c3bf5b6668a17cdd72a28",
+        "rev": "25122ee37b0c1f22b07c9fe5f970a7487093a4c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                              | Message                                                                     |
| ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`7da5f967`](https://github.com/nix-community/nixos-facter-modules/commit/7da5f96793881819255fb29dbebd33ee793e48a2) | `` networkd is still useful to have i.e. when using the wireguard module `` |