### PR TITLE
chore(flake/home-manager): `a97df40c` -> `9e0453a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -740,11 +740,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759088654,
-        "narHash": "sha256-31Xc5bIeqqOJA0Kuk9s7TAMakuyggGHBluP3LqedQiE=",
+        "lastModified": 1759236626,
+        "narHash": "sha256-1BjCUU2csqhR5umGYFnOOTU8r8Bi+bnB2SLsr0FLcws=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a97df40c1966cc46b5f6817ac8d8e240da03de96",
+        "rev": "9e0453a9b0c8ef22de0355b731d712707daa6308",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`9e0453a9`](https://github.com/nix-community/home-manager/commit/9e0453a9b0c8ef22de0355b731d712707daa6308) | `` zsh: source session variable file directly ``    |
| [`12fa8548`](https://github.com/nix-community/home-manager/commit/12fa8548feefa9a10266ba65152fd1a787cdde8f) | `` maintainers: update all-maintainers.nix ``       |
| [`619ae569`](https://github.com/nix-community/home-manager/commit/619ae569293b6427d23cce4854eb4f3c33af3eec) | `` news: add intelli-shell entry ``                 |
| [`580ff74a`](https://github.com/nix-community/home-manager/commit/580ff74a7132af3228f7dd778a07083b3c338aeb) | `` intelli-shell: add module ``                     |
| [`50375df1`](https://github.com/nix-community/home-manager/commit/50375df1f734f955a6b532bcc900c2588cddd3ab) | `` git-worktree-switcher: use cfg.package ``        |
| [`6ee84731`](https://github.com/nix-community/home-manager/commit/6ee8473173af7a0181a788e8a3d4fa164f4cc72c) | `` tests: improve debugging for failed test runs `` |
| [`e9114f96`](https://github.com/nix-community/home-manager/commit/e9114f96efc6e40ecf60e3db130c0a0ca88d1800) | `` tests: rename test-all-* tests ``                |