### PR TITLE
chore(flake/nur): `e5996a32` -> `1ffe52b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1222,11 +1222,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1759359898,
-        "narHash": "sha256-/RJrIc3GMnqzUTv5vxVgdrpzpj1cp2ubEHTWSFLUJIA=",
+        "lastModified": 1759377114,
+        "narHash": "sha256-o8jdAgk7E8vQUag9O2GkxAYKdm7XGil3P0xnVZhmy8Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e5996a324a35e040241c9219e048a154175c2040",
+        "rev": "1ffe52b6b4754ae7a560be89203959db25fb4aae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1ffe52b6`](https://github.com/nix-community/NUR/commit/1ffe52b6b4754ae7a560be89203959db25fb4aae) | `` automatic update `` |
| [`3b3a13be`](https://github.com/nix-community/NUR/commit/3b3a13be5f0a55d8bfa7d922179fa33887cf7f12) | `` automatic update `` |
| [`2645626e`](https://github.com/nix-community/NUR/commit/2645626eb1cfe96612c504b306857b0a2788988d) | `` automatic update `` |
| [`f5016fa5`](https://github.com/nix-community/NUR/commit/f5016fa5fdf6d313246c676c32dac97c060d2a8d) | `` automatic update `` |
| [`83ba90e4`](https://github.com/nix-community/NUR/commit/83ba90e41efc8e596dd4f7bc76f6f2d8e11b54ff) | `` automatic update `` |