### PR TITLE
chore(flake/emacs-overlay): `855ce6d4` -> `132734ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1757149542,
-        "narHash": "sha256-nea8RTJJq78shii1qn6FKd7Fg0Sy0bfE8Rq+4OQ55BI=",
+        "lastModified": 1757178312,
+        "narHash": "sha256-Z1HEVI+sphdRndNu8/iqGuupjtj1i3vBZXRXj9UA2RQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "855ce6d45c9a753612790353d72c36b974531d8b",
+        "rev": "132734acf812c4cbe44fd6aed54920ae731da986",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`132734ac`](https://github.com/nix-community/emacs-overlay/commit/132734acf812c4cbe44fd6aed54920ae731da986) | `` Updated melpa ``  |
| [`d6320989`](https://github.com/nix-community/emacs-overlay/commit/d6320989261a42c149f3e5b55f0075fb6501efca) | `` Updated emacs ``  |
| [`7e7d0977`](https://github.com/nix-community/emacs-overlay/commit/7e7d09774264663a60ffabf5285f4246b7d9006d) | `` Updated elpa ``   |
| [`662194eb`](https://github.com/nix-community/emacs-overlay/commit/662194eb39f4ee8357f3c9e66d0ba94eb1263471) | `` Updated nongnu `` |