### PR TITLE
chore(flake/emacs-overlay): `feaf095a` -> `a00b3ead`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1759165795,
-        "narHash": "sha256-XbsOV8yPIjUjrlAaDU1GwVRle51dKDhf+ThxIyJAiA4=",
+        "lastModified": 1759396170,
+        "narHash": "sha256-zu8sepuVsRVYmpOZ3CsHiSUnIcZQ2/cRryt4cYe8ROo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "feaf095a36708c269687bc2ebd565d3bfcd0322b",
+        "rev": "a00b3ead3ecc7128243ed28fd21a1d49508e730c",
         "type": "github"
       },
       "original": {
@@ -1069,11 +1069,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1758791193,
-        "narHash": "sha256-F8WmEwFoHsnix7rt290R0rFXNJiMbClMZyIC/e+HYf0=",
+        "lastModified": 1759281824,
+        "narHash": "sha256-FIBE1qXv9TKvSNwst6FumyHwCRH3BlWDpfsnqRDCll0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "25e53aa156d47bad5082ff7618f5feb1f5e02d01",
+        "rev": "5b5be50345d4113d04ba58c444348849f5585b4a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`a00b3ead`](https://github.com/nix-community/emacs-overlay/commit/a00b3ead3ecc7128243ed28fd21a1d49508e730c) | `` Updated melpa ``        |
| [`e8a15f25`](https://github.com/nix-community/emacs-overlay/commit/e8a15f25bcbd4e29cd7a36e1fbc3df525cca9acb) | `` Updated melpa ``        |
| [`1c8a0fd5`](https://github.com/nix-community/emacs-overlay/commit/1c8a0fd5ea2cd31db5b2c2ed3a3d45060a622a5d) | `` Updated emacs ``        |
| [`df4d4eaa`](https://github.com/nix-community/emacs-overlay/commit/df4d4eaa4e92b1d099f34e57c27c8e9a398799e0) | `` Updated elpa ``         |
| [`13a5647e`](https://github.com/nix-community/emacs-overlay/commit/13a5647e7a959c7ed0717ec8c253d806cd923a87) | `` Updated nongnu ``       |
| [`780ff0f6`](https://github.com/nix-community/emacs-overlay/commit/780ff0f6ef955ef28231c5af7508726a421fa8f9) | `` Updated flake inputs `` |
| [`a2c021dd`](https://github.com/nix-community/emacs-overlay/commit/a2c021dd19cc56b8befc083f4b4c88cad01e1547) | `` Updated melpa ``        |
| [`c3373711`](https://github.com/nix-community/emacs-overlay/commit/c33737114e1fbd9f234d9fa268aac77c8e574081) | `` Updated emacs ``        |
| [`bd0a6623`](https://github.com/nix-community/emacs-overlay/commit/bd0a6623f24f277d4603bde8310e50990bcd0d99) | `` Updated elpa ``         |
| [`a3993664`](https://github.com/nix-community/emacs-overlay/commit/a3993664a26fbefdf71e27b4f892418b107520c9) | `` Updated nongnu ``       |
| [`d25b41c5`](https://github.com/nix-community/emacs-overlay/commit/d25b41c528f5d2f5a5689df1b873bc6f11dd79a4) | `` Updated melpa ``        |
| [`ba93f91e`](https://github.com/nix-community/emacs-overlay/commit/ba93f91ed8c6dd3e05bf8c70665e419f25b8a797) | `` Updated emacs ``        |
| [`e0929cc9`](https://github.com/nix-community/emacs-overlay/commit/e0929cc9ff9bfd638f60b38b1f55605b5e75363a) | `` Updated melpa ``        |
| [`bbad22cd`](https://github.com/nix-community/emacs-overlay/commit/bbad22cd2964bceeab39137e32e2863d0bdb1399) | `` Updated emacs ``        |
| [`500f7260`](https://github.com/nix-community/emacs-overlay/commit/500f7260d7f7595691e384a66d0e995c7fe7c3d1) | `` Updated elpa ``         |
| [`4f9f8c7b`](https://github.com/nix-community/emacs-overlay/commit/4f9f8c7b720c3f1a449a283e756648880578fedf) | `` Updated nongnu ``       |
| [`cfbc2529`](https://github.com/nix-community/emacs-overlay/commit/cfbc2529bc343fd8bb2c7d69e29f2fe440ce8461) | `` Updated melpa ``        |
| [`4352af03`](https://github.com/nix-community/emacs-overlay/commit/4352af0369fe5d4e18c9131db3ed8a44dc879bfd) | `` Updated emacs ``        |
| [`6bbda1ce`](https://github.com/nix-community/emacs-overlay/commit/6bbda1ce5dc002b22c95323b01d40518e843a00d) | `` Updated elpa ``         |
| [`a179972e`](https://github.com/nix-community/emacs-overlay/commit/a179972e2d614813cc0948e59213c2d0bd784a7a) | `` Updated nongnu ``       |
| [`1eb9943e`](https://github.com/nix-community/emacs-overlay/commit/1eb9943e35d52668cebd5c87573b8d7bdac6beee) | `` Updated flake inputs `` |