### PR TITLE
chore(flake/nur): `c6508c49` -> `203c285f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -845,11 +845,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1755729137,
-        "narHash": "sha256-eON36fTYYgAL1J/31FZfSyJzt+T9TFOn5p6P8ddyyqA=",
+        "lastModified": 1755787749,
+        "narHash": "sha256-WiPoEu+INsUx7/Qhi833roT2aOuqS4BNFYjkZdXbuO4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c6508c49a36f20ea2d28920d1b5d55a48d072a4a",
+        "rev": "203c285f8ad8faf047660044bd40049dfe98974d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`203c285f`](https://github.com/nix-community/NUR/commit/203c285f8ad8faf047660044bd40049dfe98974d) | `` automatic update `` |
| [`5dee0440`](https://github.com/nix-community/NUR/commit/5dee0440f395c68e6dc161a506cde3adf2a55e87) | `` automatic update `` |
| [`297fce91`](https://github.com/nix-community/NUR/commit/297fce91176042104c293405e99de188209dcfa3) | `` automatic update `` |
| [`f579dc81`](https://github.com/nix-community/NUR/commit/f579dc81337c902da373b91bf57896d69d6c602a) | `` automatic update `` |
| [`e1cbed66`](https://github.com/nix-community/NUR/commit/e1cbed667dcae06f778c9680522df3ae8c259b62) | `` automatic update `` |
| [`bed88eb5`](https://github.com/nix-community/NUR/commit/bed88eb56c4893b400c524619f823a1906cf4140) | `` automatic update `` |
| [`3224e7f5`](https://github.com/nix-community/NUR/commit/3224e7f5637a9a6d2fde71fb9ccb8a7a22bb15b7) | `` automatic update `` |
| [`e1402def`](https://github.com/nix-community/NUR/commit/e1402defda15e34a085a3c4a00ea0b3fec268b87) | `` automatic update `` |
| [`77adb760`](https://github.com/nix-community/NUR/commit/77adb760309293f0fe46a3f5a9f05ab521017037) | `` automatic update `` |
| [`be0a0bf1`](https://github.com/nix-community/NUR/commit/be0a0bf16503238a291563ec84ea9eb537f4f03a) | `` automatic update `` |
| [`ca5f5ac4`](https://github.com/nix-community/NUR/commit/ca5f5ac4f6c8e02a10b3ded1a57f7fc097d7bde9) | `` automatic update `` |
| [`468be9ba`](https://github.com/nix-community/NUR/commit/468be9ba59d7cff1fa9ff4fa2da6e6e9a3f40e96) | `` automatic update `` |
| [`a6b45ca9`](https://github.com/nix-community/NUR/commit/a6b45ca9b75729d3d00e01486fb46ff6d043c36e) | `` automatic update `` |
| [`d6d189b4`](https://github.com/nix-community/NUR/commit/d6d189b40f96738749da8429885247b3421ba4f2) | `` automatic update `` |
| [`1ba19c9d`](https://github.com/nix-community/NUR/commit/1ba19c9dd44b629314534caa8ae07cff86b88174) | `` automatic update `` |
| [`61f635f4`](https://github.com/nix-community/NUR/commit/61f635f438aee43068b02d7c98572d03f79202dd) | `` automatic update `` |
| [`de302604`](https://github.com/nix-community/NUR/commit/de3026043743970a2aa625922307a7f2655a26c2) | `` automatic update `` |