### PR TITLE
chore(flake/sops-nix): `e0fdaea3` -> `9ac51832`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1317,11 +1317,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758425756,
-        "narHash": "sha256-L3N8zV6wsViXiD8i3WFyrvjDdz76g3tXKEdZ4FkgQ+Y=",
+        "lastModified": 1759030640,
+        "narHash": "sha256-53VP3BqMXJqD1He1WADTFyUnpta3mie56H7nC59tSic=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "e0fdaea3c31646e252a60b42d0ed8eafdb289762",
+        "rev": "9ac51832c70f2ff34fcc97b05fa74b4a78317f9e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                      |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`71b8132d`](https://github.com/Mic92/sops-nix/commit/71b8132daf07cbd7019d49c566547a607357236b) | `` [create-pull-request] automated change `` |