### PR TITLE
chore(flake/nur): `0d7cc91a` -> `32b846c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1206,11 +1206,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1758080795,
-        "narHash": "sha256-oXzvcBli7VS6cfw7znzksOLZCGyIT/az17oJYYWO4P0=",
+        "lastModified": 1758137232,
+        "narHash": "sha256-8OL31Mu6nHWJbzNar/1SQcUcil7lU0o7r3dGycydKr8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0d7cc91a2665c82922af6c78a4239b5b858c66ac",
+        "rev": "32b846c44f3af23fe35a5169e072764ee9116eb8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`32b846c4`](https://github.com/nix-community/NUR/commit/32b846c44f3af23fe35a5169e072764ee9116eb8) | `` automatic update `` |
| [`0b3eab92`](https://github.com/nix-community/NUR/commit/0b3eab9274f36edc45a0e8fe25f1dd0643fd3ba8) | `` automatic update `` |
| [`75db73fa`](https://github.com/nix-community/NUR/commit/75db73fa583b779c4605e963ff27238f3515e89f) | `` automatic update `` |
| [`958d2ac3`](https://github.com/nix-community/NUR/commit/958d2ac30171494df975b22d1364502560307bdf) | `` automatic update `` |
| [`1db115a4`](https://github.com/nix-community/NUR/commit/1db115a421a7cf95bd700b49482b63dcf9d9e80e) | `` automatic update `` |
| [`ac513a85`](https://github.com/nix-community/NUR/commit/ac513a8529e3afc3949338c86d2f68d51352862c) | `` automatic update `` |
| [`b95b4698`](https://github.com/nix-community/NUR/commit/b95b4698ec3874af4195c00124ecbc4cdf65a887) | `` automatic update `` |
| [`619c1818`](https://github.com/nix-community/NUR/commit/619c18181cc8800620391b039194ed77cbe28a54) | `` automatic update `` |
| [`2f610c4f`](https://github.com/nix-community/NUR/commit/2f610c4f373970eb05cc0427dd84101f57db2605) | `` automatic update `` |
| [`8ddfe16b`](https://github.com/nix-community/NUR/commit/8ddfe16be4f0878ac1efd3d9b72d563da147b348) | `` automatic update `` |
| [`fd8b7a0a`](https://github.com/nix-community/NUR/commit/fd8b7a0aabea9b76780c309a534e9737978c6338) | `` automatic update `` |
| [`5d2e99bd`](https://github.com/nix-community/NUR/commit/5d2e99bd13c56536be8598b77adb5a1e005504dc) | `` automatic update `` |
| [`8c08ab7d`](https://github.com/nix-community/NUR/commit/8c08ab7dbfba494a0c5fdbb8143f41454e1914b6) | `` automatic update `` |
| [`e7f85625`](https://github.com/nix-community/NUR/commit/e7f85625fc91e2304464bcfeac568bee8333c2e0) | `` automatic update `` |
| [`af8dcc2b`](https://github.com/nix-community/NUR/commit/af8dcc2b544e2cefa9087fb53687d2ef07c6f8a2) | `` automatic update `` |
| [`0bb5abc7`](https://github.com/nix-community/NUR/commit/0bb5abc78108ea6dbec8f936c7ca3140d936be2c) | `` automatic update `` |
| [`a3ce7a2a`](https://github.com/nix-community/NUR/commit/a3ce7a2aaac86ebcf8ffa3f9a3b0e1b4ff28aad6) | `` automatic update `` |