### PR TITLE
chore(flake/nur): `7a21866e` -> `dbba7336`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1757836686,
-        "narHash": "sha256-SQymUUSpGBHc4W6sSJl1GMBdgmrSxWP6kyVNuje/XGI=",
+        "lastModified": 1757850257,
+        "narHash": "sha256-iGPeHG9/pPsQkhbgoxl6JAHaLT1LriJKM5jZ8o4EO1k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7a21866ea37347e06e03e6ac8a766d155b33d30d",
+        "rev": "dbba733604535685d3f5b6ece3d1168f7b4565aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dbba7336`](https://github.com/nix-community/NUR/commit/dbba733604535685d3f5b6ece3d1168f7b4565aa) | `` automatic update `` |
| [`c8366ece`](https://github.com/nix-community/NUR/commit/c8366ecedc158e4884015657a8eb739ccb0092a6) | `` automatic update `` |
| [`87a1579b`](https://github.com/nix-community/NUR/commit/87a1579b2bff6f90d102433020fff698fec07c9b) | `` automatic update `` |