### PR TITLE
chore(flake/emacs-overlay): `04c2ead2` -> `5ddab1ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1757728856,
-        "narHash": "sha256-GBEKLGhEE0iitGMNwpkqzxrWWWYLZ0HPUOuVZQ/sctM=",
+        "lastModified": 1757754437,
+        "narHash": "sha256-jUtkQXyESLdjesnry3gom8nW8McGPsoJN/E2IKx4oWM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "04c2ead2d49e1a4bd1f4e53528f05a4f51c5eae0",
+        "rev": "5ddab1acd2df3dde0906bbc25d77e667fea46ef3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`5ddab1ac`](https://github.com/nix-community/emacs-overlay/commit/5ddab1acd2df3dde0906bbc25d77e667fea46ef3) | `` Updated melpa `` |
| [`bb3f1414`](https://github.com/nix-community/emacs-overlay/commit/bb3f1414f01bcfb816457ff3dce9c21056c73576) | `` Updated emacs `` |