### PR TITLE
chore(flake/sops-nix): `0bf79382` -> `ee6f91c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1281,11 +1281,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757503115,
-        "narHash": "sha256-S9F6bHUBh+CFEUalv/qxNImRapCxvSnOzWBUZgK1zDU=",
+        "lastModified": 1757847158,
+        "narHash": "sha256-TumOaykhZO8SOs/faz6GQhqkOcFLoQvESLSF1cJ4mZc=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "0bf793823386187dff101ee2a9d4ed26de8bbf8c",
+        "rev": "ee6f91c1c11acf7957d94a130de77561ec24b8ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                      |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`582e7dcc`](https://github.com/Mic92/sops-nix/commit/582e7dccbfc5cee6aa3ff9fb26adc2b4a0081b8c) | `` [create-pull-request] automated change `` |