### PR TITLE
chore(flake/nur): `b820a5b8` -> `27b56692`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -845,11 +845,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1755963829,
-        "narHash": "sha256-2tON0rztjaw0oS8bxrJ/FOgfU9HHYmEK//kkHwl6UIs=",
+        "lastModified": 1756064598,
+        "narHash": "sha256-v60OgTprkhnsNwrN2PjXGZag14YJ6XWkkZ2v2fQ4d6Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b820a5b8019264f623f3ed36f2153df997020647",
+        "rev": "27b566927d44b545d2c9b22751f88bd7a3ef0a4e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`27b56692`](https://github.com/nix-community/NUR/commit/27b566927d44b545d2c9b22751f88bd7a3ef0a4e) | `` automatic update `` |
| [`6d2c0e62`](https://github.com/nix-community/NUR/commit/6d2c0e62df145173fae10e025ee0d18e702ccc20) | `` automatic update `` |
| [`98f1a1dc`](https://github.com/nix-community/NUR/commit/98f1a1dc68d023faa7e0cbcef46a1baa37c41c13) | `` automatic update `` |
| [`a5d85d24`](https://github.com/nix-community/NUR/commit/a5d85d24fa84289d3d63e484bac7ccfe4e9182e5) | `` automatic update `` |
| [`48577555`](https://github.com/nix-community/NUR/commit/485775552c60d1392244d9736b4a37f6ff121213) | `` automatic update `` |
| [`f6233aca`](https://github.com/nix-community/NUR/commit/f6233aca7cff49a707f0ba551ccf460abbf4c902) | `` automatic update `` |
| [`5ab0fe21`](https://github.com/nix-community/NUR/commit/5ab0fe2197dd07b82a11d01197d01656f6a1ff93) | `` automatic update `` |
| [`5bfb3e83`](https://github.com/nix-community/NUR/commit/5bfb3e837f6126c6aec3fc8d533525bbcf7e6577) | `` automatic update `` |
| [`12e8be26`](https://github.com/nix-community/NUR/commit/12e8be26cf39b4e3a3a303a3c3b8034667f4c1f8) | `` automatic update `` |
| [`63954461`](https://github.com/nix-community/NUR/commit/63954461eb7acad315e038a1936acf62c5f8b2a6) | `` automatic update `` |
| [`91b1a7c3`](https://github.com/nix-community/NUR/commit/91b1a7c35515c114697a63f616d0676364b62b7b) | `` automatic update `` |
| [`a8871110`](https://github.com/nix-community/NUR/commit/a887111066805187e95e20c3ca7272639bd61617) | `` automatic update `` |
| [`d16cada7`](https://github.com/nix-community/NUR/commit/d16cada7d10863ed3fbfdf42ecd22d2a5866c271) | `` automatic update `` |
| [`55d8c47a`](https://github.com/nix-community/NUR/commit/55d8c47a1c60d0280a18c126fc087311327494ce) | `` automatic update `` |
| [`92972b42`](https://github.com/nix-community/NUR/commit/92972b4260142ff0528c34f5740c6c845dbc81ef) | `` automatic update `` |
| [`20caa31d`](https://github.com/nix-community/NUR/commit/20caa31dbef80914895e41b56be4cabc740b2126) | `` automatic update `` |
| [`af2605b5`](https://github.com/nix-community/NUR/commit/af2605b5e79051af019d61c6d5fa180101feb75b) | `` automatic update `` |
| [`39d39de2`](https://github.com/nix-community/NUR/commit/39d39de27089c2c2c44565d12db1f05654f56d68) | `` automatic update `` |
| [`cb6f7bd3`](https://github.com/nix-community/NUR/commit/cb6f7bd38d1198938d5404516484a6b2f3fc0855) | `` automatic update `` |
| [`7c64ee78`](https://github.com/nix-community/NUR/commit/7c64ee78146699a2b899bac16a5623cf674b1d31) | `` automatic update `` |
| [`2a4e354d`](https://github.com/nix-community/NUR/commit/2a4e354d7ebb34c8b88068aaf89b5db6419f1484) | `` automatic update `` |
| [`aebf61ca`](https://github.com/nix-community/NUR/commit/aebf61cab6d272654032867064607279c39d7750) | `` automatic update `` |
| [`6dda7eba`](https://github.com/nix-community/NUR/commit/6dda7eba089c0721c2235bb48740097051dee507) | `` automatic update `` |
| [`da9b28f6`](https://github.com/nix-community/NUR/commit/da9b28f6f375bce911cb44f70e2d937013d2a50d) | `` automatic update `` |