### PR TITLE
chore(flake/nur): `1d38cb6e` -> `593a50e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1222,11 +1222,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1759475326,
-        "narHash": "sha256-bXXGDZQm05KmaSf/TDqAOkPK4i6Ba5y12aL6/hcJiro=",
+        "lastModified": 1759519535,
+        "narHash": "sha256-cp6JlAe//eAz8C8NNL0T/lhrg5NiOHUflAPMAl+t7M8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1d38cb6e7f916b7a31f4d8ef1995ba9fbaf93380",
+        "rev": "593a50e6c29c55e9f4fa213d942f67e4e7d249e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`593a50e6`](https://github.com/nix-community/NUR/commit/593a50e6c29c55e9f4fa213d942f67e4e7d249e2) | `` automatic update `` |
| [`9568f38f`](https://github.com/nix-community/NUR/commit/9568f38ff4695a32aeb2b7ed9c6ae4fa691522a2) | `` automatic update `` |
| [`c7efa84d`](https://github.com/nix-community/NUR/commit/c7efa84d747fb3949e4a19f30c10c7ad09bee7da) | `` automatic update `` |
| [`e292c9bb`](https://github.com/nix-community/NUR/commit/e292c9bb58d0e09b686d5a6835d24444ea3819d6) | `` automatic update `` |
| [`06df014f`](https://github.com/nix-community/NUR/commit/06df014f1ca12e064f3f4b4bb4b54fe30d6c3f51) | `` automatic update `` |
| [`6d5935af`](https://github.com/nix-community/NUR/commit/6d5935af0f29a31efe6be997c48d02aef4bd87dc) | `` automatic update `` |
| [`e14a90ff`](https://github.com/nix-community/NUR/commit/e14a90ffeaca1bb5ef04a5ab25f3b3b5ffe29384) | `` automatic update `` |
| [`1a26ccba`](https://github.com/nix-community/NUR/commit/1a26ccba259dbf1e8cc333179fab911c31ffab6f) | `` automatic update `` |
| [`58ed6fc0`](https://github.com/nix-community/NUR/commit/58ed6fc09dc11580c2f875cff9cc4d03015ae1ae) | `` automatic update `` |
| [`79f74235`](https://github.com/nix-community/NUR/commit/79f74235d46273e3e85c8db65215eae4c1a60a38) | `` automatic update `` |