### PR TITLE
chore(flake/emacs-overlay): `132734ac` -> `eabe0333`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1757178312,
-        "narHash": "sha256-Z1HEVI+sphdRndNu8/iqGuupjtj1i3vBZXRXj9UA2RQ=",
+        "lastModified": 1757265531,
+        "narHash": "sha256-qivcU4dbflK4DR703s0YlmOzk365zKUJKzdei8oBdWE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "132734acf812c4cbe44fd6aed54920ae731da986",
+        "rev": "eabe03335ec98f151eefcdbe859abacfeea5e7f5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`eabe0333`](https://github.com/nix-community/emacs-overlay/commit/eabe03335ec98f151eefcdbe859abacfeea5e7f5) | `` Updated emacs ``        |
| [`2a32f99d`](https://github.com/nix-community/emacs-overlay/commit/2a32f99decbd08320210d3cc1e01fd20abab4b93) | `` Updated melpa ``        |
| [`e2c86c25`](https://github.com/nix-community/emacs-overlay/commit/e2c86c258d1b95c45143f64555af017075ffa03d) | `` Updated melpa ``        |
| [`7b9f44e5`](https://github.com/nix-community/emacs-overlay/commit/7b9f44e5c9d1f987576be9e2262131caffb6fe23) | `` Updated emacs ``        |
| [`691ac84e`](https://github.com/nix-community/emacs-overlay/commit/691ac84e299f043a189628c39691a3546177a0bc) | `` Updated flake inputs `` |
| [`e86c84e6`](https://github.com/nix-community/emacs-overlay/commit/e86c84e6027624768ea2bef9e704d8c050d16f1b) | `` Updated melpa ``        |