### PR TITLE
chore(flake/git-hooks): `4b04db83` -> `3ff45966`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -314,11 +314,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755446520,
-        "narHash": "sha256-I0Ok1OGDwc1jPd8cs2VvAYZsHriUVFGIUqW+7uSsOUM=",
+        "lastModified": 1755879220,
+        "narHash": "sha256-2KZl6cU5rzEwXKMW369kLTzinJXXkF3TRExA6qEeVbc=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4b04db83821b819bbbe32ed0a025b31e7971f22e",
+        "rev": "3ff4596663c8cbbffe06d863ee4c950bce2c3b78",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                  |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`19adc97d`](https://github.com/cachix/git-hooks.nix/commit/19adc97dac491c7aafaa6ad09767b2e1dbf0e6f6) | `` feat(gotest): Pass flags to gotest `` |
| [`c3628084`](https://github.com/cachix/git-hooks.nix/commit/c3628084b15de5f88f73e0968c24a07569284818) | `` feat: add zizmor ``                   |