### PR TITLE
chore(flake/nur): `4a87cbb9` -> `e4de97a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1756410140,
-        "narHash": "sha256-KaobzAEYG9rlacHDDTKxYEC0H5KKWeLROtzu8A+LRx0=",
+        "lastModified": 1756416356,
+        "narHash": "sha256-xcqREhXocGZPbDsvjD7ncDz8++jfX5ZwpGc0maiD9CY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4a87cbb97f2de584dffae7fd89184ed4f1bf7cc4",
+        "rev": "e4de97a152b367ba92ee590ff67fee4f33c46d92",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e4de97a1`](https://github.com/nix-community/NUR/commit/e4de97a152b367ba92ee590ff67fee4f33c46d92) | `` automatic update `` |
| [`c6a840c6`](https://github.com/nix-community/NUR/commit/c6a840c65768a73531d437e6845766a8d6e50381) | `` automatic update `` |
| [`f9bc9402`](https://github.com/nix-community/NUR/commit/f9bc9402cf2de28ad2da5d9f0c7446c8a842dd1e) | `` automatic update `` |