### PR TITLE
chore(flake/srvos): `bebcf12b` -> `cb563ace`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1301,11 +1301,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755770475,
-        "narHash": "sha256-piB4s87GvBJkzWLbzOMyX4adjMBmTMxzMu0SNT/b8hU=",
+        "lastModified": 1756480423,
+        "narHash": "sha256-fojiSdj6a9dF4RTwMu62T2iEm543KzVjq3HtwMnj4qA=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "bebcf12b45df0b7d6f422ebd5da06f92b52169a8",
+        "rev": "cb563ace92aba958a706f86efaaa65e3a6ca2dff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                              |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`623dc2f8`](https://github.com/nix-community/srvos/commit/623dc2f83cccb7ceaf987a8700884d4bf9e63f02) | `` latest-zfs-kernel: fix with latest nixpkgs api `` |