### PR TITLE
chore(flake/nur): `203c285f` -> `332abf45`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -845,11 +845,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1755787749,
-        "narHash": "sha256-WiPoEu+INsUx7/Qhi833roT2aOuqS4BNFYjkZdXbuO4=",
+        "lastModified": 1755877557,
+        "narHash": "sha256-AjUqNCIgjQKfhvH+HUXZQLlSDiRTFQPSPN8Ws/O7mVQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "203c285f8ad8faf047660044bd40049dfe98974d",
+        "rev": "332abf45be8133422a97e134b35782400ffc65bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                                 |
| -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`332abf45`](https://github.com/nix-community/NUR/commit/332abf45be8133422a97e134b35782400ffc65bd) | `` automatic update ``                                                  |
| [`4b7f21c0`](https://github.com/nix-community/NUR/commit/4b7f21c02f1c4598552f4dc5f16f5b8ca5eca45b) | `` automatic update ``                                                  |
| [`9055bc87`](https://github.com/nix-community/NUR/commit/9055bc8750ab86fb5195f03d826de20450f9cc38) | `` automatic update ``                                                  |
| [`880fd5b3`](https://github.com/nix-community/NUR/commit/880fd5b3a3806a5500449b56be111c1a06c9e5ea) | `` automatic update ``                                                  |
| [`8798139b`](https://github.com/nix-community/NUR/commit/8798139b0d9de9b8c24853041de2d89d11e829b3) | `` automatic update ``                                                  |
| [`b18403bb`](https://github.com/nix-community/NUR/commit/b18403bbe85de488bdf848d018f329645bd96a76) | `` automatic update ``                                                  |
| [`e1d5145e`](https://github.com/nix-community/NUR/commit/e1d5145ec09fd08ed9838479f3f4bf345bdd6a37) | `` automatic update ``                                                  |
| [`8e715e0a`](https://github.com/nix-community/NUR/commit/8e715e0a139291966e637683003c49bbd2b9584d) | `` automatic update ``                                                  |
| [`2c1b16ba`](https://github.com/nix-community/NUR/commit/2c1b16bad3eb54f2106412cbc989ea3852128594) | `` automatic update ``                                                  |
| [`350ba402`](https://github.com/nix-community/NUR/commit/350ba4022fa87d6bb8b9eceae4b079bad338d991) | `` automatic update ``                                                  |
| [`ac363177`](https://github.com/nix-community/NUR/commit/ac3631775e38781054c9d4e738c4ac894b84c124) | `` automatic update ``                                                  |
| [`2fa4b42f`](https://github.com/nix-community/NUR/commit/2fa4b42f274a5f38ff50012a70ee6342fb6ae53b) | `` automatic update ``                                                  |
| [`2ae89183`](https://github.com/nix-community/NUR/commit/2ae891833195ce38949a3f79ecec2cc05c8f7f90) | `` automatic update ``                                                  |
| [`6375380d`](https://github.com/nix-community/NUR/commit/6375380d497a3acc0200372027b8e98820943253) | `` automatic update ``                                                  |
| [`0038eb10`](https://github.com/nix-community/NUR/commit/0038eb1094a8e6503081fd739b3cabf18d2ef392) | `` automatic update ``                                                  |
| [`cc55fe45`](https://github.com/nix-community/NUR/commit/cc55fe4504dddee5e76cd70852f611b74319fb2b) | `` automatic update ``                                                  |
| [`2095ec01`](https://github.com/nix-community/NUR/commit/2095ec01405110eed6a27e8fb78159bd09a3b21d) | `` automatic update ``                                                  |
| [`71136668`](https://github.com/nix-community/NUR/commit/71136668d0c149af3371e9da26a6a8c1fb6e22b9) | `` automatic update ``                                                  |
| [`39e285fb`](https://github.com/nix-community/NUR/commit/39e285fbe5dc3a253650ff604718664ed6247b3b) | `` automatic update ``                                                  |
| [`cfa95fb7`](https://github.com/nix-community/NUR/commit/cfa95fb7da8934b301009a6ffd145f8cbfd655d6) | `` automatic update ``                                                  |
| [`20d5283d`](https://github.com/nix-community/NUR/commit/20d5283dafd2d1a27c06d518918474d9b8493f59) | `` ...and remove the parameter from the function that didn't need it `` |
| [`8c32c718`](https://github.com/nix-community/NUR/commit/8c32c718925bec793ed2938c39f5f06c9fd17f7d) | `` Add dirs_exist_ok to combine.py ``                                   |
| [`591f2fb3`](https://github.com/nix-community/NUR/commit/591f2fb306fb5a4c67b6acf6ab0d59c086592a52) | `` automatic update ``                                                  |
| [`1b97ab0b`](https://github.com/nix-community/NUR/commit/1b97ab0ba152bd2f4460a901cd7c44ebbacf7d6d) | `` automatic update ``                                                  |
| [`e81c242e`](https://github.com/nix-community/NUR/commit/e81c242e4fa3d2906e850912e314d3d4ac97bbc6) | `` automatic update ``                                                  |