### PR TITLE
chore(flake/emacs-overlay): `a00b3ead` -> `d9b6b807`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1759396170,
-        "narHash": "sha256-zu8sepuVsRVYmpOZ3CsHiSUnIcZQ2/cRryt4cYe8ROo=",
+        "lastModified": 1759425175,
+        "narHash": "sha256-RiZ/hh21blseTtqH+y1qfnKceIBJjAp6zHQjWs70C/4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a00b3ead3ecc7128243ed28fd21a1d49508e730c",
+        "rev": "d9b6b807f63697236c11efd101e85c051a532213",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`d9b6b807`](https://github.com/nix-community/emacs-overlay/commit/d9b6b807f63697236c11efd101e85c051a532213) | `` Updated melpa ``  |
| [`b0eeb91b`](https://github.com/nix-community/emacs-overlay/commit/b0eeb91b08a848c04e6f729c82e510c3a31e4110) | `` Updated elpa ``   |
| [`e65f5d84`](https://github.com/nix-community/emacs-overlay/commit/e65f5d84a9201883f12e8c5baa959698a39e7e3b) | `` Updated nongnu `` |
| [`53329f8c`](https://github.com/nix-community/emacs-overlay/commit/53329f8c9594a5ef2ebf2947a76dd84213364abb) | `` Updated emacs ``  |