### PR TITLE
chore(flake/nur): `65f25423` -> `6172faa4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1756755795,
-        "narHash": "sha256-lpD6BTl0UEt2tnFwVTbP8bGABp8lA0kKINUyg+PIPLA=",
+        "lastModified": 1756841130,
+        "narHash": "sha256-9g+bkdbLP9+CeujhkHTnyVwswygwZTm9cFNg17ndSXg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "65f254239faf83fb43e672a544ed6681aff472d7",
+        "rev": "6172faa42e3fde720fb8ee632f96686a774d3533",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6172faa4`](https://github.com/nix-community/NUR/commit/6172faa42e3fde720fb8ee632f96686a774d3533) | `` automatic update `` |
| [`931c653b`](https://github.com/nix-community/NUR/commit/931c653b4ecee6d21326626409721f742022591b) | `` automatic update `` |
| [`46ca2903`](https://github.com/nix-community/NUR/commit/46ca29032c89a78b943b7c37fddf5742a36c6e01) | `` automatic update `` |
| [`959a03fe`](https://github.com/nix-community/NUR/commit/959a03fe31a83362741b83a0ad0cbfe46a3217ea) | `` automatic update `` |
| [`c9c4e73a`](https://github.com/nix-community/NUR/commit/c9c4e73a1b1edb2dce5ed903be2be1b49947964d) | `` automatic update `` |
| [`b8e7bafc`](https://github.com/nix-community/NUR/commit/b8e7bafc21fbc2b3fb9bafd4ae0c8f789d14349d) | `` automatic update `` |
| [`904ccc0d`](https://github.com/nix-community/NUR/commit/904ccc0db023d9dc4ab9dfa2adb0282e4294b737) | `` automatic update `` |
| [`bb53c97b`](https://github.com/nix-community/NUR/commit/bb53c97b200b0b92c5795b5d9696389e53a1653a) | `` automatic update `` |
| [`17592a6e`](https://github.com/nix-community/NUR/commit/17592a6e8f9e4bc6f9dd8d577e80010f216c811e) | `` automatic update `` |
| [`1d4a42c8`](https://github.com/nix-community/NUR/commit/1d4a42c87f9627a6d211a0fd0e2f1b9c2525c845) | `` automatic update `` |
| [`daf72458`](https://github.com/nix-community/NUR/commit/daf72458b0b2379681f8978a429b5f1428865c13) | `` automatic update `` |
| [`94b0b2ad`](https://github.com/nix-community/NUR/commit/94b0b2ad8785904c0ecc53ad746207392063c3c3) | `` automatic update `` |
| [`678bf16a`](https://github.com/nix-community/NUR/commit/678bf16a5f1a7e2df5b75d4c62da44bc67921462) | `` automatic update `` |
| [`2cc1337c`](https://github.com/nix-community/NUR/commit/2cc1337cc18f60d9fd9df787dae2bc7a5239202d) | `` automatic update `` |
| [`c66615c6`](https://github.com/nix-community/NUR/commit/c66615c6892d6a7f17c5ee9bb6d001f7fee12e4b) | `` automatic update `` |
| [`7a8a4b4b`](https://github.com/nix-community/NUR/commit/7a8a4b4bfbb0f2268d31f37b4d7aa127450510ef) | `` automatic update `` |
| [`38d05e3e`](https://github.com/nix-community/NUR/commit/38d05e3ed2bfadddd5a8aecb03eb4988ad9399f5) | `` automatic update `` |
| [`e0dd581f`](https://github.com/nix-community/NUR/commit/e0dd581fe4388b99545889845f7d26a9358d445b) | `` automatic update `` |
| [`34d99d18`](https://github.com/nix-community/NUR/commit/34d99d18b79389d26cfad4c4584e4bbce93bbf8f) | `` automatic update `` |
| [`8790f83f`](https://github.com/nix-community/NUR/commit/8790f83fdd680a8480717944032caf2275de928a) | `` automatic update `` |
| [`4153e362`](https://github.com/nix-community/NUR/commit/4153e362b943a9fabc15a2a4aeddc93c7d6cd2d3) | `` automatic update `` |
| [`932edc60`](https://github.com/nix-community/NUR/commit/932edc60b98cc9fadb0d37018925ca5b9a83cf73) | `` automatic update `` |
| [`0d07ee13`](https://github.com/nix-community/NUR/commit/0d07ee13c482fa637d56f281583fc5b0da22a0de) | `` automatic update `` |
| [`ade8edc0`](https://github.com/nix-community/NUR/commit/ade8edc03289b193c1d23daa3ca553b13f327c4e) | `` automatic update `` |
| [`0684882e`](https://github.com/nix-community/NUR/commit/0684882ee6d2ebb142c7f0b64072976473d23b6a) | `` automatic update `` |