### PR TITLE
chore(flake/srvos): `b2eeb751` -> `bebcf12b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -981,11 +981,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755479226,
-        "narHash": "sha256-G7AVmVJhqMraf1iqMoyQ/aWuYvcFFFrMMkrMjWwVyHY=",
+        "lastModified": 1755770475,
+        "narHash": "sha256-piB4s87GvBJkzWLbzOMyX4adjMBmTMxzMu0SNT/b8hU=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "b2eeb75153c3e2c7c82991a5c335de3b6c151f51",
+        "rev": "bebcf12b45df0b7d6f422ebd5da06f92b52169a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`bebcf12b`](https://github.com/nix-community/srvos/commit/bebcf12b45df0b7d6f422ebd5da06f92b52169a8) | `` dev/private/flake.lock: Update `` |
| [`b13a83cd`](https://github.com/nix-community/srvos/commit/b13a83cda607716611d08b693c966e0f2cd6eba5) | `` flake.lock: Update ``             |