### PR TITLE
chore(flake/flake-parts): `45242719` -> `758cf729`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -601,11 +601,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1756770412,
-        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
+        "lastModified": 1759362264,
+        "narHash": "sha256-wfG0S7pltlYyZTM+qqlhJ7GMw2fTF4mLKCIVhLii/4M=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "4524271976b625a4a605beefd893f270620fd751",
+        "rev": "758cf7296bee11f1706a574c77d072b8a7baa881",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                      |
| -------------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`20ee5bcf`](https://github.com/hercules-ci/flake-parts/commit/20ee5bcff28157d165aec8f58725c3a6db668f2d) | `` dev/flake.lock: Update `` |