### PR TITLE
chore(flake/nur): `1a6b6450` -> `180ae0f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1206,11 +1206,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1758295980,
-        "narHash": "sha256-jH1SaOJKUW5B/KfIiXnzP1JrD0vm0ScrhbZ65S0xuPQ=",
+        "lastModified": 1758314668,
+        "narHash": "sha256-UeSA8UbYgBeeI/r6YRlkwKrBMhnE2ZliSFb7QB7p4zQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1a6b645095e3c1f148b6a1d9a3f0e302116e9bc7",
+        "rev": "180ae0f66d4d50d36c01e750bd7c05f49ff8f24b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`180ae0f6`](https://github.com/nix-community/NUR/commit/180ae0f66d4d50d36c01e750bd7c05f49ff8f24b) | `` automatic update `` |
| [`a039cbeb`](https://github.com/nix-community/NUR/commit/a039cbeb1c163a3481744cf2b306396bef373ace) | `` automatic update `` |
| [`05c2afe4`](https://github.com/nix-community/NUR/commit/05c2afe4c9d758e4baa865605ecd69a4e2a1eb92) | `` automatic update `` |
| [`3d4074cc`](https://github.com/nix-community/NUR/commit/3d4074cc9b59e119cfb8866da67b4a81e9210b56) | `` automatic update `` |
| [`65544a1a`](https://github.com/nix-community/NUR/commit/65544a1a085c5ceb128570a855a07e346401e374) | `` automatic update `` |