### PR TITLE
chore(flake/nur): `7f659ff3` -> `50d2c97c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1206,11 +1206,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1758578969,
-        "narHash": "sha256-yoSMXYaBxy94+z1fologEIJb5l+RYYqk1GrG5EY4qQE=",
+        "lastModified": 1758597760,
+        "narHash": "sha256-HdkQaKzMMxdgrBOpFxskfe9745ULI20ONad+vNIlASo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7f659ff3f1e52eaba0476053a9740882da666572",
+        "rev": "50d2c97c73f71a6544d69ff20feeb1dcfe1c8159",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`50d2c97c`](https://github.com/nix-community/NUR/commit/50d2c97c73f71a6544d69ff20feeb1dcfe1c8159) | `` automatic update `` |
| [`ff840448`](https://github.com/nix-community/NUR/commit/ff840448846e6f4413e02b5d35f61eb1772c3750) | `` automatic update `` |
| [`1bce9fa9`](https://github.com/nix-community/NUR/commit/1bce9fa9947e7f138ba7aaea15df2d1171060b77) | `` automatic update `` |
| [`39ca5f52`](https://github.com/nix-community/NUR/commit/39ca5f52b1f13a70672d8ccac9a5a4ff2f552190) | `` automatic update `` |
| [`386857f1`](https://github.com/nix-community/NUR/commit/386857f1aec8c3a809e929cc9493edfbd9b7fbad) | `` automatic update `` |