### PR TITLE
chore(flake/sops-nix): `ee6f91c1` -> `f77d4cfa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1300,11 +1300,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757847158,
-        "narHash": "sha256-TumOaykhZO8SOs/faz6GQhqkOcFLoQvESLSF1cJ4mZc=",
+        "lastModified": 1758007585,
+        "narHash": "sha256-HYnwlbY6RE5xVd5rh0bYw77pnD8lOgbT4mlrfjgNZ0c=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "ee6f91c1c11acf7957d94a130de77561ec24b8ab",
+        "rev": "f77d4cfa075c3de66fc9976b80e0c4fc69e2c139",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                              |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`e416a208`](https://github.com/Mic92/sops-nix/commit/e416a20843537a0e744277c38feb90e57305846e) | `` update vendorHash ``                              |
| [`5c8bbda9`](https://github.com/Mic92/sops-nix/commit/5c8bbda93a0420c08a9d17e7534fdc923fe23a00) | `` Bump golang.org/x/crypto from 0.41.0 to 0.42.0 `` |