### PR TITLE
chore(flake/srvos): `27067044` -> `0070590b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1301,11 +1301,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756947399,
-        "narHash": "sha256-BP+tghzkQpt5NDcPhUsRjZtPd53jsubSNlmtWJclQZ8=",
+        "lastModified": 1757298062,
+        "narHash": "sha256-bSaQxOCzj0ky6HYSCJxoT8XEeqwzzJFP6R80bgGJVjM=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "27067044062111dfb077e735ee8641f05acaf4dc",
+        "rev": "0070590bf5bd5dc97b8e644720c3c7c90e16f8bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                      |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`0070590b`](https://github.com/nix-community/srvos/commit/0070590bf5bd5dc97b8e644720c3c7c90e16f8bc) | `` treefmt: set no-lambda-arg for deadnix `` |
| [`ac4bba0c`](https://github.com/nix-community/srvos/commit/ac4bba0cc48161b52a68b3aeaa35ebd2b500a4ee) | `` dev/private/flake.lock: Update ``         |
| [`017ef514`](https://github.com/nix-community/srvos/commit/017ef51479cc7b4dcd368e3fe2c7ee453ced9bff) | `` flake.lock: Update ``                     |