### PR TITLE
chore(flake/emacs-overlay): `bd5cff74` -> `792b33fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1756344201,
-        "narHash": "sha256-iW3F3pLmw3Bra0RPo5g5uY/SLE90cZf22kCx1ktmZxk=",
+        "lastModified": 1756433238,
+        "narHash": "sha256-90TzmsvvqAihUcJKEG3cwp8pvGLP3P1oc3gAGU4EzOU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bd5cff74db13473beb87ffa2eee94853f93e4286",
+        "rev": "792b33fe5e6914c3ed0a59c5c543dfa4f63a55d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------- |
| [`792b33fe`](https://github.com/nix-community/emacs-overlay/commit/792b33fe5e6914c3ed0a59c5c543dfa4f63a55d6) | `` Updated melpa ``                    |
| [`ed41a187`](https://github.com/nix-community/emacs-overlay/commit/ed41a1871addef809f6b87845ee6c576e2a23b1a) | `` Updated elpa ``                     |
| [`1385f894`](https://github.com/nix-community/emacs-overlay/commit/1385f894b52be475da89833fb6d1158fea870834) | `` Updated nongnu ``                   |
| [`452a7694`](https://github.com/nix-community/emacs-overlay/commit/452a76945fd25463c5855a8eb419f0580104cef1) | `` Updated melpa ``                    |
| [`e4002c05`](https://github.com/nix-community/emacs-overlay/commit/e4002c05c262b1c41681704775d489800d8e3fb6) | `` Updated emacs ``                    |
| [`e6284e76`](https://github.com/nix-community/emacs-overlay/commit/e6284e769bcc1beb81b35f56fc0598ad613ac51f) | `` Updated elpa ``                     |
| [`c58a057d`](https://github.com/nix-community/emacs-overlay/commit/c58a057db0e2ca21742c7e0e9388f7a6428e370c) | `` fixup! Remove `srcRepo` override `` |
| [`d6459e39`](https://github.com/nix-community/emacs-overlay/commit/d6459e395f0cd9d8673a776728491781083b207a) | `` Updated melpa ``                    |
| [`25ecba3b`](https://github.com/nix-community/emacs-overlay/commit/25ecba3b3ae6620f672066ddc6e568cd09b177e7) | `` Updated emacs ``                    |
| [`656c4043`](https://github.com/nix-community/emacs-overlay/commit/656c40437f2ad596a9f26110d774098d869a96ad) | `` Updated elpa ``                     |
| [`3ebbd963`](https://github.com/nix-community/emacs-overlay/commit/3ebbd963cdb783d8260219bfcf37b07aeb8ecf0f) | `` Remove `srcRepo` override ``        |