### PR TITLE
chore(flake/git-hooks): `3ff45966` -> `e891a93b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -314,11 +314,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755879220,
-        "narHash": "sha256-2KZl6cU5rzEwXKMW369kLTzinJXXkF3TRExA6qEeVbc=",
+        "lastModified": 1755960406,
+        "narHash": "sha256-RF7j6C1TmSTK9tYWO6CdEMtg6XZaUKcvZwOCD2SICZs=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3ff4596663c8cbbffe06d863ee4c950bce2c3b78",
+        "rev": "e891a93b193fcaf2fc8012d890dc7f0befe86ec2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                      |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`e891a93b`](https://github.com/cachix/git-hooks.nix/commit/e891a93b193fcaf2fc8012d890dc7f0befe86ec2) | `` docs: document `nix fmt` support ``                                       |
| [`c8409843`](https://github.com/cachix/git-hooks.nix/commit/c84098434e3a01b8a8b1cf572f1004f3aca77bfb) | `` docs: note that `nix flake check` is a poor choice for auto-formatters `` |
| [`2a2b75f6`](https://github.com/cachix/git-hooks.nix/commit/2a2b75f65a914577ad9e8987f3e1dee05f0f2120) | `` docs: document `nix develop -c` ``                                        |