### PR TITLE
chore(flake/home-manager): `173a29f7` -> `bc2afee5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -740,11 +740,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758876467,
-        "narHash": "sha256-ueGMsCYo6S6WiszKPpXoRCdMDVmsCwfA09L7blUEPlY=",
+        "lastModified": 1758928860,
+        "narHash": "sha256-ZqaRdd+KoR54dNJPtd7UX4O0X+02YItnTpQVu28lSVI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "173a29f735c69950cfeaac310d7e567115976be0",
+        "rev": "bc2afee55bc5d3b825287829d6592b9cc1405aad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                     |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`bc2afee5`](https://github.com/nix-community/home-manager/commit/bc2afee55bc5d3b825287829d6592b9cc1405aad) | `` Translate using Weblate (Russian) ``     |
| [`497e2bfa`](https://github.com/nix-community/home-manager/commit/497e2bfa8a45bebe9788e2aa13e766e6a96677cd) | `` news: add aichat agents option entry ``  |
| [`e3e15e76`](https://github.com/nix-community/home-manager/commit/e3e15e765d164454db72ca30290c2d3a4917daf9) | `` aichat: add agents option ``             |
| [`35329d44`](https://github.com/nix-community/home-manager/commit/35329d44f3e3578fb33fc7e410c5b26a05fb1e53) | `` news: add aider-chat entry ``            |
| [`9947d3c0`](https://github.com/nix-community/home-manager/commit/9947d3c003e414e29b13e76884b21a482563f5fb) | `` aider-chat: add module ``                |
| [`fb2ae64b`](https://github.com/nix-community/home-manager/commit/fb2ae64bed1ee4997a8e350bc18f4bc5bffa670c) | `` news: add airlift entry ``               |
| [`8a135785`](https://github.com/nix-community/home-manager/commit/8a1357854d21246059d79258b0752834f965ee25) | `` airlift: add module ``                   |
| [`6238bbc0`](https://github.com/nix-community/home-manager/commit/6238bbc0ae04951b64a3ad1b69d3e03b8b329e51) | `` tailscale-systray: add module (#7821) `` |