### PR TITLE
chore(flake/nur): `af2e804a` -> `a2b7c1f3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1206,11 +1206,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1758640565,
-        "narHash": "sha256-ElrlkD9NTp27BR+K8RO6KYF/5gHURj6b9Vpan/bf8wk=",
+        "lastModified": 1758656720,
+        "narHash": "sha256-ummQJyDJtTn8mTIssGut3WSCDisaZFGr51UEkzWrgzw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "af2e804a55892665adfd0b30c75088b1ad1b462c",
+        "rev": "a2b7c1f3f0796c5a63a57f21eb22e98bddded6f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a2b7c1f3`](https://github.com/nix-community/NUR/commit/a2b7c1f3f0796c5a63a57f21eb22e98bddded6f4) | `` automatic update `` |
| [`aa14f4f0`](https://github.com/nix-community/NUR/commit/aa14f4f00f9df07df0bedb02c2ba55e3b46c2b05) | `` automatic update `` |
| [`57d051cc`](https://github.com/nix-community/NUR/commit/57d051cc0417b267ce191f0f3c52004531624a25) | `` automatic update `` |
| [`5485cb56`](https://github.com/nix-community/NUR/commit/5485cb562f16cc5c92ec0046620c7eaf5fe31f8d) | `` automatic update `` |
| [`77687c76`](https://github.com/nix-community/NUR/commit/77687c76ab8cf1a899cb4770813b14904fcfade1) | `` automatic update `` |