### PR TITLE
chore(flake/home-manager): `9e0453a9` -> `5a21f481`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -740,11 +740,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759236626,
-        "narHash": "sha256-1BjCUU2csqhR5umGYFnOOTU8r8Bi+bnB2SLsr0FLcws=",
+        "lastModified": 1759261733,
+        "narHash": "sha256-G104PUPKBgJmcu4NWs0LUaPpSOTD4jiq4mamLWu3Oc0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9e0453a9b0c8ef22de0355b731d712707daa6308",
+        "rev": "5a21f4819ee1be645f46d6b255d49f4271ef6723",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                           |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`5a21f481`](https://github.com/nix-community/home-manager/commit/5a21f4819ee1be645f46d6b255d49f4271ef6723) | `` fish: support theme plugins `` |
| [`dcf52ade`](https://github.com/nix-community/home-manager/commit/dcf52ade95a79eb2a02aa9e80ae6763aa1ee610d) | `` news: add aliae entry ``       |
| [`10bcab77`](https://github.com/nix-community/home-manager/commit/10bcab77af34616244a2eca5dde5d15dcd37151c) | `` aliae: add module ``           |
| [`48e7d821`](https://github.com/nix-community/home-manager/commit/48e7d821876baee76553435104f91f1543881587) | `` news: add algia entry ``       |
| [`a65df807`](https://github.com/nix-community/home-manager/commit/a65df807835d3ba8b13604da34f730d2fc616a31) | `` algia: add module ``           |