### PR TITLE
chore(flake/nur): `980f3afa` -> `1fc33f07`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -828,11 +828,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1756238551,
-        "narHash": "sha256-f3VNgBIGeL3kugYooGAad+M/fA0wt7XGPG7Su1+3OQ0=",
+        "lastModified": 1756280694,
+        "narHash": "sha256-bWrjbQwAbh9sthCuu8ImJGsB9AOwv1Ul+w7B9NNtALE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "980f3afa0bef2b0c4a07ac2a5ab98bc9ac24aa69",
+        "rev": "1fc33f0742baa8fcb365317ded628630bbd0305a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                           |
| -------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`1fc33f07`](https://github.com/nix-community/NUR/commit/1fc33f0742baa8fcb365317ded628630bbd0305a) | `` automatic update ``            |
| [`01edf600`](https://github.com/nix-community/NUR/commit/01edf6006a601e634d623b2fdf99c37b7a7a0159) | `` automatic update ``            |
| [`0768df88`](https://github.com/nix-community/NUR/commit/0768df88122ee3795d2544aabce4161bb1e6efcd) | `` automatic update ``            |
| [`9824fee9`](https://github.com/nix-community/NUR/commit/9824fee9eb7676a3624d8dcf8e36879fdbe5ccf6) | `` automatic update ``            |
| [`5bfce522`](https://github.com/nix-community/NUR/commit/5bfce5225f9eb659023708c10d16bb0abb56f4b3) | `` automatic update ``            |
| [`6f0a647e`](https://github.com/nix-community/NUR/commit/6f0a647e79499984c965866626e6b90716f4d0ed) | `` automatic update ``            |
| [`5e37e460`](https://github.com/nix-community/NUR/commit/5e37e460711df07217ab247f3fec3d8e1ecc0c3b) | `` automatic update ``            |
| [`d540f21a`](https://github.com/nix-community/NUR/commit/d540f21ac38e2339ccfef0552dc497204281a502) | `` automatic update ``            |
| [`11f099c5`](https://github.com/nix-community/NUR/commit/11f099c5fd0cddb14352dfee7d56b54f3c6c6f91) | `` automatic update ``            |
| [`147fbfd0`](https://github.com/nix-community/NUR/commit/147fbfd0361367d402111cc6abdcdb832bab9a17) | `` automatic update ``            |
| [`b60e9210`](https://github.com/nix-community/NUR/commit/b60e92106e48214f51e91eadbc099f2717af7167) | `` automatic update ``            |
| [`506ce468`](https://github.com/nix-community/NUR/commit/506ce4680a7efe22b4b357ccf749bde6f42fe11d) | `` automatic update ``            |
| [`d972ed4c`](https://github.com/nix-community/NUR/commit/d972ed4c47dcf0406ce582d0f958610d9d6c469d) | `` add Ev357 repository ``        |
| [`14c7fc25`](https://github.com/nix-community/NUR/commit/14c7fc255bf2eb4e44a1892f1ed6fd88bd395cea) | `` fix: incorrect argument ``     |
| [`10cf97de`](https://github.com/nix-community/NUR/commit/10cf97dee46dd9ae6b10b182959d23172915b396) | `` fix: type error in copytree `` |
| [`91ff8049`](https://github.com/nix-community/NUR/commit/91ff8049dea88cecdb80034796c1ce297a6ceba2) | `` automatic update ``            |
| [`02934957`](https://github.com/nix-community/NUR/commit/029349570e7e2bd5256014035f9b5e0cfaf7f59b) | `` automatic update ``            |