### PR TITLE
chore(flake/nur): `b12d9127` -> `48446fc3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1222,11 +1222,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1758986280,
-        "narHash": "sha256-xuvw0q3JAcUZteJ5x46ukkArWInTvSroWb23Wsd+sHs=",
+        "lastModified": 1759009476,
+        "narHash": "sha256-GjQOvevIwjZ71Q7OQSKKMrJ9eR2FfBJwYiK60hlzsC8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b12d9127abe1fde785f751ddcf046b6707f53990",
+        "rev": "48446fc335b69c4de9ee9a457d77bf785e31d18d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`48446fc3`](https://github.com/nix-community/NUR/commit/48446fc335b69c4de9ee9a457d77bf785e31d18d) | `` automatic update `` |
| [`c7afcaa1`](https://github.com/nix-community/NUR/commit/c7afcaa1e00f9ffb92f43ab1474c81e0f47778a0) | `` automatic update `` |
| [`821c99d6`](https://github.com/nix-community/NUR/commit/821c99d673856397df95db304d7ee94a88aa05b5) | `` automatic update `` |
| [`d623c3e6`](https://github.com/nix-community/NUR/commit/d623c3e63c2fbafb7625ce6f03e4a3ca0d3a1874) | `` automatic update `` |
| [`9c675d56`](https://github.com/nix-community/NUR/commit/9c675d568e9e812eaa84e78e4a7aa768af0bf28a) | `` automatic update `` |
| [`ba8d9c98`](https://github.com/nix-community/NUR/commit/ba8d9c98f5f4630bcb0e815ab456afd90c930728) | `` automatic update `` |