### PR TITLE
chore(flake/emacs-overlay): `ed45d1a1` -> `016d29b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1755853871,
-        "narHash": "sha256-WyWaBlZSqnydtAPa8eIrbltiHmFs08ql/qW9MGALU18=",
+        "lastModified": 1755882549,
+        "narHash": "sha256-BoiJ6CnM0feswbJ+32waU4aqAimmsrn4vLUx80KtLq8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ed45d1a140ce3e712fff9b6e9e8c09855faacc8e",
+        "rev": "016d29b671ddce7500e7b7d448259008fe9ad6c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`016d29b6`](https://github.com/nix-community/emacs-overlay/commit/016d29b671ddce7500e7b7d448259008fe9ad6c3) | `` Updated melpa ``  |
| [`ffcbc1b4`](https://github.com/nix-community/emacs-overlay/commit/ffcbc1b4f36021dde45bf2234bfdf2ab7971be68) | `` Updated emacs ``  |
| [`04ba6f25`](https://github.com/nix-community/emacs-overlay/commit/04ba6f25aa7f646c7903435ddaaf3dc8048c5221) | `` Updated elpa ``   |
| [`c9499389`](https://github.com/nix-community/emacs-overlay/commit/c94993894ffc1c8cc79186ee7ec75aff0386496c) | `` Updated nongnu `` |