### PR TITLE
chore(flake/nur): `d299518c` -> `9e187765`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1757015008,
-        "narHash": "sha256-DsBK8ezk4efidBNHJn5aIfCudqSRxYdmjBUUzQtjNjk=",
+        "lastModified": 1757025145,
+        "narHash": "sha256-tsiqGMH2xzVXxAjQi4hoVdA+WhHrLSXLUVaWpvmsWTU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d299518c172661c7f3f796fe950e3365f34400e4",
+        "rev": "9e187765083059d9201af2cdf48750b86a88f30c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                       |
| -------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`9e187765`](https://github.com/nix-community/NUR/commit/9e187765083059d9201af2cdf48750b86a88f30c) | `` automatic update ``                        |
| [`2bc296e2`](https://github.com/nix-community/NUR/commit/2bc296e2e442392e3c4651cf012029a8fbfeba87) | `` automatic update ``                        |
| [`15e88ad4`](https://github.com/nix-community/NUR/commit/15e88ad4c568a56520fb80683d16fd2496ce5844) | `` add magnap repository ``                   |
| [`7af8e33b`](https://github.com/nix-community/NUR/commit/7af8e33b9a68086883142a08d43970777def484a) | `` add doomhammer repository ``               |
| [`e9c3b0c9`](https://github.com/nix-community/NUR/commit/e9c3b0c9f6036f568f7094eb918f5f4014bd2c2f) | `` add shirok1 repository ``                  |
| [`9a207b45`](https://github.com/nix-community/NUR/commit/9a207b45b9e858948b86bf1844797847ac2715be) | `` add kagura repository ``                   |
| [`5cb94b2a`](https://github.com/nix-community/NUR/commit/5cb94b2a134be7330e781e28a50d9e42af615716) | `` add vladexa repository ``                  |
| [`c45d7985`](https://github.com/nix-community/NUR/commit/c45d79859c380cc38d20fc39f909d7e92d8e3414) | `` add eerieaerial repository ``              |
| [`71d8689a`](https://github.com/nix-community/NUR/commit/71d8689ac54db87799c2c138125b793d17f35e3d) | `` Add `hilorioze/nur-packages` repository `` |
| [`4f158b03`](https://github.com/nix-community/NUR/commit/4f158b03c32b74653522982636a150823978d18b) | `` automatic update ``                        |