### PR TITLE
chore(flake/nur): `7d2d5b7f` -> `62b197c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1148,11 +1148,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "lastModified": 1759381078,
+        "narHash": "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "rev": "7df7ff7d8e00218376575f0acdcc5d66741351ee",
         "type": "github"
       },
       "original": {
@@ -1222,11 +1222,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1759410446,
-        "narHash": "sha256-IuzzxubrrirbHMdlDAmtf8pZQvgFhIpZHKXl5c4GWuM=",
+        "lastModified": 1759448651,
+        "narHash": "sha256-V4ljHJPt8i8Ic7rGjapCwbw8uSo/NxaR5aWkACm2epQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7d2d5b7f6c4dbe3c5ba579a81e7fd27dc2e13c05",
+        "rev": "62b197c6bfd4e2f6ff6a94a8221c5d1f5308ef9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                            |
| -------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`62b197c6`](https://github.com/nix-community/NUR/commit/62b197c6bfd4e2f6ff6a94a8221c5d1f5308ef9a) | `` automatic update ``             |
| [`6dca1435`](https://github.com/nix-community/NUR/commit/6dca1435284b181fe1f02a6fd2a3e1a0e48912a2) | `` automatic update ``             |
| [`0d5fd8f0`](https://github.com/nix-community/NUR/commit/0d5fd8f00e9142e9e2c4761221a1f1944d703a5d) | `` automatic update ``             |
| [`360074c0`](https://github.com/nix-community/NUR/commit/360074c0ace6fe90a4f48abab8e5c9d70e4eb72e) | `` automatic update ``             |
| [`27b7f767`](https://github.com/nix-community/NUR/commit/27b7f7675b3a09af7888e8bfa3071bd87b835a75) | `` automatic update ``             |
| [`0132754c`](https://github.com/nix-community/NUR/commit/0132754c9de1061ea1e395459e0be3dca5bb2e74) | `` automatic update ``             |
| [`621c0133`](https://github.com/nix-community/NUR/commit/621c01330499e0ec6580a7ef3a56dc8884c1c335) | `` Globally disable LFS locking `` |