### PR TITLE
chore(flake/nur): `8a0c9c76` -> `ea777b8d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1187,11 +1187,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1757908580,
-        "narHash": "sha256-c8sYoJUaA9o5wIlj6TNxUmijIu0VFHTFS3esuaUt9gk=",
+        "lastModified": 1757921958,
+        "narHash": "sha256-otqGx5ALUBczeCH3A1oWlLBc3k6De0fdrXS8XQaPqAc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8a0c9c76f6349a9be46687120b4c079ed083dbec",
+        "rev": "ea777b8da72d16f8b145cd9bf45f6790d482870c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ea777b8d`](https://github.com/nix-community/NUR/commit/ea777b8da72d16f8b145cd9bf45f6790d482870c) | `` automatic update `` |
| [`580fb81d`](https://github.com/nix-community/NUR/commit/580fb81de55289fcfb13b6de744706efcc483139) | `` automatic update `` |
| [`ef33d6c1`](https://github.com/nix-community/NUR/commit/ef33d6c1b7f367a7ccd08039b81940d40019d980) | `` automatic update `` |
| [`814a665d`](https://github.com/nix-community/NUR/commit/814a665dec85168be24b9b95f58a86ca9e3b18b3) | `` automatic update `` |
| [`ae5c59b5`](https://github.com/nix-community/NUR/commit/ae5c59b5579fdcf43a408a59fe1d572c612ff21a) | `` automatic update `` |