### PR TITLE
chore(flake/emacs-overlay): `c23bf31a` -> `38f372e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1756002349,
-        "narHash": "sha256-Y8BNooXWqgNwyFsabEpFmW8mDb70dGYbTqH28q0IzFc=",
+        "lastModified": 1756113254,
+        "narHash": "sha256-T2O0ijFnp1iWALTU3Boua5GLjqCMw0UWi2RFNyFR6nU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c23bf31aade269bebf5b2ed4ce442f5bcabdc52d",
+        "rev": "38f372e203d68849c672f3a06bb892e9875f237e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`38f372e2`](https://github.com/nix-community/emacs-overlay/commit/38f372e203d68849c672f3a06bb892e9875f237e) | `` Updated melpa ``  |
| [`fd440a9e`](https://github.com/nix-community/emacs-overlay/commit/fd440a9e5f980a18270df764ce17facc7a328249) | `` Updated emacs ``  |
| [`9e3a5b9a`](https://github.com/nix-community/emacs-overlay/commit/9e3a5b9a0c79e66b4a1e2490be606a058a6712fe) | `` Updated melpa ``  |
| [`2a014d1e`](https://github.com/nix-community/emacs-overlay/commit/2a014d1eaec40908ea07fb1822c0f77a8dcbc2e9) | `` Updated emacs ``  |
| [`9f303ef4`](https://github.com/nix-community/emacs-overlay/commit/9f303ef429e3a6cf0aabedd007e4ea6398a6f67b) | `` Updated elpa ``   |
| [`45149a7a`](https://github.com/nix-community/emacs-overlay/commit/45149a7a11823b8e730802f514c0399fdab5e32d) | `` Updated emacs ``  |
| [`e4783894`](https://github.com/nix-community/emacs-overlay/commit/e478389446d1cf56b5bb33f15501248d2c53b136) | `` Updated melpa ``  |
| [`4991be3c`](https://github.com/nix-community/emacs-overlay/commit/4991be3c8ede9978a02904f9d2559511fc0806a1) | `` Updated elpa ``   |
| [`8626bfcb`](https://github.com/nix-community/emacs-overlay/commit/8626bfcbafd429f119a23c0f18ef4ffbdd9f37d5) | `` Updated nongnu `` |
| [`5c3afeab`](https://github.com/nix-community/emacs-overlay/commit/5c3afeab1a0a913290098a782b485a8e48634a30) | `` Updated melpa ``  |
| [`980386b3`](https://github.com/nix-community/emacs-overlay/commit/980386b329df4557265accca44d7cd0805a16b4a) | `` Updated emacs ``  |