### PR TITLE
chore(flake/nur): `9ad5c0e3` -> `d03c8bf5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1757217197,
-        "narHash": "sha256-MpWJgUdaE6USqrRiUrJFCjBCOQJTmyMGaB47DFcZdlQ=",
+        "lastModified": 1757228486,
+        "narHash": "sha256-5hFL7TwbpYwjHpOEbsj3qAFp4rAW14+AT6rMG93NVvw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ad5c0e35f1c891cb8cfb29b3fa9c675a7463f3e",
+        "rev": "d03c8bf5f965d104d551e33b7acb5539d88a147e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d03c8bf5`](https://github.com/nix-community/NUR/commit/d03c8bf5f965d104d551e33b7acb5539d88a147e) | `` automatic update `` |
| [`6642db7e`](https://github.com/nix-community/NUR/commit/6642db7e89840ab903a200e90322a29344b0ddd3) | `` automatic update `` |
| [`5c68f6ca`](https://github.com/nix-community/NUR/commit/5c68f6ca670d9f6b7f5a24971ab65236e0f70b2c) | `` automatic update `` |
| [`c8199f22`](https://github.com/nix-community/NUR/commit/c8199f22106c3e248487911ce96739a8d9efce48) | `` automatic update `` |
| [`1a5eb488`](https://github.com/nix-community/NUR/commit/1a5eb488cecdc8288ac491ab74b658e75f80c5d9) | `` automatic update `` |