### PR TITLE
chore(flake/emacs-overlay): `5ddab1ac` -> `5c2f59a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1757754437,
-        "narHash": "sha256-jUtkQXyESLdjesnry3gom8nW8McGPsoJN/E2IKx4oWM=",
+        "lastModified": 1757783175,
+        "narHash": "sha256-Wko6aZsgmfYF/dAmHuUDjCyGIWbmA0YfYW+9kaT/+Qc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5ddab1acd2df3dde0906bbc25d77e667fea46ef3",
+        "rev": "5c2f59a0a0d9958d91e63974772f0a24a5150b8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`5c2f59a0`](https://github.com/nix-community/emacs-overlay/commit/5c2f59a0a0d9958d91e63974772f0a24a5150b8d) | `` Updated melpa ``  |
| [`867add27`](https://github.com/nix-community/emacs-overlay/commit/867add278cf53e04481ab386b9c80699073cb995) | `` Updated emacs ``  |
| [`88113ff5`](https://github.com/nix-community/emacs-overlay/commit/88113ff571eb496575f9f923b7084e36fe7b0600) | `` Updated elpa ``   |
| [`6bbc472b`](https://github.com/nix-community/emacs-overlay/commit/6bbc472b14258da37770da2cf646062572fe5174) | `` Updated nongnu `` |