### PR TITLE
chore(flake/nixos-hardware): `7e56e39d` -> `11b2a10c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -988,11 +988,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1757081837,
-        "narHash": "sha256-wAgZ+BaRR/cqmKP0bWnJ9rO9KLz91R5aOdJiT+k/J2E=",
+        "lastModified": 1757103352,
+        "narHash": "sha256-PtT7ix43ss8PONJ1VJw3f6t2yAoGH+q462Sn8lrmWmk=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "7e56e39db4008521552e9d2b0d9ae9bf8e0cdce2",
+        "rev": "11b2a10c7be726321bb854403fdeec391e798bf0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`7e40faf5`](https://github.com/NixOS/nixos-hardware/commit/7e40faf569db5ecb30aa50a0df88fdd50fa74e6f) | `` fydetab/duo: enable hid sensor hub kernel module `` |
| [`295e0f92`](https://github.com/NixOS/nixos-hardware/commit/295e0f92ff26b8260c78d141a4ee1210816c9ede) | `` fydetab/duo: clarify graphics support ``            |
| [`410a1773`](https://github.com/NixOS/nixos-hardware/commit/410a17733a70b9c103e60684aa30fc8f3249e285) | `` fydetab/duo: fix himax firmware source hash ``      |
| [`a6cc50d9`](https://github.com/NixOS/nixos-hardware/commit/a6cc50d994a0fceca775cfb70dbe4a0dc1c8cadd) | `` fydetab/duo: fix hardware.firmware being applied `` |
| [`e9db0225`](https://github.com/NixOS/nixos-hardware/commit/e9db02252a3bdccb1031ec0f7ecddadd0d308401) | `` fydetab/duo: fix typo with enable option ``         |