### PR TITLE
chore(flake/nur): `3229aa61` -> `e5996a32`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1222,11 +1222,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1759334203,
-        "narHash": "sha256-b7LUTRBNcSK0WkJGQQZxMFZl8VrNSIw4vd+P4cAw3Uk=",
+        "lastModified": 1759359898,
+        "narHash": "sha256-/RJrIc3GMnqzUTv5vxVgdrpzpj1cp2ubEHTWSFLUJIA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3229aa61bd9a9245ec76d8191068c6aa39bf0bfe",
+        "rev": "e5996a324a35e040241c9219e048a154175c2040",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                                  |
| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`e5996a32`](https://github.com/nix-community/NUR/commit/e5996a324a35e040241c9219e048a154175c2040) | `` Should fix https://github.com/nix-community/nur-combined/issues/41 `` |
| [`28e7ada0`](https://github.com/nix-community/NUR/commit/28e7ada07b589d429d25adb190e582af537c9a53) | `` automatic update ``                                                   |
| [`07ef8895`](https://github.com/nix-community/NUR/commit/07ef88952d079ee5e287f25178060508aa5d80a7) | `` automatic update ``                                                   |
| [`e9ad6dbc`](https://github.com/nix-community/NUR/commit/e9ad6dbc1abce2c321b691b08db554b5e086dd9a) | `` automatic update ``                                                   |
| [`40d58317`](https://github.com/nix-community/NUR/commit/40d58317e97e60351bc08f3c95b94194c52e4219) | `` automatic update ``                                                   |
| [`5e751a52`](https://github.com/nix-community/NUR/commit/5e751a5236ff28f1405a9ace5324b693097e92e7) | `` automatic update ``                                                   |