### PR TITLE
chore(flake/emacs-overlay): `1ce287ba` -> `91d631ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1757322698,
-        "narHash": "sha256-eUOyjGer4C+hMbOOb9pXa/bpq89+3vfxJox9N/ColQs=",
+        "lastModified": 1757383564,
+        "narHash": "sha256-8d9TGk7VlaFyuUYpmW7uerxmlJ2UhOlZMxdfVRFxJVU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1ce287ba4398f442fbaa6a8aaf17f159a029e824",
+        "rev": "91d631ed20ac3d71771f64e3c1a91dffde1944ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`91d631ed`](https://github.com/nix-community/emacs-overlay/commit/91d631ed20ac3d71771f64e3c1a91dffde1944ca) | `` Updated melpa ``  |
| [`674c4807`](https://github.com/nix-community/emacs-overlay/commit/674c4807f44482a21b8069c6c5d576788d9398a4) | `` Updated emacs ``  |
| [`44b506ed`](https://github.com/nix-community/emacs-overlay/commit/44b506ed72ddc5092104ff73f1d8d45557d69bd2) | `` Updated elpa ``   |
| [`7b1b73d4`](https://github.com/nix-community/emacs-overlay/commit/7b1b73d4a47494fa3a3b30cf94644b5707732a92) | `` Updated nongnu `` |
| [`1db6a2db`](https://github.com/nix-community/emacs-overlay/commit/1db6a2db0cfa156e783dc0dcee06b490ba420a2c) | `` Updated melpa ``  |
| [`37c27914`](https://github.com/nix-community/emacs-overlay/commit/37c27914ae0c7126e7ab68ab2de42fd980a795de) | `` Updated emacs ``  |