### PR TITLE
chore(flake/emacs-overlay): `57d1c7ab` -> `c23bf31a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1755968767,
-        "narHash": "sha256-XePYDL0JRHMIBFnpg+dkHMkX38rdzjavZB+Mlxx/LTA=",
+        "lastModified": 1756002349,
+        "narHash": "sha256-Y8BNooXWqgNwyFsabEpFmW8mDb70dGYbTqH28q0IzFc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "57d1c7abf226954672ef6fd46a1c7d598f5661cf",
+        "rev": "c23bf31aade269bebf5b2ed4ce442f5bcabdc52d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`c23bf31a`](https://github.com/nix-community/emacs-overlay/commit/c23bf31aade269bebf5b2ed4ce442f5bcabdc52d) | `` Updated melpa ``  |
| [`0d7e7b6f`](https://github.com/nix-community/emacs-overlay/commit/0d7e7b6f2b01d7511d784e1a46daff7339f9b8dc) | `` Updated emacs ``  |
| [`83d0b7bc`](https://github.com/nix-community/emacs-overlay/commit/83d0b7bc8a150c08f27141f7c21fc2fe5ca2ab64) | `` Updated elpa ``   |
| [`5203d973`](https://github.com/nix-community/emacs-overlay/commit/5203d97308a655287bcbd78076be433fcae4b228) | `` Updated nongnu `` |