### PR TITLE
chore(flake/nur): `0a555a3a` -> `544f12f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1132,11 +1132,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1758427187,
-        "narHash": "sha256-pHpxZ/IyCwoTQPtFIAG2QaxuSm8jWzrzBGjwQZIttJc=",
+        "lastModified": 1758690382,
+        "narHash": "sha256-NY3kSorgqE5LMm1LqNwGne3ZLMF2/ILgLpFr1fS4X3o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
+        "rev": "e643668fd71b949c53f8626614b21ff71a07379d",
         "type": "github"
       },
       "original": {
@@ -1206,11 +1206,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1758786415,
-        "narHash": "sha256-v/XlALb6Ous0yKyye5+fiGBrYA+X3qtroz47xcaiMWA=",
+        "lastModified": 1758828503,
+        "narHash": "sha256-IgOibVOqWSZqWsHKK6TuALfuItRymW2YpsdZBjU2yrk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0a555a3a5592846a9ce82612e482ac3b90fa5463",
+        "rev": "544f12f6987ceb94fe2052696da65623c238da4c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`544f12f6`](https://github.com/nix-community/NUR/commit/544f12f6987ceb94fe2052696da65623c238da4c) | `` automatic update `` |
| [`8e3c5973`](https://github.com/nix-community/NUR/commit/8e3c5973cb8e217bb20271ac820feaad646e3dd1) | `` automatic update `` |
| [`60032b2e`](https://github.com/nix-community/NUR/commit/60032b2e37e2b7accd8408273c2ba879d0982c3b) | `` automatic update `` |
| [`652ff2fe`](https://github.com/nix-community/NUR/commit/652ff2fec39136b1c9e4c9b9766b19652f120771) | `` automatic update `` |
| [`c96d18a7`](https://github.com/nix-community/NUR/commit/c96d18a720b20ef3dd6a9a78061aeb251a857df6) | `` automatic update `` |
| [`5de03c8b`](https://github.com/nix-community/NUR/commit/5de03c8b3c26de4a6fca64c78e6c657add3a3f67) | `` automatic update `` |
| [`c45eead6`](https://github.com/nix-community/NUR/commit/c45eead6fec45c3c1b46b2bdf8f03f224ffba22b) | `` automatic update `` |
| [`e44f6cf8`](https://github.com/nix-community/NUR/commit/e44f6cf81905ba8c4af42f036eae9acad742ea26) | `` automatic update `` |
| [`2bf3626c`](https://github.com/nix-community/NUR/commit/2bf3626c2e2239fe32e8add155d75464ad1feb06) | `` automatic update `` |
| [`a7051d59`](https://github.com/nix-community/NUR/commit/a7051d5988ccfc58ed0c88b2aa1ffd22cb1e9a2b) | `` automatic update `` |
| [`037ace13`](https://github.com/nix-community/NUR/commit/037ace1389861cc9e3406e6bc9f2b67851aaee46) | `` automatic update `` |