### PR TITLE
chore(flake/emacs-overlay): `42daca73` -> `bd648ab2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1757612879,
-        "narHash": "sha256-EiubKNP4WGBbrJ6I+gHmHzOWJ7OKZTr1X+gzqgnTiJc=",
+        "lastModified": 1757642614,
+        "narHash": "sha256-bt4pch2hhyMf4Qtwt3XF+4UFaYsrCSW82aQxUtrDDqg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "42daca7332fa865169d9caf8da55e68c97336ea0",
+        "rev": "bd648ab202cb87c76919fa180d80b46d02ac5634",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`bd648ab2`](https://github.com/nix-community/emacs-overlay/commit/bd648ab202cb87c76919fa180d80b46d02ac5634) | `` Updated melpa `` |
| [`6701e15c`](https://github.com/nix-community/emacs-overlay/commit/6701e15cc1777d01f42bee1df599183dc5c0f827) | `` Updated emacs `` |
| [`26daaec7`](https://github.com/nix-community/emacs-overlay/commit/26daaec7db03909fd188fdb4961593b95ec5900e) | `` Updated elpa ``  |