### PR TITLE
chore(flake/nixpkgs): `d7600c77` -> `d0fc3089`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1097,11 +1097,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1756542300,
-        "narHash": "sha256-tlOn88coG5fzdyqz6R93SQL5Gpq+m/DsWpekNFhqPQk=",
+        "lastModified": 1756787288,
+        "narHash": "sha256-rw/PHa1cqiePdBxhF66V7R+WAP8WekQ0mCDG4CFqT8Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d7600c775f877cd87b4f5a831c28aa94137377aa",
+        "rev": "d0fc30899600b9b3466ddb260fd83deb486c32f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`cb54c881`](https://github.com/NixOS/nixpkgs/commit/cb54c881c62b4d040276162b1fa2255f7334a0ee) | `` python31{2,3}Packages.localstack-ext: fix build error ``                         |
| [`000aa76a`](https://github.com/NixOS/nixpkgs/commit/000aa76a6b854e8e094c4e1fb8641855d50303ca) | `` bmake: cmd-interrupt test tries to `SIGINT` make itself, is flaky as a result `` |
| [`c8b076cb`](https://github.com/NixOS/nixpkgs/commit/c8b076cb07e9a55e3d3389e3253a5f6715300cb1) | `` libwebp: set meta.pkgConfigModules ``                                            |
| [`ce6c940c`](https://github.com/NixOS/nixpkgs/commit/ce6c940c90a2886f0dbabaecc4b892762fd91c9a) | `` nixos/tests/headscale: test dns records config ``                                |
| [`bd531a25`](https://github.com/NixOS/nixpkgs/commit/bd531a25851820457c4eddc5747017b91c3d748e) | `` python3Packages.kanidm: 1.0.0-2024-04-22 -> 1.2.0 ``                             |
| [`71701ca8`](https://github.com/NixOS/nixpkgs/commit/71701ca8a54608a30455fd91b06672bace2376de) | `` chhoto-url: 6.3.0 -> 6.3.1 ``                                                    |
| [`2ad5124a`](https://github.com/NixOS/nixpkgs/commit/2ad5124a6f2c2764da1acabd0582b1a66e1c660a) | `` wyoming-piper: relax constraint on regex dependency ``                           |
| [`8c4b4fc4`](https://github.com/NixOS/nixpkgs/commit/8c4b4fc42cfd7abe5e086ef0f20cdf9653fbfe93) | `` zigbee2mqtt: 2.6.0 -> 2.6.1 ``                                                   |
| [`7f99e08c`](https://github.com/NixOS/nixpkgs/commit/7f99e08ccb7e4b745737607b2c7f8ca1e32f2d6c) | `` nixos/pihole-ftl: fix privacyLevel option ``                                     |
| [`2d6f552a`](https://github.com/NixOS/nixpkgs/commit/2d6f552a2167c2ae83f6faa2ba4542b1ec1d7cb0) | `` python3Packages.osc-sdk-python: remove maintainer ``                             |
| [`cbb859c6`](https://github.com/NixOS/nixpkgs/commit/cbb859c673cce7c6c0b0893d8823cd90df93268d) | `` pscale: 0.250.0 -> 0.255.0 ``                                                    |
| [`de2fd966`](https://github.com/NixOS/nixpkgs/commit/de2fd96686b4c39ecdb51a08da402bc7ee8c31f5) | `` jasmin-compiler: 2025.06.0 → 2025.06.1 ``                                        |
| [`455fa0b1`](https://github.com/NixOS/nixpkgs/commit/455fa0b191623a8f2c0f50df5cf7b3cdb9f838d9) | `` python313Packages.typer-shell: 0.2.1 -> 1.0.3 ``                                 |
| [`1d1496d3`](https://github.com/NixOS/nixpkgs/commit/1d1496d39df4255a6991947ef81e73d807ae3491) | `` dbip-asn-lite: 2025-08 -> 2025-09 ``                                             |
| [`04b58661`](https://github.com/NixOS/nixpkgs/commit/04b58661fb27c8dd68f0ac09b7e88b662b04241a) | `` dbip-city-lite: 2025-08 -> 2025-09 ``                                            |
| [`da6367b9`](https://github.com/NixOS/nixpkgs/commit/da6367b9cbddf2068ce608cc18df3e1d03233b5e) | `` dbip-country-lite: 2025-08 -> 2025-09 ``                                         |
| [`0c50579d`](https://github.com/NixOS/nixpkgs/commit/0c50579dfcbf343378ce3d1adffec032792c4f76) | `` emacs.pkgs.emacs-application-framework: use xdotool when available ``            |
| [`d1461bac`](https://github.com/NixOS/nixpkgs/commit/d1461bacd2d7031991045e55fb74e5eab8a9575c) | `` python313Packages.jproperties: modernize ``                                      |
| [`fcb95a47`](https://github.com/NixOS/nixpkgs/commit/fcb95a4719a08bfa790d1db9969ea1f201e52f5f) | `` python3Packages.pyezvizapi: 1.0.1.6 -> 1.0.1.7 ``                                |
| [`396a0181`](https://github.com/NixOS/nixpkgs/commit/396a01814ddde78d179b0eb5f7d0c5ece849807e) | `` tlsx: 1.2.0 -> 1.2.1 ``                                                          |
| [`c4a5576f`](https://github.com/NixOS/nixpkgs/commit/c4a5576f7bdd10916321d8d580881368f7fe9f85) | `` haskellPackages.llvm-ffi: always use default LLVM version ``                     |
| [`88647678`](https://github.com/NixOS/nixpkgs/commit/886476780f339e0ad1bb36164a08bf7e5721a96a) | `` tshark: 4.4.8 -> 4.4.9 ``                                                        |
| [`daa0650f`](https://github.com/NixOS/nixpkgs/commit/daa0650f53f46e1ae6a57613bbd46fc087c732fc) | `` python3Packages.unstructured-inference: 1.0.2 -> 1.0.5 ``                        |
| [`234eddda`](https://github.com/NixOS/nixpkgs/commit/234eddda0d068e886f7466ea6d1feb3a6102a0f9) | `` dbeaver-bin: 25.1.5 -> 25.2.0 ``                                                 |
| [`792f0917`](https://github.com/NixOS/nixpkgs/commit/792f0917cbcfb694e459690f1dda6df045837728) | `` python3Packages.llama-cloud: 0.1.37 -> 0.1.40 ``                                 |
| [`5034e108`](https://github.com/NixOS/nixpkgs/commit/5034e108f97c525095fb12256cbbd701a5c6790b) | `` python3Packages.reolink-aio: 0.14.6 -> 0.15.0 ``                                 |
| [`4a6c2ff4`](https://github.com/NixOS/nixpkgs/commit/4a6c2ff4a08a7dcf0b7574bdebac79133f68771a) | `` nixos/home-assistant: set permission for input devices ``                        |
| [`c1a260ee`](https://github.com/NixOS/nixpkgs/commit/c1a260ee1bedc3f3e8f43179ad3acce6157c2944) | `` super-productivity: 14.3.3 -> 14.4.1 ``                                          |
| [`3f14c2cf`](https://github.com/NixOS/nixpkgs/commit/3f14c2cf0c0e5a8b73fd198810318a085f3f4d54) | `` home-assistant-custom-components.frigate: 5.9.3 -> 5.9.4 (#439055) ``            |
| [`6ef10ab0`](https://github.com/NixOS/nixpkgs/commit/6ef10ab044b36770b77d89fb5e10b5ea290498a4) | `` nixos/glitchtip: add stateDir option ``                                          |
| [`95968f2f`](https://github.com/NixOS/nixpkgs/commit/95968f2f73a77cad96bbab0c474b6c67a4133f11) | `` nixos/glitchtip: fix sourcemap uploads ``                                        |
| [`73589bae`](https://github.com/NixOS/nixpkgs/commit/73589bae9524e6cd232b903f975546c38acd454a) | `` postgresqlPackages.pg_csv: init at 1.0 ``                                        |
| [`1a1af609`](https://github.com/NixOS/nixpkgs/commit/1a1af609adb7eb58696f45a42bb3673dd83e9427) | `` node-gyp: 11.4.1 -> 11.4.2 ``                                                    |
| [`a1fffa47`](https://github.com/NixOS/nixpkgs/commit/a1fffa47ebad2e7a0c46366fb6097c4b6170d709) | `` mailpit: move to pkgs/by-name ``                                                 |
| [`5f293560`](https://github.com/NixOS/nixpkgs/commit/5f29356038421e52d52bdf3e76b880dc10ba758a) | `` python3Packages.jproperties: 2.1.1 -> 2.1.2 ``                                   |
| [`3f2761c0`](https://github.com/NixOS/nixpkgs/commit/3f2761c053cfd0a4cb9aa06d1d3897114448cd2a) | `` mailpit: 1.26.0 -> 1.27.7 ``                                                     |
| [`1b0478e1`](https://github.com/NixOS/nixpkgs/commit/1b0478e165bfbbc666e4cd60124be35db3881798) | `` angrr: init at 0.1.1 ``                                                          |
| [`0413c886`](https://github.com/NixOS/nixpkgs/commit/0413c886a8ad434586124dd5b1a5595d552aa708) | `` gh-f: 1.6.0 -> 1.7.0 ``                                                          |
| [`a5c0180f`](https://github.com/NixOS/nixpkgs/commit/a5c0180ff5c93259bc6a4b5e9af5811d3cf921a9) | `` python3Packages.sphinx-hoverxref: 1.3.0 -> 1.5.0 ``                              |
| [`fe8dda1b`](https://github.com/NixOS/nixpkgs/commit/fe8dda1bb04365fb6a327828d9e8593f34591473) | `` k6: 1.2.2 -> 1.2.3 ``                                                            |
| [`f2ca5796`](https://github.com/NixOS/nixpkgs/commit/f2ca5796dea9a929995db23999e93ad0d690f030) | `` ci/eval/compare: handle missing packages ``                                      |
| [`b61d0aa2`](https://github.com/NixOS/nixpkgs/commit/b61d0aa2f05a7814f2c97398defd8cfc4b53e1aa) | `` nixos/tests/openvswitch: improve ping check resiliency ``                        |
| [`d4e52ac5`](https://github.com/NixOS/nixpkgs/commit/d4e52ac55bbaec78b294de710a97f7d760214ef0) | `` python3Packages.langgraph-sdk: 0.2.3 -> 0.2.4 ``                                 |
| [`0c186805`](https://github.com/NixOS/nixpkgs/commit/0c186805acd7d3fa8d0ea97ecf253d2528f064de) | `` llvmPackages_git: 22.0.0-unstable-2025-08-24 -> 22.0.0-unstable-2025-08-31 ``    |
| [`57bc254a`](https://github.com/NixOS/nixpkgs/commit/57bc254a13f63de76b951f4e425b9cc576657bad) | `` vimPlugins.codecompanion-nvim: fix darwin ``                                     |
| [`f19299e2`](https://github.com/NixOS/nixpkgs/commit/f19299e2cdad0862a7deddf504c1470a3c188657) | `` libsForQt5.qtpbfimageplugin: 4.5 -> 4.7 ``                                       |
| [`2ed2556c`](https://github.com/NixOS/nixpkgs/commit/2ed2556c04493ca429d8391784d91d1655962409) | `` vital: clarify license ``                                                        |
| [`87a9e3c8`](https://github.com/NixOS/nixpkgs/commit/87a9e3c8b1678675958a767b71eaf98f6f170a79) | `` neovim[-unwrapped]: 0.11.3 -> 0.11.4 ``                                          |
| [`a629f770`](https://github.com/NixOS/nixpkgs/commit/a629f770b5133b6ba0f158badf882796a0b21cc6) | `` proton-pass: 1.32.3 -> 1.32.5 ``                                                 |
| [`5d5cf81b`](https://github.com/NixOS/nixpkgs/commit/5d5cf81be9519c1fbb6e90ea5769f5e8e2d47ed6) | `` art-standalone: disable failing wolfssl tests ``                                 |
| [`95809ba5`](https://github.com/NixOS/nixpkgs/commit/95809ba5dd0776fd84d97004f8abc0313f7b7440) | `` jp-zip-codes: 0-unstable-2025-08-01 -> 0-unstable-2025-09-01 ``                  |
| [`c82b20e9`](https://github.com/NixOS/nixpkgs/commit/c82b20e93277b61f940d941b6f794edf52518832) | `` python3Packages.sparsezoo: drop ``                                               |
| [`baad46ea`](https://github.com/NixOS/nixpkgs/commit/baad46eaefe7752b02fcc391c49ba8036165ccdc) | `` josm: 19423 -> 19439 ``                                                          |
| [`5dcc22a5`](https://github.com/NixOS/nixpkgs/commit/5dcc22a5a8c753dc9b7d0e4988a676721c01e6a9) | `` josm: fix update script ``                                                       |
| [`06977dd4`](https://github.com/NixOS/nixpkgs/commit/06977dd4c38f242d799864a7a29837edd2427000) | `` python313Packages.boto3-stubs: 1.40.20 -> 1.40.21 ``                             |
| [`f13a7080`](https://github.com/NixOS/nixpkgs/commit/f13a70809912f78504b4a7728f32007722c2030e) | `` python313Packages.botocore-stubs: 1.38.46 -> 1.40.21 ``                          |
| [`46b64676`](https://github.com/NixOS/nixpkgs/commit/46b64676b6f18d60d2908f09301998f8be319f35) | `` python312Packages.mypy-boto3-xray: 1.40.20 -> 1.40.21 ``                         |
| [`8162419d`](https://github.com/NixOS/nixpkgs/commit/8162419d61921e4321679b4ce93240d43e8463eb) | `` python312Packages.mypy-boto3-ec2: 1.40.20 -> 1.40.21 ``                          |
| [`2c81d984`](https://github.com/NixOS/nixpkgs/commit/2c81d984d9e9c7d7c83851840737922188f16d80) | `` memray: fix textual 0.6.0 compatibility ``                                       |
| [`5248b136`](https://github.com/NixOS/nixpkgs/commit/5248b1367bf6b08651dc75c7e375bc2fe5592ebb) | `` android-translation-layer: add bintools to PATH ``                               |
| [`0b84d12a`](https://github.com/NixOS/nixpkgs/commit/0b84d12a7f17d1c5bcc116096af45ca71e2ad615) | `` android-translation-layer: 0-unstable-2025-07-14 -> 0-unstable-2025-08-06 ``     |
| [`7e9b23ec`](https://github.com/NixOS/nixpkgs/commit/7e9b23ecf3f581d7508ea5434591227ab26c9259) | `` rexi: fix textual 0.6.0 compatibility ``                                         |
| [`2875ed12`](https://github.com/NixOS/nixpkgs/commit/2875ed1290a24a25273b70ff2649117b594a49a8) | `` harlequin: fix by relaxing tree-sitter dependency ``                             |
| [`6f2a943d`](https://github.com/NixOS/nixpkgs/commit/6f2a943d4f5a69d447d3fb0a9ccab42bd5430c1f) | `` art-standalone: add pkg-config support ``                                        |
| [`17c24ab0`](https://github.com/NixOS/nixpkgs/commit/17c24ab0759b95d90166bdde01ead0a97ff62306) | `` android-translation-layer: update art-standalone patch ``                        |
| [`25535663`](https://github.com/NixOS/nixpkgs/commit/255356634a79239ec401a0fc00944a5aee04f289) | `` act: 0.2.80 -> 0.2.81 ``                                                         |
| [`3f0207c0`](https://github.com/NixOS/nixpkgs/commit/3f0207c08727eac156f74241ac6dd7eb9884b593) | `` bandwidth: drop ``                                                               |
| [`ed855914`](https://github.com/NixOS/nixpkgs/commit/ed855914185c2c045847fd0dd71ff59594122e6b) | `` python313Packages.tencentcloud-sdk-python: 3.0.1452 -> 3.0.1453 ``               |
| [`7578723d`](https://github.com/NixOS/nixpkgs/commit/7578723d73560e6d6539ee1d379d81c3f0c3b779) | `` python3Packages.textual: 5.3.0 -> 6.0.0 ``                                       |
| [`3d72dc65`](https://github.com/NixOS/nixpkgs/commit/3d72dc65d22b298b1055658f5dec6558e9b4909c) | `` uuu: 1.5.222 -> 1.5.233 ``                                                       |
| [`70048118`](https://github.com/NixOS/nixpkgs/commit/700481183fd6e7657ae96269381b3755277e4bcc) | `` lavacli: 2.2.0 -> 2.4 ``                                                         |
| [`a7a86457`](https://github.com/NixOS/nixpkgs/commit/a7a8645787d0e90ba45a2c3619e3e679ca603ed9) | `` python3Packages.functions-framework: relax cloudevents dependency ``             |
| [`0554d301`](https://github.com/NixOS/nixpkgs/commit/0554d301bf33eb92a59e4552552d563b0b050dcf) | `` comaps: 2025.08.13-8 -> 2025.08.31-15 ``                                         |