### PR TITLE
chore(flake/home-manager): `29ab63bb` -> `30fc1b53`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -740,11 +740,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756734952,
-        "narHash": "sha256-H6jmduj4QIncLPAPODPSG/8ry9lpr1kRq6fYytU52qU=",
+        "lastModified": 1756842514,
+        "narHash": "sha256-XbtRMewPGJwTNhBC4pnBu3w/xT1XejvB0HfohC2Kga8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "29ab63bbb3d9eee4a491f7ce701b189becd34068",
+        "rev": "30fc1b532645a21e157b6e33e3f8b4c154f86382",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`30fc1b53`](https://github.com/nix-community/home-manager/commit/30fc1b532645a21e157b6e33e3f8b4c154f86382) | `` nix-init: ensure settings example produces a valid configuration `` |
| [`a1316b0a`](https://github.com/nix-community/home-manager/commit/a1316b0a77ef3e082a75bc5dc685c249b3c25f2c) | `` new: add swappy entry ``                                            |
| [`1a6f6fb4`](https://github.com/nix-community/home-manager/commit/1a6f6fb4091a6eb9c3bae8bac6d233f6ee51d489) | `` swappy: add module ``                                               |
| [`f3d3b459`](https://github.com/nix-community/home-manager/commit/f3d3b4592a73fb64b5423234c01985ea73976596) | `` news: add hyprland submap entry ``                                  |
| [`06179315`](https://github.com/nix-community/home-manager/commit/061793150a092e24315d14ff9e06510889849e75) | `` tests/hyprland: add submap test ``                                  |
| [`5f64bccc`](https://github.com/nix-community/home-manager/commit/5f64bcccef6d54a8fda5f70b29a3a423596c90ea) | `` hyprland: tweak submap line formatting ``                           |
| [`1ecfd8e5`](https://github.com/nix-community/home-manager/commit/1ecfd8e5626b27a9610f468be32cd6a7011f56a0) | `` hyprland: add support for submaps (#6062) (#7277) ``                |
| [`e31db614`](https://github.com/nix-community/home-manager/commit/e31db6141e47f1007a54bc9e4d8b2a26a9fbd697) | `` Translate using Weblate (Hindi) ``                                  |
| [`aa35affc`](https://github.com/nix-community/home-manager/commit/aa35affc6f8561bed3dd6ca67fc9d1a7d01a8233) | `` Translate using Weblate (Hindi) ``                                  |
| [`9bd58094`](https://github.com/nix-community/home-manager/commit/9bd580947cdd01f30f043d827cef7b6ac8733f7a) | `` Translate using Weblate (Hindi) ``                                  |
| [`e7c24fc5`](https://github.com/nix-community/home-manager/commit/e7c24fc522443c402b21b25f8cd78ec90d238ee2) | `` Translate using Weblate (Dutch) ``                                  |