### PR TITLE
chore(flake/minimal-emacs-d): `8d975e88` -> `c2883bb1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     "minimal-emacs-d": {
       "flake": false,
       "locked": {
-        "lastModified": 1757108561,
-        "narHash": "sha256-BAywB7Yyw4Tb0WlAH6Ta6KwEeozu079rj+cERVpFsoQ=",
+        "lastModified": 1758139253,
+        "narHash": "sha256-nqoeImZNdyu8lIKFTk95YtAJ84ZAHvzVCD0qPW2mshE=",
         "owner": "jamescherti",
         "repo": "minimal-emacs.d",
-        "rev": "8d975e882026f1433086e6dcf86c1b9acaac61a1",
+        "rev": "c2883bb14064a09a4ad6e60563e3d43fa0185f92",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                             |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------- |
| [`c2883bb1`](https://github.com/jamescherti/minimal-emacs.d/commit/c2883bb14064a09a4ad6e60563e3d43fa0185f92) | `` Remove provide from init.el and early-init.el `` |