### PR TITLE
chore(flake/emacs-overlay): `38f372e2` -> `f4a1a64e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1756113254,
-        "narHash": "sha256-T2O0ijFnp1iWALTU3Boua5GLjqCMw0UWi2RFNyFR6nU=",
+        "lastModified": 1756260465,
+        "narHash": "sha256-kKq9MNh9lAIziMPb8rZ+wTEv3QR4K2LTM7nf2i8EbjI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "38f372e203d68849c672f3a06bb892e9875f237e",
+        "rev": "f4a1a64e3581bf49791529105ae4b1c664c17072",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`f4a1a64e`](https://github.com/nix-community/emacs-overlay/commit/f4a1a64e3581bf49791529105ae4b1c664c17072) | `` Updated melpa ``        |
| [`3849e50c`](https://github.com/nix-community/emacs-overlay/commit/3849e50c6fa6573ae7d78627f2c0162e674fc27a) | `` Updated emacs ``        |
| [`c25de825`](https://github.com/nix-community/emacs-overlay/commit/c25de8251c745da2788a38126665eb648610af2a) | `` Updated elpa ``         |
| [`ca74057e`](https://github.com/nix-community/emacs-overlay/commit/ca74057e78c7eaa94e7c830364340e89c96efd86) | `` Updated nongnu ``       |
| [`3b3e842c`](https://github.com/nix-community/emacs-overlay/commit/3b3e842cce376e332b0a4606ca18a846fbc49430) | `` Updated melpa ``        |
| [`2ff48aaf`](https://github.com/nix-community/emacs-overlay/commit/2ff48aaf3821624e9b2ed088ba1a38a643f59653) | `` Updated emacs ``        |
| [`650853c4`](https://github.com/nix-community/emacs-overlay/commit/650853c4edcb96f0e567964ad38dbf1fba47695f) | `` Updated elpa ``         |
| [`73f09ad1`](https://github.com/nix-community/emacs-overlay/commit/73f09ad17753af7637d349ed88652351038bb612) | `` Updated nongnu ``       |
| [`cf7aaac0`](https://github.com/nix-community/emacs-overlay/commit/cf7aaac09acc0fad9b15d8fe76745396125c0e3e) | `` Updated emacs ``        |
| [`3cfeca94`](https://github.com/nix-community/emacs-overlay/commit/3cfeca94a7a3d08018fb165cbe71b12d9f477f93) | `` Updated melpa ``        |
| [`2742a674`](https://github.com/nix-community/emacs-overlay/commit/2742a67491818ab16da4ffabd9c127a0cae3f507) | `` Updated flake inputs `` |
| [`074188fe`](https://github.com/nix-community/emacs-overlay/commit/074188feb9e37d326cbcb0d6815c90182c5789a7) | `` Updated melpa ``        |
| [`2d1971b2`](https://github.com/nix-community/emacs-overlay/commit/2d1971b21f1ca04b4e88bc2c0f4dac15903923ad) | `` Updated emacs ``        |
| [`fc95ce28`](https://github.com/nix-community/emacs-overlay/commit/fc95ce286d06c08305079493962de94f2bfca910) | `` Updated elpa ``         |
| [`b2c2b727`](https://github.com/nix-community/emacs-overlay/commit/b2c2b727913631e4e83657daf6cd4e76a0b8a09a) | `` Updated nongnu ``       |
| [`6e64ccc5`](https://github.com/nix-community/emacs-overlay/commit/6e64ccc5fe49ef8bbda0cecb3e281afdb53b3af7) | `` Updated melpa ``        |
| [`05a04760`](https://github.com/nix-community/emacs-overlay/commit/05a04760ee0101d28cf25334e4b3e9654276d50c) | `` Updated emacs ``        |
| [`2c3341cc`](https://github.com/nix-community/emacs-overlay/commit/2c3341cc0fb268c865bfa1e932b89ec4614f22bd) | `` Updated elpa ``         |
| [`ba62cc53`](https://github.com/nix-community/emacs-overlay/commit/ba62cc538d20816710ac815e3d79448c1ada62ea) | `` Updated nongnu ``       |