### PR TITLE
chore(flake/minimal-emacs-d): `bc3615e7` -> `8d975e88`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     "minimal-emacs-d": {
       "flake": false,
       "locked": {
-        "lastModified": 1756998462,
-        "narHash": "sha256-MPoQWoZcBTylL1oQHA+sg8JKB31CPvbfGFNAO2fZRI8=",
+        "lastModified": 1757108561,
+        "narHash": "sha256-BAywB7Yyw4Tb0WlAH6Ta6KwEeozu079rj+cERVpFsoQ=",
         "owner": "jamescherti",
         "repo": "minimal-emacs.d",
-        "rev": "bc3615e706153a7e09872194d858e95e41aa94ec",
+        "rev": "8d975e882026f1433086e6dcf86c1b9acaac61a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                |
| ------------------------------------------------------------------------------------------------------------ | ---------------------- |
| [`8d975e88`](https://github.com/jamescherti/minimal-emacs.d/commit/8d975e882026f1433086e6dcf86c1b9acaac61a1) | `` Update README.md `` |
| [`87714bef`](https://github.com/jamescherti/minimal-emacs.d/commit/87714bef466e0809f77e5112d5eeb70b7f002c16) | `` Update README.md `` |
| [`862b6dc2`](https://github.com/jamescherti/minimal-emacs.d/commit/862b6dc253615da2681257aa410d91c2e0359519) | `` Update README.md `` |