### PR TITLE
chore(flake/srvos): `d6cdf08a` -> `27067044`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1301,11 +1301,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756688979,
-        "narHash": "sha256-bVeg9CSlKrAzhwnJBgoPLNhm3GeO64HrLXHDQ4PSnsM=",
+        "lastModified": 1756947399,
+        "narHash": "sha256-BP+tghzkQpt5NDcPhUsRjZtPd53jsubSNlmtWJclQZ8=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "d6cdf08adfdb0b7f6e4d95075799f59dc6197681",
+        "rev": "27067044062111dfb077e735ee8641f05acaf4dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`27067044`](https://github.com/nix-community/srvos/commit/27067044062111dfb077e735ee8641f05acaf4dc) | `` dev/private/flake.lock: Update `` |
| [`50f96b9b`](https://github.com/nix-community/srvos/commit/50f96b9b96a65900b0db7b034ffc667b7de47cdd) | `` flake.lock: Update ``             |