### PR TITLE
chore(flake/emacs-overlay): `73c17b08` -> `e9954371`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1756832996,
-        "narHash": "sha256-pW+QqeXIIKzo4GkX+WM86t7vai++RHaDE32aMDAIUJs=",
+        "lastModified": 1756864982,
+        "narHash": "sha256-NPpRPaIVGRSh4nrq+37ufZBECWCLP+YQP3BZgL5UOmY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "73c17b083cd9383d9dd0c98ca33c5d7cdabfec6c",
+        "rev": "e99543717040244141e250186828604e4a1f6567",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`e9954371`](https://github.com/nix-community/emacs-overlay/commit/e99543717040244141e250186828604e4a1f6567) | `` Updated melpa ``  |
| [`f6e1f3c8`](https://github.com/nix-community/emacs-overlay/commit/f6e1f3c8c3ce46c8d4dee136fae99542a0604219) | `` Updated emacs ``  |
| [`45b76224`](https://github.com/nix-community/emacs-overlay/commit/45b76224dd68488ed388534bf37340755cedaea8) | `` Updated elpa ``   |
| [`c8c77e60`](https://github.com/nix-community/emacs-overlay/commit/c8c77e6086518d679d92f2cfd17b6c88f9be6b37) | `` Updated nongnu `` |