### PR TITLE
chore(flake/nur): `a35d25ac` -> `92d3cb9b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1757058204,
-        "narHash": "sha256-nqKBawIiA6fwI8JsVenoKh5ChgvHI+xasOE3DyFvJ6A=",
+        "lastModified": 1757069041,
+        "narHash": "sha256-ar9XVjQ1CBcY8a6C1C4hHJxD13jBKX15l3P7HDSu1m0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a35d25ac91a6a53ef5fcc7d4e5d4559bb7b719e6",
+        "rev": "92d3cb9bef86769b24fe5b27f39ffeb41f8fd8f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`92d3cb9b`](https://github.com/nix-community/NUR/commit/92d3cb9bef86769b24fe5b27f39ffeb41f8fd8f1) | `` automatic update `` |
| [`e3681adc`](https://github.com/nix-community/NUR/commit/e3681adc1c423e371a0f0874c6664c88e1b126ba) | `` automatic update `` |
| [`3c205d4b`](https://github.com/nix-community/NUR/commit/3c205d4b2e6274be643ac15a24ed0efae01ab98e) | `` automatic update `` |
| [`bbf38284`](https://github.com/nix-community/NUR/commit/bbf382848bb97565fff6d852cde1bac45587f075) | `` automatic update `` |