### PR TITLE
chore(flake/home-manager): `99a69bdf` -> `e4454907`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -740,11 +740,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756579987,
-        "narHash": "sha256-duCce8zGsaMsrqqOmLOsuaV1PVIw/vXWnKuLKZClsGg=",
+        "lastModified": 1756650373,
+        "narHash": "sha256-Iz0dNCNvLLxVGjOOF1/TJvZ4iKXE96BTgKDObCs9u+M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "99a69bdf8a3c6bf038c4121e9c4b6e99706a187a",
+        "rev": "e44549074a574d8bda612945a88e4a1fd3c456a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`e4454907`](https://github.com/nix-community/home-manager/commit/e44549074a574d8bda612945a88e4a1fd3c456a8) | `` programs.rclone: fix injecting secret when value begins with "-" `` |
| [`4896177e`](https://github.com/nix-community/home-manager/commit/4896177e2c01ea9c93bd19f4ae0af9c8b3db376d) | `` programs.rclone: set Service.Type=notify ``                         |
| [`feba2b2d`](https://github.com/nix-community/home-manager/commit/feba2b2daa9823b27dc53b53e8e159d9aba33dbd) | `` programs.rclone: fix typo ``                                        |
| [`27d306e1`](https://github.com/nix-community/home-manager/commit/27d306e1e46faac9ae24d50ad75dc93efbb61d51) | `` Translate using Weblate (Bulgarian) ``                              |
| [`30fbfd27`](https://github.com/nix-community/home-manager/commit/30fbfd27a262a86d8c9d4acfff0650c03fe18603) | `` Translate using Weblate (Bulgarian) ``                              |
| [`6c8db975`](https://github.com/nix-community/home-manager/commit/6c8db97536780085f2e7c25d0ea5a9e5c6f19971) | `` Translate using Weblate (Bulgarian) ``                              |