### PR TITLE
chore(flake/nur): `8699a532` -> `af2e804a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1206,11 +1206,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1758619662,
-        "narHash": "sha256-HpgXebe9RMJpYisgIQrX6hkbf+duVQ1SzcKaPFqswcY=",
+        "lastModified": 1758640565,
+        "narHash": "sha256-ElrlkD9NTp27BR+K8RO6KYF/5gHURj6b9Vpan/bf8wk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8699a532a9e8c7cc19fb39feb38164f5a25a3336",
+        "rev": "af2e804a55892665adfd0b30c75088b1ad1b462c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`af2e804a`](https://github.com/nix-community/NUR/commit/af2e804a55892665adfd0b30c75088b1ad1b462c) | `` automatic update `` |
| [`0ac3e575`](https://github.com/nix-community/NUR/commit/0ac3e575bed9f0869ceafd5bb3c57a5856b279a0) | `` automatic update `` |
| [`2f55e54f`](https://github.com/nix-community/NUR/commit/2f55e54fe689ab1edfb24b21a1d40b0bba4ef222) | `` automatic update `` |