### PR TITLE
chore(flake/srvos): `ec58f16b` -> `bffcdb33`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1301,11 +1301,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757552363,
-        "narHash": "sha256-4dtGagSfwMabRi59g7E8T6FcdghNizLbR4PwU1g8lDI=",
+        "lastModified": 1757898151,
+        "narHash": "sha256-FmI8VUvFKkZrQkJ/oqx0F0CnvXdv2O3nlPhVBtCGqWo=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "ec58f16bdb57cf3a17bba79f687945dca1703c64",
+        "rev": "bffcdb335e9dae8d2242ec0bfe4bab4484870c65",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`bffcdb33`](https://github.com/nix-community/srvos/commit/bffcdb335e9dae8d2242ec0bfe4bab4484870c65) | `` dev/private/flake.lock: Update `` |
| [`38229ad3`](https://github.com/nix-community/srvos/commit/38229ad3fad7281ed08549dd85b781f2ac4f00f3) | `` flake.lock: Update ``             |