### PR TITLE
chore(flake/nur): `e37c2aa6` -> `aa927e8a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1113,11 +1113,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1756266583,
-        "narHash": "sha256-cr748nSmpfvnhqSXPiCfUPxRz2FJnvf/RjJGvFfaCsM=",
+        "lastModified": 1756386758,
+        "narHash": "sha256-1wxxznpW2CKvI9VdniaUnTT2Os6rdRJcRUf65ZK9OtE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8a6d5427d99ec71c64f0b93d45778c889005d9c2",
+        "rev": "dfb2f12e899db4876308eba6d93455ab7da304cd",
         "type": "github"
       },
       "original": {
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1756452985,
-        "narHash": "sha256-8yhrRLvB2o5k8YUnQtgyMHFJG8Q6KBTp5xq19Pstl8Q=",
+        "lastModified": 1756480509,
+        "narHash": "sha256-4EGJ3l7hP6pwkLhN+CC4tK59w7Wp80I/fFYa8uM/yxQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e37c2aa66cd0229d0c1d7afcfe52240377f3ac56",
+        "rev": "aa927e8a965ef0fd55a4bc25e64d3bb626852d42",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`aa927e8a`](https://github.com/nix-community/NUR/commit/aa927e8a965ef0fd55a4bc25e64d3bb626852d42) | `` automatic update `` |
| [`548300f4`](https://github.com/nix-community/NUR/commit/548300f46c019ae8829caf13593dddefefdceead) | `` automatic update `` |
| [`60d07d72`](https://github.com/nix-community/NUR/commit/60d07d72cc303086935552885a5c3821eb598bef) | `` automatic update `` |
| [`f8b2246d`](https://github.com/nix-community/NUR/commit/f8b2246d06dc7798de1910c849e12f5624eb30d6) | `` automatic update `` |
| [`c2d968fa`](https://github.com/nix-community/NUR/commit/c2d968fa6f06f5fdd545408082e812a02d1ffd8a) | `` automatic update `` |
| [`8a8e6a40`](https://github.com/nix-community/NUR/commit/8a8e6a40629e22f8f7560bdf1c1468556f6ce8ad) | `` automatic update `` |
| [`03705ef6`](https://github.com/nix-community/NUR/commit/03705ef6b1649096c83aa15908a921f17a32c5b0) | `` automatic update `` |
| [`c491462a`](https://github.com/nix-community/NUR/commit/c491462aee2fc0787e92bf2c54f95b59585ac5a5) | `` automatic update `` |