### PR TITLE
chore(flake/nur): `cadc2eaa` -> `ffaf7fa0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -845,11 +845,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1755934986,
-        "narHash": "sha256-L3vZbzNfjkLyFJrRoZN/g/n72iwyqyOxqGxfk6Fxxvg=",
+        "lastModified": 1755949401,
+        "narHash": "sha256-CNgdT65mgn/mHa/SUTtAuosDrmuBHU1LqYE0GaiXXEs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cadc2eaa4c611d8b6bed6ea28992469e7babc88f",
+        "rev": "ffaf7fa085f6da161289e4223651872f57be9683",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ffaf7fa0`](https://github.com/nix-community/NUR/commit/ffaf7fa085f6da161289e4223651872f57be9683) | `` automatic update `` |
| [`67508e51`](https://github.com/nix-community/NUR/commit/67508e513c893c7572d27964f85f83306fc92b21) | `` automatic update `` |
| [`ab6dfe65`](https://github.com/nix-community/NUR/commit/ab6dfe65180e9ba167b18f0a6ff55df87ed87a04) | `` automatic update `` |
| [`25a49240`](https://github.com/nix-community/NUR/commit/25a49240b3eb5d2206dc4e03242dda9640f34773) | `` automatic update `` |