### PR TITLE
chore(flake/nur): `c236ae06` -> `8d3d2c60`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1222,11 +1222,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1758914824,
-        "narHash": "sha256-g1I8IBhN+efu2Er1T+/x7nIAUHgLyi5smMjdoqZtjYI=",
+        "lastModified": 1758945035,
+        "narHash": "sha256-QSeoU10il7Zh4EuUAFL/TGUx3a3HNLUrWa9NlmO0wPQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c236ae06d3bbd76b592259383ac752761d6d406b",
+        "rev": "8d3d2c603a5ee01e440cfa6183888c26e462e47a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8d3d2c60`](https://github.com/nix-community/NUR/commit/8d3d2c603a5ee01e440cfa6183888c26e462e47a) | `` automatic update `` |
| [`c898a1ed`](https://github.com/nix-community/NUR/commit/c898a1ed2da0164bc6f395f44aad52edb84c84d4) | `` automatic update `` |
| [`c9973236`](https://github.com/nix-community/NUR/commit/c9973236cf98b0cb1e0eadade782e967224e8cea) | `` automatic update `` |
| [`61abf365`](https://github.com/nix-community/NUR/commit/61abf365408b00b3306b7d9691df4fb957b250eb) | `` automatic update `` |
| [`6b219faa`](https://github.com/nix-community/NUR/commit/6b219faa81c094a5cc2e46e865a2fd8b2bff9f99) | `` automatic update `` |
| [`1711a198`](https://github.com/nix-community/NUR/commit/1711a198acfd0a32b2499834680e981f70dddbc9) | `` automatic update `` |
| [`12803d52`](https://github.com/nix-community/NUR/commit/12803d52c7354c69577b9128df32582f732bde01) | `` automatic update `` |
| [`4d606b49`](https://github.com/nix-community/NUR/commit/4d606b49d29710ccf0e323490d070ced5aac983f) | `` automatic update `` |
| [`661e7228`](https://github.com/nix-community/NUR/commit/661e72282f5a74a9e905db8e994aeabff1279aa2) | `` automatic update `` |