### PR TITLE
chore(flake/nur): `6172faa4` -> `143985f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1756841130,
-        "narHash": "sha256-9g+bkdbLP9+CeujhkHTnyVwswygwZTm9cFNg17ndSXg=",
+        "lastModified": 1756856604,
+        "narHash": "sha256-7UTJ5JLQos2rWyxOqlNDzCkSRqhN7SAAvtdf8AHci7c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6172faa42e3fde720fb8ee632f96686a774d3533",
+        "rev": "143985f9f846656911cb35fdc3403a68a2363b87",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`143985f9`](https://github.com/nix-community/NUR/commit/143985f9f846656911cb35fdc3403a68a2363b87) | `` automatic update `` |
| [`d93f4f98`](https://github.com/nix-community/NUR/commit/d93f4f98abf2f40fcf7f01e767b921fd464c0f71) | `` automatic update `` |
| [`223667f0`](https://github.com/nix-community/NUR/commit/223667f0bf566fde8c8e1791e8e0a1be8603c24e) | `` automatic update `` |
| [`e5a00c9e`](https://github.com/nix-community/NUR/commit/e5a00c9e0aa0ea3987864e642a6ab3bc38d4e835) | `` automatic update `` |
| [`026cbef0`](https://github.com/nix-community/NUR/commit/026cbef09e235753672904ff30253130f08b9557) | `` automatic update `` |