### PR TITLE
chore(flake/emacs-overlay): `a94e89d2` -> `bd5cff74`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1756314506,
-        "narHash": "sha256-leW0Z/uZVNY+IqXWy/TrHr9Kw53MnFQzyuxj89FNPzQ=",
+        "lastModified": 1756344201,
+        "narHash": "sha256-iW3F3pLmw3Bra0RPo5g5uY/SLE90cZf22kCx1ktmZxk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a94e89d207acc053fe1e954a68838c67e1f3770f",
+        "rev": "bd5cff74db13473beb87ffa2eee94853f93e4286",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`bd5cff74`](https://github.com/nix-community/emacs-overlay/commit/bd5cff74db13473beb87ffa2eee94853f93e4286) | `` Updated nongnu ``       |
| [`e35ef693`](https://github.com/nix-community/emacs-overlay/commit/e35ef69369eb7120c6e6144722e05fd9407fef07) | `` Updated flake inputs `` |