### PR TITLE
chore(flake/emacs-overlay): `c902fe2d` -> `f7be96f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1758877935,
-        "narHash": "sha256-I3tQqmGR9F5rUFGqL4DB0amQ0iQMfD+KCKz0n+/gYM0=",
+        "lastModified": 1758993728,
+        "narHash": "sha256-Bb2su0eYMc0xBdpY/7B2292YuACWxOEj0b1emk/6nkc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c902fe2dc5bc7d95381876e7b68065173af971b6",
+        "rev": "f7be96f6f80ba65df30222d9a5cfadf26cf62355",
         "type": "github"
       },
       "original": {
@@ -1069,11 +1069,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1758589230,
-        "narHash": "sha256-zMTCFGe8aVGTEr2RqUi/QzC1nOIQ0N1HRsbqB4f646k=",
+        "lastModified": 1758791193,
+        "narHash": "sha256-F8WmEwFoHsnix7rt290R0rFXNJiMbClMZyIC/e+HYf0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d1d883129b193f0b495d75c148c2c3a7d95789a0",
+        "rev": "25e53aa156d47bad5082ff7618f5feb1f5e02d01",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`f7be96f6`](https://github.com/nix-community/emacs-overlay/commit/f7be96f6f80ba65df30222d9a5cfadf26cf62355) | `` Updated emacs ``        |
| [`c277c4eb`](https://github.com/nix-community/emacs-overlay/commit/c277c4eb24ccb99e0085793968e3b4be96117bec) | `` Updated melpa ``        |
| [`934817c1`](https://github.com/nix-community/emacs-overlay/commit/934817c122e91467fa40bce02d6a75b22409d36e) | `` Updated elpa ``         |
| [`8090a7e8`](https://github.com/nix-community/emacs-overlay/commit/8090a7e800c7807399550eddabaf7ee737dcbe63) | `` Updated nongnu ``       |
| [`fc94b22f`](https://github.com/nix-community/emacs-overlay/commit/fc94b22fd2b6110333e03180c0e36ffd10ae2029) | `` Updated melpa ``        |
| [`0b082e40`](https://github.com/nix-community/emacs-overlay/commit/0b082e40b028bff0ab5f587105ace1c990fb2129) | `` Updated melpa ``        |
| [`1ae07374`](https://github.com/nix-community/emacs-overlay/commit/1ae073740413b053024a6cb7d112795f1716fb0d) | `` Updated emacs ``        |
| [`c4503a39`](https://github.com/nix-community/emacs-overlay/commit/c4503a398eeb6cd8baa5f1a7ed27c1c611f436e0) | `` Updated nongnu ``       |
| [`804e75fd`](https://github.com/nix-community/emacs-overlay/commit/804e75fd1406faceeddd75014bf463dbf5140063) | `` Updated emacs ``        |
| [`aac62a1d`](https://github.com/nix-community/emacs-overlay/commit/aac62a1d330cd4d512a1a85c969d6059c06b79aa) | `` Updated melpa ``        |
| [`a34cb671`](https://github.com/nix-community/emacs-overlay/commit/a34cb6712f9e49b13613141c1e4e1b18c0e16de2) | `` Updated elpa ``         |
| [`bcd72eda`](https://github.com/nix-community/emacs-overlay/commit/bcd72edaec09fe4f6d00e2f771abbd3e076ba0d3) | `` Updated nongnu ``       |
| [`a18cb9f4`](https://github.com/nix-community/emacs-overlay/commit/a18cb9f41f256f4bddfa7ad24eea1bf597ed447f) | `` Updated flake inputs `` |