### PR TITLE
chore(flake/nur): `6a9adb2a` -> `ed07b729`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1206,11 +1206,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1758195540,
-        "narHash": "sha256-fRWTZMqA0Kao3tohMA50D3GDAEU/2dvYR5xlSFz6Cak=",
+        "lastModified": 1758224299,
+        "narHash": "sha256-re2rlOE0z0KGcTbYFR75tS5IgkLeILCeK1JCpp0pKHQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6a9adb2a32f99087a3723a90ba4f82825c80aaba",
+        "rev": "ed07b72916e851cdf138502cad68468c5f9158cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                        |
| -------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`ed07b729`](https://github.com/nix-community/NUR/commit/ed07b72916e851cdf138502cad68468c5f9158cc) | `` automatic update ``         |
| [`af04692c`](https://github.com/nix-community/NUR/commit/af04692c6c979bea3325b8b60a1413ed3ce46c2a) | `` automatic update ``         |
| [`49d02e75`](https://github.com/nix-community/NUR/commit/49d02e75216fe69a7b71e15c87abc8db349983d2) | `` automatic update ``         |
| [`ea8c4288`](https://github.com/nix-community/NUR/commit/ea8c4288ca2e18bf307ff8a4003971b05c3b9c23) | `` automatic update ``         |
| [`c246863e`](https://github.com/nix-community/NUR/commit/c246863eec092ba5b183fe028c5ed9ed5597bf87) | `` automatic update ``         |
| [`ef4877b4`](https://github.com/nix-community/NUR/commit/ef4877b498ab68459f0284692ef9c03372f65921) | `` automatic update ``         |
| [`4983ecb0`](https://github.com/nix-community/NUR/commit/4983ecb03879577c9d81dfb3e90a933986be0057) | `` qchem: remove repository `` |
| [`2bfd52bc`](https://github.com/nix-community/NUR/commit/2bfd52bc62846023a8bcd891eca77e281904936b) | `` remove nolith repository `` |
| [`fa0fea4a`](https://github.com/nix-community/NUR/commit/fa0fea4ae6d742ea7220572f1f260a0fccc312eb) | `` automatic update ``         |
| [`403ff116`](https://github.com/nix-community/NUR/commit/403ff116d6e752f31888aceb281b944dc469aa2b) | `` automatic update ``         |
| [`38eba84c`](https://github.com/nix-community/NUR/commit/38eba84c4a94ecd15937191f29b9dcfd5ad21180) | `` automatic update ``         |
| [`c65133bc`](https://github.com/nix-community/NUR/commit/c65133bcbc1a44afc0f43eceb64c440f81f6a63e) | `` automatic update ``         |