### PR TITLE
chore(flake/darwin): `7220b01d` -> `3a0a38a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755275010,
-        "narHash": "sha256-lEApCoWUEWh0Ifc3k1JdVjpMtFFXeL2gG1qvBnoRc2I=",
+        "lastModified": 1755751773,
+        "narHash": "sha256-d1H34kko9J5fWrxCVgfa1TkIwdkGt/eDSVopAWenw24=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "7220b01d679e93ede8d7b25d6f392855b81dd475",
+        "rev": "3a0a38a1e7ac2c4b4150ea37a491fdffdc9c92e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                               |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------- |
| [`f0b44d68`](https://github.com/nix-darwin/nix-darwin/commit/f0b44d685478fd3b5fc7860b80821084c24790da) | `` Add eval warning ``                |
| [`23acc59c`](https://github.com/nix-darwin/nix-darwin/commit/23acc59c99dce9faf61ca55701c13588b03366d9) | `` Update tests ``                    |
| [`66911b7d`](https://github.com/nix-darwin/nix-darwin/commit/66911b7d169c44b625b2dee718f8854d9c93de3a) | `` Remove manual escaping ``          |
| [`423929a5`](https://github.com/nix-darwin/nix-darwin/commit/423929a5337dbcfe5c4ab526f2fda595d14d783a) | `` Escape XML generated by toPlist `` |