### PR TITLE
chore(flake/emacs-overlay): `d9b6b807` -> `68529e78`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1759425175,
-        "narHash": "sha256-RiZ/hh21blseTtqH+y1qfnKceIBJjAp6zHQjWs70C/4=",
+        "lastModified": 1759456943,
+        "narHash": "sha256-WjK2qcb1+jYYtIBEROW8/IE+q781r6hEP+97Kf2ITvE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d9b6b807f63697236c11efd101e85c051a532213",
+        "rev": "68529e783b91782936f01883d7fbf071c3e58da4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`68529e78`](https://github.com/nix-community/emacs-overlay/commit/68529e783b91782936f01883d7fbf071c3e58da4) | `` Updated melpa ``        |
| [`72909bac`](https://github.com/nix-community/emacs-overlay/commit/72909bac1260c8e9e71818330e52df4cdeaafe3a) | `` Updated emacs ``        |
| [`287e295c`](https://github.com/nix-community/emacs-overlay/commit/287e295c2452400c40cf203a3817e072f0c099cf) | `` Updated elpa ``         |
| [`851cc896`](https://github.com/nix-community/emacs-overlay/commit/851cc89640a3763506e5d013678408ef463faac9) | `` Updated nongnu ``       |
| [`06adeb1d`](https://github.com/nix-community/emacs-overlay/commit/06adeb1dba271f018959919c1a0fa4ac739b7688) | `` Updated flake inputs `` |