### PR TITLE
chore(flake/nur): `73e2e780` -> `36249811`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1132,11 +1132,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1758198701,
-        "narHash": "sha256-7To75JlpekfUmdkUZewnT6MoBANS0XVypW6kjUOXQwc=",
+        "lastModified": 1758277210,
+        "narHash": "sha256-iCGWf/LTy+aY0zFu8q12lK8KuZp7yvdhStehhyX1v8w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0147c2f1d54b30b5dd6d4a8c8542e8d7edf93b5d",
+        "rev": "8eaee110344796db060382e15d3af0a9fc396e0e",
         "type": "github"
       },
       "original": {
@@ -1206,11 +1206,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1758354255,
-        "narHash": "sha256-iGLzGxt1EQ+4M2vz+6sWuewq9EiinivefruI7VHZgeE=",
+        "lastModified": 1758498273,
+        "narHash": "sha256-Onx1d4UtSUZAMf2ksHy8Df2c+e3ID3wEB8VcFo5jxbI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "73e2e780964a03fbed6c140c79e5f176a5e985b0",
+        "rev": "36249811548d137fdbd06b74e956bb87529a4306",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                   |
| -------------------------------------------------------------------------------------------------- | ------------------------- |
| [`36249811`](https://github.com/nix-community/NUR/commit/36249811548d137fdbd06b74e956bb87529a4306) | `` automatic update ``    |
| [`c25e0474`](https://github.com/nix-community/NUR/commit/c25e04748de8ea4c9c3f09b63df404c1c0aa463b) | `` automatic update ``    |
| [`92b538f5`](https://github.com/nix-community/NUR/commit/92b538f525c3a5d67eabe75bf3baab5e5ef0a433) | `` add sorz repository `` |
| [`a147fdc3`](https://github.com/nix-community/NUR/commit/a147fdc34a8a19741fe9979be2d81ff5f3589cc8) | `` automatic update ``    |
| [`2cd11d9b`](https://github.com/nix-community/NUR/commit/2cd11d9bd570625e6b21c2edf5f10053bf94c02d) | `` automatic update ``    |
| [`b8392a3c`](https://github.com/nix-community/NUR/commit/b8392a3c142ba2d3c4145785c769f4f22e2a6ab7) | `` automatic update ``    |
| [`69487852`](https://github.com/nix-community/NUR/commit/69487852af657127184fbf299bcf0db18a0f5b7c) | `` automatic update ``    |
| [`3fdb9c34`](https://github.com/nix-community/NUR/commit/3fdb9c347ce81370edb7d529394841a0f9742d30) | `` automatic update ``    |
| [`74565f4c`](https://github.com/nix-community/NUR/commit/74565f4c9b78ec9b00e704ee42d7a1577a8175ea) | `` automatic update ``    |
| [`3513699d`](https://github.com/nix-community/NUR/commit/3513699d4adccb29efa4629e68b09d6ad5db7fa3) | `` automatic update ``    |
| [`b5331734`](https://github.com/nix-community/NUR/commit/b53317340d231acb7c742eb308e301af1b94af70) | `` automatic update ``    |
| [`4ac4b05a`](https://github.com/nix-community/NUR/commit/4ac4b05a074a0b1aab9a4799e1b49a985847a52b) | `` automatic update ``    |
| [`09bf63d6`](https://github.com/nix-community/NUR/commit/09bf63d621279655c7d4c6d4f0dc5fdad9a72a71) | `` automatic update ``    |
| [`2729a7e2`](https://github.com/nix-community/NUR/commit/2729a7e25be295dd2e812946987c4807088ab76d) | `` automatic update ``    |
| [`cf20df7f`](https://github.com/nix-community/NUR/commit/cf20df7fec0a9dff5271f1f50b9be96559a58d4a) | `` automatic update ``    |
| [`ffc1c639`](https://github.com/nix-community/NUR/commit/ffc1c63903ffd6dff3ef6dc0fb014aeb7707f804) | `` automatic update ``    |
| [`b1fb4589`](https://github.com/nix-community/NUR/commit/b1fb458916c940a2a47e4f01f24129c719d53343) | `` automatic update ``    |
| [`0d04d8f9`](https://github.com/nix-community/NUR/commit/0d04d8f9a258ef72b4bb9c9779c5c97904c92503) | `` automatic update ``    |
| [`e3fc23fd`](https://github.com/nix-community/NUR/commit/e3fc23fd79e5fc7f7937fca2de69d8b2267f0193) | `` automatic update ``    |
| [`c58bc8e6`](https://github.com/nix-community/NUR/commit/c58bc8e66492ff28a8bcdbe04b5b6b00f6f386b0) | `` automatic update ``    |
| [`0b39a4bc`](https://github.com/nix-community/NUR/commit/0b39a4bc26b048efcfa476ad9f88c690250deb60) | `` automatic update ``    |
| [`42749e10`](https://github.com/nix-community/NUR/commit/42749e1003a6349e0d87fab6733e85c2c6b19acc) | `` automatic update ``    |
| [`86f5d2ef`](https://github.com/nix-community/NUR/commit/86f5d2efe861e4fa2a9e3823d621c5ed7ecfb56f) | `` automatic update ``    |
| [`7bc5e120`](https://github.com/nix-community/NUR/commit/7bc5e1209804dca3b36a80a544e9da298be4b6e6) | `` automatic update ``    |
| [`f401a975`](https://github.com/nix-community/NUR/commit/f401a9753e3805505566ec3eacd781cd687ba18d) | `` automatic update ``    |
| [`7bc97b44`](https://github.com/nix-community/NUR/commit/7bc97b44e29ccdc5cf29dee777b1fa01ed909d0f) | `` automatic update ``    |
| [`5eca0579`](https://github.com/nix-community/NUR/commit/5eca057943e4dbfbddd97a973de05a5ae8b6f28e) | `` automatic update ``    |
| [`f6bd0003`](https://github.com/nix-community/NUR/commit/f6bd0003a34b4317ecffdef774ef1c0a7a0ac659) | `` automatic update ``    |
| [`5e592510`](https://github.com/nix-community/NUR/commit/5e59251099713784f550837c72ea4ed2ccb3c838) | `` automatic update ``    |
| [`c302d926`](https://github.com/nix-community/NUR/commit/c302d926c96b0a2a50e679d685621f7d409fe3fb) | `` automatic update ``    |
| [`1392008c`](https://github.com/nix-community/NUR/commit/1392008c0ac44fb1992523a6997790da6cd769ca) | `` automatic update ``    |
| [`3604689d`](https://github.com/nix-community/NUR/commit/3604689d537d08a85641a7e8fb038c7e52f2891a) | `` automatic update ``    |
| [`ff4a742b`](https://github.com/nix-community/NUR/commit/ff4a742b1a7d95d355c562f6ad8faadd4318c4f5) | `` automatic update ``    |
| [`ed350841`](https://github.com/nix-community/NUR/commit/ed350841f6738603d1dbeddb574f8ce0cbb3d737) | `` automatic update ``    |
| [`f58aa340`](https://github.com/nix-community/NUR/commit/f58aa34093b57a517ab023a7708c06e976864ae2) | `` automatic update ``    |
| [`9ea40815`](https://github.com/nix-community/NUR/commit/9ea4081544cdadedaf3a296961a4ecba5f13ea0b) | `` automatic update ``    |
| [`096b8685`](https://github.com/nix-community/NUR/commit/096b8685f854c00ced81789c81ad77f577347cb6) | `` automatic update ``    |
| [`e6cd4922`](https://github.com/nix-community/NUR/commit/e6cd4922c556fe2d47d543a0b7752bbf31cac72a) | `` automatic update ``    |
| [`62688dab`](https://github.com/nix-community/NUR/commit/62688dab3927fc080aad78d6814250b65cac1261) | `` automatic update ``    |
| [`cd7b12c0`](https://github.com/nix-community/NUR/commit/cd7b12c0cf455f5fad0c7f0a3a80f22d71aef42c) | `` automatic update ``    |
| [`53d6cf7b`](https://github.com/nix-community/NUR/commit/53d6cf7b4197a3623154ba8540ba93e1a40b35e7) | `` automatic update ``    |