### PR TITLE
chore(flake/nur): `143985f9` -> `55dd30d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1756856604,
-        "narHash": "sha256-7UTJ5JLQos2rWyxOqlNDzCkSRqhN7SAAvtdf8AHci7c=",
+        "lastModified": 1756870625,
+        "narHash": "sha256-vQQK4Z5UbOc5mNPk93r+msUMAtABYkXBa/zNQuwh5xA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "143985f9f846656911cb35fdc3403a68a2363b87",
+        "rev": "55dd30d13ba308aa08e5494552f86f1eff13c9a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`55dd30d1`](https://github.com/nix-community/NUR/commit/55dd30d13ba308aa08e5494552f86f1eff13c9a7) | `` automatic update `` |
| [`8729ec59`](https://github.com/nix-community/NUR/commit/8729ec59450d7bda9c3ab14a167bf7a10442901c) | `` automatic update `` |
| [`888f3383`](https://github.com/nix-community/NUR/commit/888f3383ea4dc678be67317e5e9f229bb772584b) | `` automatic update `` |
| [`56dde8b9`](https://github.com/nix-community/NUR/commit/56dde8b941b873709a2eee5e912ce8a161fe47a1) | `` automatic update `` |
| [`8c520217`](https://github.com/nix-community/NUR/commit/8c5202177d2830f9affbd629206f7916b9a27303) | `` automatic update `` |
| [`5fd13c87`](https://github.com/nix-community/NUR/commit/5fd13c8731a4689e99b33469620c91fd930eb937) | `` automatic update `` |