### PR TITLE
chore(flake/emacs-overlay): `f4a59c08` -> `ed45d1a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1755739440,
-        "narHash": "sha256-EyuB5HtD04iOIdQ4D4WqFVV7RUbJCL9E004HnaYdOWc=",
+        "lastModified": 1755853871,
+        "narHash": "sha256-WyWaBlZSqnydtAPa8eIrbltiHmFs08ql/qW9MGALU18=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f4a59c089b953ec3f5e8983df6bb946317a36ad9",
+        "rev": "ed45d1a140ce3e712fff9b6e9e8c09855faacc8e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`ed45d1a1`](https://github.com/nix-community/emacs-overlay/commit/ed45d1a140ce3e712fff9b6e9e8c09855faacc8e) | `` Updated melpa ``  |
| [`46854f3a`](https://github.com/nix-community/emacs-overlay/commit/46854f3aa55ca95915288e752e67ecdad7a4adcf) | `` Updated emacs ``  |
| [`aa2b75fe`](https://github.com/nix-community/emacs-overlay/commit/aa2b75fea660839482abc3432808afcae5bb2998) | `` Updated melpa ``  |
| [`5b63476c`](https://github.com/nix-community/emacs-overlay/commit/5b63476c115c9bca5595eb853890c9132099b119) | `` Updated emacs ``  |
| [`6ad93abe`](https://github.com/nix-community/emacs-overlay/commit/6ad93abe00d34c3720c6c50cb55c890be191e713) | `` Updated elpa ``   |
| [`c51b4bec`](https://github.com/nix-community/emacs-overlay/commit/c51b4becdeba996eafe13856ef9276ed63fbafa3) | `` Updated nongnu `` |