### PR TITLE
chore(flake/nur): `f294db93` -> `980f3afa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -845,11 +845,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1756223213,
-        "narHash": "sha256-VUsxfx6AKBPWXctdIjV7VbkJIMYuu6yj9vPGXHhBgok=",
+        "lastModified": 1756238551,
+        "narHash": "sha256-f3VNgBIGeL3kugYooGAad+M/fA0wt7XGPG7Su1+3OQ0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f294db93bf5709df481b9d12ad9bb9ba1ec081fa",
+        "rev": "980f3afa0bef2b0c4a07ac2a5ab98bc9ac24aa69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                              |
| -------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`980f3afa`](https://github.com/nix-community/NUR/commit/980f3afa0bef2b0c4a07ac2a5ab98bc9ac24aa69) | `` I bet this is more correct too ``                 |
| [`cfb55011`](https://github.com/nix-community/NUR/commit/cfb550112797ec57d97d22a91d05c09e06afa0ca) | `` fix: maybe using shutil.move will work better? `` |
| [`6f7706b1`](https://github.com/nix-community/NUR/commit/6f7706b1347ffc261a2a4f775880666902cef0d6) | `` fix: ci unformatted file ``                       |
| [`d9fa25f6`](https://github.com/nix-community/NUR/commit/d9fa25f61319872a5678595cdd07b4c00f2e7dd8) | `` Oops, missed a dirs_exist_ok ``                   |
| [`335d3c16`](https://github.com/nix-community/NUR/commit/335d3c168e984a2b3caced34f7d13f982e5379cc) | `` automatic update ``                               |
| [`f954417b`](https://github.com/nix-community/NUR/commit/f954417b89e8ff1a3a1674ea7812af63176bfe0c) | `` automatic update ``                               |
| [`d56a42ef`](https://github.com/nix-community/NUR/commit/d56a42ef8831e46cbfea49d8d6ed995397211689) | `` automatic update ``                               |
| [`9b93cfba`](https://github.com/nix-community/NUR/commit/9b93cfba00d9bce6022fba9a30cd63f3dc7c86bc) | `` automatic update ``                               |
| [`4ab446f4`](https://github.com/nix-community/NUR/commit/4ab446f4dca26b2f3d549a0fec85dbf99d12c251) | `` automatic update ``                               |