### PR TITLE
chore(flake/nur): `6ca27b26` -> `4385b643`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1756961635,
-        "narHash": "sha256-hETvQcILTg5kChjYNns1fD5ELdsYB/VVgVmBtqKQj9A=",
+        "lastModified": 1757000811,
+        "narHash": "sha256-WXGmJKKIPhdjyM5rqDDie9fHUOyhDJNUqgCR3YzBMYk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6ca27b2654ac55e3f6e0ca434c1b4589ae22b370",
+        "rev": "4385b6432daaf4820bd206c4c359db2dec541997",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4385b643`](https://github.com/nix-community/NUR/commit/4385b6432daaf4820bd206c4c359db2dec541997) | `` automatic update `` |
| [`4afb7733`](https://github.com/nix-community/NUR/commit/4afb77330dd461444b3df5dd997ca6e3d441fdd3) | `` automatic update `` |
| [`bac20268`](https://github.com/nix-community/NUR/commit/bac202687eb587c6e599db878c487bfe3169341d) | `` automatic update `` |
| [`67ec92c4`](https://github.com/nix-community/NUR/commit/67ec92c42741fc61204745d5e5e10bf65c19f5cd) | `` automatic update `` |
| [`674e3af3`](https://github.com/nix-community/NUR/commit/674e3af377e5b2c14019382c4e071c7a42e60107) | `` automatic update `` |
| [`d7843c8e`](https://github.com/nix-community/NUR/commit/d7843c8e7bcd55ebc4ba26d4d618bafaa41268f6) | `` automatic update `` |
| [`36672620`](https://github.com/nix-community/NUR/commit/36672620ca0010440e1df9007b133543de4a174c) | `` automatic update `` |
| [`52c7f62e`](https://github.com/nix-community/NUR/commit/52c7f62eb3e5c74c9079ce883f123d7902f70d67) | `` automatic update `` |
| [`5675a2af`](https://github.com/nix-community/NUR/commit/5675a2af522928febb98d2d65797eabe0fb06925) | `` automatic update `` |
| [`5965e128`](https://github.com/nix-community/NUR/commit/5965e128ef5e6806f2fe71829805d2068da3dabe) | `` automatic update `` |