### PR TITLE
chore(flake/nur): `aa927e8a` -> `6a9b4f10`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1756480509,
-        "narHash": "sha256-4EGJ3l7hP6pwkLhN+CC4tK59w7Wp80I/fFYa8uM/yxQ=",
+        "lastModified": 1756526415,
+        "narHash": "sha256-UNwhZKzzl9sW9Igb262gcx+sx7+VmvQoRjRu4/NR2Ds=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "aa927e8a965ef0fd55a4bc25e64d3bb626852d42",
+        "rev": "6a9b4f1024750decd179e59d57dc3c2b586af414",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6a9b4f10`](https://github.com/nix-community/NUR/commit/6a9b4f1024750decd179e59d57dc3c2b586af414) | `` automatic update `` |
| [`3b3c996b`](https://github.com/nix-community/NUR/commit/3b3c996bbe9e8dc3788a2222beda3967b78534f8) | `` automatic update `` |
| [`e82a8b00`](https://github.com/nix-community/NUR/commit/e82a8b0095f54edb6bbbb1d862f3da502dca1396) | `` automatic update `` |
| [`f5a72b6f`](https://github.com/nix-community/NUR/commit/f5a72b6fb998a069c155b0b81590daff63ad098c) | `` automatic update `` |
| [`f7d227cd`](https://github.com/nix-community/NUR/commit/f7d227cda218f964b87783715fd50caa8f8eec44) | `` automatic update `` |
| [`ef21027c`](https://github.com/nix-community/NUR/commit/ef21027c9847f69026ee1d83885dc416593422c8) | `` automatic update `` |
| [`d5d977b0`](https://github.com/nix-community/NUR/commit/d5d977b038ea81fa09ea21dde15dffdb2589359b) | `` automatic update `` |
| [`e52eff6b`](https://github.com/nix-community/NUR/commit/e52eff6b35a0c45ab6d6da89f63d887c6303b760) | `` automatic update `` |
| [`a188dc3b`](https://github.com/nix-community/NUR/commit/a188dc3b0cf84b4e33d8e6a78082fab84a6f49bc) | `` automatic update `` |
| [`01bf774f`](https://github.com/nix-community/NUR/commit/01bf774fb095f9b61f9e22a7f5749a4e81a9a8e4) | `` automatic update `` |
| [`8f90aebc`](https://github.com/nix-community/NUR/commit/8f90aebc0a8fa73f86b3b5b05ae1e7fc3f4cafc2) | `` automatic update `` |
| [`b2265b49`](https://github.com/nix-community/NUR/commit/b2265b493740043246359d0a0e81cbcee920b42e) | `` automatic update `` |
| [`3efe965f`](https://github.com/nix-community/NUR/commit/3efe965f5eb94fd3c54d5e3f52ed2ca9ad0b7863) | `` automatic update `` |