### PR TITLE
chore(flake/emacs-overlay): `8af7ba0d` -> `7caed428`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1757869557,
-        "narHash": "sha256-Mc18xmMnCqe7ivf9xJgMVCHTedlfVIAyY2if17V3yPE=",
+        "lastModified": 1757956155,
+        "narHash": "sha256-LqiYwpqIgbUE3H8nA5CK08pXWFf3WuEsXdBRPn0sIEU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8af7ba0dd800534f54d96af15e8d89eb18a27f57",
+        "rev": "7caed42858e94832749eb0087bd6b1c7eab1752b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`7caed428`](https://github.com/nix-community/emacs-overlay/commit/7caed42858e94832749eb0087bd6b1c7eab1752b) | `` Updated melpa ``  |
| [`4234efdd`](https://github.com/nix-community/emacs-overlay/commit/4234efdd0888c5fc088ffb083ec9daba9a62ba8e) | `` Updated emacs ``  |
| [`6305bca1`](https://github.com/nix-community/emacs-overlay/commit/6305bca10c3a7c2f7493553744dbf8f76cd57222) | `` Updated elpa ``   |
| [`ba8d8683`](https://github.com/nix-community/emacs-overlay/commit/ba8d86836e7f6544db3cd4ea40da24cc6f330040) | `` Updated nongnu `` |
| [`6302a8a5`](https://github.com/nix-community/emacs-overlay/commit/6302a8a5904203bc18532e71b3d61f4b324d20fb) | `` Updated melpa ``  |
| [`2eadd129`](https://github.com/nix-community/emacs-overlay/commit/2eadd129c00b17c1dffa6c05a6372be4d6698be5) | `` Updated melpa ``  |
| [`25651827`](https://github.com/nix-community/emacs-overlay/commit/25651827bbe533ea41154f7c9291bfdae0a5f485) | `` Updated emacs ``  |
| [`6810d985`](https://github.com/nix-community/emacs-overlay/commit/6810d985c9eaa4b3148ebd0386d5407d3fa0652a) | `` Updated elpa ``   |
| [`3dc8fb16`](https://github.com/nix-community/emacs-overlay/commit/3dc8fb164c27095fbf1fa6890e9c17fd986cceb4) | `` Updated nongnu `` |