### PR TITLE
chore(flake/emacs-overlay): `016d29b6` -> `a3473437`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1755882549,
-        "narHash": "sha256-BoiJ6CnM0feswbJ+32waU4aqAimmsrn4vLUx80KtLq8=",
+        "lastModified": 1755914825,
+        "narHash": "sha256-nUS2zqOW8/KUPBBc+gumbBp74nLj8S1B+k7nxOpiTxM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "016d29b671ddce7500e7b7d448259008fe9ad6c3",
+        "rev": "a3473437f19dcac71650c90a4ff4cd735079556e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`a3473437`](https://github.com/nix-community/emacs-overlay/commit/a3473437f19dcac71650c90a4ff4cd735079556e) | `` Updated melpa ``  |
| [`2135488c`](https://github.com/nix-community/emacs-overlay/commit/2135488c3adbb010fb3a305c1c430ae8a5a6d6b5) | `` Updated elpa ``   |
| [`6da78fcf`](https://github.com/nix-community/emacs-overlay/commit/6da78fcfcff23bd1205a698376b2e232dd3cccfd) | `` Updated nongnu `` |