### PR TITLE
chore(flake/nur): `9dc277f6` -> `5418a240`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -845,11 +845,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1756151021,
-        "narHash": "sha256-LrBImc/Wqs6hYvIbi6nNdW/uqDjxjktyhqAvXvGy5Kc=",
+        "lastModified": 1756180788,
+        "narHash": "sha256-uHAakTKGFeAMjSa42tJPxoLBsTxHWeC2LyFZn3PJVdI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9dc277f6c14285ae5da982ace53ca208aa9cb253",
+        "rev": "5418a24093aaa78c9e877b0e6254c462c7f1b60a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5418a240`](https://github.com/nix-community/NUR/commit/5418a24093aaa78c9e877b0e6254c462c7f1b60a) | `` automatic update `` |
| [`278516db`](https://github.com/nix-community/NUR/commit/278516dbc557696d283514f8c33a054dcace4ace) | `` automatic update `` |
| [`d4fd8427`](https://github.com/nix-community/NUR/commit/d4fd84272c576f42573e7a76aaf81a41b36d214a) | `` automatic update `` |
| [`787c0d97`](https://github.com/nix-community/NUR/commit/787c0d97fc77abc7507644bf9ef2c0d26464b70a) | `` automatic update `` |
| [`9d7eab8e`](https://github.com/nix-community/NUR/commit/9d7eab8e2b29c3140312fd64e65e200b9426869c) | `` automatic update `` |
| [`d81438d5`](https://github.com/nix-community/NUR/commit/d81438d52a643b84a8bdd7ed0ba39a8e3b97f628) | `` automatic update `` |
| [`6e1acb6d`](https://github.com/nix-community/NUR/commit/6e1acb6d05eb49ac32fdaf2ccf2fb50965d3d637) | `` automatic update `` |