### PR TITLE
chore(flake/nur): `335d0a7e` -> `ad1392c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1206,11 +1206,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1758671074,
-        "narHash": "sha256-eUfnGDEdRtuoyP2K1+aljohrElF7DpSdjcdV5tplnrg=",
+        "lastModified": 1758685743,
+        "narHash": "sha256-tN8njXni6d3vSe8nIw29Dj9OZQ35xmuVzBAAqhS8sgI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "335d0a7e0af02b7d1a9f8a8cf78e6f677c7367ea",
+        "rev": "ad1392c0c028f83dd93021a3b237109c7837a98b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ad1392c0`](https://github.com/nix-community/NUR/commit/ad1392c0c028f83dd93021a3b237109c7837a98b) | `` automatic update `` |
| [`b67fea3e`](https://github.com/nix-community/NUR/commit/b67fea3e1c830a8a9f88ddfd44f7c9090abea837) | `` automatic update `` |
| [`4ef66e4c`](https://github.com/nix-community/NUR/commit/4ef66e4c6c00ee485b2926dd371114daa0110411) | `` automatic update `` |
| [`ee27bca8`](https://github.com/nix-community/NUR/commit/ee27bca8db59ebccce8c1407c88e089929105eb1) | `` automatic update `` |
| [`7be5bbcb`](https://github.com/nix-community/NUR/commit/7be5bbcbd9611b67c5c9bfb6167e4e6dcda1a3bb) | `` automatic update `` |