### PR TITLE
chore(flake/nur): `32b846c4` -> `47a4f851`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1206,11 +1206,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1758137232,
-        "narHash": "sha256-8OL31Mu6nHWJbzNar/1SQcUcil7lU0o7r3dGycydKr8=",
+        "lastModified": 1758144108,
+        "narHash": "sha256-fq/Fd89pUrdVcFmw8aNVQoF9UPq7L5gtS/0ioPTUNKg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "32b846c44f3af23fe35a5169e072764ee9116eb8",
+        "rev": "47a4f8514d9aecd033d53a84f698a115b3074f2b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`47a4f851`](https://github.com/nix-community/NUR/commit/47a4f8514d9aecd033d53a84f698a115b3074f2b) | `` automatic update `` |
| [`ec19dfbc`](https://github.com/nix-community/NUR/commit/ec19dfbcd4fcc12ac85abad94f3de90dd4f81e86) | `` automatic update `` |