### PR TITLE
chore(flake/nur): `7eea3cf5` -> `acda1261`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1148,11 +1148,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1758690382,
-        "narHash": "sha256-NY3kSorgqE5LMm1LqNwGne3ZLMF2/ILgLpFr1fS4X3o=",
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e643668fd71b949c53f8626614b21ff71a07379d",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
         "type": "github"
       },
       "original": {
@@ -1222,11 +1222,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1759074636,
-        "narHash": "sha256-e0ObpwRfrKU1QNOm3RJmTOeRb31V6mP3UJ2+IebfBNE=",
+        "lastModified": 1759160562,
+        "narHash": "sha256-3xbZAndEXnRW9XBD573HuFDUZIjlfZAc0XkODQSMJVo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7eea3cf5c0f2b96464a6a2c21877773d1a459e11",
+        "rev": "acda1261f03f441c17558e575fb77f3097a37293",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`acda1261`](https://github.com/nix-community/NUR/commit/acda1261f03f441c17558e575fb77f3097a37293) | `` automatic update `` |
| [`f2ba85a5`](https://github.com/nix-community/NUR/commit/f2ba85a5fdca89261795d936b1729c5775b33eda) | `` automatic update `` |
| [`044b2a51`](https://github.com/nix-community/NUR/commit/044b2a51d63b4c1084dfd2755fe00c53ba49255c) | `` automatic update `` |
| [`a089a6a1`](https://github.com/nix-community/NUR/commit/a089a6a1d9e609a0c4406d444dabd15648f53d90) | `` automatic update `` |
| [`9112cb78`](https://github.com/nix-community/NUR/commit/9112cb788344b678711ea1ca70bb833995e5c873) | `` automatic update `` |
| [`660590c6`](https://github.com/nix-community/NUR/commit/660590c6a1e82e6940eadb77b37f70dd878e8633) | `` automatic update `` |
| [`f1683296`](https://github.com/nix-community/NUR/commit/f16832965e360e4db9b76e9e675a0408ae5399b4) | `` automatic update `` |
| [`781a5290`](https://github.com/nix-community/NUR/commit/781a5290f677ca8afc785f2d3a2a3ad22c956293) | `` automatic update `` |
| [`0c9f9d03`](https://github.com/nix-community/NUR/commit/0c9f9d03d8d5658b3c0142ef795c3e143ee0408d) | `` automatic update `` |
| [`c7f19a28`](https://github.com/nix-community/NUR/commit/c7f19a28eaa25be9451bd48508eabf2b386fb72d) | `` automatic update `` |
| [`5ead982f`](https://github.com/nix-community/NUR/commit/5ead982fc43ab43e013e05db1fb0eca210ad8db7) | `` automatic update `` |
| [`4edcc30d`](https://github.com/nix-community/NUR/commit/4edcc30d423cad749c216428403842ba34cefb8a) | `` automatic update `` |
| [`daed4e48`](https://github.com/nix-community/NUR/commit/daed4e48d334bcd08be45bbf50d89308d957b592) | `` automatic update `` |
| [`fccc09df`](https://github.com/nix-community/NUR/commit/fccc09dffa659dc1410eceb33285831ba12bc7f6) | `` automatic update `` |
| [`1110ff3c`](https://github.com/nix-community/NUR/commit/1110ff3cee4ac510d5ab89e573e813a3803b8e00) | `` automatic update `` |
| [`0239e35d`](https://github.com/nix-community/NUR/commit/0239e35d66f89be5b983f882de9f197b376d4812) | `` automatic update `` |
| [`24d7cd39`](https://github.com/nix-community/NUR/commit/24d7cd3997567801a05c1541d027292abde5c727) | `` automatic update `` |
| [`e88fd776`](https://github.com/nix-community/NUR/commit/e88fd7766e9b1af996a438341cbbd51d6ca1c621) | `` automatic update `` |
| [`f4f4e3fe`](https://github.com/nix-community/NUR/commit/f4f4e3fecf360340d4ed2740d7e02881616e7be9) | `` automatic update `` |
| [`1eac073d`](https://github.com/nix-community/NUR/commit/1eac073db3f04be9eca753c8f0bf54b341e85e14) | `` automatic update `` |
| [`30213cdb`](https://github.com/nix-community/NUR/commit/30213cdb479b2ac4f6bded9982439a82c3d760b3) | `` automatic update `` |
| [`669ab83f`](https://github.com/nix-community/NUR/commit/669ab83f6fe35cae4bee00e9a66e79b1936612cd) | `` automatic update `` |