### PR TITLE
chore(flake/nur): `4385b643` -> `d299518c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1757000811,
-        "narHash": "sha256-WXGmJKKIPhdjyM5rqDDie9fHUOyhDJNUqgCR3YzBMYk=",
+        "lastModified": 1757015008,
+        "narHash": "sha256-DsBK8ezk4efidBNHJn5aIfCudqSRxYdmjBUUzQtjNjk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4385b6432daaf4820bd206c4c359db2dec541997",
+        "rev": "d299518c172661c7f3f796fe950e3365f34400e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d299518c`](https://github.com/nix-community/NUR/commit/d299518c172661c7f3f796fe950e3365f34400e4) | `` automatic update `` |
| [`013f349c`](https://github.com/nix-community/NUR/commit/013f349cd4cb734e9a79eeaa934ffd0cb9b686b9) | `` automatic update `` |
| [`30ebeecf`](https://github.com/nix-community/NUR/commit/30ebeecfa46d5604b8fd15c3ac971d3a37022b46) | `` automatic update `` |
| [`b76f27a1`](https://github.com/nix-community/NUR/commit/b76f27a18b17a44de12df32fe03da2695b04eefc) | `` automatic update `` |