### PR TITLE
chore(flake/emacs-overlay): `ae2a5949` -> `feaf095a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1759079154,
-        "narHash": "sha256-ViNoTyurHYed96NA9sWCxKegtF4JPFXLcD2A4EOp444=",
+        "lastModified": 1759165795,
+        "narHash": "sha256-XbsOV8yPIjUjrlAaDU1GwVRle51dKDhf+ThxIyJAiA4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ae2a59490e94c38d917d1e1bc479bdab6c9c8f1c",
+        "rev": "feaf095a36708c269687bc2ebd565d3bfcd0322b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`feaf095a`](https://github.com/nix-community/emacs-overlay/commit/feaf095a36708c269687bc2ebd565d3bfcd0322b) | `` Updated melpa ``        |
| [`3c0da90f`](https://github.com/nix-community/emacs-overlay/commit/3c0da90f6e3c7d30201126ba830a457e2c5dc3d1) | `` Updated elpa ``         |
| [`a821cd87`](https://github.com/nix-community/emacs-overlay/commit/a821cd87671c3f0c92d4b55778c9b33fd6639c5f) | `` Updated emacs ``        |
| [`11a9ae10`](https://github.com/nix-community/emacs-overlay/commit/11a9ae10961f511d4c45f115337e982d5ae46e95) | `` Updated flake inputs `` |
| [`a10bc128`](https://github.com/nix-community/emacs-overlay/commit/a10bc128d5f7163149fab25c0e9d56113709356e) | `` Updated melpa ``        |
| [`fa566057`](https://github.com/nix-community/emacs-overlay/commit/fa5660576dbbd2ae3a68f2e4e6ce8d2855cd4e9e) | `` Updated emacs ``        |
| [`c8f778ca`](https://github.com/nix-community/emacs-overlay/commit/c8f778ca07cc9d8182599be4e794db6c8e03682e) | `` Updated melpa ``        |
| [`08ced8ed`](https://github.com/nix-community/emacs-overlay/commit/08ced8ed79afe6dcd0c93d37d2620d4aaf02d226) | `` Updated elpa ``         |
| [`2166fe91`](https://github.com/nix-community/emacs-overlay/commit/2166fe91297633f2628f531e851d815953a5f171) | `` Updated nongnu ``       |