### PR TITLE
chore(flake/nur): `67a4c3e6` -> `73e2e780`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1206,11 +1206,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1758340142,
-        "narHash": "sha256-xR87UWuT24hSJj2LvyRzhLj9LR/Hh2uX8pnGDaFYfWw=",
+        "lastModified": 1758354255,
+        "narHash": "sha256-iGLzGxt1EQ+4M2vz+6sWuewq9EiinivefruI7VHZgeE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "67a4c3e602f041d78da023d0a86ce40834004113",
+        "rev": "73e2e780964a03fbed6c140c79e5f176a5e985b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`73e2e780`](https://github.com/nix-community/NUR/commit/73e2e780964a03fbed6c140c79e5f176a5e985b0) | `` automatic update `` |
| [`9ea2a0fa`](https://github.com/nix-community/NUR/commit/9ea2a0faddc79c2bf04a4cdc480ff7237f266f82) | `` automatic update `` |
| [`acf48f1d`](https://github.com/nix-community/NUR/commit/acf48f1dd6c01ea37a3307be2fcce965ea884b6d) | `` automatic update `` |
| [`730d5fc6`](https://github.com/nix-community/NUR/commit/730d5fc6cddbf8f9fe06415b62dba54d4dbb898d) | `` automatic update `` |
| [`d9772f80`](https://github.com/nix-community/NUR/commit/d9772f802e49449b3729220426cc6ba51aa86c5d) | `` automatic update `` |