### PR TITLE
chore(flake/minimal-emacs-d): `80813db2` -> `8f5b2030`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     "minimal-emacs-d": {
       "flake": false,
       "locked": {
-        "lastModified": 1756149233,
-        "narHash": "sha256-AvlzMR2sPCNUJyzZT6T+3PordgksFIDdaxmy2kWzf9I=",
+        "lastModified": 1756318123,
+        "narHash": "sha256-xMYXKOm0ugaw8JMQHSnEBcJUUQr+kJPDyDZspHlqhfM=",
         "owner": "jamescherti",
         "repo": "minimal-emacs.d",
-        "rev": "80813db2d57d3243891189602a91b5ce25576bdb",
+        "rev": "8f5b2030fdaa6cf33d117ec32203864b367fc587",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                                                  |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
| [`8f5b2030`](https://github.com/jamescherti/minimal-emacs.d/commit/8f5b2030fdaa6cf33d117ec32203864b367fc587) | `` Make minimal-emacs-load-user-init display messages when init-file-debug is non-nil `` |
| [`19427b19`](https://github.com/jamescherti/minimal-emacs.d/commit/19427b19cc4f0c29e6d55fd431702517006e034b) | `` Update README.md ``                                                                   |
| [`2d69fbf5`](https://github.com/jamescherti/minimal-emacs.d/commit/2d69fbf55441010404cae77cdf52aed278f4ba26) | `` Enhance minimal-emacs-load-user-init ``                                               |
| [`429d3a66`](https://github.com/jamescherti/minimal-emacs.d/commit/429d3a6697ba92428213553717109287ba4f9fb3) | `` Update README.md ``                                                                   |