### PR TITLE
chore(flake/nur): `a102051b` -> `0b6ad842`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1206,11 +1206,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1758554259,
-        "narHash": "sha256-OWusAvgPsZIGiHo54bpZIn6HbIkTOzk4po5ifNUK5BE=",
+        "lastModified": 1758569261,
+        "narHash": "sha256-luR1Np0Bx3WTMmKw00frwY4q7O5P962bwwCyvBRYhG8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a102051ba5331bc85f03a49f1bc56345e6444d66",
+        "rev": "0b6ad842c2c500ce7dd1496af2c6260bdb5b7acd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0b6ad842`](https://github.com/nix-community/NUR/commit/0b6ad842c2c500ce7dd1496af2c6260bdb5b7acd) | `` automatic update `` |
| [`2c8121b4`](https://github.com/nix-community/NUR/commit/2c8121b44ea0f2b8917340d22e7f9098e1d09029) | `` automatic update `` |
| [`b09c5848`](https://github.com/nix-community/NUR/commit/b09c58487af8c2e608aa4968f7e54ab5cdf447bf) | `` automatic update `` |