### PR TITLE
chore(flake/catppuccin): `039cd593` -> `ff94d16c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1757929733,
-        "narHash": "sha256-dzKGtCdGbW7v95MS6pxb97u025JP24QsqCLE5bHAumI=",
+        "lastModified": 1758186094,
+        "narHash": "sha256-uvfqk4A5pCKwGvq0f/ZrmqarF80KViSNfYWKdeOYFaw=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "039cd59357bc6fdd8d9848717069fbc9ee609a73",
+        "rev": "ff94d16ca2d7f51b9fc4a7f6559dc18de54d1915",
         "type": "github"
       },
       "original": {
@@ -1006,11 +1006,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1756266583,
-        "narHash": "sha256-cr748nSmpfvnhqSXPiCfUPxRz2FJnvf/RjJGvFfaCsM=",
+        "lastModified": 1757487488,
+        "narHash": "sha256-zwE/e7CuPJUWKdvvTCB7iunV4E/+G0lKfv4kk/5Izdg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8a6d5427d99ec71c64f0b93d45778c889005d9c2",
+        "rev": "ab0f3607a6c7486ea22229b92ed2d355f1482ee0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`ff94d16c`](https://github.com/catppuccin/nix/commit/ff94d16ca2d7f51b9fc4a7f6559dc18de54d1915) | `` feat(home-manager): add support for vivid (#722) `` |
| [`751b99dc`](https://github.com/catppuccin/nix/commit/751b99dca72c7f9df5475c67dcf1059893564e32) | `` chore: update flakes (#716) ``                      |
| [`492eaf63`](https://github.com/catppuccin/nix/commit/492eaf6375aea16be27a2ec746051b14d06e6838) | `` chore: update port sources (#717) ``                |