### PR TITLE
chore(flake/home-manager): `edc7468e` -> `939e91e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -740,11 +740,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758375677,
-        "narHash": "sha256-BLtD+6qWz7fQjPk2wpwyXQLGI0E30Ikgf2ppn2nVadI=",
+        "lastModified": 1758464306,
+        "narHash": "sha256-i56XRXqjwJRdVYmpzVUQ0ktqBBHqNzQHQMQvFRF/acQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "edc7468e12be92e926847cb02418e649b02b59dd",
+        "rev": "939e91e1cff1f99736c5b02529658218ed819a2a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                         |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`939e91e1`](https://github.com/nix-community/home-manager/commit/939e91e1cff1f99736c5b02529658218ed819a2a) | `` news: add fabric-ai entry `` |
| [`61c84a3b`](https://github.com/nix-community/home-manager/commit/61c84a3bbfcf75953f0eeb150a68f54ca1aad964) | `` fabric: add module ``        |
| [`f3ff73a5`](https://github.com/nix-community/home-manager/commit/f3ff73a5e13b62b4bebc69849eac58913aa2fc3a) | `` news: add animdl entry ``    |
| [`20d75ecd`](https://github.com/nix-community/home-manager/commit/20d75ecd36fae11588aa86730f916b23d5f93123) | `` animdl: add module ``        |
| [`7a615e2a`](https://github.com/nix-community/home-manager/commit/7a615e2a56429dee04524c9bacaae2c3d9ab8520) | `` flake.lock: Update ``        |