### PR TITLE
chore(flake/nur): `d3cd12b8` -> `f45c90f7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1756612486,
-        "narHash": "sha256-fbRUr1H2GFK4IY9vq1mGxvFcaoj6YMwyb1muc/IH21U=",
+        "lastModified": 1756626191,
+        "narHash": "sha256-vB3+tezKrjiW9QukWgyELLPaCN5cn3L4KnyrnI2LD8U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d3cd12b86af1cb398277b9bca2dda63998ba63ba",
+        "rev": "f45c90f7f8aed2e6f64d0fe6e17a7237d5fe81e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f45c90f7`](https://github.com/nix-community/NUR/commit/f45c90f7f8aed2e6f64d0fe6e17a7237d5fe81e0) | `` automatic update `` |
| [`b781e5e4`](https://github.com/nix-community/NUR/commit/b781e5e4cb8d82bb972b4b33506cece14d88759f) | `` automatic update `` |
| [`8a70a9a5`](https://github.com/nix-community/NUR/commit/8a70a9a512821727d86aca265757822c7bb1109c) | `` automatic update `` |
| [`c7b8c3d8`](https://github.com/nix-community/NUR/commit/c7b8c3d80160c5b733d383d69020196b2601e976) | `` automatic update `` |