### PR TITLE
chore(flake/nur): `27b56692` -> `10df67c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -845,11 +845,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1756064598,
-        "narHash": "sha256-v60OgTprkhnsNwrN2PjXGZag14YJ6XWkkZ2v2fQ4d6Y=",
+        "lastModified": 1756119064,
+        "narHash": "sha256-icuxHZS74KdqeX3uYdaC65XZ4tJDkqPk/3z6sr+A2AY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "27b566927d44b545d2c9b22751f88bd7a3ef0a4e",
+        "rev": "10df67c5ae01fa7bcd18467c0415f4b00754e6fc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`10df67c5`](https://github.com/nix-community/NUR/commit/10df67c5ae01fa7bcd18467c0415f4b00754e6fc) | `` automatic update `` |
| [`dd2d02cb`](https://github.com/nix-community/NUR/commit/dd2d02cb1c8f6f14d83d223963bb7c51b8ccf865) | `` automatic update `` |
| [`d964bd8b`](https://github.com/nix-community/NUR/commit/d964bd8bda87256ac8c7a9caf5fcee3be533a485) | `` automatic update `` |
| [`a88db488`](https://github.com/nix-community/NUR/commit/a88db4880062222fc64271ddc7fff57467e19f3f) | `` automatic update `` |
| [`e8a74dc6`](https://github.com/nix-community/NUR/commit/e8a74dc621bcb31effe2998d1950f4ebf4d505bd) | `` automatic update `` |
| [`0346d788`](https://github.com/nix-community/NUR/commit/0346d7888363a3c14538c102d899a93592d6cc46) | `` automatic update `` |
| [`f9ae6bb2`](https://github.com/nix-community/NUR/commit/f9ae6bb27ca0f9d4c2c2677dd320805a77178fa5) | `` automatic update `` |
| [`46b91b0e`](https://github.com/nix-community/NUR/commit/46b91b0ecf1276d20bf26549804ad764c3e679dc) | `` automatic update `` |
| [`d0e2a11f`](https://github.com/nix-community/NUR/commit/d0e2a11f41adaff4637c9901467cd16754dedbea) | `` automatic update `` |
| [`846c3ef9`](https://github.com/nix-community/NUR/commit/846c3ef981da3098185de8698e2d6099a1a802c2) | `` automatic update `` |
| [`17b50f46`](https://github.com/nix-community/NUR/commit/17b50f46ee0103b6303bbca5055c2e077650d6bd) | `` automatic update `` |
| [`994d1851`](https://github.com/nix-community/NUR/commit/994d1851407dde1a2f87dc26baf8997fbf9ae273) | `` automatic update `` |
| [`fb310574`](https://github.com/nix-community/NUR/commit/fb310574a36889a60a1c33f1f328f5463ac78937) | `` automatic update `` |
| [`4b342fb6`](https://github.com/nix-community/NUR/commit/4b342fb632bfbcc68ea9bc8f0c04df1ab4051f59) | `` automatic update `` |
| [`52f74f1f`](https://github.com/nix-community/NUR/commit/52f74f1fac9a23ef7364bb47edcdcfa6fa7f20f4) | `` automatic update `` |
| [`37c12447`](https://github.com/nix-community/NUR/commit/37c12447237bc64a366e64e22580a6eecc678a60) | `` automatic update `` |