### PR TITLE
chore(flake/srvos): `bffcdb33` -> `30e6b4c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1320,11 +1320,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757898151,
-        "narHash": "sha256-FmI8VUvFKkZrQkJ/oqx0F0CnvXdv2O3nlPhVBtCGqWo=",
+        "lastModified": 1758285369,
+        "narHash": "sha256-WdkeIbq2Bo6l0tzBSCxMDeDMSKBp1iiOX7EdOHrsJCQ=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "bffcdb335e9dae8d2242ec0bfe4bab4484870c65",
+        "rev": "30e6b4c2e5e7b235c7d0a266994a0c93e86bcf69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                      |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`30e6b4c2`](https://github.com/nix-community/srvos/commit/30e6b4c2e5e7b235c7d0a266994a0c93e86bcf69) | `` hetzner-online: disable usb0 link (#692) ``               |
| [`dfeecdd4`](https://github.com/nix-community/srvos/commit/dfeecdd4d8a62568481ea44655281dc659dea1a0) | `` docs: updated hetzner cloud installation docs (#690) ``   |
| [`f8fa49c1`](https://github.com/nix-community/srvos/commit/f8fa49c1a43f16b912817eff56ce7c98c76a432a) | `` feat(resolved): disable llmnr on server profile (#697) `` |
| [`2c3bf0f3`](https://github.com/nix-community/srvos/commit/2c3bf0f3b775f2aeeecad7b50d0ac9250b242e92) | `` website: publish to srvos.org (#699) ``                   |