### PR TITLE
chore(flake/nur): `5f4cd163` -> `7eea3cf5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1222,11 +1222,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1759045463,
-        "narHash": "sha256-mZ8bzPvsq7BW1q0zCeCXD9TrsJN/dVMMSMTIsuSrrcY=",
+        "lastModified": 1759074636,
+        "narHash": "sha256-e0ObpwRfrKU1QNOm3RJmTOeRb31V6mP3UJ2+IebfBNE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5f4cd1638e5cf5c912a76727bb2dac8a29ceb7ee",
+        "rev": "7eea3cf5c0f2b96464a6a2c21877773d1a459e11",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7eea3cf5`](https://github.com/nix-community/NUR/commit/7eea3cf5c0f2b96464a6a2c21877773d1a459e11) | `` automatic update `` |
| [`f4a49279`](https://github.com/nix-community/NUR/commit/f4a492798a98f8470b60357f8fc1b94245e2d2f9) | `` automatic update `` |
| [`234a8ff5`](https://github.com/nix-community/NUR/commit/234a8ff556a8995692152f1b0a7d1ee89096ad54) | `` automatic update `` |
| [`89347f05`](https://github.com/nix-community/NUR/commit/89347f05f5fc99daba28f114dd2aea42ddfc7416) | `` automatic update `` |
| [`2af79589`](https://github.com/nix-community/NUR/commit/2af795892ad4e2039fda7dcdb4dae71c4a444ad1) | `` automatic update `` |
| [`ebea906e`](https://github.com/nix-community/NUR/commit/ebea906e608cdfe7493ca461f5fcd1b36a42d365) | `` automatic update `` |