### PR TITLE
chore(flake/nur): `0b6ad842` -> `7f659ff3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1206,11 +1206,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1758569261,
-        "narHash": "sha256-luR1Np0Bx3WTMmKw00frwY4q7O5P962bwwCyvBRYhG8=",
+        "lastModified": 1758578969,
+        "narHash": "sha256-yoSMXYaBxy94+z1fologEIJb5l+RYYqk1GrG5EY4qQE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0b6ad842c2c500ce7dd1496af2c6260bdb5b7acd",
+        "rev": "7f659ff3f1e52eaba0476053a9740882da666572",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7f659ff3`](https://github.com/nix-community/NUR/commit/7f659ff3f1e52eaba0476053a9740882da666572) | `` automatic update `` |
| [`4208a555`](https://github.com/nix-community/NUR/commit/4208a555f0c519d4a9a52e9014fa2b161e344d10) | `` automatic update `` |
| [`00fe487d`](https://github.com/nix-community/NUR/commit/00fe487d36ff2a8630eb51647354a7b1c9d284f8) | `` automatic update `` |
| [`ff4edc25`](https://github.com/nix-community/NUR/commit/ff4edc2514e2f4df49c2feb2c23e463d20453387) | `` automatic update `` |