### PR TITLE
chore(flake/home-manager): `939e91e1` -> `9a2dc0ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -740,11 +740,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758464306,
-        "narHash": "sha256-i56XRXqjwJRdVYmpzVUQ0ktqBBHqNzQHQMQvFRF/acQ=",
+        "lastModified": 1758593331,
+        "narHash": "sha256-p+904PfmINyekyA/LieX3IYGsiFtExC00v5gSYfJtpM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "939e91e1cff1f99736c5b02529658218ed819a2a",
+        "rev": "9a2dc0efbc569ce9352a6ffb8e8ec8dbc098e142",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`9a2dc0ef`](https://github.com/nix-community/home-manager/commit/9a2dc0efbc569ce9352a6ffb8e8ec8dbc098e142) | `` zellij: Add extraConfig ``                         |
| [`f59891d5`](https://github.com/nix-community/home-manager/commit/f59891d511d692ac0ed0bb366b39f778d5b594ed) | `` xdg-mime-apps: no spaces in default app entries `` |
| [`de536983`](https://github.com/nix-community/home-manager/commit/de5369834ff1f75246c46be89ef993392e961c26) | `` maintainers: update all-maintainers.nix ``         |
| [`9b6e609a`](https://github.com/nix-community/home-manager/commit/9b6e609a6e41ee5ca4a46465bdc0475fe2212fc8) | `` octant: remove module ``                           |