### PR TITLE
chore(flake/nur): `e18c94d0` -> `10a9777a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1113,11 +1113,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1757068644,
-        "narHash": "sha256-NOrUtIhTkIIumj1E/Rsv1J37Yi3xGStISEo8tZm3KW4=",
+        "lastModified": 1757347588,
+        "narHash": "sha256-tLdkkC6XnsY9EOZW9TlpesTclELy8W7lL2ClL+nma8o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8eb28adfa3dc4de28e792e3bf49fcf9007ca8ac9",
+        "rev": "b599843bad24621dcaa5ab60dac98f9b0eb1cabe",
         "type": "github"
       },
       "original": {
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1757389808,
-        "narHash": "sha256-NKkUPtCD45bK2VaR3m7wVhya2QjY24WCNukT7C7ubgI=",
+        "lastModified": 1757447071,
+        "narHash": "sha256-t94sccITeyoRuc/VLMN3lJm1F/g3mAFWVD9EuneUf0s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e18c94d051c60c72b23481535ba6bf5b34bb6c60",
+        "rev": "10a9777a8e7cd7a2c78fc83cbcb8f19c40a4937f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`10a9777a`](https://github.com/nix-community/NUR/commit/10a9777a8e7cd7a2c78fc83cbcb8f19c40a4937f) | `` automatic update `` |
| [`ff5440a9`](https://github.com/nix-community/NUR/commit/ff5440a9518347fd771ef127dd7cc7ba93fca961) | `` automatic update `` |
| [`2ec53c79`](https://github.com/nix-community/NUR/commit/2ec53c798a5c3705903009612df3f5901ee16145) | `` automatic update `` |
| [`04435c5e`](https://github.com/nix-community/NUR/commit/04435c5ec1a97f99f208a646b1f54789517d160f) | `` automatic update `` |
| [`53d822bc`](https://github.com/nix-community/NUR/commit/53d822bcb1826b21845f3b350d8dfa71b47ca045) | `` automatic update `` |
| [`4f5000d7`](https://github.com/nix-community/NUR/commit/4f5000d7fed2bc4574552ce27bb22b7c97f53039) | `` automatic update `` |
| [`6cbe18c8`](https://github.com/nix-community/NUR/commit/6cbe18c86febbb94970ccc2b7c4649131c5c9509) | `` automatic update `` |
| [`c548e146`](https://github.com/nix-community/NUR/commit/c548e1468535e330663efe392247ea7604210138) | `` automatic update `` |
| [`2ff2ca0d`](https://github.com/nix-community/NUR/commit/2ff2ca0da4656f94cb6a1b6d24574d9ef2a7b90f) | `` automatic update `` |
| [`cca9d159`](https://github.com/nix-community/NUR/commit/cca9d1592e280f66f5f840c0b5cc66d37fbd7e91) | `` automatic update `` |
| [`a41e365d`](https://github.com/nix-community/NUR/commit/a41e365dbf1db17c04171e23ac17f3be5618930b) | `` automatic update `` |
| [`b00c1df9`](https://github.com/nix-community/NUR/commit/b00c1df989806aab3f604658a36103cff5d218d2) | `` automatic update `` |
| [`a6acf981`](https://github.com/nix-community/NUR/commit/a6acf9812b755b0e82b1d9d5e7ef03b719d97c46) | `` automatic update `` |
| [`4ddc7fd8`](https://github.com/nix-community/NUR/commit/4ddc7fd8b67af954a529a3cf3023394a25d330bc) | `` automatic update `` |
| [`897ae325`](https://github.com/nix-community/NUR/commit/897ae325613d8141b210513912f53c9988d06a1e) | `` automatic update `` |
| [`b8416f45`](https://github.com/nix-community/NUR/commit/b8416f45ad2bd7ad174f196139a2581f069fa03e) | `` automatic update `` |