### PR TITLE
chore(flake/nur): `ffaf7fa0` -> `b820a5b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -845,11 +845,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1755949401,
-        "narHash": "sha256-CNgdT65mgn/mHa/SUTtAuosDrmuBHU1LqYE0GaiXXEs=",
+        "lastModified": 1755963829,
+        "narHash": "sha256-2tON0rztjaw0oS8bxrJ/FOgfU9HHYmEK//kkHwl6UIs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ffaf7fa085f6da161289e4223651872f57be9683",
+        "rev": "b820a5b8019264f623f3ed36f2153df997020647",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b820a5b8`](https://github.com/nix-community/NUR/commit/b820a5b8019264f623f3ed36f2153df997020647) | `` automatic update `` |
| [`cd7b4898`](https://github.com/nix-community/NUR/commit/cd7b489898d6928e73bbf0a7e374d58f6ee7b4c6) | `` automatic update `` |