### PR TITLE
chore(flake/home-manager): `26993d87` -> `3c97248d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -740,11 +740,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757385184,
-        "narHash": "sha256-LCxtQn9ajvOgGRbQIRUJgfP7clMGGvV1SDW1HcSb0zk=",
+        "lastModified": 1757503661,
+        "narHash": "sha256-bBh9sAJn0x/EdCVA6NYj/hXpcW1YBLCRMgn8A2T1l2E=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "26993d87fd0d3b14f7667b74ad82235f120d986e",
+        "rev": "3c97248d6f896232355735e34bb518ae9f130c5d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                 |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`3c97248d`](https://github.com/nix-community/home-manager/commit/3c97248d6f896232355735e34bb518ae9f130c5d) | `` rclone: check existence of file rather than using `cat` (#7799) ``   |
| [`a60021a8`](https://github.com/nix-community/home-manager/commit/a60021a8c99bf5a28919c0a9fbb6b04422a6a8da) | `` pianobar: add module to create config file (#7734) ``                |
| [`ede1f891`](https://github.com/nix-community/home-manager/commit/ede1f891c01b948bdbdde507cffa1fc3497f329b) | `` Translate using Weblate (Polish) (#7797) ``                          |
| [`0c7c71a2`](https://github.com/nix-community/home-manager/commit/0c7c71a2128000a8596495ec0b8841cf7407bb60) | `` oh-my-posh: add cache clearing on package version changes (#7757) `` |
| [`d587e11c`](https://github.com/nix-community/home-manager/commit/d587e11cef9caa9484ed090eddc55f4c56908342) | `` kitty: add quick-access-terminal configuration ``                    |