### PR TITLE
chore(flake/nur): `e91a9181` -> `e8f97acd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1756554206,
-        "narHash": "sha256-2srNeeS08EQm3LP7VuGLxyIAQEWDv8DKgoh48Md3gNw=",
+        "lastModified": 1756568538,
+        "narHash": "sha256-nnFpWhG/jtRzI2yJKKgokhefFELHTUw9fgqcTrdX6aM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e91a91815e0351c1c82c7c8c136cbc45b2ade087",
+        "rev": "e8f97acd1ededca7944f1fe1b659b61003131ce2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e8f97acd`](https://github.com/nix-community/NUR/commit/e8f97acd1ededca7944f1fe1b659b61003131ce2) | `` automatic update `` |
| [`d702f62f`](https://github.com/nix-community/NUR/commit/d702f62fa549e8ecb35b29f88e904f88572947ec) | `` automatic update `` |
| [`7fe5f8bf`](https://github.com/nix-community/NUR/commit/7fe5f8bfcd25ac64eed00d5737051ea8d01a6ffe) | `` automatic update `` |
| [`dc4f0f39`](https://github.com/nix-community/NUR/commit/dc4f0f394610a3cd9580759296bb0ef02dc7bd29) | `` automatic update `` |