### PR TITLE
chore(flake/nur): `9e187765` -> `a35d25ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1757025145,
-        "narHash": "sha256-tsiqGMH2xzVXxAjQi4hoVdA+WhHrLSXLUVaWpvmsWTU=",
+        "lastModified": 1757058204,
+        "narHash": "sha256-nqKBawIiA6fwI8JsVenoKh5ChgvHI+xasOE3DyFvJ6A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9e187765083059d9201af2cdf48750b86a88f30c",
+        "rev": "a35d25ac91a6a53ef5fcc7d4e5d4559bb7b719e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a35d25ac`](https://github.com/nix-community/NUR/commit/a35d25ac91a6a53ef5fcc7d4e5d4559bb7b719e6) | `` automatic update `` |
| [`a978ed5a`](https://github.com/nix-community/NUR/commit/a978ed5ae76324381a216c2f42bcd46cc33506ed) | `` automatic update `` |
| [`9d7ff2d8`](https://github.com/nix-community/NUR/commit/9d7ff2d801a97ceb2acbf028f10a538b5d10bb38) | `` automatic update `` |
| [`985abf01`](https://github.com/nix-community/NUR/commit/985abf0197c75dd64c24691a7e5e0acf308d7f20) | `` automatic update `` |
| [`a9d2d583`](https://github.com/nix-community/NUR/commit/a9d2d5837afc903d9163a7d9d468fa0ec1d7ff15) | `` automatic update `` |
| [`c992b15d`](https://github.com/nix-community/NUR/commit/c992b15dabe3755f3eb40bdc2829af306bd6c3f3) | `` automatic update `` |
| [`c4abd9ca`](https://github.com/nix-community/NUR/commit/c4abd9cafa0f3dce77d52024cf89525fde114bd7) | `` automatic update `` |
| [`182d262c`](https://github.com/nix-community/NUR/commit/182d262c4a447407c7fe18b8c28f709d683471ce) | `` automatic update `` |
| [`7222db12`](https://github.com/nix-community/NUR/commit/7222db1286e0a38495ec53da5aded5c9e55cbaa3) | `` automatic update `` |