### PR TITLE
chore(flake/nur): `1f693539` -> `59625cf9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1756332267,
-        "narHash": "sha256-SBiHiR+Y074U9OZhnIrIgu/6iLZPxYhlBOmnP7ymBME=",
+        "lastModified": 1756376575,
+        "narHash": "sha256-H3/XDDicpmnCNMCS079NxsDXr2YxeL/Ys3sWMwuEec4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1f693539e1da901a6da002555d5480e887a5adc1",
+        "rev": "59625cf920bf670aa37bfa3dbc0677851e03d622",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`59625cf9`](https://github.com/nix-community/NUR/commit/59625cf920bf670aa37bfa3dbc0677851e03d622) | `` automatic update `` |
| [`f2146752`](https://github.com/nix-community/NUR/commit/f2146752bbbf85d1b0b3a67daab08b30e2345298) | `` automatic update `` |
| [`e4fe43b3`](https://github.com/nix-community/NUR/commit/e4fe43b366ebfdc6126e22d1ad4340c69a8f8edc) | `` automatic update `` |
| [`0b27ecad`](https://github.com/nix-community/NUR/commit/0b27ecadaa908972b67ed34fadd0e713466aa305) | `` automatic update `` |
| [`9d1cb2f4`](https://github.com/nix-community/NUR/commit/9d1cb2f41acb7dd148cee968875938588ee51bce) | `` automatic update `` |
| [`348fa027`](https://github.com/nix-community/NUR/commit/348fa027f5e365d2ba4fff4f3c96ac8b0a4db91b) | `` automatic update `` |
| [`d0dc086d`](https://github.com/nix-community/NUR/commit/d0dc086d7a925e6e54cdd124508f28954c383cae) | `` automatic update `` |
| [`eb506ce9`](https://github.com/nix-community/NUR/commit/eb506ce913d0e2ac0207590a8ca1f3bc23cb9993) | `` automatic update `` |
| [`848e09a7`](https://github.com/nix-community/NUR/commit/848e09a77f25fa737a45ad969aae43191a3c767c) | `` automatic update `` |
| [`93ea7d21`](https://github.com/nix-community/NUR/commit/93ea7d21d64c72341083daf1f3f86c47927bd64c) | `` automatic update `` |
| [`5f0a6570`](https://github.com/nix-community/NUR/commit/5f0a6570cd78ab94f7b2b38a74208eb4b8ada784) | `` automatic update `` |
| [`ccf16ddc`](https://github.com/nix-community/NUR/commit/ccf16ddcdefebbaeffb993e87687b0f0936de7dd) | `` automatic update `` |
| [`50343d08`](https://github.com/nix-community/NUR/commit/50343d0844606192ade2aa520b739fbe706b2c0b) | `` automatic update `` |
| [`23a23c1b`](https://github.com/nix-community/NUR/commit/23a23c1b87bb714f61c164e8e8d0566ac8104bb9) | `` automatic update `` |
| [`025b9d58`](https://github.com/nix-community/NUR/commit/025b9d589e344f571acdf10c99a27a4de379c114) | `` automatic update `` |
| [`86c7e905`](https://github.com/nix-community/NUR/commit/86c7e9052c37678510a3e7544c327877948e0637) | `` automatic update `` |
| [`c9fdb902`](https://github.com/nix-community/NUR/commit/c9fdb90218bdddde49916afd44e2d8a73e3f70aa) | `` automatic update `` |
| [`c75bc319`](https://github.com/nix-community/NUR/commit/c75bc3193585cb85fbdd56e8462a851fbc5e09f5) | `` automatic update `` |