### PR TITLE
chore(flake/emacs-overlay): `eb1c9f75` -> `04c2ead2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1757696713,
-        "narHash": "sha256-kZoe6cAoF6vHuKuQmA8o/qw5+vQaUWIqZvCto7NYuXY=",
+        "lastModified": 1757728856,
+        "narHash": "sha256-GBEKLGhEE0iitGMNwpkqzxrWWWYLZ0HPUOuVZQ/sctM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "eb1c9f75fa4f32dcae47f7304f1b4c8b6ae361dc",
+        "rev": "04c2ead2d49e1a4bd1f4e53528f05a4f51c5eae0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`04c2ead2`](https://github.com/nix-community/emacs-overlay/commit/04c2ead2d49e1a4bd1f4e53528f05a4f51c5eae0) | `` Updated melpa ``  |
| [`d88532f3`](https://github.com/nix-community/emacs-overlay/commit/d88532f324e839c2b3d43cdeabc1a858409c9048) | `` Updated elpa ``   |
| [`247e8360`](https://github.com/nix-community/emacs-overlay/commit/247e8360563a1893395a312ae06f0b7aad9527e2) | `` Updated nongnu `` |