### PR TITLE
chore(flake/nur): `ed9b9bb5` -> `338f8cc3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1113,11 +1113,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1757347588,
-        "narHash": "sha256-tLdkkC6XnsY9EOZW9TlpesTclELy8W7lL2ClL+nma8o=",
+        "lastModified": 1757487488,
+        "narHash": "sha256-zwE/e7CuPJUWKdvvTCB7iunV4E/+G0lKfv4kk/5Izdg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b599843bad24621dcaa5ab60dac98f9b0eb1cabe",
+        "rev": "ab0f3607a6c7486ea22229b92ed2d355f1482ee0",
         "type": "github"
       },
       "original": {
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1757562801,
-        "narHash": "sha256-iXrcDznVvIPSGyRYDJIYmVivVIpQfgDuf16aEMipJzA=",
+        "lastModified": 1757705205,
+        "narHash": "sha256-8xB4M6tCmaSaAAb72plJK3H8EH/yfOMnUWzIWKg521g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ed9b9bb5839f34ccd12d61e68977a7240922c742",
+        "rev": "338f8cc3d30bb635459c5198e676eb123b1ff4fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`338f8cc3`](https://github.com/nix-community/NUR/commit/338f8cc3d30bb635459c5198e676eb123b1ff4fe) | `` automatic update `` |
| [`bffdd18e`](https://github.com/nix-community/NUR/commit/bffdd18efd4e580c61a8aad3834603ef1cb81a63) | `` automatic update `` |
| [`b518bfcb`](https://github.com/nix-community/NUR/commit/b518bfcb01ccc582b13469bac48f94bd21fbf918) | `` automatic update `` |
| [`4a083b46`](https://github.com/nix-community/NUR/commit/4a083b46f2c333354531fad382d909d0f218fe3a) | `` automatic update `` |
| [`5c8a5818`](https://github.com/nix-community/NUR/commit/5c8a581830580a77b2391e1e0832c632d6865331) | `` automatic update `` |
| [`9a51a51a`](https://github.com/nix-community/NUR/commit/9a51a51a77903d4b673e1de1a8e674b2ea0fcc3a) | `` automatic update `` |
| [`4372ed6d`](https://github.com/nix-community/NUR/commit/4372ed6d3fd522b31dba6fdf22eec399aac59a0a) | `` automatic update `` |
| [`397dc9d0`](https://github.com/nix-community/NUR/commit/397dc9d07114dcea93adf32c6a46b3b912f85ea3) | `` automatic update `` |
| [`9999db6f`](https://github.com/nix-community/NUR/commit/9999db6f29808c46d17984b0ef780ec15845c162) | `` automatic update `` |
| [`7c145672`](https://github.com/nix-community/NUR/commit/7c145672f8d0c8b648aab2c8d211a2441a802cc2) | `` automatic update `` |
| [`7b27b7b3`](https://github.com/nix-community/NUR/commit/7b27b7b37727ae7fddf1b0265b5e042143a4e7d7) | `` automatic update `` |
| [`e3e51b1e`](https://github.com/nix-community/NUR/commit/e3e51b1ebaa4f8fef510b50351328d372acd8436) | `` automatic update `` |
| [`77010dfd`](https://github.com/nix-community/NUR/commit/77010dfd3ef9c981850041db1b84fa5a4559c1a5) | `` automatic update `` |
| [`3cd368e5`](https://github.com/nix-community/NUR/commit/3cd368e5c9dd1fa8208801239045050b19ed1ed4) | `` automatic update `` |
| [`7a68fe3a`](https://github.com/nix-community/NUR/commit/7a68fe3acaf11b71fe62bd927df4fb692113b702) | `` automatic update `` |
| [`b1893e40`](https://github.com/nix-community/NUR/commit/b1893e4022f43372375d902eac7d9a679a3df05d) | `` automatic update `` |
| [`7ee8683d`](https://github.com/nix-community/NUR/commit/7ee8683dcd76151499ebc6470a4215dfef990141) | `` automatic update `` |
| [`ef767aa2`](https://github.com/nix-community/NUR/commit/ef767aa25f9f917fe25d3848051f0e54ae42349f) | `` automatic update `` |
| [`3885a0d7`](https://github.com/nix-community/NUR/commit/3885a0d7685f703b20fe060c3cf80b8fe5577426) | `` automatic update `` |
| [`9fb70660`](https://github.com/nix-community/NUR/commit/9fb706606212ed07015a3b923232a85fd8e11186) | `` automatic update `` |
| [`ed551cfa`](https://github.com/nix-community/NUR/commit/ed551cfa6022de7399dee1d31a0c95295683b3e7) | `` automatic update `` |
| [`cdbaefe5`](https://github.com/nix-community/NUR/commit/cdbaefe5fd3c853ae2501719e246013cbc162b16) | `` automatic update `` |
| [`29a13e9a`](https://github.com/nix-community/NUR/commit/29a13e9a3aec0d3be0dd5526d0d461d402a0d5d7) | `` automatic update `` |
| [`fc5342ed`](https://github.com/nix-community/NUR/commit/fc5342ed19923c8a2d8864f3acd69e838223a999) | `` automatic update `` |
| [`03e674ee`](https://github.com/nix-community/NUR/commit/03e674eeebcdd82b10241b7d331ff03b0794c858) | `` automatic update `` |
| [`7447c413`](https://github.com/nix-community/NUR/commit/7447c41384fc7d69de00642f7e451488f4139a28) | `` automatic update `` |
| [`c41e2348`](https://github.com/nix-community/NUR/commit/c41e23488a8ba793ad982cf7aa271cf5b4f2e15f) | `` automatic update `` |
| [`86fa2e53`](https://github.com/nix-community/NUR/commit/86fa2e53940b838269b2f6fc8add62c6585edeaf) | `` automatic update `` |
| [`5f8b7da2`](https://github.com/nix-community/NUR/commit/5f8b7da26191a1e82ad5a3044f140bf3bb938be1) | `` automatic update `` |
| [`4e5f0487`](https://github.com/nix-community/NUR/commit/4e5f0487a96a2cadcb75b3a95f16648b8b288b9d) | `` automatic update `` |
| [`b2d4bffa`](https://github.com/nix-community/NUR/commit/b2d4bffacb3cc7641c8af331fe79c2171cd63c5e) | `` automatic update `` |
| [`fd39c46b`](https://github.com/nix-community/NUR/commit/fd39c46ba73ea9dd03b1a8e8dcfc94577421b55f) | `` automatic update `` |
| [`f916b2bb`](https://github.com/nix-community/NUR/commit/f916b2bbde891b5697f821427fbcd686a3642f9b) | `` automatic update `` |
| [`710d0433`](https://github.com/nix-community/NUR/commit/710d043379588daf6ac6cca612edc5840dc666b6) | `` automatic update `` |
| [`de2c6637`](https://github.com/nix-community/NUR/commit/de2c66370b64255fa38bd8bc737f2d79dbe49480) | `` automatic update `` |
| [`a625a24a`](https://github.com/nix-community/NUR/commit/a625a24a40e4a4c21fcb7bbaa5869b0766fc0eab) | `` automatic update `` |
| [`3159cd2c`](https://github.com/nix-community/NUR/commit/3159cd2c71f38bea2114e0e273d44eef8c8c34f5) | `` automatic update `` |
| [`e343b911`](https://github.com/nix-community/NUR/commit/e343b91179bf95452460e616f76bf568dba78858) | `` automatic update `` |
| [`b486a2a4`](https://github.com/nix-community/NUR/commit/b486a2a4a639af4d2d69749f56c1b5f54f7f9d02) | `` automatic update `` |
| [`39a49ed2`](https://github.com/nix-community/NUR/commit/39a49ed27efcce59f40089ee417dd5c26a0fe944) | `` automatic update `` |
| [`9c399f8e`](https://github.com/nix-community/NUR/commit/9c399f8ee99b7a5980be2f02ef20dede6bcf5224) | `` automatic update `` |
| [`44711d5f`](https://github.com/nix-community/NUR/commit/44711d5f41b2f96549521f83264190b9d93f56d6) | `` automatic update `` |
| [`c588a3e9`](https://github.com/nix-community/NUR/commit/c588a3e91eecc540120b51bf13db6700e692da01) | `` automatic update `` |
| [`88d5e3ee`](https://github.com/nix-community/NUR/commit/88d5e3eed7558fc6d8894ee965d6158e988f2ed6) | `` automatic update `` |