### PR TITLE
chore(flake/nur): `4ffc663c` -> `e18c94d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1757359673,
-        "narHash": "sha256-uvlTKnXNa4eh1peNVCRwRy5Eeu/b6EuTFScYfegkd4E=",
+        "lastModified": 1757389808,
+        "narHash": "sha256-NKkUPtCD45bK2VaR3m7wVhya2QjY24WCNukT7C7ubgI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ffc663c33c1c2c1164a58d7a2617ec4a2393f34",
+        "rev": "e18c94d051c60c72b23481535ba6bf5b34bb6c60",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e18c94d0`](https://github.com/nix-community/NUR/commit/e18c94d051c60c72b23481535ba6bf5b34bb6c60) | `` automatic update `` |
| [`eca627bd`](https://github.com/nix-community/NUR/commit/eca627bd7a7fe195c2b125eb10393ed71e11c78d) | `` automatic update `` |
| [`a7c281cf`](https://github.com/nix-community/NUR/commit/a7c281cff81efbf0a7c13518e35210d449515ce5) | `` automatic update `` |
| [`929197a1`](https://github.com/nix-community/NUR/commit/929197a1f0d1dd46ba07e624d884c07198b1f550) | `` automatic update `` |
| [`b67dcc3c`](https://github.com/nix-community/NUR/commit/b67dcc3c9d4c4b1edca874a26b5f5ba7c2b513ef) | `` automatic update `` |
| [`de6a9f1b`](https://github.com/nix-community/NUR/commit/de6a9f1bc390793447e672834201be4110246be8) | `` automatic update `` |
| [`612c0200`](https://github.com/nix-community/NUR/commit/612c0200df6f2ca6a1c06454f11d45e4eab78398) | `` automatic update `` |
| [`f1d4b004`](https://github.com/nix-community/NUR/commit/f1d4b004121e16a5d1add7bcc0fc2967dc4795e7) | `` automatic update `` |
| [`6f3d2aea`](https://github.com/nix-community/NUR/commit/6f3d2aeab187e646f54780f71efa77dbd175a5e3) | `` automatic update `` |
| [`6291367b`](https://github.com/nix-community/NUR/commit/6291367b23c38821ca01c64f93c11c5cb56748ad) | `` automatic update `` |
| [`759e9f7b`](https://github.com/nix-community/NUR/commit/759e9f7b4353971a1c087eeb44064252efb3ac3b) | `` automatic update `` |
| [`631207a3`](https://github.com/nix-community/NUR/commit/631207a3f8d3cad9d1f45c5c5659b0b43a0c62b7) | `` automatic update `` |