### PR TITLE
chore(flake/nur): `8bf6a7ba` -> `97efd62e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1757489490,
-        "narHash": "sha256-g8n7MzmWXw2i8Au6YllIyldGhUe7olJ1bc+eigRgaLE=",
+        "lastModified": 1757515664,
+        "narHash": "sha256-/fxYDIlhmQfXomeg2SMR7beZvdlq9u1p9hNQptiYd8w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8bf6a7ba9cbe7a3b21a0452b1bffadc6a1635739",
+        "rev": "97efd62e7b2cd2dadf610e0c5d350e7129e203d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`97efd62e`](https://github.com/nix-community/NUR/commit/97efd62e7b2cd2dadf610e0c5d350e7129e203d0) | `` automatic update `` |
| [`ff560ea4`](https://github.com/nix-community/NUR/commit/ff560ea4f649277b2a85f0f9cff57a2305dfa292) | `` automatic update `` |
| [`d719cfd1`](https://github.com/nix-community/NUR/commit/d719cfd11348193d24596b1877925bd5d42e5020) | `` automatic update `` |
| [`340373bf`](https://github.com/nix-community/NUR/commit/340373bfc192ea69ee1a3c452d45e080db2c875a) | `` automatic update `` |
| [`1c88ffb1`](https://github.com/nix-community/NUR/commit/1c88ffb1b4eb2275860ea54101c1109993e81ca6) | `` automatic update `` |
| [`356f3a0c`](https://github.com/nix-community/NUR/commit/356f3a0c8a844ca237d144bf8a58cf8ad706cf16) | `` automatic update `` |
| [`cc9ad809`](https://github.com/nix-community/NUR/commit/cc9ad80961d9ea8e3f157e17771913efe1fc676b) | `` automatic update `` |
| [`f1064e2b`](https://github.com/nix-community/NUR/commit/f1064e2b71200acc0f3d684cb4068cad5423dc34) | `` automatic update `` |