### PR TITLE
chore(flake/nixos-facter-modules): `5c37cee8` -> `c1b29520`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -973,11 +973,11 @@
     },
     "nixos-facter-modules": {
       "locked": {
-        "lastModified": 1756291602,
-        "narHash": "sha256-FYhiArSzcx60OwoH3JBp5Ho1D5HEwmZx6WoquauDv3g=",
+        "lastModified": 1756491981,
+        "narHash": "sha256-lXyDAWPw/UngVtQfgQ8/nrubs2r+waGEYIba5UX62+k=",
         "owner": "nix-community",
         "repo": "nixos-facter-modules",
-        "rev": "5c37cee817c94f50710ab11c25de572bc3604bd5",
+        "rev": "c1b29520945d3e148cd96618c8a0d1f850965d8c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                              | Message                                                   |
| ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`cb2d8603`](https://github.com/nix-community/nixos-facter-modules/commit/cb2d8603eae1f66e445a1801aba83ff5d23d453f) | `` replace useNetworkd with nixos-generate-config does `` |