### PR TITLE
chore(flake/nixpkgs): `554be649` -> `e643668f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1116,11 +1116,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1758427187,
-        "narHash": "sha256-pHpxZ/IyCwoTQPtFIAG2QaxuSm8jWzrzBGjwQZIttJc=",
+        "lastModified": 1758690382,
+        "narHash": "sha256-NY3kSorgqE5LMm1LqNwGne3ZLMF2/ILgLpFr1fS4X3o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
+        "rev": "e643668fd71b949c53f8626614b21ff71a07379d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                       |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`2dd51493`](https://github.com/NixOS/nixpkgs/commit/2dd514933a328b9147b64bb78f009ba00636508c) | `` claude-code: 1.0.119 -> 1.0.123 ``                         |
| [`7157fea0`](https://github.com/NixOS/nixpkgs/commit/7157fea0e36856fbd453f30c09f2ca4caf3132c6) | `` matrix-authentication-service: 1.2.0 -> 1.3.0 ``           |
| [`79f1c10d`](https://github.com/NixOS/nixpkgs/commit/79f1c10d6dc183918f920b08db2d31faa78a9cfb) | `` gemini-cli-bin: 0.5.4 -> 0.6.0 ``                          |
| [`32d76a9d`](https://github.com/NixOS/nixpkgs/commit/32d76a9d8d22e16e67ad6f3a046315f65069d307) | `` postfix-tlspol: restrict to linux ``                       |
| [`7d2b5907`](https://github.com/NixOS/nixpkgs/commit/7d2b5907b9c0ffe1680b8598dddb4a12f0fb867a) | `` pretix: relax sepaxml constraint ``                        |
| [`bf50dab4`](https://github.com/NixOS/nixpkgs/commit/bf50dab494fd5dca25dcdd08bed0a98754919bd3) | `` python3Packages.huggingface-hub: add versionCheckHook ``   |
| [`d04cc9d0`](https://github.com/NixOS/nixpkgs/commit/d04cc9d0c99d011117c40adf0167b9efc35c159a) | `` chromium,chromedriver: 140.0.7339.185 -> 140.0.7339.207 `` |
| [`792b5709`](https://github.com/NixOS/nixpkgs/commit/792b5709782bdbc2e4e4ff74ec2f8769c1f09b94) | `` backrest: 1.8.1 -> 1.9.2 ``                                |
| [`b3a3c0bf`](https://github.com/NixOS/nixpkgs/commit/b3a3c0bf1d67d27e2d9331d0ff84f75c8606fcb1) | `` terraform-providers.okta: 6.0.0 -> 6.1.0 ``                |
| [`7e3a4735`](https://github.com/NixOS/nixpkgs/commit/7e3a473552b570d9e61b571b472382345ce408a0) | `` python3Packages.pylance: 0.36.0 -> 0.37.0 ``               |
| [`b59f3702`](https://github.com/NixOS/nixpkgs/commit/b59f370236cabd3991371a264d8c08c0d7535374) | `` gh: 2.79.0 -> 2.80.0 ``                                    |
| [`47ea10ea`](https://github.com/NixOS/nixpkgs/commit/47ea10eaabd5ebcd2549e18c06886a650c653e57) | `` locust: fix build errors ``                                |
| [`8d3003f8`](https://github.com/NixOS/nixpkgs/commit/8d3003f838c065c1fe82284f6f66b1013983d364) | `` vscode-extensions.wakatime.vscode-wakatime: adopt ``       |
| [`fd2f6f94`](https://github.com/NixOS/nixpkgs/commit/fd2f6f94e1ffc0cddbcd110fac759e05e409ec08) | `` maintainers: add cizniarova ``                             |
| [`e7f6c1c1`](https://github.com/NixOS/nixpkgs/commit/e7f6c1c150be406bf5dab61472d88fc179f16755) | `` espanso: remove self from maintainers list ``              |
| [`6a7b9500`](https://github.com/NixOS/nixpkgs/commit/6a7b9500328a0eebd1b458d48be1b311312c463b) | `` codex: 0.39.0 -> 0.40.0 ``                                 |
| [`d1e904b5`](https://github.com/NixOS/nixpkgs/commit/d1e904b5db387485ecd60b92859c5842e2678fe0) | `` maintainers: remove bmanuel ``                             |
| [`35d05e44`](https://github.com/NixOS/nixpkgs/commit/35d05e440b27d8be6c1dd4d2b6db6a1dc80a3c49) | `` vscode-extensions.mkhl.shfmt: 1.4.0 -> 1.5.1 ``            |
| [`76a34acd`](https://github.com/NixOS/nixpkgs/commit/76a34acd0373a3dc334c29bddabc17b499870174) | `` python3Packages.rds2py: init at 0.7.3 ``                   |
| [`8a4f9ac7`](https://github.com/NixOS/nixpkgs/commit/8a4f9ac7fd083cb5f89d243bf4b9cf09b26254ba) | `` vivaldi: 7.6.3797.52 -> 7.6.3797.55 ``                     |
| [`5b30a9ec`](https://github.com/NixOS/nixpkgs/commit/5b30a9ecfdf0ab0d0dd68800a3acf5d72d4c8193) | `` panotools: add cmake4 patch from upstream ``               |
| [`a0ecd3e8`](https://github.com/NixOS/nixpkgs/commit/a0ecd3e88f2eec369791f386d3c3b4b1bdc8b55f) | `` wl-clip-persist: 0.4.3 -> 0.5.0 ``                         |
| [`0a59313b`](https://github.com/NixOS/nixpkgs/commit/0a59313b89ac1776ccadaa3bd31c8097d0d16e1f) | `` pretix: relax django-i18nfield constraint ``               |
| [`76441825`](https://github.com/NixOS/nixpkgs/commit/76441825d2792976121ce71ac2fbdc0b59dda619) | `` python3Packages.django-i18nfield: 1.10.2 -> 1.11.0 ``      |
| [`4ec3096c`](https://github.com/NixOS/nixpkgs/commit/4ec3096cf9f53a1a87d3e2563174a18fece8828f) | `` pgroll: 0.14.2 -> 0.14.3 ``                                |
| [`debbfa3e`](https://github.com/NixOS/nixpkgs/commit/debbfa3e871488e4471d2a3d3fc96c85aaaedba0) | `` patch2pr: 0.37.0 -> 0.38.0 ``                              |
| [`eed8a86c`](https://github.com/NixOS/nixpkgs/commit/eed8a86c396bada66d8747ccb42b4a24fca97c86) | `` terraform-providers.fortios: 1.22.1 -> 1.22.2 ``           |
| [`bcb4de35`](https://github.com/NixOS/nixpkgs/commit/bcb4de35b09e4a0f1a73d72eaf1b131d86b1d35c) | `` python313Packages.dissect: 3.19 -> 3.20.1 ``               |
| [`01f8cc61`](https://github.com/NixOS/nixpkgs/commit/01f8cc61fe8160612528f1c98732170786d31168) | `` python313Packages.dissect-cramfs: init at 1.0 ``           |
| [`cf16bc56`](https://github.com/NixOS/nixpkgs/commit/cf16bc5627678c3a7582ca51356c7b930180b2b8) | `` kubeseal: 0.32.1 -> 0.32.2 ``                              |