### PR TITLE
chore(flake/nur): `48446fc3` -> `5f4cd163`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1222,11 +1222,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1759009476,
-        "narHash": "sha256-GjQOvevIwjZ71Q7OQSKKMrJ9eR2FfBJwYiK60hlzsC8=",
+        "lastModified": 1759045463,
+        "narHash": "sha256-mZ8bzPvsq7BW1q0zCeCXD9TrsJN/dVMMSMTIsuSrrcY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "48446fc335b69c4de9ee9a457d77bf785e31d18d",
+        "rev": "5f4cd1638e5cf5c912a76727bb2dac8a29ceb7ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5f4cd163`](https://github.com/nix-community/NUR/commit/5f4cd1638e5cf5c912a76727bb2dac8a29ceb7ee) | `` automatic update `` |
| [`f8f80c33`](https://github.com/nix-community/NUR/commit/f8f80c33cebc18ea0748c23f39a2cfc11b1a197f) | `` automatic update `` |
| [`df3fb235`](https://github.com/nix-community/NUR/commit/df3fb235a1e0cd5e6d0907290802a22dde333337) | `` automatic update `` |
| [`b873e23f`](https://github.com/nix-community/NUR/commit/b873e23f8ab30e3d7ed85165b037eed70855e56e) | `` automatic update `` |
| [`b12b0f57`](https://github.com/nix-community/NUR/commit/b12b0f57055006b1126972894153a4a8c7c44e8d) | `` automatic update `` |
| [`eb0a72b2`](https://github.com/nix-community/NUR/commit/eb0a72b223db0a0a9095ac53b375148e5f868775) | `` automatic update `` |
| [`13700b47`](https://github.com/nix-community/NUR/commit/13700b476b9868776eee20414d5277ea1a57fbee) | `` automatic update `` |
| [`cd07e34a`](https://github.com/nix-community/NUR/commit/cd07e34a7305d828d5e507c87e8ec40f4061ba78) | `` automatic update `` |
| [`ab2ae683`](https://github.com/nix-community/NUR/commit/ab2ae683f6f718eb69bda2e05091d13210087ca0) | `` automatic update `` |
| [`88ed1655`](https://github.com/nix-community/NUR/commit/88ed1655fe115a25db9ded01b254150f2ec997ce) | `` automatic update `` |
| [`f780529d`](https://github.com/nix-community/NUR/commit/f780529d5cf7495e57eebe0b1ee9d998b4662fa7) | `` automatic update `` |