### PR TITLE
chore(flake/home-manager): `ed1a98c3` -> `f56bf065`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -740,11 +740,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756954499,
-        "narHash": "sha256-Pg4xBHzvzNY8l9x/rLWoJMnIR8ebG+xeU+IyqThIkqU=",
+        "lastModified": 1757075491,
+        "narHash": "sha256-a+NMGl5tcvm+hyfSG2DlVPa8nZLpsumuRj1FfcKb2mQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ed1a98c375450dfccf427adacd2bfd1a7b22eb25",
+        "rev": "f56bf065f9abedc7bc15e1f2454aa5c8edabaacf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`f56bf065`](https://github.com/nix-community/home-manager/commit/f56bf065f9abedc7bc15e1f2454aa5c8edabaacf) | `` polybar: make sure X-Restart-Triggers is a list ``      |
| [`a51e585a`](https://github.com/nix-community/home-manager/commit/a51e585a05d318f988dfe09ec7fe31de966d9a76) | `` Translate using Weblate (German) ``                     |
| [`b08f8737`](https://github.com/nix-community/home-manager/commit/b08f8737776f10920c330657bee8b95834b7a70f) | `` hyprpanel: fix dontAssertNotificationDaemons (#7745) `` |