### PR TITLE
chore(flake/home-manager): `9a2dc0ef` -> `142acd7a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -740,11 +740,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758593331,
-        "narHash": "sha256-p+904PfmINyekyA/LieX3IYGsiFtExC00v5gSYfJtpM=",
+        "lastModified": 1758719930,
+        "narHash": "sha256-DgHe1026Ob49CPegPMiWj1HNtlMTGQzfSZQQVlHC950=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9a2dc0efbc569ce9352a6ffb8e8ec8dbc098e142",
+        "rev": "142acd7a7d9eb7f0bb647f053b4ddfd01fdfbf1d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                            |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`142acd7a`](https://github.com/nix-community/home-manager/commit/142acd7a7d9eb7f0bb647f053b4ddfd01fdfbf1d) | `` bash: source session variable file directly ``                  |
| [`d398f95f`](https://github.com/nix-community/home-manager/commit/d398f95f1e9108f18c7dbe45423c71ccf52497c4) | `` nixgl: use original package name ``                             |
| [`f678263e`](https://github.com/nix-community/home-manager/commit/f678263ecf5b347ed98d2a187d37d052c4f71b0c) | `` mpvpaper: fix typos ``                                          |
| [`6ce2e180`](https://github.com/nix-community/home-manager/commit/6ce2e18007ff022db41d9cc042f8838e8c51ed66) | `` nix-your-shell: Allow using `nom` for `nix` commands ``         |
| [`cb68b5cd`](https://github.com/nix-community/home-manager/commit/cb68b5cd6a90325c05a9aa0cb27d8c1c98bc14ae) | `` syncthing: handle per-folder `encryptionPasswordFile` ``        |
| [`ef376249`](https://github.com/nix-community/home-manager/commit/ef3762499bb1ecd542e236b5b073c3c9399f8782) | `` flake.lock: Update (#7864) ``                                   |
| [`676c0159`](https://github.com/nix-community/home-manager/commit/676c0159ed51d10489a249ecdc61e115c2a90d03) | `` sway: print hint when checking the config file fails (#7665) `` |
| [`131f4e22`](https://github.com/nix-community/home-manager/commit/131f4e22c30c114378dcf6191cb75c97eba673d0) | `` anki: rename `sync.passwordFile`, improve documentation ``      |
| [`f5852ea3`](https://github.com/nix-community/home-manager/commit/f5852ea36c05f48d01d6e378d45449c962ba6fb4) | `` anki: fix `ankiAddons.passfail2` example ``                     |
| [`293d1059`](https://github.com/nix-community/home-manager/commit/293d105993e07fb92deb68a150ca801e3e459c85) | `` anki: strip usernameFile and passwordFile contents ``           |
| [`5468c92a`](https://github.com/nix-community/home-manager/commit/5468c92a2350ca76e15ee6617a083c0e6ce7ade7) | `` news: add ahoviewer entry ``                                    |
| [`366b60b8`](https://github.com/nix-community/home-manager/commit/366b60b8a06d237dbadd9a573ab21532dec70031) | `` ahoviewer: add module ``                                        |