### PR TITLE
chore(flake/nur): `25144181` -> `8bf6a7ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1757476264,
-        "narHash": "sha256-c8XDU/pXDdvP3oJsTY9+AWvq/oVf8vMTPICGfyhrZxk=",
+        "lastModified": 1757489490,
+        "narHash": "sha256-g8n7MzmWXw2i8Au6YllIyldGhUe7olJ1bc+eigRgaLE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "251441815f20f4ce7a46e25ae62bf902cfae690c",
+        "rev": "8bf6a7ba9cbe7a3b21a0452b1bffadc6a1635739",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8bf6a7ba`](https://github.com/nix-community/NUR/commit/8bf6a7ba9cbe7a3b21a0452b1bffadc6a1635739) | `` automatic update `` |
| [`9bfd84d2`](https://github.com/nix-community/NUR/commit/9bfd84d21cab10b94b460a4575a3bf90ac618b4c) | `` automatic update `` |
| [`93eb1798`](https://github.com/nix-community/NUR/commit/93eb17983401759ad8f12f4443156c9681c4d2eb) | `` automatic update `` |
| [`c819001d`](https://github.com/nix-community/NUR/commit/c819001dfb3d86e71c1e0d018320769ad6480d42) | `` automatic update `` |