### PR TITLE
chore(flake/emacs-overlay): `8bf7d1c4` -> `c902fe2d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1758788598,
-        "narHash": "sha256-PEQWFvzZxYkvnxbfVem3EAM9f2v/9llt/shRiGOQJZM=",
+        "lastModified": 1758877935,
+        "narHash": "sha256-I3tQqmGR9F5rUFGqL4DB0amQ0iQMfD+KCKz0n+/gYM0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8bf7d1c413a2a76e80b231d6ecd6ea7fe1b82ed6",
+        "rev": "c902fe2dc5bc7d95381876e7b68065173af971b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`c902fe2d`](https://github.com/nix-community/emacs-overlay/commit/c902fe2dc5bc7d95381876e7b68065173af971b6) | `` Updated melpa ``        |
| [`6a0d6f51`](https://github.com/nix-community/emacs-overlay/commit/6a0d6f5108fc5aeef4daed98927e77e3691db736) | `` Updated emacs ``        |
| [`86809fc1`](https://github.com/nix-community/emacs-overlay/commit/86809fc195cc3ed5537c5d486d2155b867c9b34f) | `` Updated melpa ``        |
| [`4d9dc667`](https://github.com/nix-community/emacs-overlay/commit/4d9dc6674d6fa2c3c96ae4a2726e4bf2382b2374) | `` Updated elpa ``         |
| [`1f546faa`](https://github.com/nix-community/emacs-overlay/commit/1f546faace6de422f3d04c42451c9cfb8f144467) | `` Updated nongnu ``       |
| [`01c1b347`](https://github.com/nix-community/emacs-overlay/commit/01c1b34701bd39882b4c0152f04093277c9f5964) | `` Updated emacs ``        |
| [`2a00cbdf`](https://github.com/nix-community/emacs-overlay/commit/2a00cbdf9b98bb9eb04d1bf1ecee64709062ef0a) | `` Updated melpa ``        |
| [`60f23470`](https://github.com/nix-community/emacs-overlay/commit/60f23470b563570b0e270e7ee65bb671bc6b5938) | `` Updated elpa ``         |
| [`48e1dc9c`](https://github.com/nix-community/emacs-overlay/commit/48e1dc9ce71df2f9e381f320af90f2cdde2662db) | `` Updated nongnu ``       |
| [`a14dd786`](https://github.com/nix-community/emacs-overlay/commit/a14dd786d7d9590e03e0d09b4bd0f68c60cdb22b) | `` Updated flake inputs `` |