### PR TITLE
chore(flake/minimal-emacs-d): `fa022921` -> `44bfe663`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     "minimal-emacs-d": {
       "flake": false,
       "locked": {
-        "lastModified": 1756757557,
-        "narHash": "sha256-c1T6YrbX5dbA4RaCDxf9wZTseb3Ogo1Yh/6PE0/pFiM=",
+        "lastModified": 1756927888,
+        "narHash": "sha256-z+IUNsfQ/CXOGMOrOHw2xqu5ExyJYAqzpbSyXyDBNzw=",
         "owner": "jamescherti",
         "repo": "minimal-emacs.d",
-        "rev": "fa0229219663ab848988188aec8d48c696ded00c",
+        "rev": "44bfe663930960b143505f4930ce6d0a520f5387",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                              |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
| [`44bfe663`](https://github.com/jamescherti/minimal-emacs.d/commit/44bfe663930960b143505f4930ce6d0a520f5387) | `` Remove settings that are already t by default ``  |
| [`15a27c1f`](https://github.com/jamescherti/minimal-emacs.d/commit/15a27c1f40a472395f03b27bba9f2ead351a938a) | `` Update README.md ``                               |
| [`2b27ee6b`](https://github.com/jamescherti/minimal-emacs.d/commit/2b27ee6b0e7ed1c49c19af27a618b1d87ce5f1b0) | `` Update README.md ``                               |
| [`c0a8e6bf`](https://github.com/jamescherti/minimal-emacs.d/commit/c0a8e6bf6ac5ae3d1fdeb5d76e268b3202d10843) | `` Update README.md ``                               |
| [`f03e7da9`](https://github.com/jamescherti/minimal-emacs.d/commit/f03e7da977ec791d342b82c2d122689af32b4062) | `` Add MELPA stable and update the README.md file `` |