### PR TITLE
chore(flake/treefmt-nix): `128222dc` -> `5eda4ee8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1376,11 +1376,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758206697,
-        "narHash": "sha256-/DbPkh6PZOgfueCbs3uzlk4ASU2nPPsiVWhpMCNkAd0=",
+        "lastModified": 1758728421,
+        "narHash": "sha256-ySNJ008muQAds2JemiyrWYbwbG+V7S5wg3ZVKGHSFu8=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "128222dc911b8e2e18939537bed1762b7f3a04aa",
+        "rev": "5eda4ee8121f97b218f7cc73f5172098d458f1d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`5eda4ee8`](https://github.com/numtide/treefmt-nix/commit/5eda4ee8121f97b218f7cc73f5172098d458f1d1) | `` yapf: init yapf formatter (#409) `` |