### PR TITLE
chore(flake/nixos-facter-modules): `a1042c81` -> `5c37cee8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -582,11 +582,11 @@
     },
     "nixos-facter-modules": {
       "locked": {
-        "lastModified": 1756109073,
-        "narHash": "sha256-5pjFEziluVwJ0Z50h9laKfWbDluXuA5ada05xb/QiV4=",
+        "lastModified": 1756291602,
+        "narHash": "sha256-FYhiArSzcx60OwoH3JBp5Ho1D5HEwmZx6WoquauDv3g=",
         "owner": "nix-community",
         "repo": "nixos-facter-modules",
-        "rev": "a1042c81126d9c9314c1eb1a7b89ab4d81b5dea7",
+        "rev": "5c37cee817c94f50710ab11c25de572bc3604bd5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                              | Message                                                                |
| ------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`b4321c45`](https://github.com/nix-community/nixos-facter-modules/commit/b4321c45d8faddcfb2635e52e67b3b96bbe1f701) | `` feat: Enable intel-ipu6 support if a matching camera is detected `` |