### PR TITLE
chore(flake/nur): `92d3cb9b` -> `f41e071a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1757069041,
-        "narHash": "sha256-ar9XVjQ1CBcY8a6C1C4hHJxD13jBKX15l3P7HDSu1m0=",
+        "lastModified": 1757112211,
+        "narHash": "sha256-BlK4AyjgurLofEen8ZlpHXiRL7OtTlU40GKCacMfwcU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "92d3cb9bef86769b24fe5b27f39ffeb41f8fd8f1",
+        "rev": "f41e071a63ec1bff719a3db6ba31197177586693",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f41e071a`](https://github.com/nix-community/NUR/commit/f41e071a63ec1bff719a3db6ba31197177586693) | `` automatic update `` |
| [`c3753db5`](https://github.com/nix-community/NUR/commit/c3753db57145fc2aa3b0d52756d3db05aa60263d) | `` automatic update `` |
| [`3f0eeedf`](https://github.com/nix-community/NUR/commit/3f0eeedfbb93e70a080e84b3689725ebe2051969) | `` automatic update `` |
| [`8b0e298e`](https://github.com/nix-community/NUR/commit/8b0e298eccac6ff638b07a20e04406ffa06b2d42) | `` automatic update `` |
| [`98a7fd9e`](https://github.com/nix-community/NUR/commit/98a7fd9e56640a4497fddc58b659e5e1656a6966) | `` automatic update `` |
| [`381e1fa0`](https://github.com/nix-community/NUR/commit/381e1fa04eccb9304d0f4c19a5899e13dd6290e6) | `` automatic update `` |
| [`f016bfe1`](https://github.com/nix-community/NUR/commit/f016bfe15394374b63ee5d26150e3e8540566d69) | `` automatic update `` |
| [`fe0c1eeb`](https://github.com/nix-community/NUR/commit/fe0c1eeb5f131c6579609e27766c87404ca6600c) | `` automatic update `` |