### PR TITLE
chore(flake/srvos): `97708379` -> `1dbb22b9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1337,11 +1337,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759107752,
-        "narHash": "sha256-VEdL1J4rk+Z/5wHhLSsvj5QmXWKHHDeN1P8YLGLa1RM=",
+        "lastModified": 1759366584,
+        "narHash": "sha256-GoeShBq/+xv9g9POP69vbOrObpLtS/mDfF1/pfPIQrU=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "97708379b1f3b64224632eb49a56e45fe6995e6f",
+        "rev": "1dbb22b9b15f449a7c8c92a94aec9fe5aea8ef7c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`1dbb22b9`](https://github.com/nix-community/srvos/commit/1dbb22b9b15f449a7c8c92a94aec9fe5aea8ef7c) | `` dev/private/flake.lock: Update `` |
| [`453a14c0`](https://github.com/nix-community/srvos/commit/453a14c02f7d0b57753200e533e6916cdaa51f34) | `` flake.lock: Update ``             |