### PR TITLE
chore(flake/home-manager): `11cc5449` -> `9f408dc5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -740,11 +740,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757920978,
-        "narHash": "sha256-Mv16aegXLulgyDunijP6SPFJNm8lSXb2w3Q0X+vZ9TY=",
+        "lastModified": 1758119172,
+        "narHash": "sha256-LnVuGLf0PJHqqIHroxEzwXS57mjAdHSrXi0iODKbbiU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "11cc5449c50e0e5b785be3dfcb88245232633eb8",
+        "rev": "9f408dc51c8e8216a94379e6356bdadbe8b4fef9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`9f408dc5`](https://github.com/nix-community/home-manager/commit/9f408dc51c8e8216a94379e6356bdadbe8b4fef9) | `` ssh-tpm-agent: fix test case ``                                     |
| [`5c14260f`](https://github.com/nix-community/home-manager/commit/5c14260fad23f9fda91a0dd74b1c58cf3be95221) | `` systemd: make unit definitions freeform modules ``                  |
| [`12dfb0cf`](https://github.com/nix-community/home-manager/commit/12dfb0cff99865ea9e7fd0e3db3a301102b948f9) | `` restic: fix integration test ``                                     |
| [`bc8967cd`](https://github.com/nix-community/home-manager/commit/bc8967cdb03c9d805288dd80b845b16ef8c4111b) | `` gpg-agent: write nushell initialization to config file ``           |
| [`b0355462`](https://github.com/nix-community/home-manager/commit/b035546241d842053c7f19c517e330d79d1dc801) | `` news: add opencode entry for new agent and command support ``       |
| [`53538044`](https://github.com/nix-community/home-manager/commit/53538044d9e23b30ea7d5c1b0028feb9517995b3) | `` tests/opencode: expand tests for agents / commands ``               |
| [`c104ee92`](https://github.com/nix-community/home-manager/commit/c104ee92bf1cf4c9b4ccaa773fd108627a83bbf3) | `` opencode: path support for agents/commands ``                       |
| [`d7686f26`](https://github.com/nix-community/home-manager/commit/d7686f26e8b623f32f2739cf2c5f1b37efbf1366) | `` opencode: add support for agent and command files ``                |
| [`fb928abb`](https://github.com/nix-community/home-manager/commit/fb928abb67bd4df99040721ed48c3b42e24b1d08) | `` tests/claude-code: add path tests for agents/commands ``            |
| [`846f27fb`](https://github.com/nix-community/home-manager/commit/846f27fba84839a93015c3378449edd255071e42) | `` claude-code: support paths for agents/commands ``                   |
| [`10f5a0cc`](https://github.com/nix-community/home-manager/commit/10f5a0cc4b98c61298a8d130185a25032e9fe3b8) | `` tests/oh-my-posh: expand test coverage ``                           |
| [`51372c4a`](https://github.com/nix-community/home-manager/commit/51372c4afb961c310beab90090f93d88e3b1c1e6) | `` oh-my-posh: add assertion for config source ``                      |
| [`624c97de`](https://github.com/nix-community/home-manager/commit/624c97de9cae5ba1432557df579b64a79d90fadc) | `` oh-my-posh: added option to supply config path ``                   |
| [`d507f57d`](https://github.com/nix-community/home-manager/commit/d507f57df23d067165f3d1a1dd5fb169b4f6bc37) | `` maintainers: update all-maintainers.nix (#7815) ``                  |
| [`fad8e303`](https://github.com/nix-community/home-manager/commit/fad8e3033e95d0a4595080e1efc8927b16ac18ed) | `` fontconfig: add fonts.fontconfig.extraConfigFiles option (#7754) `` |
| [`75f97fcb`](https://github.com/nix-community/home-manager/commit/75f97fcbe31cd6d4151527f3ac50cacbe8f1ff0d) | `` sway: order input config from least to most specific (#7684) ``     |
| [`ec73c06d`](https://github.com/nix-community/home-manager/commit/ec73c06d34859ed01e2ce0e15d5972b4dd539694) | `` vscode: add config and exension dir for kiro (#7825) ``             |
| [`6efc49be`](https://github.com/nix-community/home-manager/commit/6efc49be7c6115a0e07b3a2fa042cd41d9195545) | `` floorp: use -bin, as source package was dropped (#7818) ``          |
| [`0a2145ea`](https://github.com/nix-community/home-manager/commit/0a2145eae2546f8fb7ce20b5bf21c9dacce37092) | `` activitywatch: add service status cmd to desc (#7823) ``            |
| [`6c1a1efa`](https://github.com/nix-community/home-manager/commit/6c1a1efa028aff04a277fc69781081a0bd6e0ca2) | `` watcher: fix example typo for aw-watcher-window (#7822) ``          |
| [`5820376b`](https://github.com/nix-community/home-manager/commit/5820376beb804de9acf07debaaff1ac84728b708) | `` news: add cudatext entry ``                                         |
| [`10d30c91`](https://github.com/nix-community/home-manager/commit/10d30c9185697d86477e1e539ca755403d7a3216) | `` cudatext: add module ``                                             |
| [`a88781a3`](https://github.com/nix-community/home-manager/commit/a88781a35cf9de9042396c4b84d2fae127b316b5) | `` sway: drop oxalica from maintainer ``                               |