### PR TITLE
chore(flake/disko): `4f554162` -> `67ff9807`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -515,11 +515,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758160037,
-        "narHash": "sha256-fXelTdjdILspZ1IUU9aICB1+PXwSFiF8j+7ujwo1VpQ=",
+        "lastModified": 1758287904,
+        "narHash": "sha256-IGmaEf3Do8o5Cwp1kXBN1wQmZwQN3NLfq5t4nHtVtcU=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "4f554162fff88e77655073d352eec0cea71103a2",
+        "rev": "67ff9807dd148e704baadbd4fd783b54282ca627",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                     |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`67ff9807`](https://github.com/nix-community/disko/commit/67ff9807dd148e704baadbd4fd783b54282ca627) | `` lib: fix `mdadm` warning when using `config.system.build.installTest` `` |
| [`ddef55ae`](https://github.com/nix-community/disko/commit/ddef55ae5fa1710b5c30afad1daf95f70331ba89) | `` Revert "flake.lock: Update" ``                                           |