### PR TITLE
chore(flake/emacs-overlay): `792b33fe` -> `7c7fe831`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1756433238,
-        "narHash": "sha256-90TzmsvvqAihUcJKEG3cwp8pvGLP3P1oc3gAGU4EzOU=",
+        "lastModified": 1756482799,
+        "narHash": "sha256-g/bOuB+WW8FFtP0thGGu/si+1leWen+JOZ24qO+pqa0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "792b33fe5e6914c3ed0a59c5c543dfa4f63a55d6",
+        "rev": "7c7fe8312c417c20e38f2c2e318203061ceef7f5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                         |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`7c7fe831`](https://github.com/nix-community/emacs-overlay/commit/7c7fe8312c417c20e38f2c2e318203061ceef7f5) | `` Updated melpa ``                             |
| [`228497d1`](https://github.com/nix-community/emacs-overlay/commit/228497d179e680f32879242754c45f82670ddce6) | `` Updated elpa ``                              |
| [`0f2b1646`](https://github.com/nix-community/emacs-overlay/commit/0f2b16469b0d38a628aff4c215ac1ed2ea3ffa9c) | `` Updated nongnu ``                            |
| [`086c17a6`](https://github.com/nix-community/emacs-overlay/commit/086c17a63a666a4a3902799346d2daef2c76b679) | `` Update flake inputs ``                       |
| [`4ed9b132`](https://github.com/nix-community/emacs-overlay/commit/4ed9b1325679a951380c422a3a28498aa566c39f) | `` Revert "Remove `srcRepo` override" ``        |
| [`289484e7`](https://github.com/nix-community/emacs-overlay/commit/289484e721d484bda81c5180c9e602d134dcded3) | `` Revert "fixup! Remove `srcRepo` override" `` |