### PR TITLE
chore(flake/home-manager): `f56bf065` -> `f35703b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -740,11 +740,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757075491,
-        "narHash": "sha256-a+NMGl5tcvm+hyfSG2DlVPa8nZLpsumuRj1FfcKb2mQ=",
+        "lastModified": 1757256385,
+        "narHash": "sha256-WK7tOhWwr15mipcckhDg2no/eSpM1nIh4C9le8HgHhk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f56bf065f9abedc7bc15e1f2454aa5c8edabaacf",
+        "rev": "f35703b412c67b48e97beb6e27a6ab96a084cd37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                          |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`f35703b4`](https://github.com/nix-community/home-manager/commit/f35703b412c67b48e97beb6e27a6ab96a084cd37) | `` gtk: add color scheme option ``                               |
| [`ea3fe2bd`](https://github.com/nix-community/home-manager/commit/ea3fe2bd72caf2a0f75edf3cf9ece8d60c2f9557) | `` hyprsunset: fixed evaluation when hyprland package is null `` |
| [`fc2fe010`](https://github.com/nix-community/home-manager/commit/fc2fe0104db10a04138a215c0173580e67e9e0b4) | `` zoxide: load after prezto ``                                  |
| [`9f5966aa`](https://github.com/nix-community/home-manager/commit/9f5966aa05e3ea15733c60e7b3dc9a573241b604) | `` river: river -> river-classic ``                              |
| [`9136120c`](https://github.com/nix-community/home-manager/commit/9136120c369d91144910a985262e3c3b8e8872d6) | `` treewide: nix fmt ``                                          |
| [`c140680b`](https://github.com/nix-community/home-manager/commit/c140680b7a650e487cc9ca1151f0505d0cc4dd59) | `` plan9port: drop ehmry maintainer ``                           |
| [`a3699ec8`](https://github.com/nix-community/home-manager/commit/a3699ec8eee1692132e678375c72978252e82d21) | `` flake.lock: Update ``                                         |
| [`a7408ba6`](https://github.com/nix-community/home-manager/commit/a7408ba6dad7266689503b21e21089a63551d285) | `` syncthing: Fix for syncthing v2 (#7762) (#7766) ``            |