### PR TITLE
chore(flake/nix-index-database): `3fe768e1` -> `9b144dc3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756612744,
-        "narHash": "sha256-/glV6VAq8Va3ghIbmhET3S1dzkbZqicsk5h+FtvwiPE=",
+        "lastModified": 1757218147,
+        "narHash": "sha256-IwOwN70HvoBNB2ckaROxcaCvj5NudNc52taPsv5wtLk=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "3fe768e1f058961095b4a0d7a2ba15dc9736bdc6",
+        "rev": "9b144dc3ef6e42b888c4190e02746aab13b0e97f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`9b144dc3`](https://github.com/nix-community/nix-index-database/commit/9b144dc3ef6e42b888c4190e02746aab13b0e97f) | `` update generated.nix to release 2025-09-07-032516 `` |
| [`b33c3aad`](https://github.com/nix-community/nix-index-database/commit/b33c3aadca9343dbbcba8be71cb741d095aab8a9) | `` flake.lock: Update ``                                |