### PR TITLE
chore(flake/nur): `10df67c5` -> `dc884c08`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -845,11 +845,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1756119064,
-        "narHash": "sha256-icuxHZS74KdqeX3uYdaC65XZ4tJDkqPk/3z6sr+A2AY=",
+        "lastModified": 1756133362,
+        "narHash": "sha256-Jl8qjtiZqBOD37LKtzu/IUflkJ1JLy0z255p83NXOZQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "10df67c5ae01fa7bcd18467c0415f4b00754e6fc",
+        "rev": "dc884c082a0d84b774f78ffa9c715692dbff6862",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dc884c08`](https://github.com/nix-community/NUR/commit/dc884c082a0d84b774f78ffa9c715692dbff6862) | `` automatic update `` |
| [`1dcd8a27`](https://github.com/nix-community/NUR/commit/1dcd8a2769808f471b065f72c65ddd305fe32c71) | `` automatic update `` |
| [`8dab0383`](https://github.com/nix-community/NUR/commit/8dab03830a48098f861b8866fa3b30b7d2694800) | `` automatic update `` |