### PR TITLE
chore(flake/srvos): `0070590b` -> `ec58f16b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1301,11 +1301,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757298062,
-        "narHash": "sha256-bSaQxOCzj0ky6HYSCJxoT8XEeqwzzJFP6R80bgGJVjM=",
+        "lastModified": 1757552363,
+        "narHash": "sha256-4dtGagSfwMabRi59g7E8T6FcdghNizLbR4PwU1g8lDI=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "0070590bf5bd5dc97b8e644720c3c7c90e16f8bc",
+        "rev": "ec58f16bdb57cf3a17bba79f687945dca1703c64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`ec58f16b`](https://github.com/nix-community/srvos/commit/ec58f16bdb57cf3a17bba79f687945dca1703c64) | `` dev/private/flake.lock: Update `` |
| [`7d7fa7c4`](https://github.com/nix-community/srvos/commit/7d7fa7c48f99fcd974d3d318aa7c59135db38c01) | `` flake.lock: Update ``             |