### PR TITLE
chore(flake/nur): `8df9a549` -> `e37c2aa6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1756438231,
-        "narHash": "sha256-ygHQWiCuNWjHky4+0+CNOmcyvOZHgX9a/UgaXp8JEpU=",
+        "lastModified": 1756452985,
+        "narHash": "sha256-8yhrRLvB2o5k8YUnQtgyMHFJG8Q6KBTp5xq19Pstl8Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8df9a54900dfd3573d77845ede54bc1414226511",
+        "rev": "e37c2aa66cd0229d0c1d7afcfe52240377f3ac56",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e37c2aa6`](https://github.com/nix-community/NUR/commit/e37c2aa66cd0229d0c1d7afcfe52240377f3ac56) | `` automatic update `` |
| [`23434fd7`](https://github.com/nix-community/NUR/commit/23434fd75614ec677013b3554dbb0481c11dd6ab) | `` automatic update `` |
| [`9e911d2a`](https://github.com/nix-community/NUR/commit/9e911d2a0e9d74a5ab28da8a1f32134a1e374be7) | `` automatic update `` |
| [`cd2dd40f`](https://github.com/nix-community/NUR/commit/cd2dd40f42140aa120795cfd6d12e6dda2ee3d36) | `` automatic update `` |