### PR TITLE
chore(flake/nur): `544f12f6` -> `17afb292`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1222,11 +1222,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1758828503,
-        "narHash": "sha256-IgOibVOqWSZqWsHKK6TuALfuItRymW2YpsdZBjU2yrk=",
+        "lastModified": 1758858928,
+        "narHash": "sha256-1USNXX4bZg5iAQPP5lOE55JZ6TlAyyjKHGERlqQqtFU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "544f12f6987ceb94fe2052696da65623c238da4c",
+        "rev": "17afb2924ba90cab1074aecc057069db6633b41e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`17afb292`](https://github.com/nix-community/NUR/commit/17afb2924ba90cab1074aecc057069db6633b41e) | `` automatic update `` |
| [`0b0cd971`](https://github.com/nix-community/NUR/commit/0b0cd971224e65905db781249d3d359ae8313efb) | `` automatic update `` |
| [`e92f6d43`](https://github.com/nix-community/NUR/commit/e92f6d43b4a0fb79f4f99b228067ce216fb6e1f4) | `` automatic update `` |
| [`22c0f479`](https://github.com/nix-community/NUR/commit/22c0f47962ec31c5b81c12659d187867dffcac20) | `` automatic update `` |
| [`d39e95e9`](https://github.com/nix-community/NUR/commit/d39e95e918ee44504f897b52cddf6b2bc70acc36) | `` automatic update `` |
| [`b4e5c5a7`](https://github.com/nix-community/NUR/commit/b4e5c5a72db023737e0ff3f989707968c29c0f07) | `` automatic update `` |
| [`d3f92062`](https://github.com/nix-community/NUR/commit/d3f920624a37f24d323782909b959fe3ef2d9760) | `` automatic update `` |
| [`4640fcc3`](https://github.com/nix-community/NUR/commit/4640fcc3816e020cc941cb15aa68ceeb71305df6) | `` automatic update `` |
| [`6b6972b2`](https://github.com/nix-community/NUR/commit/6b6972b2cb544033d3366b9094dade9514820c84) | `` automatic update `` |