### PR TITLE
chore(flake/nixos-hardware): `f89c620d` -> `67a709cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -988,11 +988,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1757775351,
-        "narHash": "sha256-xWsxmNHwt9jV/yFJqzsNeilpH4BR8MPe44Yt0eaGAIM=",
+        "lastModified": 1757943327,
+        "narHash": "sha256-w6cDExPBqbq7fTLo4dZ1ozDGeq3yV6dSN4n/sAaS6OM=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "f89c620d3d6e584d98280b48f0af7be4f8506ab5",
+        "rev": "67a709cfe5d0643dafd798b0b613ed579de8be05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                           |
| ----------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`0632a5e1`](https://github.com/NixOS/nixos-hardware/commit/0632a5e10fa0d4a81a59e9b084d4dc898f0e26ba) | `` MacBookAir6,x: fix wireless `` |
| [`82e5fcb5`](https://github.com/NixOS/nixos-hardware/commit/82e5fcb58cf7d2b3f3bd2264a5acdc8816c38bf4) | `` Fix fydetab duo eval ``        |