### PR TITLE
chore(flake/emacs-overlay): `68529e78` -> `94253087`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1759456943,
-        "narHash": "sha256-WjK2qcb1+jYYtIBEROW8/IE+q781r6hEP+97Kf2ITvE=",
+        "lastModified": 1759544172,
+        "narHash": "sha256-oSkKuK4qWhN9ccvRMcnYhSCO9TJOmBb67z9+LIRdtNg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "68529e783b91782936f01883d7fbf071c3e58da4",
+        "rev": "942530872529aad21e9ac205b630694ef6b755de",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`94253087`](https://github.com/nix-community/emacs-overlay/commit/942530872529aad21e9ac205b630694ef6b755de) | `` Updated emacs ``  |
| [`0a84126e`](https://github.com/nix-community/emacs-overlay/commit/0a84126e5fc76adbb6a3a3701413cde0374c6c74) | `` Updated melpa ``  |
| [`f9c8efd9`](https://github.com/nix-community/emacs-overlay/commit/f9c8efd93d0b3bbafb2c64f796a66e2f50e7cf1d) | `` Updated elpa ``   |
| [`904d5409`](https://github.com/nix-community/emacs-overlay/commit/904d5409bcf23db3b546be2ef875049691a06560) | `` Updated nongnu `` |