### PR TITLE
chore(flake/emacs-overlay): `e8a89297` -> `ecdeee43`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1758387960,
-        "narHash": "sha256-cYT5+cVYV+8HHT1DisSqqAYS5bBDaY7N2Q8BhLRu5BQ=",
+        "lastModified": 1758420825,
+        "narHash": "sha256-ADGgTjVUgJfsIxD99WVF05oBrcfyHd6aIkae0JWWS4A=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e8a8929793f54a3e80e29a2e357fbeaa81a3b1a6",
+        "rev": "ecdeee43fa4e1047496367bfcafff020e1d69d33",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`ecdeee43`](https://github.com/nix-community/emacs-overlay/commit/ecdeee43fa4e1047496367bfcafff020e1d69d33) | `` Updated melpa `` |
| [`871a991a`](https://github.com/nix-community/emacs-overlay/commit/871a991a9a17961e628ea88a0ee0fcf609576045) | `` Updated emacs `` |
| [`1ac9e5fd`](https://github.com/nix-community/emacs-overlay/commit/1ac9e5fd1cc2dcb4b7df9f716442ba3fe0f51cdf) | `` Updated elpa ``  |