### PR TITLE
chore(flake/emacs-overlay): `7caed428` -> `99a77c3d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1757956155,
-        "narHash": "sha256-LqiYwpqIgbUE3H8nA5CK08pXWFf3WuEsXdBRPn0sIEU=",
+        "lastModified": 1758013932,
+        "narHash": "sha256-gEBGpudXp12l2oOGFbqJ6V1oiwt0kqDT8/Y92TNLIbM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7caed42858e94832749eb0087bd6b1c7eab1752b",
+        "rev": "99a77c3da5376924f367515fee48795b8ac2368e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`99a77c3d`](https://github.com/nix-community/emacs-overlay/commit/99a77c3da5376924f367515fee48795b8ac2368e) | `` Updated melpa ``  |
| [`22ede968`](https://github.com/nix-community/emacs-overlay/commit/22ede9682b17e7f1df70c083f3e8b02ce1b8d11e) | `` Updated emacs ``  |
| [`42b14295`](https://github.com/nix-community/emacs-overlay/commit/42b14295a6c6d45a9cc6a24a4a9d82ec59547955) | `` Updated elpa ``   |
| [`6026be88`](https://github.com/nix-community/emacs-overlay/commit/6026be88a9938658bd1943b7497c22ce95a33e60) | `` Updated nongnu `` |