### PR TITLE
chore(flake/deploy-rs): `6bc76b87` -> `125ae9e3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -495,11 +495,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749105467,
-        "narHash": "sha256-hXh76y/wDl15almBcqvjryB50B0BaiXJKk20f314RoE=",
+        "lastModified": 1756719547,
+        "narHash": "sha256-N9gBKUmjwRKPxAafXEk1EGadfk2qDZPBQp4vXWPHINQ=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "6bc76b872374845ba9d645a2f012b764fecd765f",
+        "rev": "125ae9e3ecf62fb2c0fd4f2d894eb971f1ecaed2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                            |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`125ae9e3`](https://github.com/serokell/deploy-rs/commit/125ae9e3ecf62fb2c0fd4f2d894eb971f1ecaed2) | `` remove no longer necessary apple_sdk from buildInputs (#339) `` |