### PR TITLE
chore(flake/nur): `ed07b729` -> `25758d43`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1132,11 +1132,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1758035966,
-        "narHash": "sha256-qqIJ3yxPiB0ZQTT9//nFGQYn8X/PBoJbofA7hRKZnmE=",
+        "lastModified": 1758198701,
+        "narHash": "sha256-7To75JlpekfUmdkUZewnT6MoBANS0XVypW6kjUOXQwc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8d4ddb19d03c65a36ad8d189d001dc32ffb0306b",
+        "rev": "0147c2f1d54b30b5dd6d4a8c8542e8d7edf93b5d",
         "type": "github"
       },
       "original": {
@@ -1206,11 +1206,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1758224299,
-        "narHash": "sha256-re2rlOE0z0KGcTbYFR75tS5IgkLeILCeK1JCpp0pKHQ=",
+        "lastModified": 1758268707,
+        "narHash": "sha256-gr+NOiM0H/4ZUlkcQur9G0GYZA5c/1NKglMIZO6Mv0o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ed07b72916e851cdf138502cad68468c5f9158cc",
+        "rev": "25758d433497b2adab46ed3e481a3c136a4329cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                      |
| -------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`25758d43`](https://github.com/nix-community/NUR/commit/25758d433497b2adab46ed3e481a3c136a4329cf) | `` automatic update ``       |
| [`67bc010b`](https://github.com/nix-community/NUR/commit/67bc010b0b244c6fb0e24700bd5d4c32bc9ff5bc) | `` automatic update ``       |
| [`9e2efe4c`](https://github.com/nix-community/NUR/commit/9e2efe4c536d1821fcb2252e5205d78458e0e573) | `` automatic update ``       |
| [`f1ee8889`](https://github.com/nix-community/NUR/commit/f1ee8889e667e4c206fdfcf0de45ccb32fd4568c) | `` automatic update ``       |
| [`0c542bbb`](https://github.com/nix-community/NUR/commit/0c542bbbd8fe18b031fd8587c891b793647472b8) | `` automatic update ``       |
| [`4432b525`](https://github.com/nix-community/NUR/commit/4432b525d3019e55c0c18a25d85b051790d03f48) | `` automatic update ``       |
| [`7c730acb`](https://github.com/nix-community/NUR/commit/7c730acb9ffd4638273a7d3125e7ec51e5fef929) | `` automatic update ``       |
| [`99e56071`](https://github.com/nix-community/NUR/commit/99e56071fe355e92f394f421d6279b49aa0ff39e) | `` automatic update ``       |
| [`d9510cc2`](https://github.com/nix-community/NUR/commit/d9510cc2deac660cb0303d321c32885c25828a9d) | `` automatic update ``       |
| [`e2090345`](https://github.com/nix-community/NUR/commit/e2090345f37c486f1a6be91e4b6ef4b3da707a44) | `` automatic update ``       |
| [`3da45486`](https://github.com/nix-community/NUR/commit/3da45486f0756911371961d8cacb2a71f61aeb01) | `` automatic update ``       |
| [`9db5734b`](https://github.com/nix-community/NUR/commit/9db5734b74c5a3742f63ae1d5301ac763df1afa7) | `` automatic update ``       |
| [`0c1197bf`](https://github.com/nix-community/NUR/commit/0c1197bfe9c426827e4e2658c834e92cc3e209ce) | `` automatic update ``       |
| [`ff7a8c10`](https://github.com/nix-community/NUR/commit/ff7a8c1049479ff485f5e79f8f335bac58613746) | `` automatic update ``       |
| [`ca1d9635`](https://github.com/nix-community/NUR/commit/ca1d96350c964229ef1391d8660c7381d030cf83) | `` add juxgd repository ``   |
| [`d7592803`](https://github.com/nix-community/NUR/commit/d7592803b705df7b1b7c68aea27d4881e605bfbe) | `` add dmfrpro repository `` |
| [`1113830c`](https://github.com/nix-community/NUR/commit/1113830c10a7531dc83b93168200332f7b0268b8) | `` automatic update ``       |
| [`b731f513`](https://github.com/nix-community/NUR/commit/b731f513724a4168d3d5d3b9ccf0505570beb152) | `` automatic update ``       |