### PR TITLE
chore(flake/nur): `6a9b4f10` -> `e91a9181`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1756526415,
-        "narHash": "sha256-UNwhZKzzl9sW9Igb262gcx+sx7+VmvQoRjRu4/NR2Ds=",
+        "lastModified": 1756554206,
+        "narHash": "sha256-2srNeeS08EQm3LP7VuGLxyIAQEWDv8DKgoh48Md3gNw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6a9b4f1024750decd179e59d57dc3c2b586af414",
+        "rev": "e91a91815e0351c1c82c7c8c136cbc45b2ade087",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e91a9181`](https://github.com/nix-community/NUR/commit/e91a91815e0351c1c82c7c8c136cbc45b2ade087) | `` automatic update `` |
| [`6601ad51`](https://github.com/nix-community/NUR/commit/6601ad51748e8300809cd91d863ca2fb1b61b777) | `` automatic update `` |
| [`35d8dc0a`](https://github.com/nix-community/NUR/commit/35d8dc0a41322f126498f395575df74c2f03d6ec) | `` automatic update `` |
| [`83369ce5`](https://github.com/nix-community/NUR/commit/83369ce5e97d54965283cf02e7f8969b93e00a83) | `` automatic update `` |
| [`079e3cfb`](https://github.com/nix-community/NUR/commit/079e3cfb90e6111b17e9440daa272878ed40ba3e) | `` automatic update `` |
| [`94fc286b`](https://github.com/nix-community/NUR/commit/94fc286b50459ae33020e65bc80d358042a02b64) | `` automatic update `` |