### PR TITLE
chore(flake/home-manager): `3c97248d` -> `e0154ae4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -740,11 +740,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757503661,
-        "narHash": "sha256-bBh9sAJn0x/EdCVA6NYj/hXpcW1YBLCRMgn8A2T1l2E=",
+        "lastModified": 1757529548,
+        "narHash": "sha256-If5AT3dPXH0BM+q+pwyZvtWLTmlqJmGW6IDZ2MqlGRU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3c97248d6f896232355735e34bb518ae9f130c5d",
+        "rev": "e0154ae41614e32a443c43ee51eee9eed3ad9a48",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`e0154ae4`](https://github.com/nix-community/home-manager/commit/e0154ae41614e32a443c43ee51eee9eed3ad9a48) | `` pistol: change config path for macOS `` |
| [`b5cb3a5d`](https://github.com/nix-community/home-manager/commit/b5cb3a5daa9218d790f5183a43454abcab2eeec1) | `` tests/darwinScrublist: add lazysql ``   |
| [`7846968d`](https://github.com/nix-community/home-manager/commit/7846968d23e7417fde9b40084e16fcdbab2fd5d6) | `` flake.lock: Update ``                   |