### PR TITLE
chore(flake/nur): `edffca29` -> `b894e1c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -845,11 +845,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1755906241,
-        "narHash": "sha256-+HqaiSm85fjMWgCYeubjZ1cT2Jp+Tm2sZrHs/DXCFxs=",
+        "lastModified": 1755921154,
+        "narHash": "sha256-PhMVJ3zO1bvnLLS5abamuBWW6qcxAn5miaT6MS4nQuM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "edffca2954feecc63f406d9b16c31f3e47420f8c",
+        "rev": "b894e1c63dda216bc27b1c45a5b34c9fd04ae7fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b894e1c6`](https://github.com/nix-community/NUR/commit/b894e1c63dda216bc27b1c45a5b34c9fd04ae7fd) | `` automatic update `` |
| [`1a47d83c`](https://github.com/nix-community/NUR/commit/1a47d83c521c098debd6d1f2c2ae313a5bb729f9) | `` automatic update `` |
| [`38f8d8cf`](https://github.com/nix-community/NUR/commit/38f8d8cfed50ee29f9ef6d9c3b8f0e0179f168ca) | `` automatic update `` |
| [`67055023`](https://github.com/nix-community/NUR/commit/67055023c050c79f95da43d890fac44ebf77c022) | `` automatic update `` |
| [`e702b65a`](https://github.com/nix-community/NUR/commit/e702b65a8488eb50ba706b9f9b0c7fd3a5193781) | `` automatic update `` |