### PR TITLE
chore(flake/nur): `6cd33d55` -> `5395b789`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -845,11 +845,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1756194313,
-        "narHash": "sha256-5cTK/GsIb4ed8f55GdigySCw3abUrJ+3JdvCUpYVkeo=",
+        "lastModified": 1756208690,
+        "narHash": "sha256-r7fXEpz99MQvAY5XsmpEuV0+oQhhiJLao/qsXP5ovkA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6cd33d55c8d5a8b09800a9114e21ce92c60aee1c",
+        "rev": "5395b789b6ffe8d445f9044825800eedfcc77c1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5395b789`](https://github.com/nix-community/NUR/commit/5395b789b6ffe8d445f9044825800eedfcc77c1e) | `` automatic update `` |
| [`5703c2e7`](https://github.com/nix-community/NUR/commit/5703c2e786cedb4b939a2acd6717a7f658e03f93) | `` automatic update `` |
| [`320af97c`](https://github.com/nix-community/NUR/commit/320af97cd25b03d8494ee13ce744eb4f030841a8) | `` automatic update `` |
| [`fd3f2c78`](https://github.com/nix-community/NUR/commit/fd3f2c785c408e1828ab7281b0ceb8b46307b545) | `` automatic update `` |
| [`b2cb4218`](https://github.com/nix-community/NUR/commit/b2cb4218df9568b515fef7adaea4bfefcadb4f2d) | `` automatic update `` |
| [`b1950898`](https://github.com/nix-community/NUR/commit/b195089853677d8f5bfef339057736aaca46a222) | `` automatic update `` |
| [`26d9af72`](https://github.com/nix-community/NUR/commit/26d9af72ac41eed907f69b05866efee78f870925) | `` automatic update `` |
| [`5093f08b`](https://github.com/nix-community/NUR/commit/5093f08bc48b4aa62d0d55e4bcafc00a2d0f9a50) | `` automatic update `` |
| [`81e3bd13`](https://github.com/nix-community/NUR/commit/81e3bd138df1f68f3a768a6ce66a2bcedda2b149) | `` automatic update `` |