### PR TITLE
chore(flake/nur): `a2b7c1f3` -> `335d0a7e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1206,11 +1206,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1758656720,
-        "narHash": "sha256-ummQJyDJtTn8mTIssGut3WSCDisaZFGr51UEkzWrgzw=",
+        "lastModified": 1758671074,
+        "narHash": "sha256-eUfnGDEdRtuoyP2K1+aljohrElF7DpSdjcdV5tplnrg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a2b7c1f3f0796c5a63a57f21eb22e98bddded6f4",
+        "rev": "335d0a7e0af02b7d1a9f8a8cf78e6f677c7367ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`335d0a7e`](https://github.com/nix-community/NUR/commit/335d0a7e0af02b7d1a9f8a8cf78e6f677c7367ea) | `` automatic update `` |
| [`8a943d6b`](https://github.com/nix-community/NUR/commit/8a943d6bdc50caf26b5522ee746dadb00be929e4) | `` automatic update `` |
| [`c29d18f2`](https://github.com/nix-community/NUR/commit/c29d18f2060236fe71cdc1dbe27d69757c2e542e) | `` automatic update `` |
| [`2521014d`](https://github.com/nix-community/NUR/commit/2521014dd72310cce13854d9db828ae5c3cee005) | `` automatic update `` |
| [`699442e5`](https://github.com/nix-community/NUR/commit/699442e5319ab19512881e0397ea9ee555f8d822) | `` automatic update `` |
| [`5083a7b3`](https://github.com/nix-community/NUR/commit/5083a7b30f45e8a0a36df21162ea4511af1fa064) | `` automatic update `` |