### PR TITLE
chore(flake/emacs-overlay): `f1f919a5` -> `5eba1234`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1757037883,
-        "narHash": "sha256-VFxrVB4eTc1wAReTTFiattSe/QA+DVRPPVonb2/vfIw=",
+        "lastModified": 1757092030,
+        "narHash": "sha256-Y8Sf2JbqpVC7LSaoWX9nN5kppLlTsT3pZlvt6M6h+DQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f1f919a574146174bda34d6f232db7bf5bc5a6fa",
+        "rev": "5eba1234fb1dcc80a7d449d0ea64df63bdd15b7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`5eba1234`](https://github.com/nix-community/emacs-overlay/commit/5eba1234fb1dcc80a7d449d0ea64df63bdd15b7f) | `` Updated melpa ``  |
| [`ce94c9d0`](https://github.com/nix-community/emacs-overlay/commit/ce94c9d0bdae8501c8315238b52b943aeddc24d0) | `` Updated emacs ``  |
| [`1831571d`](https://github.com/nix-community/emacs-overlay/commit/1831571d5aa5bf9f387ae69de97a328734488e17) | `` Updated elpa ``   |
| [`1dbd0941`](https://github.com/nix-community/emacs-overlay/commit/1dbd0941d0c324fe2d1b9ad40167d52a40d0a892) | `` Updated nongnu `` |