### PR TITLE
chore(flake/nixpkgs): `e643668f` -> `e9f00bd8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1132,11 +1132,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1758690382,
-        "narHash": "sha256-NY3kSorgqE5LMm1LqNwGne3ZLMF2/ILgLpFr1fS4X3o=",
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e643668fd71b949c53f8626614b21ff71a07379d",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`ee239adf`](https://github.com/NixOS/nixpkgs/commit/ee239adf013686e672a7d1f50b96e9a7fed59781) | `` python3Packages.guidance: 0.2.5 -> 0.3.0 ``                                |
| [`a4ebe2ee`](https://github.com/NixOS/nixpkgs/commit/a4ebe2ee6fc371e287b4a198b4a6bec011eb581d) | `` python313Packages.python-fx: disable failing tests ``                      |
| [`1f270079`](https://github.com/NixOS/nixpkgs/commit/1f270079cfcd4672c6e23ec4c19201fd757ea455) | `` python313Packages.pynng: override version ``                               |
| [`60acdc42`](https://github.com/NixOS/nixpkgs/commit/60acdc429f3fee2628377233e38c045277c255a9) | `` python313Packages.questionary: 2.1.0 -> 2.1.1 ``                           |
| [`2cf65cfb`](https://github.com/NixOS/nixpkgs/commit/2cf65cfb6d6bd753d97dcf297d7b1e079085794b) | `` python313Packages.requests-unixsocket2: 1.0.0 -> 1.0.1 ``                  |
| [`25c300a3`](https://github.com/NixOS/nixpkgs/commit/25c300a3c2822714c824c556732ea1ed524b9867) | `` codeberg-cli: 0.5.0 -> 0.5.1 ``                                            |
| [`eb26dc68`](https://github.com/NixOS/nixpkgs/commit/eb26dc68240b4b0300830659a5889b8012a48106) | `` python313Packages.reolink-aio: 0.15.0 -> 0.15.2 ``                         |
| [`a3eef9f0`](https://github.com/NixOS/nixpkgs/commit/a3eef9f05b96e112183ceee7fdccfd6d328782e5) | `` python313Packages.rfc3161-client: 1.0.4 -> 1.0.5 ``                        |
| [`5438eca3`](https://github.com/NixOS/nixpkgs/commit/5438eca3808ffc2bfb65a11bf38c36c400fc4dc0) | `` python313Packages.datalad-next: 1.5.0 -> 1.6.0-unstable-2025-07-04 ``      |
| [`de36c65e`](https://github.com/NixOS/nixpkgs/commit/de36c65efe101b387d0e5504cf306f74e3fa82ce) | `` terraform-providers.hcloud: 1.52.0 -> 1.53.1 ``                            |
| [`4a56804f`](https://github.com/NixOS/nixpkgs/commit/4a56804f90a07b58187be6d399c5b14efd100baf) | `` python313Packages.pylamarzocco: 2.1.0 -> 2.1.1 ``                          |
| [`bc18f554`](https://github.com/NixOS/nixpkgs/commit/bc18f5545c1bbf801d57a4480e4a8ae33d5df260) | `` python313Packages.pylamarzocco: remove disabled ``                         |
| [`f7fcf92b`](https://github.com/NixOS/nixpkgs/commit/f7fcf92bbec328de95761f8ddee6c4c7c6c61ff3) | `` python3Packages.llama-index-llms-ollama: 0.7.3 -> 0.7.4 ``                 |
| [`801c7d25`](https://github.com/NixOS/nixpkgs/commit/801c7d255cb52d58b1d2dc19783c92ae169a5391) | `` upsies: 2025.04.21 -> 2025.09.20 ``                                        |
| [`b48a0417`](https://github.com/NixOS/nixpkgs/commit/b48a0417240137f0a717a5a06ed35c53b6606ff7) | `` python313Packages.aiobtclientrpc: disable outdated tests ``                |
| [`5c8fc450`](https://github.com/NixOS/nixpkgs/commit/5c8fc450822ef43e44a30b3cf3bb7ffc15a4e69d) | `` python3Packages.tf2onnx: disable on darwin (segmentation fault) ``         |
| [`09ce48dd`](https://github.com/NixOS/nixpkgs/commit/09ce48dd3a9fe1988839c016dc45ab57f764dd6c) | `` python313Packages.mwdblib: 4.5.0 -> 4.6.0 ``                               |
| [`8241c312`](https://github.com/NixOS/nixpkgs/commit/8241c31289b4228357885ff7a0ef3daf1b9fdfed) | `` python313Packages.pgmpy: adjust check section ``                           |
| [`385f435c`](https://github.com/NixOS/nixpkgs/commit/385f435cc220c2d8c58e854dc4f19c2e8902d99e) | `` python313Packages.busylight-for-humans: 0.37.0 -> 0.45.2 ``                |
| [`09183d45`](https://github.com/NixOS/nixpkgs/commit/09183d455a176a6d9cb9185b3459839cc541e406) | `` python313Packages.phik: disable failing test ``                            |
| [`a11e8d07`](https://github.com/NixOS/nixpkgs/commit/a11e8d076eeaca3edcff35e1df1840564c377c9d) | `` python313Packages.busylight-core: init at 0.15.2 ``                        |
| [`1d4f11fa`](https://github.com/NixOS/nixpkgs/commit/1d4f11fa0e3f9f0be0ca64afbf6555d4cbce28db) | `` scala-cli: 1.9.0 -> 1.9.1 ``                                               |
| [`9fec6b80`](https://github.com/NixOS/nixpkgs/commit/9fec6b80b068dccde4a77e236bd1cd241a3a0c34) | `` python313Packages.awsiotsdk: 1.25.1 -> 1.26.0 ``                           |
| [`22727f84`](https://github.com/NixOS/nixpkgs/commit/22727f84a9caae3811ee862ea4a81c3b57fd7c20) | `` python313Packages.pyworxcloud: relax awsiotsdk ``                          |
| [`34fb2559`](https://github.com/NixOS/nixpkgs/commit/34fb2559fd24770cb1cfd9a22eeab36eac0c31e5) | `` zwave-js-ui: 11.2.1 -> 11.3.1 ``                                           |
| [`8b918123`](https://github.com/NixOS/nixpkgs/commit/8b918123e7e06a9f94686476e895b2046a70d4b7) | `` python313Packages.niaaml: modernize ``                                     |
| [`e08109d4`](https://github.com/NixOS/nixpkgs/commit/e08109d41a43cf39806c530057243edc0c297f12) | `` python313Packages.niaaml: relax typer ``                                   |
| [`4dcbb0c6`](https://github.com/NixOS/nixpkgs/commit/4dcbb0c6ada0223f73fa91bed4d679c6da5c8ef3) | `` python313Packages.orgparse: re-work ``                                     |
| [`222580ca`](https://github.com/NixOS/nixpkgs/commit/222580cad310e61772c8dc6fd2cff35ff775622b) | `` roddhjav-apparmor-rules: 0-unstable-2025-09-14 -> 0-unstable-2025-09-27 `` |
| [`e3e62d99`](https://github.com/NixOS/nixpkgs/commit/e3e62d997855b24477a25695519bdcf0ca45db3f) | `` python313Packages.nidaqmx: clean-up ``                                     |
| [`804305fc`](https://github.com/NixOS/nixpkgs/commit/804305fc1f20028839106f249ece8fc3d3894a33) | `` python313Packages.nocasedict: add setuptools-scm ``                        |
| [`fbccb36d`](https://github.com/NixOS/nixpkgs/commit/fbccb36decd7d920c8b65fe96e252c601ec0578a) | `` python313Packages.iamdata: 0.1.202509261 -> 0.1.202509271 ``               |
| [`55d13716`](https://github.com/NixOS/nixpkgs/commit/55d1371622a9f022f5f9e0525011faedda164c09) | `` python313Packages.datasalad: 0.5.0 -> 0.6.0 ``                             |
| [`70e5cc7f`](https://github.com/NixOS/nixpkgs/commit/70e5cc7fdb44059823eeb3391ae761be084d2b18) | `` python313Packages.bumps: 1.0.2 -> 1.0.3 ``                                 |
| [`2196c2f9`](https://github.com/NixOS/nixpkgs/commit/2196c2f94102df16c4534525d535f73c39f0b15c) | `` python313Packages.cantools: 40.5.0 -> 40.7.0 ``                            |
| [`3cb2150c`](https://github.com/NixOS/nixpkgs/commit/3cb2150c84614ba1513d0f3ed18f892d6fc63309) | `` python314: fix pythonAttr value ``                                         |
| [`09184fe0`](https://github.com/NixOS/nixpkgs/commit/09184fe0d4ac8bed50296ef12fac86880fc13a01) | `` python313Packages.bentoml: 1.4.23 -> 1.4.25 ``                             |
| [`6aedeec9`](https://github.com/NixOS/nixpkgs/commit/6aedeec9ec478c40b551f8ba87d7a50333e6cc5a) | `` python313Packages.rich-toolkit: 0.14.9 -> 0.15.1 ``                        |
| [`81145881`](https://github.com/NixOS/nixpkgs/commit/81145881f44441ca416b97a77d7675de78421315) | `` python3Packages.niaclass: 0.2.3 -> 0.2.4 ``                                |
| [`059eeab8`](https://github.com/NixOS/nixpkgs/commit/059eeab822fffb63958efd4970335f619261d460) | `` airwindows: 0-unstable-2025-08-24 -> 0-unstable-2025-09-20 ``              |
| [`5d1f187d`](https://github.com/NixOS/nixpkgs/commit/5d1f187d97cf8e01a4c80f7e96aa3672b1e69ee6) | `` python3Packages.google-cloud-securitycenter: 1.39.0 -> 1.40.0 ``           |
| [`50497b00`](https://github.com/NixOS/nixpkgs/commit/50497b00c2a003c840bbf07bcc9ec3a9136a0f82) | `` windsurf: 1.12.6 -> 1.12.11 ``                                             |
| [`6f58ee5d`](https://github.com/NixOS/nixpkgs/commit/6f58ee5d7edb6ef5fa2b14188017e7c5f10512ea) | `` jetuml: fix desktop icon not showing ``                                    |
| [`f5f19115`](https://github.com/NixOS/nixpkgs/commit/f5f1911538ac1f0bc4bfadda9335e1b6a365db2c) | `` python313Packages.clarifai: 11.6.7 -> 11.8.2 ``                            |
| [`a6d81ee8`](https://github.com/NixOS/nixpkgs/commit/a6d81ee8c54e2f7880484968cbef539b23e2fba7) | `` lxgw-neoxihei: 1.220 -> 1.223 ``                                           |
| [`aa07ce7c`](https://github.com/NixOS/nixpkgs/commit/aa07ce7c5e20c9653a292ed251d848a98e74e491) | `` python313Packages.linearmodels: disable long-running tests ``              |
| [`eb1132d3`](https://github.com/NixOS/nixpkgs/commit/eb1132d39cbe2837c9154c29ed09caa2421a9354) | `` python3Packages.granian: 2.5.3 -> 2.5.4 ``                                 |
| [`c45b6ea6`](https://github.com/NixOS/nixpkgs/commit/c45b6ea641d4f3540921953a5ea814884b8ec056) | `` open-webui: 0.6.30 -> 0.6.31 ``                                            |
| [`8d85b6d7`](https://github.com/NixOS/nixpkgs/commit/8d85b6d71bdd4f70ac339007efda9b67cf03b737) | `` python3Packages.starsessions: init at 2.2.1 ``                             |
| [`3c224870`](https://github.com/NixOS/nixpkgs/commit/3c224870f97db1bddd4277082dc82df917b867b4) | `` python313Packages.publicsuffixlist: 1.0.2.20250925 -> 1.0.2.20250927 ``    |
| [`baa4c891`](https://github.com/NixOS/nixpkgs/commit/baa4c8913ba0946a549d7f9c567b7e01f57a43c1) | `` python313Packages.types-docutils: 0.22.1.20250923 -> 0.22.2.20250924 ``    |
| [`5f4efa42`](https://github.com/NixOS/nixpkgs/commit/5f4efa428844330f41e20ab37967189054c03ee3) | `` python313Packages.types-html5lib: 1.1.11.20250809 -> 1.1.11.20250917 ``    |
| [`ededda68`](https://github.com/NixOS/nixpkgs/commit/ededda6875cadf59433e397df5644a80558524e4) | `` frigate: only works with full protobuf and not protobuf-lite ``            |
| [`5f441444`](https://github.com/NixOS/nixpkgs/commit/5f4414443c137a9d49f6fcfa8d2bb50f943dcdb6) | `` onnxruntime: add option to link full protobuf, not protobuf-lite ``        |
| [`05a81726`](https://github.com/NixOS/nixpkgs/commit/05a81726bf906786d3d8a1543c2b6a3afc77c066) | `` irrd: modernize ``                                                         |
| [`7bd2f81a`](https://github.com/NixOS/nixpkgs/commit/7bd2f81a1505e562c520032691b6bc08bc817f87) | `` irrd: set to pytest-asyncio_0 ``                                           |
| [`ede7b7ef`](https://github.com/NixOS/nixpkgs/commit/ede7b7ef0b55e297881007d7bed13b977ec8f503) | `` python313Packages.twilio: 9.8.1 -> 9.8.2 ``                                |
| [`e3adc694`](https://github.com/NixOS/nixpkgs/commit/e3adc694e7470d5dfef2f0c76cd8000f02fe21a3) | `` python313Packages.nicegui: 2.24.1 -> 2.24.2 ``                             |
| [`188a50c8`](https://github.com/NixOS/nixpkgs/commit/188a50c81ab6f05f2a6aaee0c06763ad6b6c6fb1) | `` libretro.play: 0-unstable-2025-09-12 -> 0-unstable-2025-09-22 ``           |
| [`1bae9299`](https://github.com/NixOS/nixpkgs/commit/1bae9299d495502bb245b4c7fac509d17ecd233e) | `` espup: 0.15.1 -> 0.16.0 ``                                                 |
| [`25e50ca7`](https://github.com/NixOS/nixpkgs/commit/25e50ca7e8ac577f8ed1339893a5e48f66bc352a) | `` python3Packages.reflex: 0.8.11 -> 0.8.12 ``                                |
| [`2569d923`](https://github.com/NixOS/nixpkgs/commit/2569d923d7d494e10d65ed0f51e023944efa9f7d) | `` xemu: 0.8.98 -> 0.8.105 ``                                                 |
| [`2d52222a`](https://github.com/NixOS/nixpkgs/commit/2d52222a470e1be3a195dc41c96f183b3b32533e) | `` python313Packages.lacuscore: 1.16.6 -> 1.18.0 ``                           |
| [`231c50bf`](https://github.com/NixOS/nixpkgs/commit/231c50bfc2acf09926a9923bc3868ae619ca74a6) | `` python313Packages.linearmodels: relax setuptools-scm ``                    |
| [`033768b7`](https://github.com/NixOS/nixpkgs/commit/033768b72fb64fef84c7ce0c51fff2e63609c97f) | `` python3Packages.types-regex: 2025.9.1.20250903 -> 2025.9.18.20250921 ``    |
| [`59c6f927`](https://github.com/NixOS/nixpkgs/commit/59c6f92762fb1f32e4e8e1b16b443753f871d09d) | `` traefik: 3.5.2 -> 3.5.3 ``                                                 |
| [`e5c4a53b`](https://github.com/NixOS/nixpkgs/commit/e5c4a53b92e7e9ab856c1950e5307ab216047cac) | `` python313Packages.playwrightcapture: 1.31.7 -> 1.33.0 ``                   |
| [`d79c8e20`](https://github.com/NixOS/nixpkgs/commit/d79c8e20236856c151b03d3578d96fcfea8db983) | `` python313Packages.switchbot-api: 2.7.0 -> 2.8.0 ``                         |
| [`d42c0242`](https://github.com/NixOS/nixpkgs/commit/d42c0242f69657276b70dae6141475318c6f96d5) | `` phpunit: 12.3.11 -> 12.3.14 ``                                             |
| [`1d6e29aa`](https://github.com/NixOS/nixpkgs/commit/1d6e29aa65703491d574885f10b6ac1810e6ea4d) | `` python313Packages.tree-sitter-sql: add changelog to meta ``                |
| [`1c68b1bb`](https://github.com/NixOS/nixpkgs/commit/1c68b1bbed103704651c39839bc41bf49102bc24) | `` python313Packages.binsync: add wordfreq ``                                 |
| [`3c6c343d`](https://github.com/NixOS/nixpkgs/commit/3c6c343d73f0feefeff1d434f17ab5b3394badfe) | `` nixos/tests/evcc: fix charger messaging ``                                 |
| [`6ff46b7b`](https://github.com/NixOS/nixpkgs/commit/6ff46b7b5ac6948add64620ee1997372953eb2ef) | `` python313Packages.parquet: adjust check section ``                         |
| [`49365386`](https://github.com/NixOS/nixpkgs/commit/493653869c40a50a6aae0af427e0f3e64e2c2976) | `` evcc: 0.207.6 -> 0.208.1 ``                                                |
| [`45068b4d`](https://github.com/NixOS/nixpkgs/commit/45068b4d2634ccd11dc3ada09e09fed249002d6e) | `` enzyme: 0.0.196 -> 0.0.201 ``                                              |
| [`129a2fee`](https://github.com/NixOS/nixpkgs/commit/129a2fee63da98ba16862cfc02032eb173b07460) | `` ghostfolio: 2.199.0 -> 2.202.0 ``                                          |
| [`66969ae9`](https://github.com/NixOS/nixpkgs/commit/66969ae959535411a73b96124b367463c454ae4b) | `` cross-seed: 6.13.1 -> 6.13.5 ``                                            |
| [`3747f496`](https://github.com/NixOS/nixpkgs/commit/3747f496e7e2f927bcfc0b1861e1666b5a1b43ba) | `` python3Packages.mkdocstrings: 0.30.0 -> 0.30.1 ``                          |
| [`c0f2682b`](https://github.com/NixOS/nixpkgs/commit/c0f2682bb424ca6b3dbb8016357eae5cc455c399) | `` benhsm-minesweeper: init at 0.3.1 ``                                       |
| [`2d2f5f1f`](https://github.com/NixOS/nixpkgs/commit/2d2f5f1f31193880a1019265ba340ae57caf0bb7) | `` python313Packages.libbs: add binaries for tests ``                         |
| [`e6ac74e9`](https://github.com/NixOS/nixpkgs/commit/e6ac74e94359ae42815cbf37447641231d116a5d) | `` maintainers: update leixb ``                                               |
| [`b1a51e5e`](https://github.com/NixOS/nixpkgs/commit/b1a51e5e45f01fda6eda67109a60e99c9bc6feec) | `` qmake2cmake: modernize ``                                                  |
| [`8c621437`](https://github.com/NixOS/nixpkgs/commit/8c6214375e47337d2f859e8299da352c365c0a17) | `` emacs-macport: enable librsvg for proper SVG rendering parity ``           |
| [`663dcbd4`](https://github.com/NixOS/nixpkgs/commit/663dcbd48a5a0958ff891a97db7f56ab67cbaa8e) | `` xenia-canary: 0-unstable-2025-09-14 -> 0-unstable-2025-09-27 ``            |
| [`e9ddb8ca`](https://github.com/NixOS/nixpkgs/commit/e9ddb8ca47c1f01011579f4d609001d7657de701) | `` k2pdfopt: drop ``                                                          |
| [`a5d7f30f`](https://github.com/NixOS/nixpkgs/commit/a5d7f30f8a95b4b97d1d0c66bfd7755bb0d7ecb2) | `` python3Packages.tree-sitter-sql: 0.3.8 -> 0.3.10 ``                        |
| [`5b831bc1`](https://github.com/NixOS/nixpkgs/commit/5b831bc177eb700780022a74b7c28e655d81b497) | `` volanta: 1.13.2 -> 1.13.3 ``                                               |
| [`1e0b7d69`](https://github.com/NixOS/nixpkgs/commit/1e0b7d6926c642bee71378bb42b3e2a0a67dc62e) | `` python313Packages.gdsfactory: 9.12.0 -> 9.17.0 ``                          |
| [`411c69d8`](https://github.com/NixOS/nixpkgs/commit/411c69d8992673230ae4040f77eb28d9a2036e3c) | `` python313Packages.kfactory: 1.12.1 -> 1.14.3 ``                            |
| [`3935e68f`](https://github.com/NixOS/nixpkgs/commit/3935e68f27381a4dff35ad450187352e9e7cb1ca) | `` luau: 0.692 -> 0.693 ``                                                    |
| [`4fa55979`](https://github.com/NixOS/nixpkgs/commit/4fa55979560cd591f6f7b32e080c1b90ed1a8021) | `` opencollada-blender: fix build with cmake 4 ``                             |
| [`f5102af8`](https://github.com/NixOS/nixpkgs/commit/f5102af824e7037cfd28c1803f006fb826b24fe0) | `` opencollada-blender: fix homepage url ``                                   |
| [`9a6974fb`](https://github.com/NixOS/nixpkgs/commit/9a6974fbae8b38e3071079f6b06e0d1665ae16fb) | `` terraform-providers.harbor: 3.11.0 -> 3.11.2 ``                            |
| [`9c05f6bc`](https://github.com/NixOS/nixpkgs/commit/9c05f6bc87416e6b18ccf48dccc4e411546d2e37) | `` python313Packages.flickrapi: disable failing test ``                       |
| [`6ad38065`](https://github.com/NixOS/nixpkgs/commit/6ad38065da53cd92246f72687a7e4baf0ab6ae86) | `` python313Packages.awswrangler: 3.12.1 -> 3.13.0 ``                         |
| [`34941de8`](https://github.com/NixOS/nixpkgs/commit/34941de8923076fe2d069dd34f60feaf8314a5d1) | `` python313Packages.control: update check part ``                            |
| [`f1de0221`](https://github.com/NixOS/nixpkgs/commit/f1de022127fb4d8351c39359fe4ddcae495a4db9) | `` python313Packages.celery-redbeat: 2.3.3 -> 2.8.1 ``                        |
| [`8eb316a1`](https://github.com/NixOS/nixpkgs/commit/8eb316a1514722716d392441e2499fcd2be575c7) | `` dolibarr: 22.0.1 -> 22.0.2 ``                                              |