### PR TITLE
chore(flake/home-manager): `39d26c16` -> `40e91665`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -740,11 +740,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758810399,
-        "narHash": "sha256-bpWoE1tiFX5T1tr5EudkpW9Kk02XR+6olkoSkf3nHZU=",
+        "lastModified": 1758873093,
+        "narHash": "sha256-tBKPuan1dw0NxP2EyechIG93Nw5f2wWGXtvpvTndyhI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "39d26c16866260eee6d0487fe9c102ba1c1bf7b2",
+        "rev": "40e916658dcbd4e66647a68f502ff8e98c311027",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`40e91665`](https://github.com/nix-community/home-manager/commit/40e916658dcbd4e66647a68f502ff8e98c311027) | `` maintainers: remove ipsavitsky ``                     |
| [`ef5c1426`](https://github.com/nix-community/home-manager/commit/ef5c1426bfb558f13cf0e585e1b2830ded87a970) | `` maintainers: update all-maintainers.nix ``            |
| [`f3235d91`](https://github.com/nix-community/home-manager/commit/f3235d91abedc9bcfdcbf1d7807b5bce94258884) | `` mods: get ipsavitsky from Nixpkgs maintainers list `` |
| [`c1a47eae`](https://github.com/nix-community/home-manager/commit/c1a47eae05fb93788d3e3a7f1e63d7fc34d60c63) | `` desktoppr: init module (#7878) ``                     |