### PR TITLE
chore(flake/home-manager): `30fc1b53` -> `ed1a98c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -740,11 +740,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756842514,
-        "narHash": "sha256-XbtRMewPGJwTNhBC4pnBu3w/xT1XejvB0HfohC2Kga8=",
+        "lastModified": 1756954499,
+        "narHash": "sha256-Pg4xBHzvzNY8l9x/rLWoJMnIR8ebG+xeU+IyqThIkqU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "30fc1b532645a21e157b6e33e3f8b4c154f86382",
+        "rev": "ed1a98c375450dfccf427adacd2bfd1a7b22eb25",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                    |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`ed1a98c3`](https://github.com/nix-community/home-manager/commit/ed1a98c375450dfccf427adacd2bfd1a7b22eb25) | `` aerospace: use upstream example for exec-on-workspace-change (#7765) `` |
| [`b21c1a61`](https://github.com/nix-community/home-manager/commit/b21c1a61a765acea932eef1e4d225fde25a166e0) | `` vivid: add module (#7772) ``                                            |
| [`6159629d`](https://github.com/nix-community/home-manager/commit/6159629d05a0e92bb7fb7211e74106ae1d552401) | `` swayosd: Remove non-existing `display` arg option (#7752) ``            |