### PR TITLE
chore(flake/nur): `97197815` -> `b12d9127`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1222,11 +1222,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1758954406,
-        "narHash": "sha256-MCP/VGjybBfDJvWW8SgJwmEe0DuqyQ42GN6EGRiQigk=",
+        "lastModified": 1758986280,
+        "narHash": "sha256-xuvw0q3JAcUZteJ5x46ukkArWInTvSroWb23Wsd+sHs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9719781501c879bfffe618adc5ba736e06011b0d",
+        "rev": "b12d9127abe1fde785f751ddcf046b6707f53990",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b12d9127`](https://github.com/nix-community/NUR/commit/b12d9127abe1fde785f751ddcf046b6707f53990) | `` automatic update `` |
| [`f64b7b5c`](https://github.com/nix-community/NUR/commit/f64b7b5cce4c13ffba0582caae5e05c92a9c7899) | `` automatic update `` |
| [`dc6aa258`](https://github.com/nix-community/NUR/commit/dc6aa258292b2c4411e0f6b6ebb03d880ac5b00d) | `` automatic update `` |
| [`482ba74c`](https://github.com/nix-community/NUR/commit/482ba74c70a5afab4c6e920716a4b0ad86e452f4) | `` automatic update `` |
| [`e39e2b15`](https://github.com/nix-community/NUR/commit/e39e2b15a41cb527c8b68baf946e98a37a806847) | `` automatic update `` |