### PR TITLE
chore(flake/srvos): `30e6b4c2` -> `97708379`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1337,11 +1337,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758285369,
-        "narHash": "sha256-WdkeIbq2Bo6l0tzBSCxMDeDMSKBp1iiOX7EdOHrsJCQ=",
+        "lastModified": 1759107752,
+        "narHash": "sha256-VEdL1J4rk+Z/5wHhLSsvj5QmXWKHHDeN1P8YLGLa1RM=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "30e6b4c2e5e7b235c7d0a266994a0c93e86bcf69",
+        "rev": "97708379b1f3b64224632eb49a56e45fe6995e6f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`97708379`](https://github.com/nix-community/srvos/commit/97708379b1f3b64224632eb49a56e45fe6995e6f) | `` dev/private/flake.lock: Update `` |
| [`a62544bc`](https://github.com/nix-community/srvos/commit/a62544bc833af59c8acf18188961bafe453e58a2) | `` flake.lock: Update ``             |