### PR TITLE
chore(flake/darwin): `7be9c1b1` -> `25381509`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -453,11 +453,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758387173,
-        "narHash": "sha256-E5Ru709RoQEFl+Q0MHRXTIvbY0l6LSR1UHqwTulSeog=",
+        "lastModified": 1758447883,
+        "narHash": "sha256-yGA6MV0E4JSEXqLTb4ZZkmdJZcoQ8HUzihRRX12Bvpg=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "7be9c1b136ef7083e60eb060be0a66dcb254e3ca",
+        "rev": "25381509d5c91bbf3c30e23abc6d8476d2143cd1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                               |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
| [`5206a9fd`](https://github.com/nix-darwin/nix-darwin/commit/5206a9fd30951ff80e83c7a4b250b30735c055f3) | `` Correct enum values for system.defaults.NSGlobalDomain.AppleIconAppearanceTheme `` |