### PR TITLE
chore(flake/minimal-emacs-d): `c2883bb1` -> `a1536a75`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -802,11 +802,11 @@
     "minimal-emacs-d": {
       "flake": false,
       "locked": {
-        "lastModified": 1758139253,
-        "narHash": "sha256-nqoeImZNdyu8lIKFTk95YtAJ84ZAHvzVCD0qPW2mshE=",
+        "lastModified": 1759086170,
+        "narHash": "sha256-YR3reaTomDIeH0Bceb9DzE0cKdqQKXX1WttMt7lMwj4=",
         "owner": "jamescherti",
         "repo": "minimal-emacs.d",
-        "rev": "c2883bb14064a09a4ad6e60563e3d43fa0185f92",
+        "rev": "a1536a757c83496bbf4b7e99ae932148bfe67fa7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                      |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------- |
| [`a1536a75`](https://github.com/jamescherti/minimal-emacs.d/commit/a1536a757c83496bbf4b7e99ae932148bfe67fa7) | `` Update README.md ``       |
| [`238f41e7`](https://github.com/jamescherti/minimal-emacs.d/commit/238f41e79f1fe20f15a4c4cac5bdfac7f0659fb4) | `` Update README.md ``       |
| [`05d4898f`](https://github.com/jamescherti/minimal-emacs.d/commit/05d4898f7f548386c97ab281e2c5813bd47b2a36) | `` Update README.md ``       |
| [`be7fdce5`](https://github.com/jamescherti/minimal-emacs.d/commit/be7fdce532cdf8d6ebbf8c0a1783463549a3ab28) | `` Remove recentf-exclude `` |