### PR TITLE
chore(flake/nur): `180ae0f6` -> `67a4c3e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1206,11 +1206,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1758314668,
-        "narHash": "sha256-UeSA8UbYgBeeI/r6YRlkwKrBMhnE2ZliSFb7QB7p4zQ=",
+        "lastModified": 1758340142,
+        "narHash": "sha256-xR87UWuT24hSJj2LvyRzhLj9LR/Hh2uX8pnGDaFYfWw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "180ae0f66d4d50d36c01e750bd7c05f49ff8f24b",
+        "rev": "67a4c3e602f041d78da023d0a86ce40834004113",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`67a4c3e6`](https://github.com/nix-community/NUR/commit/67a4c3e602f041d78da023d0a86ce40834004113) | `` automatic update `` |
| [`957eddcb`](https://github.com/nix-community/NUR/commit/957eddcb40c8c7dd4120f808786ea4d8b77a7feb) | `` automatic update `` |
| [`f0af31a4`](https://github.com/nix-community/NUR/commit/f0af31a404363c39d0530b4bdda574a5e831cf43) | `` automatic update `` |
| [`bf2dda64`](https://github.com/nix-community/NUR/commit/bf2dda645a5ec188df466658a1fea1ac3b1b95de) | `` automatic update `` |
| [`b094377b`](https://github.com/nix-community/NUR/commit/b094377bf25162765b8ef5d75a752b055ab3701a) | `` automatic update `` |
| [`178b3bfa`](https://github.com/nix-community/NUR/commit/178b3bfaea83e31b5779beb7ef4773587af85b0b) | `` automatic update `` |
| [`83dd4507`](https://github.com/nix-community/NUR/commit/83dd450702b7eb5168fff28d05b20d6e17ec6280) | `` automatic update `` |
| [`9b1c8f7b`](https://github.com/nix-community/NUR/commit/9b1c8f7b61c5cb3eb77476cd4562be52c8bb3bc7) | `` automatic update `` |