### PR TITLE
chore(flake/emacs-overlay): `b2151128` -> `eb1c9f75`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1757668180,
-        "narHash": "sha256-pqxwsvg8cVOY4bgEy5PUsWLVGDbgYFDnGP20bdWhjiM=",
+        "lastModified": 1757696713,
+        "narHash": "sha256-kZoe6cAoF6vHuKuQmA8o/qw5+vQaUWIqZvCto7NYuXY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b21511280c6e1ea516e551fc5e7bb27372f6c8c3",
+        "rev": "eb1c9f75fa4f32dcae47f7304f1b4c8b6ae361dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`eb1c9f75`](https://github.com/nix-community/emacs-overlay/commit/eb1c9f75fa4f32dcae47f7304f1b4c8b6ae361dc) | `` Updated melpa `` |
| [`602cebfc`](https://github.com/nix-community/emacs-overlay/commit/602cebfce48ade3dc76385fff77c9a06a185208a) | `` Updated emacs `` |
| [`89156f18`](https://github.com/nix-community/emacs-overlay/commit/89156f18feb926ea1e2628ecc043fb74b57ba1e1) | `` Updated elpa ``  |