### PR TITLE
chore(flake/emacs-overlay): `91d631ed` -> `62c78d24`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1757383564,
-        "narHash": "sha256-8d9TGk7VlaFyuUYpmW7uerxmlJ2UhOlZMxdfVRFxJVU=",
+        "lastModified": 1757437755,
+        "narHash": "sha256-t1lP1hU5NwQLQDtsdIpVQn80/ygEiOKVVJ/LJ8oPTcI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "91d631ed20ac3d71771f64e3c1a91dffde1944ca",
+        "rev": "62c78d24987666748e67c99d9ea6359ce26c930e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`62c78d24`](https://github.com/nix-community/emacs-overlay/commit/62c78d24987666748e67c99d9ea6359ce26c930e) | `` Updated melpa ``        |
| [`5b9aa8b2`](https://github.com/nix-community/emacs-overlay/commit/5b9aa8b28eb5fc4d7110f22fa6a55bf3d922fce4) | `` Updated emacs ``        |
| [`18e9db43`](https://github.com/nix-community/emacs-overlay/commit/18e9db43165e32ea786cc69befa761e975a2daad) | `` Updated elpa ``         |
| [`4f72129c`](https://github.com/nix-community/emacs-overlay/commit/4f72129c711eafb02f5271ff97ad67ffa9a4204a) | `` Updated nongnu ``       |
| [`60763d27`](https://github.com/nix-community/emacs-overlay/commit/60763d2735d890b6c3218d06899aac441d323da3) | `` Updated flake inputs `` |