### PR TITLE
chore(flake/emacs-overlay): `9372cba0` -> `42daca73`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1757556412,
-        "narHash": "sha256-LRZ02sScX2lDqxz2sKyXih2QBCt3NTM+e7zhX8/IZ48=",
+        "lastModified": 1757612879,
+        "narHash": "sha256-EiubKNP4WGBbrJ6I+gHmHzOWJ7OKZTr1X+gzqgnTiJc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9372cba0f4cafea7af3e8422ed9baba8710a8b96",
+        "rev": "42daca7332fa865169d9caf8da55e68c97336ea0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`42daca73`](https://github.com/nix-community/emacs-overlay/commit/42daca7332fa865169d9caf8da55e68c97336ea0) | `` Updated emacs ``        |
| [`9fd7ca27`](https://github.com/nix-community/emacs-overlay/commit/9fd7ca2741d75304157efcc2655686ce408e5844) | `` Updated melpa ``        |
| [`202b159f`](https://github.com/nix-community/emacs-overlay/commit/202b159f9466dae227f09678097419cb2107875d) | `` Updated elpa ``         |
| [`71bf45c4`](https://github.com/nix-community/emacs-overlay/commit/71bf45c4d217a72bb06974fc0eee74bd8ea8bd66) | `` Updated nongnu ``       |
| [`284ccfb2`](https://github.com/nix-community/emacs-overlay/commit/284ccfb2bc50af5127cc84892a10d5dbb0776d0c) | `` Updated flake inputs `` |
| [`41e2499a`](https://github.com/nix-community/emacs-overlay/commit/41e2499a89e1bfa717fd2403b675c6c72c65e9fa) | `` Updated melpa ``        |