### PR TITLE
chore(flake/emacs-overlay): `226b43dd` -> `0b89d219`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1756657328,
-        "narHash": "sha256-8mkj3NvMYGRrUVmUEzO6Sh+ZAQEbbBDFHRmD5LcRSks=",
+        "lastModified": 1756718044,
+        "narHash": "sha256-6bhIP6Ykf0bcVisnq26LO/OSOh5fZ0CL/MySTFO7SjA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "226b43dd8907c28899c02527e27ca5961f96a064",
+        "rev": "0b89d219c50df84ddbc823950607b414b0da8e6f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`0b89d219`](https://github.com/nix-community/emacs-overlay/commit/0b89d219c50df84ddbc823950607b414b0da8e6f) | `` Updated melpa ``  |
| [`1d184329`](https://github.com/nix-community/emacs-overlay/commit/1d184329d8b9bc160b5ecf5f5ce529c80ea8dab0) | `` Updated emacs ``  |
| [`b5511d28`](https://github.com/nix-community/emacs-overlay/commit/b5511d28b27db41bae80efb10f8d13125d9ac450) | `` Updated nongnu `` |
| [`25638814`](https://github.com/nix-community/emacs-overlay/commit/25638814bf09e766b92c814e9161d7cebc8b8348) | `` Updated elpa ``   |