### PR TITLE
chore(flake/nur): `5df818e5` -> `6ca27b26`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1756895101,
-        "narHash": "sha256-xj2D79SywQewwTuNu/bYvGcMTbfAABys1ERoBLVdo30=",
+        "lastModified": 1756961635,
+        "narHash": "sha256-hETvQcILTg5kChjYNns1fD5ELdsYB/VVgVmBtqKQj9A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5df818e5b09b36da300d6ea41fa0952cb02cfe47",
+        "rev": "6ca27b2654ac55e3f6e0ca434c1b4589ae22b370",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6ca27b26`](https://github.com/nix-community/NUR/commit/6ca27b2654ac55e3f6e0ca434c1b4589ae22b370) | `` automatic update `` |
| [`eb715078`](https://github.com/nix-community/NUR/commit/eb715078c5bc28280ee58d4a79c547dbda11eb79) | `` automatic update `` |
| [`3c3568dd`](https://github.com/nix-community/NUR/commit/3c3568ddbc9e0b1dc41595a273cb9fb876a7c6eb) | `` automatic update `` |
| [`dd182564`](https://github.com/nix-community/NUR/commit/dd182564771bb89df85270c740f06063ee0829a1) | `` automatic update `` |
| [`a535df5a`](https://github.com/nix-community/NUR/commit/a535df5a7a43a3f67a7aa169b57a446dd2541cde) | `` automatic update `` |
| [`6b3dd332`](https://github.com/nix-community/NUR/commit/6b3dd33277a0902f71b015befab9a15df9042602) | `` automatic update `` |
| [`1f0371a4`](https://github.com/nix-community/NUR/commit/1f0371a4a94a9d7d2cb92974fd6a25ac2f529201) | `` automatic update `` |
| [`e54de3c2`](https://github.com/nix-community/NUR/commit/e54de3c212379cd0c2ec1b2a205fe5629418fe54) | `` automatic update `` |
| [`21f6498d`](https://github.com/nix-community/NUR/commit/21f6498d8b91893c7342ad2c89f2b8e889c80ffc) | `` automatic update `` |
| [`4819403d`](https://github.com/nix-community/NUR/commit/4819403ddfde2dadb4ef81f06eb52fbd19d8d368) | `` automatic update `` |
| [`849e949d`](https://github.com/nix-community/NUR/commit/849e949d461b5b1ac83450254f71b47d429e4923) | `` automatic update `` |
| [`401d5bdf`](https://github.com/nix-community/NUR/commit/401d5bdfbce5d969a4654ee61c21cca744eb9911) | `` automatic update `` |
| [`0951866d`](https://github.com/nix-community/NUR/commit/0951866da58eb749d4a25eb241ab4df65866db70) | `` automatic update `` |
| [`da0d0a30`](https://github.com/nix-community/NUR/commit/da0d0a30c9c9d8eb44526a6e545a47aec3b576cd) | `` automatic update `` |
| [`d3aeae12`](https://github.com/nix-community/NUR/commit/d3aeae122319e2494327bec090962655e5353b77) | `` automatic update `` |
| [`61863e1c`](https://github.com/nix-community/NUR/commit/61863e1cb58c7842a7dcad2a4d56c269af5df770) | `` automatic update `` |
| [`b8d6fb99`](https://github.com/nix-community/NUR/commit/b8d6fb9913e279b7ec3495b844c968882eb3eeb6) | `` automatic update `` |
| [`f97cfb54`](https://github.com/nix-community/NUR/commit/f97cfb549b11588db68bb52400c5ec7edcad928e) | `` automatic update `` |
| [`97f7c5b7`](https://github.com/nix-community/NUR/commit/97f7c5b74a6ccfa1b4c0766f0dea179cdd230fce) | `` automatic update `` |
| [`525f4697`](https://github.com/nix-community/NUR/commit/525f4697cd608fbf92bce414495d86dc5baba233) | `` automatic update `` |
| [`c8eb00f9`](https://github.com/nix-community/NUR/commit/c8eb00f9c3953d72fc8a8d6fcf67db009b77bdb2) | `` automatic update `` |
| [`d424cfdf`](https://github.com/nix-community/NUR/commit/d424cfdf387c4c4c88e2db2444a0a2aeb382b8df) | `` automatic update `` |
| [`d8cfb3ad`](https://github.com/nix-community/NUR/commit/d8cfb3ad481b6b86982c0fe6220eef68ea53695c) | `` automatic update `` |
| [`dbc389f3`](https://github.com/nix-community/NUR/commit/dbc389f337e2a9a01e5b3c412b303394c2058f26) | `` automatic update `` |