### PR TITLE
chore(flake/emacs-overlay): `9ea70e7e` -> `045f679c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1756519376,
-        "narHash": "sha256-ssyp3oGb9oCSTGT667+vdzEMZtH+qF9N8zKpQPdAkl8=",
+        "lastModified": 1756573581,
+        "narHash": "sha256-xlPQqXXhT8DKN0zGCnnph7aVkEmrDrHankKe7Ke7K7s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9ea70e7ea6d66396f414fc661b1f02ebc27bef8d",
+        "rev": "045f679c6863cd4d1090472933165f264a7dc1db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`045f679c`](https://github.com/nix-community/emacs-overlay/commit/045f679c6863cd4d1090472933165f264a7dc1db) | `` Updated melpa `` |
| [`b0fbf3b9`](https://github.com/nix-community/emacs-overlay/commit/b0fbf3b96866ef5f0c8976d0cce5c41dedf9de96) | `` Updated emacs `` |
| [`134039e3`](https://github.com/nix-community/emacs-overlay/commit/134039e337e85d114e26f9265ba5d113c81f2c98) | `` Updated elpa ``  |
| [`1c6ba6fb`](https://github.com/nix-community/emacs-overlay/commit/1c6ba6fb3b8a444dec1cbebff0d5914b569b4d24) | `` Updated melpa `` |
| [`2e4d97a5`](https://github.com/nix-community/emacs-overlay/commit/2e4d97a53a1cd7e5aa28b54dcc86e5e63670edd3) | `` Updated emacs `` |