### PR TITLE
chore(flake/emacs-overlay): `8a1407c6` -> `dff97e46`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1758445590,
-        "narHash": "sha256-JNeU+azstHhxzzoRFZ6b0C0HLfyaWDtv6TPnSQPUR50=",
+        "lastModified": 1758593134,
+        "narHash": "sha256-nS2eA5qb4ezeJ/dtxltl0omm69pWTTBx2pIvapPsSoQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8a1407c6c868212574126672bc6342612013cb45",
+        "rev": "dff97e46997a60c0ade49d2c7fbd3d7326685401",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`dff97e46`](https://github.com/nix-community/emacs-overlay/commit/dff97e46997a60c0ade49d2c7fbd3d7326685401) | `` Updated melpa ``  |
| [`9a099da4`](https://github.com/nix-community/emacs-overlay/commit/9a099da4716649b9348d807c2cede581c0e657e4) | `` Updated emacs ``  |
| [`3e015f31`](https://github.com/nix-community/emacs-overlay/commit/3e015f31aaa873395d1c5a147cfd3efcd1dc3ec4) | `` Updated elpa ``   |
| [`e56e3cf9`](https://github.com/nix-community/emacs-overlay/commit/e56e3cf9c95955f7afeaafb3963ce8ba7ea87f45) | `` Updated nongnu `` |
| [`f6188135`](https://github.com/nix-community/emacs-overlay/commit/f6188135617b494d9b72d2afdfcc494eb1b1aae1) | `` Updated melpa ``  |
| [`3f5391ed`](https://github.com/nix-community/emacs-overlay/commit/3f5391edb3f54201632ff6ed05a5e3069f6f1215) | `` Updated emacs ``  |
| [`ee925145`](https://github.com/nix-community/emacs-overlay/commit/ee925145ceeb4ff7733696bfc757366526aad520) | `` Updated nongnu `` |
| [`633b25a0`](https://github.com/nix-community/emacs-overlay/commit/633b25a08a0fd1b931a12dc185240443946e06df) | `` Updated emacs ``  |
| [`90c2cdd9`](https://github.com/nix-community/emacs-overlay/commit/90c2cdd92cdad829c7c9559e0ecf95107a73efeb) | `` Updated melpa ``  |
| [`e88a8c1e`](https://github.com/nix-community/emacs-overlay/commit/e88a8c1edf089b1a31378cf48f7ca3854950dc2a) | `` Updated nongnu `` |
| [`43ffdf3f`](https://github.com/nix-community/emacs-overlay/commit/43ffdf3f1b3fdef5cfda0647e3e7b2ae001a8970) | `` Updated emacs ``  |
| [`a0d5de7e`](https://github.com/nix-community/emacs-overlay/commit/a0d5de7eb9918bf34e4d6fd23e801068b93e91a1) | `` Updated melpa ``  |
| [`56eac524`](https://github.com/nix-community/emacs-overlay/commit/56eac524f805feb8eca1858c3631a46246bac54c) | `` Updated elpa ``   |