### PR TITLE
chore(flake/nix-index-database): `fd2569ca` -> `ec7a78cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758427679,
-        "narHash": "sha256-xwjWRJTKDCjQ0iwfh7WhDhgcS0Wt3d1Yscg83mKBCn4=",
+        "lastModified": 1759032422,
+        "narHash": "sha256-WZf+FhebP2/1pK2np5xj/NuDjD6fXK2BHnq/tPUN18o=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "fd2569ca2ef7d69f244cd9ffcb66a0540772ff85",
+        "rev": "ec7a78cb0e098832d8acac091a4df393259c4839",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`ec7a78cb`](https://github.com/nix-community/nix-index-database/commit/ec7a78cb0e098832d8acac091a4df393259c4839) | `` update generated.nix to release 2025-09-28-033035 `` |
| [`dba023c4`](https://github.com/nix-community/nix-index-database/commit/dba023c457b6a7c826cd63397f5c6d6ff4d8b828) | `` flake.lock: Update ``                                |