### PR TITLE
chore(flake/home-manager): `2c4ef7d7` -> `77f348da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -372,11 +372,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756247014,
-        "narHash": "sha256-aqMKFVMK/xhv0eJ1006zSmrUaXFO09AkaU8FutDbaZs=",
+        "lastModified": 1756261190,
+        "narHash": "sha256-eiy0klFK5EVJLNilutR7grsZN/7Itj9DyD75eyOf83k=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2c4ef7d7172708f6247d2ed9b56f0341b9ce63e1",
+        "rev": "77f348da3176dc68b20a73dab94852a417daf361",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                              |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`77f348da`](https://github.com/nix-community/home-manager/commit/77f348da3176dc68b20a73dab94852a417daf361) | `` fcitx5: migrate to qt6Packages `` |