### PR TITLE
chore(flake/nur): `47a4f851` -> `6a9adb2a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1132,11 +1132,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1757745802,
-        "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
+        "lastModified": 1758035966,
+        "narHash": "sha256-qqIJ3yxPiB0ZQTT9//nFGQYn8X/PBoJbofA7hRKZnmE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
+        "rev": "8d4ddb19d03c65a36ad8d189d001dc32ffb0306b",
         "type": "github"
       },
       "original": {
@@ -1206,11 +1206,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1758144108,
-        "narHash": "sha256-fq/Fd89pUrdVcFmw8aNVQoF9UPq7L5gtS/0ioPTUNKg=",
+        "lastModified": 1758195540,
+        "narHash": "sha256-fRWTZMqA0Kao3tohMA50D3GDAEU/2dvYR5xlSFz6Cak=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "47a4f8514d9aecd033d53a84f698a115b3074f2b",
+        "rev": "6a9adb2a32f99087a3723a90ba4f82825c80aaba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6a9adb2a`](https://github.com/nix-community/NUR/commit/6a9adb2a32f99087a3723a90ba4f82825c80aaba) | `` automatic update `` |
| [`82fb7db6`](https://github.com/nix-community/NUR/commit/82fb7db65972486e5a200af470154b6ad5751307) | `` automatic update `` |
| [`b65ea76b`](https://github.com/nix-community/NUR/commit/b65ea76b988f26cbc4a9325c3acae4736be26461) | `` automatic update `` |
| [`a9d395a6`](https://github.com/nix-community/NUR/commit/a9d395a6a130e3225561181d39330c6479767b0b) | `` automatic update `` |
| [`426a853e`](https://github.com/nix-community/NUR/commit/426a853e38fa0386793bf6d18aaa7a2f2ce0a5c0) | `` automatic update `` |
| [`a5569020`](https://github.com/nix-community/NUR/commit/a556902055024d7833a5344c42062fb1d4b2981d) | `` automatic update `` |
| [`c7effeab`](https://github.com/nix-community/NUR/commit/c7effeabc71464687db97585e88cd622d579c69b) | `` automatic update `` |
| [`ccfb1478`](https://github.com/nix-community/NUR/commit/ccfb1478d48514e7bd2c61cdc0d0bf51b0a5aca1) | `` automatic update `` |
| [`a0078057`](https://github.com/nix-community/NUR/commit/a007805777b46c53bbcdc4079e1dd05ce885f2b5) | `` automatic update `` |
| [`6f56c23c`](https://github.com/nix-community/NUR/commit/6f56c23cba3d8a3997ac27a7e787015a34079bdc) | `` automatic update `` |
| [`4b2799fb`](https://github.com/nix-community/NUR/commit/4b2799fb2578679296345102a691a07fcb48ed46) | `` automatic update `` |
| [`001d3a68`](https://github.com/nix-community/NUR/commit/001d3a682dfc31c7da4bd572022576acadd2c0fe) | `` automatic update `` |
| [`245a6b07`](https://github.com/nix-community/NUR/commit/245a6b07981ac45ce88ac29f6700eea682337e7e) | `` automatic update `` |
| [`fec7c6c7`](https://github.com/nix-community/NUR/commit/fec7c6c7247e1f8cfb55053cbccf411e9934e462) | `` automatic update `` |
| [`3f22106e`](https://github.com/nix-community/NUR/commit/3f22106e4e7978ff78227621431161735a91793e) | `` automatic update `` |
| [`f1ebc404`](https://github.com/nix-community/NUR/commit/f1ebc404910dd3fc394e5aff32d3121b6a15077e) | `` automatic update `` |
| [`fec3acb9`](https://github.com/nix-community/NUR/commit/fec3acb91b07deca7d11d0647da90da67a142d79) | `` automatic update `` |
| [`22819395`](https://github.com/nix-community/NUR/commit/22819395d9252ec2de040e0a517c33c8f0b1c94f) | `` automatic update `` |
| [`1e16a55f`](https://github.com/nix-community/NUR/commit/1e16a55f2b52a2dfb3feaa128413906b6290d758) | `` automatic update `` |