### PR TITLE
chore(flake/emacs-overlay): `c6613c13` -> `69f77500`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1755681184,
-        "narHash": "sha256-iW4UaW6me6+VqDSyFE8mwgW6zXTcdIn2mVUEAAXzMeo=",
+        "lastModified": 1755709798,
+        "narHash": "sha256-iPTOQCy1xoJLg6RuOBTHgEEq/cWbfCCRfG8qFmyjF/s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c6613c134b4140f1c96f2da095f80e08d2b28a41",
+        "rev": "69f77500f06ee7f2e59cb9f2d9b7f50d2b6ac0b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`69f77500`](https://github.com/nix-community/emacs-overlay/commit/69f77500f06ee7f2e59cb9f2d9b7f50d2b6ac0b7) | `` Updated melpa ``        |
| [`40493389`](https://github.com/nix-community/emacs-overlay/commit/404933899705192fd19225fa4be4d36404c505f5) | `` Updated emacs ``        |
| [`6df759a2`](https://github.com/nix-community/emacs-overlay/commit/6df759a268d3c38cf5182a3aec98735bb9fc73c8) | `` Updated elpa ``         |
| [`988cd961`](https://github.com/nix-community/emacs-overlay/commit/988cd9611f47a1c2acff1e9a1bc6b7ace4e1c884) | `` Updated flake inputs `` |