### PR TITLE
chore(flake/emacs-overlay): `f4a1a64e` -> `a94e89d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1756260465,
-        "narHash": "sha256-kKq9MNh9lAIziMPb8rZ+wTEv3QR4K2LTM7nf2i8EbjI=",
+        "lastModified": 1756314506,
+        "narHash": "sha256-leW0Z/uZVNY+IqXWy/TrHr9Kw53MnFQzyuxj89FNPzQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f4a1a64e3581bf49791529105ae4b1c664c17072",
+        "rev": "a94e89d207acc053fe1e954a68838c67e1f3770f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`a94e89d2`](https://github.com/nix-community/emacs-overlay/commit/a94e89d207acc053fe1e954a68838c67e1f3770f) | `` Updated melpa `` |
| [`6203ac91`](https://github.com/nix-community/emacs-overlay/commit/6203ac910f37c7cf7d09bfc92b55d6db0a428723) | `` Updated emacs `` |
| [`fcf35e87`](https://github.com/nix-community/emacs-overlay/commit/fcf35e87032e244e2cf85f1e0fc1c1c26f3400d0) | `` Updated elpa ``  |