### PR TITLE
chore(flake/nur): `25758d43` -> `2d644af2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1206,11 +1206,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1758268707,
-        "narHash": "sha256-gr+NOiM0H/4ZUlkcQur9G0GYZA5c/1NKglMIZO6Mv0o=",
+        "lastModified": 1758273929,
+        "narHash": "sha256-8ZhQaoeWOcCpe14PLgJ7ZEhWFFISA2qcVuXTGlNZGgU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "25758d433497b2adab46ed3e481a3c136a4329cf",
+        "rev": "2d644af21cc32d53594b9d17fa167c4eec6431cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`2d644af2`](https://github.com/nix-community/NUR/commit/2d644af21cc32d53594b9d17fa167c4eec6431cd) | `` automatic update `` |
| [`5f48e0b5`](https://github.com/nix-community/NUR/commit/5f48e0b5e61151acbca4f03d4c2853993eb72262) | `` automatic update `` |