### PR TITLE
chore(flake/emacs-overlay): `c536443f` -> `57d1c7ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1755940114,
-        "narHash": "sha256-xxOWWbBNOjtlIpbHuZrbBIpqsy1e44WreC0wYeQW+DA=",
+        "lastModified": 1755968767,
+        "narHash": "sha256-XePYDL0JRHMIBFnpg+dkHMkX38rdzjavZB+Mlxx/LTA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c536443f1d592b96267bb3973a17e9ed8693330c",
+        "rev": "57d1c7abf226954672ef6fd46a1c7d598f5661cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`57d1c7ab`](https://github.com/nix-community/emacs-overlay/commit/57d1c7abf226954672ef6fd46a1c7d598f5661cf) | `` Updated melpa ``  |
| [`a1c9b681`](https://github.com/nix-community/emacs-overlay/commit/a1c9b68194e1262b820c2ab6f92612bb78b45a88) | `` Updated emacs ``  |
| [`e4bb798d`](https://github.com/nix-community/emacs-overlay/commit/e4bb798dabebcacb473c7d9f19dd00b9845f3f03) | `` Updated elpa ``   |
| [`cae0c030`](https://github.com/nix-community/emacs-overlay/commit/cae0c0305e1e27b0dfaec4bd9f17db5612a7e246) | `` Updated nongnu `` |