### PR TITLE
chore(flake/treefmt-nix): `74e1a52d` -> `1aabc6c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1357,11 +1357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755934250,
-        "narHash": "sha256-CsDojnMgYsfshQw3t4zjRUkmMmUdZGthl16bXVWgRYU=",
+        "lastModified": 1756662192,
+        "narHash": "sha256-F1oFfV51AE259I85av+MAia221XwMHCOtZCMcZLK2Jk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "74e1a52d5bd9430312f8d1b8b0354c92c17453e5",
+        "rev": "1aabc6c05ccbcbf4a635fb7a90400e44282f61c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                            |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`1aabc6c0`](https://github.com/numtide/treefmt-nix/commit/1aabc6c05ccbcbf4a635fb7a90400e44282f61c4) | `` aiken: init at 1.1.19 (#406) `` |