### PR TITLE
chore(flake/nur): `338f8cc3` -> `7a21866e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1113,11 +1113,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1757487488,
-        "narHash": "sha256-zwE/e7CuPJUWKdvvTCB7iunV4E/+G0lKfv4kk/5Izdg=",
+        "lastModified": 1757745802,
+        "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ab0f3607a6c7486ea22229b92ed2d355f1482ee0",
+        "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
         "type": "github"
       },
       "original": {
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1757705205,
-        "narHash": "sha256-8xB4M6tCmaSaAAb72plJK3H8EH/yfOMnUWzIWKg521g=",
+        "lastModified": 1757836686,
+        "narHash": "sha256-SQymUUSpGBHc4W6sSJl1GMBdgmrSxWP6kyVNuje/XGI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "338f8cc3d30bb635459c5198e676eb123b1ff4fe",
+        "rev": "7a21866ea37347e06e03e6ac8a766d155b33d30d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7a21866e`](https://github.com/nix-community/NUR/commit/7a21866ea37347e06e03e6ac8a766d155b33d30d) | `` automatic update `` |
| [`25ca7f34`](https://github.com/nix-community/NUR/commit/25ca7f344cb20df6ccbc01ba3e0fd9d6c14ef8ac) | `` automatic update `` |
| [`9c750a83`](https://github.com/nix-community/NUR/commit/9c750a83934d6b0b2ddedbd1e52241f948cb352c) | `` automatic update `` |
| [`2fdfe405`](https://github.com/nix-community/NUR/commit/2fdfe405cdaf0f10601d91208f1e6bf4ce49e822) | `` automatic update `` |
| [`5cb8a920`](https://github.com/nix-community/NUR/commit/5cb8a9201971d7da5f7574b5caee7317189952b1) | `` automatic update `` |
| [`d12cb9e4`](https://github.com/nix-community/NUR/commit/d12cb9e4f3217be622949faec2c08d578de4d97c) | `` automatic update `` |
| [`11de5631`](https://github.com/nix-community/NUR/commit/11de5631c5714167f1e3d224385045d41617043a) | `` automatic update `` |
| [`1dba3036`](https://github.com/nix-community/NUR/commit/1dba3036b4b095ac231cdb978674c651cef5b70f) | `` automatic update `` |
| [`4d74a5db`](https://github.com/nix-community/NUR/commit/4d74a5dbb4bca00730d6215b537d70ce17e0dede) | `` automatic update `` |
| [`d21e3688`](https://github.com/nix-community/NUR/commit/d21e3688e21fe726df6af48c55a188336b934966) | `` automatic update `` |
| [`39e64d7d`](https://github.com/nix-community/NUR/commit/39e64d7d38ecf78d78c695182480a033e17ed6af) | `` automatic update `` |
| [`1543c6c3`](https://github.com/nix-community/NUR/commit/1543c6c3e143cc0f73410c2ec9aab382e8da3365) | `` automatic update `` |
| [`5d182ee1`](https://github.com/nix-community/NUR/commit/5d182ee144a0c0422b749327745a5673efe9761b) | `` automatic update `` |
| [`503b43c8`](https://github.com/nix-community/NUR/commit/503b43c8930ebfea451b1e617a1e99bf6d5894ab) | `` automatic update `` |
| [`4332660b`](https://github.com/nix-community/NUR/commit/4332660bff00fbfab9c33cf85f59ade4521c9ca5) | `` automatic update `` |
| [`e30d26b9`](https://github.com/nix-community/NUR/commit/e30d26b997f127ac3cdbf0e0b98481d1070a0a21) | `` automatic update `` |
| [`d87d9007`](https://github.com/nix-community/NUR/commit/d87d9007d2342fca8fe037277abb701c2f4ca53f) | `` automatic update `` |
| [`18fe43ab`](https://github.com/nix-community/NUR/commit/18fe43abcae48d18fadd019899e621fbd631f0b2) | `` automatic update `` |
| [`65ac4256`](https://github.com/nix-community/NUR/commit/65ac4256d05a33f2d1fe18cdc8dda34d177ad0d3) | `` automatic update `` |
| [`80bd5773`](https://github.com/nix-community/NUR/commit/80bd5773bf3c1a74f4543a6de9b0eefdbbea3fb8) | `` automatic update `` |
| [`22b0e920`](https://github.com/nix-community/NUR/commit/22b0e920a2e2b7d61ea7ce57c34f6dda93b601a2) | `` automatic update `` |
| [`e944a857`](https://github.com/nix-community/NUR/commit/e944a857f0f66056d80dda20cbed0c649fede72d) | `` automatic update `` |
| [`19874b35`](https://github.com/nix-community/NUR/commit/19874b3522a3e5950a2834752ef7027e54a1b7d7) | `` automatic update `` |
| [`51ec2db7`](https://github.com/nix-community/NUR/commit/51ec2db7a9f27ed4a4953389a2dd86ed1d777853) | `` automatic update `` |
| [`56e0f934`](https://github.com/nix-community/NUR/commit/56e0f9346098a15330a7587c9480fa19a6397c3b) | `` automatic update `` |
| [`d3a2c81d`](https://github.com/nix-community/NUR/commit/d3a2c81d187f6e61db57e8fd4f78eaec648328a9) | `` automatic update `` |
| [`29af2c5e`](https://github.com/nix-community/NUR/commit/29af2c5edbedf501922c04735f9a975b0b35f417) | `` automatic update `` |
| [`492f636f`](https://github.com/nix-community/NUR/commit/492f636fe5eb9f4bff47c37b9e17418a4ce003b4) | `` automatic update `` |
| [`3332e091`](https://github.com/nix-community/NUR/commit/3332e0914da238ef6ec3091cb1dfcae2aac81286) | `` automatic update `` |
| [`9c63893f`](https://github.com/nix-community/NUR/commit/9c63893fcc79eb93caf37b3d7eff209897b16a61) | `` automatic update `` |
| [`8a93aa24`](https://github.com/nix-community/NUR/commit/8a93aa245ea5190634a6eaaa0e6a4faaba850f69) | `` automatic update `` |
| [`ad3bc202`](https://github.com/nix-community/NUR/commit/ad3bc2020e9139ff9ac79dd1d2f698dca07e4bcb) | `` automatic update `` |
| [`567f0297`](https://github.com/nix-community/NUR/commit/567f0297e5c1fdf9484b30319727e8e587456ce9) | `` automatic update `` |
| [`1d9539de`](https://github.com/nix-community/NUR/commit/1d9539de96b131120dd46831283f2034c97eb70f) | `` automatic update `` |
| [`8ac8a692`](https://github.com/nix-community/NUR/commit/8ac8a6925fd9d78000a2afd622c000741eb021c7) | `` automatic update `` |
| [`e09f3359`](https://github.com/nix-community/NUR/commit/e09f3359b3ea3f82b4403dfcded216bb5ca834af) | `` automatic update `` |
| [`0fe6bc2e`](https://github.com/nix-community/NUR/commit/0fe6bc2ebd5c15cc42f0451e17d8a3e78b27b838) | `` automatic update `` |
| [`45cc9fe3`](https://github.com/nix-community/NUR/commit/45cc9fe39e7f14d95a6f64e757dca7c2fa1bf456) | `` automatic update `` |
| [`111fd847`](https://github.com/nix-community/NUR/commit/111fd8470ae52c2320f50a021cd672d88aaf35ca) | `` automatic update `` |
| [`4cd6732b`](https://github.com/nix-community/NUR/commit/4cd6732b742dcd1913c0c8215e2b6bc146c58e25) | `` automatic update `` |