### PR TITLE
chore(flake/nur): `62b197c6` -> `187c3cd0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1222,11 +1222,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1759448651,
-        "narHash": "sha256-V4ljHJPt8i8Ic7rGjapCwbw8uSo/NxaR5aWkACm2epQ=",
+        "lastModified": 1759463366,
+        "narHash": "sha256-mI4iE8qXcNK8t8cCN0Ug/6HULBguW37eCpViztUa3sk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "62b197c6bfd4e2f6ff6a94a8221c5d1f5308ef9a",
+        "rev": "187c3cd095d223e4f0236ae4b46778ffb662e234",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`187c3cd0`](https://github.com/nix-community/NUR/commit/187c3cd095d223e4f0236ae4b46778ffb662e234) | `` automatic update `` |
| [`37ca70b7`](https://github.com/nix-community/NUR/commit/37ca70b7f051080f35c068b4d7b8db84eb03eaa7) | `` automatic update `` |
| [`2b96b86a`](https://github.com/nix-community/NUR/commit/2b96b86a17bf6c00b3af2faec10be383be2db7dd) | `` automatic update `` |
| [`4eb59ad2`](https://github.com/nix-community/NUR/commit/4eb59ad283cfa94ef0d3cbbe460c2f74b568991a) | `` automatic update `` |
| [`cbdd606b`](https://github.com/nix-community/NUR/commit/cbdd606b255b0654ae00befebd56ac8b0a59f9b4) | `` automatic update `` |
| [`209f6d87`](https://github.com/nix-community/NUR/commit/209f6d87a39a790847343f55471f6238b88dcf26) | `` automatic update `` |
| [`b5b05675`](https://github.com/nix-community/NUR/commit/b5b056750117ab68fe911174cee9e1e656650064) | `` automatic update `` |