### PR TITLE
chore(flake/nixos-facter-modules): `25122ee3` -> `a1042c81`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -583,11 +583,11 @@
     },
     "nixos-facter-modules": {
       "locked": {
-        "lastModified": 1755678220,
-        "narHash": "sha256-Yvmm03o7Z7gTAOfCnIetHomaDDJVBdLBPHD9dZ5kUcc=",
+        "lastModified": 1756109073,
+        "narHash": "sha256-5pjFEziluVwJ0Z50h9laKfWbDluXuA5ada05xb/QiV4=",
         "owner": "nix-community",
         "repo": "nixos-facter-modules",
-        "rev": "25122ee37b0c1f22b07c9fe5f970a7487093a4c0",
+        "rev": "a1042c81126d9c9314c1eb1a7b89ab4d81b5dea7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                              | Message                                                               |
| ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`756a72df`](https://github.com/nix-community/nixos-facter-modules/commit/756a72df9c762609fd22c8d6afc109f5cd6aeecd) | `` don't use networkd if networkmanager and wait-online is enabled `` |