### PR TITLE
chore(flake/home-manager): `142acd7a` -> `39d26c16`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -740,11 +740,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758719930,
-        "narHash": "sha256-DgHe1026Ob49CPegPMiWj1HNtlMTGQzfSZQQVlHC950=",
+        "lastModified": 1758810399,
+        "narHash": "sha256-bpWoE1tiFX5T1tr5EudkpW9Kk02XR+6olkoSkf3nHZU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "142acd7a7d9eb7f0bb647f053b4ddfd01fdfbf1d",
+        "rev": "39d26c16866260eee6d0487fe9c102ba1c1bf7b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                             |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`39d26c16`](https://github.com/nix-community/home-manager/commit/39d26c16866260eee6d0487fe9c102ba1c1bf7b2) | `` ssh-agent: add defaultMaximumIdentityLifetime setting (#7876) `` |
| [`23245405`](https://github.com/nix-community/home-manager/commit/232454052008027c8e925979d13a951e92729781) | `` syncthing: assert tray service content in test ``                |
| [`ade85015`](https://github.com/nix-community/home-manager/commit/ade850153b41793e785e730f812b09302e9fd3b4) | `` syncthing: remove deprecated code ``                             |
| [`74a78aac`](https://github.com/nix-community/home-manager/commit/74a78aacb7fe6b5d8fac79f9314abddbdaf07f09) | `` maintainers: update all-maintainers.nix ``                       |
| [`e2ecfbf6`](https://github.com/nix-community/home-manager/commit/e2ecfbf6d034617f85b38fa9043d0539da2d5c03) | `` tahoe-lafs: update default package ``                            |
| [`2e260431`](https://github.com/nix-community/home-manager/commit/2e260431fca7a782e0d0591985f2040944b43541) | `` news: add aiac entry ``                                          |
| [`68a92b03`](https://github.com/nix-community/home-manager/commit/68a92b0301ac0a2d5ac2c60aadce6bc8460591b5) | `` aiac: add module ``                                              |