### PR TITLE
chore(flake/nur): `50d2c97c` -> `8699a532`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1132,11 +1132,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1758277210,
-        "narHash": "sha256-iCGWf/LTy+aY0zFu8q12lK8KuZp7yvdhStehhyX1v8w=",
+        "lastModified": 1758427187,
+        "narHash": "sha256-pHpxZ/IyCwoTQPtFIAG2QaxuSm8jWzrzBGjwQZIttJc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8eaee110344796db060382e15d3af0a9fc396e0e",
+        "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
         "type": "github"
       },
       "original": {
@@ -1206,11 +1206,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1758597760,
-        "narHash": "sha256-HdkQaKzMMxdgrBOpFxskfe9745ULI20ONad+vNIlASo=",
+        "lastModified": 1758619662,
+        "narHash": "sha256-HpgXebe9RMJpYisgIQrX6hkbf+duVQ1SzcKaPFqswcY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "50d2c97c73f71a6544d69ff20feeb1dcfe1c8159",
+        "rev": "8699a532a9e8c7cc19fb39feb38164f5a25a3336",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8699a532`](https://github.com/nix-community/NUR/commit/8699a532a9e8c7cc19fb39feb38164f5a25a3336) | `` automatic update `` |
| [`246a1a5e`](https://github.com/nix-community/NUR/commit/246a1a5e9000efa9695ddd0457e3db718bf26966) | `` automatic update `` |
| [`35c6fe70`](https://github.com/nix-community/NUR/commit/35c6fe700af0d4d9e884b1953346a39efa064408) | `` automatic update `` |
| [`beca08bc`](https://github.com/nix-community/NUR/commit/beca08bc972f7828b47936784918b5a27b67c547) | `` automatic update `` |
| [`1378b47f`](https://github.com/nix-community/NUR/commit/1378b47fa7c799d1b8039995b3eb7e223d2140da) | `` automatic update `` |
| [`2f247753`](https://github.com/nix-community/NUR/commit/2f2477539e4f28a6f58e971091ea2398785aab84) | `` automatic update `` |
| [`de4f5ff4`](https://github.com/nix-community/NUR/commit/de4f5ff4f5dabad8356f67119fbe582a44c9e969) | `` automatic update `` |
| [`72ed02e7`](https://github.com/nix-community/NUR/commit/72ed02e7f65db82f7274a1dccf0196763a1317c3) | `` automatic update `` |