### PR TITLE
chore(flake/srvos): `cb563ace` -> `403438bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1301,11 +1301,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756480423,
-        "narHash": "sha256-fojiSdj6a9dF4RTwMu62T2iEm543KzVjq3HtwMnj4qA=",
+        "lastModified": 1756489363,
+        "narHash": "sha256-7dh3vXtZi7cMxdq7E/j+/b6Gw+DrIAVGdiCIjZJtcSI=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "cb563ace92aba958a706f86efaaa65e3a6ca2dff",
+        "rev": "403438bb81f599b65a2500d9355cf95ff169cc22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                   |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`39695f05`](https://github.com/nix-community/srvos/commit/39695f058c9b07ef6e0d1f84c9e86e88f3fe98a8) | `` mdns: fix filtering dhcp interfaces `` |