### PR TITLE
chore(flake/nur): `b894e1c6` -> `cadc2eaa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -845,11 +845,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1755921154,
-        "narHash": "sha256-PhMVJ3zO1bvnLLS5abamuBWW6qcxAn5miaT6MS4nQuM=",
+        "lastModified": 1755934986,
+        "narHash": "sha256-L3vZbzNfjkLyFJrRoZN/g/n72iwyqyOxqGxfk6Fxxvg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b894e1c63dda216bc27b1c45a5b34c9fd04ae7fd",
+        "rev": "cadc2eaa4c611d8b6bed6ea28992469e7babc88f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cadc2eaa`](https://github.com/nix-community/NUR/commit/cadc2eaa4c611d8b6bed6ea28992469e7babc88f) | `` automatic update `` |
| [`b3af752c`](https://github.com/nix-community/NUR/commit/b3af752c4e2477d8460556c2c992d950930a4a53) | `` automatic update `` |