### PR TITLE
chore(flake/home-manager): `40e91665` -> `173a29f7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -740,11 +740,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758873093,
-        "narHash": "sha256-tBKPuan1dw0NxP2EyechIG93Nw5f2wWGXtvpvTndyhI=",
+        "lastModified": 1758876467,
+        "narHash": "sha256-ueGMsCYo6S6WiszKPpXoRCdMDVmsCwfA09L7blUEPlY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "40e916658dcbd4e66647a68f502ff8e98c311027",
+        "rev": "173a29f735c69950cfeaac310d7e567115976be0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`173a29f7`](https://github.com/nix-community/home-manager/commit/173a29f735c69950cfeaac310d7e567115976be0) | `` docs: add note of Synthing tray option removal ``       |
| [`b91c7e43`](https://github.com/nix-community/home-manager/commit/b91c7e43ed7ee644b032b068343472a48c703a10) | `` syncthing: add aionescu as maintainer ``                |
| [`29e8b08f`](https://github.com/nix-community/home-manager/commit/29e8b08f65b4f45831ae6d6e4d14affb6c86fa31) | `` maintainers: add aionescu ``                            |
| [`80094132`](https://github.com/nix-community/home-manager/commit/800941320b26d699cd78dd427ecaf116b2bafbf3) | `` syncthing: install tray package when tray is enabled `` |