### PR TITLE
chore(flake/nur): `5395b789` -> `f294db93`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -845,11 +845,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1756208690,
-        "narHash": "sha256-r7fXEpz99MQvAY5XsmpEuV0+oQhhiJLao/qsXP5ovkA=",
+        "lastModified": 1756223213,
+        "narHash": "sha256-VUsxfx6AKBPWXctdIjV7VbkJIMYuu6yj9vPGXHhBgok=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5395b789b6ffe8d445f9044825800eedfcc77c1e",
+        "rev": "f294db93bf5709df481b9d12ad9bb9ba1ec081fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f294db93`](https://github.com/nix-community/NUR/commit/f294db93bf5709df481b9d12ad9bb9ba1ec081fa) | `` automatic update `` |
| [`1272a2e3`](https://github.com/nix-community/NUR/commit/1272a2e336db343cff24461505375891f31e786e) | `` automatic update `` |
| [`233a3247`](https://github.com/nix-community/NUR/commit/233a32471f21d1cd57fc0a68324ffe6defa867e8) | `` automatic update `` |
| [`a3535b8d`](https://github.com/nix-community/NUR/commit/a3535b8d6752d551f3ecfedd6440cf2a7a0ef839) | `` automatic update `` |