### PR TITLE
chore(flake/nur): `f41e071a` -> `9ad5c0e3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1113,11 +1113,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1756787288,
-        "narHash": "sha256-rw/PHa1cqiePdBxhF66V7R+WAP8WekQ0mCDG4CFqT8Y=",
+        "lastModified": 1757068644,
+        "narHash": "sha256-NOrUtIhTkIIumj1E/Rsv1J37Yi3xGStISEo8tZm3KW4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d0fc30899600b9b3466ddb260fd83deb486c32f1",
+        "rev": "8eb28adfa3dc4de28e792e3bf49fcf9007ca8ac9",
         "type": "github"
       },
       "original": {
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1757112211,
-        "narHash": "sha256-BlK4AyjgurLofEen8ZlpHXiRL7OtTlU40GKCacMfwcU=",
+        "lastModified": 1757217197,
+        "narHash": "sha256-MpWJgUdaE6USqrRiUrJFCjBCOQJTmyMGaB47DFcZdlQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f41e071a63ec1bff719a3db6ba31197177586693",
+        "rev": "9ad5c0e35f1c891cb8cfb29b3fa9c675a7463f3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                  |
| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`9ad5c0e3`](https://github.com/nix-community/NUR/commit/9ad5c0e35f1c891cb8cfb29b3fa9c675a7463f3e) | `` automatic update ``                                   |
| [`4a5b1c4d`](https://github.com/nix-community/NUR/commit/4a5b1c4dcc80999b3cc7c8579524759ee5517e06) | `` automatic update ``                                   |
| [`c0380f2b`](https://github.com/nix-community/NUR/commit/c0380f2b11bd14e9718144bf378b6f05b2922177) | `` Update cachix/install-nix-action digest to 56a7bb7 `` |
| [`0cf8e952`](https://github.com/nix-community/NUR/commit/0cf8e952f2336d09ef7695dccc7fe9e89445ea9c) | `` automatic update ``                                   |
| [`7b68e165`](https://github.com/nix-community/NUR/commit/7b68e1657603ae9226666c92f94fdc8432054a62) | `` automatic update ``                                   |
| [`0fa961ea`](https://github.com/nix-community/NUR/commit/0fa961eaeb9aad03af42c19f20c60b682e920bd3) | `` Add willenbug to repos ``                             |
| [`38addda1`](https://github.com/nix-community/NUR/commit/38addda19d2ac5676e98a2c95494d9cb55d7944b) | `` add AstroOrbis repository ``                          |
| [`2f7c629f`](https://github.com/nix-community/NUR/commit/2f7c629f6a98d48a0235b3ccb68c301eeb62ffd2) | `` automatic update ``                                   |
| [`0b567e06`](https://github.com/nix-community/NUR/commit/0b567e06e3fb68ce9995f81892201387d5e752e7) | `` automatic update ``                                   |
| [`94a29ecb`](https://github.com/nix-community/NUR/commit/94a29ecb577dbda9fc597a874d8556ce181ca865) | `` automatic update ``                                   |
| [`56a58305`](https://github.com/nix-community/NUR/commit/56a58305f2668b2d5519f64eaac93e8d1cef1827) | `` automatic update ``                                   |
| [`9ec3aa59`](https://github.com/nix-community/NUR/commit/9ec3aa599e7c3c3550c2ccecfebd5d57527bb000) | `` automatic update ``                                   |
| [`bee71e97`](https://github.com/nix-community/NUR/commit/bee71e973617ccdba8d48f88a478460745b4d263) | `` automatic update ``                                   |
| [`4d10e65c`](https://github.com/nix-community/NUR/commit/4d10e65c528b1d24c98c7ec850423aabd635647a) | `` automatic update ``                                   |
| [`fbc47a63`](https://github.com/nix-community/NUR/commit/fbc47a63bdcd73f11ba4b6ee1babadeb0a948645) | `` automatic update ``                                   |
| [`a526a67c`](https://github.com/nix-community/NUR/commit/a526a67cecb4aee7c2d1f8ee2d00c8c642b1e10f) | `` automatic update ``                                   |
| [`8054d4d5`](https://github.com/nix-community/NUR/commit/8054d4d5a95852868746fa3f14ea2f9eb18ba68e) | `` automatic update ``                                   |
| [`8009dbff`](https://github.com/nix-community/NUR/commit/8009dbffdc33f5e7beee5cbe000527991faf8783) | `` automatic update ``                                   |
| [`e81b0f0b`](https://github.com/nix-community/NUR/commit/e81b0f0b76610dc5fdfaca70a8e298dfc8fa0cd0) | `` automatic update ``                                   |
| [`ebc8ca55`](https://github.com/nix-community/NUR/commit/ebc8ca55275ce264aa5388a00f63d83d02fb09dd) | `` automatic update ``                                   |
| [`eb7c6acc`](https://github.com/nix-community/NUR/commit/eb7c6acc50c3102593696717380985a12188699b) | `` automatic update ``                                   |
| [`1047bb61`](https://github.com/nix-community/NUR/commit/1047bb615b4cd70ece868f84ee1654b4388b17af) | `` automatic update ``                                   |
| [`eed070ec`](https://github.com/nix-community/NUR/commit/eed070ec61779ca471d5501f9fdee3144735d2f9) | `` automatic update ``                                   |
| [`c3ba10a3`](https://github.com/nix-community/NUR/commit/c3ba10a3e727990158f320b2deacdb67cedde572) | `` automatic update ``                                   |
| [`c9b6d431`](https://github.com/nix-community/NUR/commit/c9b6d43164299ad7e6ba1d1eec0a9cd94b03d402) | `` automatic update ``                                   |