### PR TITLE
chore(flake/nix-index-database): `9b144dc3` -> `050a5feb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757218147,
-        "narHash": "sha256-IwOwN70HvoBNB2ckaROxcaCvj5NudNc52taPsv5wtLk=",
+        "lastModified": 1757822619,
+        "narHash": "sha256-3HIpe3P2h1AUPYcAH9cjuX0tZOqJpX01c0iDwoUYNZ8=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "9b144dc3ef6e42b888c4190e02746aab13b0e97f",
+        "rev": "050a5feb5d1bb5b6e5fc04a7d3d816923a87c9ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`050a5feb`](https://github.com/nix-community/nix-index-database/commit/050a5feb5d1bb5b6e5fc04a7d3d816923a87c9ea) | `` update generated.nix to release 2025-09-14-032502 `` |
| [`80b92602`](https://github.com/nix-community/nix-index-database/commit/80b92602ddca79bd46ffa8fd244af0319c22551b) | `` flake.lock: Update ``                                |