### PR TITLE
chore(flake/emacs-overlay): `99a77c3d` -> `f834197d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1758013932,
-        "narHash": "sha256-gEBGpudXp12l2oOGFbqJ6V1oiwt0kqDT8/Y92TNLIbM=",
+        "lastModified": 1758042545,
+        "narHash": "sha256-GQSI7r/0Ys4+PtzhPgxC3SrrM1GR5sfPNIRM+M5XBDQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "99a77c3da5376924f367515fee48795b8ac2368e",
+        "rev": "f834197dfd4d117ff82d12bd786df02ae16184ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`f834197d`](https://github.com/nix-community/emacs-overlay/commit/f834197dfd4d117ff82d12bd786df02ae16184ec) | `` Updated melpa ``  |
| [`b887fad1`](https://github.com/nix-community/emacs-overlay/commit/b887fad13f43c1413cd0c02d9075e2fa7475c054) | `` Updated emacs ``  |
| [`04941f76`](https://github.com/nix-community/emacs-overlay/commit/04941f76d73d89b2685bcee582cccd8e3caddee5) | `` Updated elpa ``   |
| [`5288aebc`](https://github.com/nix-community/emacs-overlay/commit/5288aebc1845c595d226aacb3f401ecc154a59e9) | `` Updated nongnu `` |