### PR TITLE
chore(flake/emacs-overlay): `dff97e46` -> `cf579e6a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1758593134,
-        "narHash": "sha256-nS2eA5qb4ezeJ/dtxltl0omm69pWTTBx2pIvapPsSoQ=",
+        "lastModified": 1758681245,
+        "narHash": "sha256-cv+9jc090EX4TMGBgVI/MfZpevfm5F428oPr+pw8/kg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "dff97e46997a60c0ade49d2c7fbd3d7326685401",
+        "rev": "cf579e6aea7aa153c4bacfb0b75869f4194447fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`cf579e6a`](https://github.com/nix-community/emacs-overlay/commit/cf579e6aea7aa153c4bacfb0b75869f4194447fd) | `` Updated emacs ``        |
| [`aab07703`](https://github.com/nix-community/emacs-overlay/commit/aab07703746ba0617c263ccdccfb0062dc0814fd) | `` Updated melpa ``        |
| [`058a43b0`](https://github.com/nix-community/emacs-overlay/commit/058a43b0a9a8630e657bc14f45c236bebef8d9be) | `` Updated elpa ``         |
| [`d21be2ca`](https://github.com/nix-community/emacs-overlay/commit/d21be2ca90a6cca9472badf9daf0996eaea558f4) | `` Updated nongnu ``       |
| [`5c63591b`](https://github.com/nix-community/emacs-overlay/commit/5c63591b945d6481ee22c2bd97a1a91b7623be5b) | `` Updated melpa ``        |
| [`725cd770`](https://github.com/nix-community/emacs-overlay/commit/725cd7702e72d0abc79dc20b77b2d1357248fad1) | `` Updated elpa ``         |
| [`97f944f3`](https://github.com/nix-community/emacs-overlay/commit/97f944f361d883b47ad966c55b2db4f617bd99aa) | `` Updated nongnu ``       |
| [`2683597c`](https://github.com/nix-community/emacs-overlay/commit/2683597cc70f74a05204ef55c09ef3e6404c4571) | `` Updated melpa ``        |
| [`d3276d9c`](https://github.com/nix-community/emacs-overlay/commit/d3276d9c743cb8513c1e794d604e1a9921c92e52) | `` Updated emacs ``        |
| [`6c807468`](https://github.com/nix-community/emacs-overlay/commit/6c807468657f849e02da981f0d2bfd9b61b1c9ca) | `` Updated flake inputs `` |