### PR TITLE
chore(flake/nur): `acda1261` -> `6f603a6f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1222,11 +1222,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1759160562,
-        "narHash": "sha256-3xbZAndEXnRW9XBD573HuFDUZIjlfZAc0XkODQSMJVo=",
+        "lastModified": 1759174121,
+        "narHash": "sha256-l9KhDNjdNmIRjorS8OGUOgLC3MfMeVI1OxEfL+MOcdE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "acda1261f03f441c17558e575fb77f3097a37293",
+        "rev": "6f603a6f59b644569ba52e46183a8012c35f06e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6f603a6f`](https://github.com/nix-community/NUR/commit/6f603a6f59b644569ba52e46183a8012c35f06e8) | `` automatic update `` |
| [`e46ad957`](https://github.com/nix-community/NUR/commit/e46ad957db068a2a2f05576933e6a31bcfc3ae15) | `` automatic update `` |
| [`df4b8eb9`](https://github.com/nix-community/NUR/commit/df4b8eb9572141b462610f9758341a9981541711) | `` automatic update `` |