### PR TITLE
chore(flake/nur): `c0824978` -> `65f25423`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1756699482,
-        "narHash": "sha256-G6gJT6LqmRb9NTCOSy+X64bJVrOKUTplKNABiptX3pQ=",
+        "lastModified": 1756755795,
+        "narHash": "sha256-lpD6BTl0UEt2tnFwVTbP8bGABp8lA0kKINUyg+PIPLA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c0824978e58d3d0ea7ac01a1e0ec384604118c23",
+        "rev": "65f254239faf83fb43e672a544ed6681aff472d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`65f25423`](https://github.com/nix-community/NUR/commit/65f254239faf83fb43e672a544ed6681aff472d7) | `` automatic update `` |
| [`70f33939`](https://github.com/nix-community/NUR/commit/70f339391f2e60c7bfe2a540677508947a881d29) | `` automatic update `` |
| [`092fc22e`](https://github.com/nix-community/NUR/commit/092fc22e7002ce083b7cd5cc1b0d5dac97d39c25) | `` automatic update `` |
| [`c643c3c2`](https://github.com/nix-community/NUR/commit/c643c3c29f97210fe3fddfa3ea78208234c6df03) | `` automatic update `` |
| [`a180e837`](https://github.com/nix-community/NUR/commit/a180e837cadff3e66502353a5dbdaffd05b049ac) | `` automatic update `` |
| [`1c4f0751`](https://github.com/nix-community/NUR/commit/1c4f075157a014fe4b809e4d7f3ddde3aef5dc56) | `` automatic update `` |
| [`3594b296`](https://github.com/nix-community/NUR/commit/3594b29676526eb280155fbc3bc1fc57677bd75f) | `` automatic update `` |
| [`9eedce97`](https://github.com/nix-community/NUR/commit/9eedce975c6324407871669fd27b10582832fd27) | `` automatic update `` |
| [`effb8c7a`](https://github.com/nix-community/NUR/commit/effb8c7ab9fbfba86d31703a6101469489ab9df8) | `` automatic update `` |
| [`5c499545`](https://github.com/nix-community/NUR/commit/5c49954555ad21b9dfd18d772988b1f97935e3ea) | `` automatic update `` |
| [`a8b026eb`](https://github.com/nix-community/NUR/commit/a8b026eb0836d4aaabb7b3ad3c7d3549072b1af0) | `` automatic update `` |