### PR TITLE
chore(flake/emacs-overlay): `7c7fe831` -> `9ea70e7e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1756482799,
-        "narHash": "sha256-g/bOuB+WW8FFtP0thGGu/si+1leWen+JOZ24qO+pqa0=",
+        "lastModified": 1756519376,
+        "narHash": "sha256-ssyp3oGb9oCSTGT667+vdzEMZtH+qF9N8zKpQPdAkl8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7c7fe8312c417c20e38f2c2e318203061ceef7f5",
+        "rev": "9ea70e7ea6d66396f414fc661b1f02ebc27bef8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`9ea70e7e`](https://github.com/nix-community/emacs-overlay/commit/9ea70e7ea6d66396f414fc661b1f02ebc27bef8d) | `` Updated melpa ``  |
| [`3e33bb09`](https://github.com/nix-community/emacs-overlay/commit/3e33bb09007a170bb39c2784761170bcc0f3c991) | `` Updated emacs ``  |
| [`81148fdf`](https://github.com/nix-community/emacs-overlay/commit/81148fdf7566226833dc07c0d70cabd1d3d53c96) | `` Updated elpa ``   |
| [`81acff4c`](https://github.com/nix-community/emacs-overlay/commit/81acff4c0f1ddfa734fbb145e405d2013c52cb81) | `` Updated nongnu `` |
| [`70f78565`](https://github.com/nix-community/emacs-overlay/commit/70f78565e9055b2f39249b7630073d59f8663efb) | `` Updated emacs ``  |