### PR TITLE
chore(flake/nur): `76db07ba` -> `e24ff10d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1222,11 +1222,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1759262205,
-        "narHash": "sha256-LuqUMQ7FHWpmOPqmReRhoLEAJel5TOEJW8cERNSQqOU=",
+        "lastModified": 1759275872,
+        "narHash": "sha256-UrLy0ArM9I49T9cHWMbgAUP5m1A4lF4YP+Hvh8yJ4Hc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "76db07ba65227604f23daf96de4b9488af28a356",
+        "rev": "e24ff10daaf9e9c4381fd2c645364591a6a7bdf3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e24ff10d`](https://github.com/nix-community/NUR/commit/e24ff10daaf9e9c4381fd2c645364591a6a7bdf3) | `` automatic update `` |
| [`c9429f2a`](https://github.com/nix-community/NUR/commit/c9429f2adac6096639c5890eaa972de5ee150e8c) | `` automatic update `` |
| [`75e92a93`](https://github.com/nix-community/NUR/commit/75e92a93b86449bf230e0d7bfda0d4d6b743563a) | `` automatic update `` |
| [`710ba297`](https://github.com/nix-community/NUR/commit/710ba29773c6cc2642f61bcee9ef25e4907a3341) | `` automatic update `` |
| [`f380795a`](https://github.com/nix-community/NUR/commit/f380795a168accfd710fdad3fcdb478a594ca988) | `` automatic update `` |