### PR TITLE
chore(flake/nur): `dc884c08` -> `9dc277f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -845,11 +845,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1756133362,
-        "narHash": "sha256-Jl8qjtiZqBOD37LKtzu/IUflkJ1JLy0z255p83NXOZQ=",
+        "lastModified": 1756151021,
+        "narHash": "sha256-LrBImc/Wqs6hYvIbi6nNdW/uqDjxjktyhqAvXvGy5Kc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dc884c082a0d84b774f78ffa9c715692dbff6862",
+        "rev": "9dc277f6c14285ae5da982ace53ca208aa9cb253",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9dc277f6`](https://github.com/nix-community/NUR/commit/9dc277f6c14285ae5da982ace53ca208aa9cb253) | `` automatic update `` |
| [`619a7304`](https://github.com/nix-community/NUR/commit/619a7304cdb79098287729421d3efdfdf67f0cd7) | `` automatic update `` |
| [`35fdc605`](https://github.com/nix-community/NUR/commit/35fdc605987124c6ca01feee113fda2ed983d88e) | `` automatic update `` |
| [`c9c985b6`](https://github.com/nix-community/NUR/commit/c9c985b60eb46d97370f7d3fefdc300b953c044d) | `` automatic update `` |
| [`3aada358`](https://github.com/nix-community/NUR/commit/3aada358b8b7fa629fa8ab3561286779e99f62fd) | `` automatic update `` |
| [`d17df02a`](https://github.com/nix-community/NUR/commit/d17df02acd4ed103147d6393a8162604065ab82b) | `` automatic update `` |