### PR TITLE
chore(flake/nixos-avf): `87a6e00a` -> `1b7bf91c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -912,12 +912,15 @@
       }
     },
     "nixos-avf": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_3"
+      },
       "locked": {
-        "lastModified": 1756812631,
-        "narHash": "sha256-EjRPR6EnTVjiHI5H0dsJNSbmpVJ65DLurdAeldqE1tI=",
+        "lastModified": 1758048506,
+        "narHash": "sha256-I7cLckLwnppaqoUFvTrgGKDevNnIn3qV/3ELxetm6jk=",
         "owner": "nix-community",
         "repo": "nixos-avf",
-        "rev": "87a6e00a69a918c7d7c3bb40115b91f4e5f88214",
+        "rev": "1b7bf91cef5e3aeada4bc81977eb12b71585b45c",
         "type": "github"
       },
       "original": {
@@ -1097,6 +1100,22 @@
     },
     "nixpkgs_3": {
       "locked": {
+        "lastModified": 1757545623,
+        "narHash": "sha256-mCxPABZ6jRjUQx3bPP4vjA68ETbPLNz9V2pk9tO7pRQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8cd5ce828d5d1d16feff37340171a98fc3bf6526",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
         "lastModified": 1757745802,
         "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
         "owner": "NixOS",
@@ -1111,7 +1130,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1757745802,
         "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
@@ -1184,7 +1203,7 @@
     "nur": {
       "inputs": {
         "flake-parts": "flake-parts_2",
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "lastModified": 1757964442,
@@ -1227,7 +1246,7 @@
         "nixos-cosmic": "nixos-cosmic",
         "nixos-facter-modules": "nixos-facter-modules",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_4",
         "nixpkgs_tmux": "nixpkgs_tmux",
         "nur": "nur",
         "sops-nix": "sops-nix",


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                        |
| -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`40fe269d`](https://github.com/nix-community/nixos-avf/commit/40fe269d8b405015399c8a1dc9f01cfb614a2075) | `` fix: formatting and naming fixes ``                         |
| [`bc93e122`](https://github.com/nix-community/nixos-avf/commit/bc93e12266e896dee85076b0e565e3dd7d001451) | `` add: editorconfig ``                                        |
| [`980cf817`](https://github.com/nix-community/nixos-avf/commit/980cf8172299bdfd2c32b4f206b712ef961e6739) | `` add: formatter to flake ``                                  |
| [`24375b32`](https://github.com/nix-community/nixos-avf/commit/24375b322db2355efbc1482784d20d914bced152) | `` fix: structuredExtraConfig is needed for 25.05 and later `` |
| [`61d33032`](https://github.com/nix-community/nixos-avf/commit/61d33032ff93ca454dce71140a2279e7b03a69a3) | `` fix: systemd services dependency ``                         |