### PR TITLE
chore(flake/emacs-overlay): `e9954371` -> `f1f919a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1756864982,
-        "narHash": "sha256-NPpRPaIVGRSh4nrq+37ufZBECWCLP+YQP3BZgL5UOmY=",
+        "lastModified": 1757037883,
+        "narHash": "sha256-VFxrVB4eTc1wAReTTFiattSe/QA+DVRPPVonb2/vfIw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e99543717040244141e250186828604e4a1f6567",
+        "rev": "f1f919a574146174bda34d6f232db7bf5bc5a6fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`f1f919a5`](https://github.com/nix-community/emacs-overlay/commit/f1f919a574146174bda34d6f232db7bf5bc5a6fa) | `` Updated melpa ``        |
| [`e5e2c982`](https://github.com/nix-community/emacs-overlay/commit/e5e2c982a6d9c4e7bca3dca655a6a44ac921be39) | `` Updated emacs ``        |
| [`806726b1`](https://github.com/nix-community/emacs-overlay/commit/806726b1e4c299a1f607c9a6f4bf6214b27ade53) | `` Updated elpa ``         |
| [`df685914`](https://github.com/nix-community/emacs-overlay/commit/df685914bca43fde069b59aebd964b1752c8728e) | `` Updated nongnu ``       |
| [`42bd9415`](https://github.com/nix-community/emacs-overlay/commit/42bd941581a7b5b8e133d3507cce1343d8b600e7) | `` Updated melpa ``        |
| [`a0a93e00`](https://github.com/nix-community/emacs-overlay/commit/a0a93e009d8b1b056ed90e6b27907ac7eca61450) | `` Updated emacs ``        |
| [`39a51dcc`](https://github.com/nix-community/emacs-overlay/commit/39a51dcc368300f4053e6b84fc8652320280a8d3) | `` Updated elpa ``         |
| [`485ab778`](https://github.com/nix-community/emacs-overlay/commit/485ab778d4aa8045358d9a79b43661691de3ee4c) | `` Updated nongnu ``       |
| [`4478783c`](https://github.com/nix-community/emacs-overlay/commit/4478783c30738c4641fc82e4e9077aab81e90cb2) | `` Updated emacs ``        |
| [`d0f94895`](https://github.com/nix-community/emacs-overlay/commit/d0f94895aa3ba129a6357f304009d2ccb59c4221) | `` Updated melpa ``        |
| [`1790dceb`](https://github.com/nix-community/emacs-overlay/commit/1790dceb107b23584bf713348526b57c38a7df0f) | `` Updated elpa ``         |
| [`4d06a7cf`](https://github.com/nix-community/emacs-overlay/commit/4d06a7cf8096476b87cf13fe18a4f0632a97e81f) | `` Updated nongnu ``       |
| [`9fa79fea`](https://github.com/nix-community/emacs-overlay/commit/9fa79fea1f7ecc4c6550df0065c26da5d202b853) | `` Updated melpa ``        |
| [`0d9abb5f`](https://github.com/nix-community/emacs-overlay/commit/0d9abb5f4e7de37f2a964687de3274a03ad4ebd8) | `` Updated emacs ``        |
| [`fbae1504`](https://github.com/nix-community/emacs-overlay/commit/fbae150436d45c46d585c6d8ecfaf50a1a091d4b) | `` Updated elpa ``         |
| [`0069964d`](https://github.com/nix-community/emacs-overlay/commit/0069964d01f2cedca4a56e79126ad964cfa7955d) | `` Updated nongnu ``       |
| [`a72d7da8`](https://github.com/nix-community/emacs-overlay/commit/a72d7da8929b4fdf5d9679762b305a84f04e58d8) | `` Updated melpa ``        |
| [`d49fd6a7`](https://github.com/nix-community/emacs-overlay/commit/d49fd6a72d1fc4cbbfa9c2de96485c02edad50fb) | `` Updated emacs ``        |
| [`29e23edd`](https://github.com/nix-community/emacs-overlay/commit/29e23edd74721ebb7d7c1fa3720cd713982a27b1) | `` Updated flake inputs `` |