### PR TITLE
chore(flake/emacs-overlay): `eabe0333` -> `1ce287ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1757265531,
-        "narHash": "sha256-qivcU4dbflK4DR703s0YlmOzk365zKUJKzdei8oBdWE=",
+        "lastModified": 1757322698,
+        "narHash": "sha256-eUOyjGer4C+hMbOOb9pXa/bpq89+3vfxJox9N/ColQs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "eabe03335ec98f151eefcdbe859abacfeea5e7f5",
+        "rev": "1ce287ba4398f442fbaa6a8aaf17f159a029e824",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`1ce287ba`](https://github.com/nix-community/emacs-overlay/commit/1ce287ba4398f442fbaa6a8aaf17f159a029e824) | `` Updated melpa ``  |
| [`d846a6b5`](https://github.com/nix-community/emacs-overlay/commit/d846a6b55c54567bf488be32290ac3d367410e3e) | `` Updated melpa ``  |
| [`18e76cde`](https://github.com/nix-community/emacs-overlay/commit/18e76cde02ad90b22a6bb848fbc4dfbaeb2b20bc) | `` Updated emacs ``  |
| [`7022aeb0`](https://github.com/nix-community/emacs-overlay/commit/7022aeb0f1a1b6c23072f4beaf2ab100e2d0c162) | `` Updated elpa ``   |
| [`2303f07d`](https://github.com/nix-community/emacs-overlay/commit/2303f07deb9e084ea6cfdb9262e7ba18756a220d) | `` Updated nongnu `` |