### PR TITLE
chore(flake/nur): `187c3cd0` -> `1d38cb6e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1222,11 +1222,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1759463366,
-        "narHash": "sha256-mI4iE8qXcNK8t8cCN0Ug/6HULBguW37eCpViztUa3sk=",
+        "lastModified": 1759475326,
+        "narHash": "sha256-bXXGDZQm05KmaSf/TDqAOkPK4i6Ba5y12aL6/hcJiro=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "187c3cd095d223e4f0236ae4b46778ffb662e234",
+        "rev": "1d38cb6e7f916b7a31f4d8ef1995ba9fbaf93380",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1d38cb6e`](https://github.com/nix-community/NUR/commit/1d38cb6e7f916b7a31f4d8ef1995ba9fbaf93380) | `` automatic update `` |
| [`710020b2`](https://github.com/nix-community/NUR/commit/710020b24e452e9c55a03314dd8583df28e68c03) | `` automatic update `` |
| [`74b574ed`](https://github.com/nix-community/NUR/commit/74b574ed94de7e324ec15bcfa432f28e398b5ad2) | `` automatic update `` |
| [`924e2856`](https://github.com/nix-community/NUR/commit/924e285632da281132a7b8528c21e4e17cc54b31) | `` automatic update `` |