### PR TITLE
chore(flake/nur): `277bf808` -> `20c18f1c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1222,11 +1222,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1759208743,
-        "narHash": "sha256-gsQDpRxDf6EyON14ng4uRvwCsO+V0a/aUy7J/tDiZ2g=",
+        "lastModified": 1759232664,
+        "narHash": "sha256-IK8v2QQmcQsdpNkXT7BODerJb6nwT33ZJqvNbBCIS9s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "277bf80893db769e7c5b665fd62ebd23424543b5",
+        "rev": "20c18f1c6f384b062e6183057539e4541b12e03b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`20c18f1c`](https://github.com/nix-community/NUR/commit/20c18f1c6f384b062e6183057539e4541b12e03b) | `` automatic update `` |
| [`44937306`](https://github.com/nix-community/NUR/commit/449373069db61749a064981e039d15f82b8355d3) | `` automatic update `` |
| [`69fda6d9`](https://github.com/nix-community/NUR/commit/69fda6d9dcae315c1c3da68cf00ba3f540320f98) | `` automatic update `` |