### PR TITLE
chore(flake/catppuccin): `d2e2bc91` -> `eeada129`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1759502011,
-        "narHash": "sha256-kj9TNrReaJwKkGQO8YBTgSsJ2I/whbDKSxLkOr28vRY=",
+        "lastModified": 1759572023,
+        "narHash": "sha256-2fzYq/m2PXie5WZO5LhyiZrTIUdUFp1SCLZAwvPL5xo=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "d2e2bc9186631cc39df23b769864f7604eaa3195",
+        "rev": "eeada12912d80d04733383d231a9d66172858718",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                 |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`eeada129`](https://github.com/catppuccin/nix/commit/eeada12912d80d04733383d231a9d66172858718) | `` fix(home-manager/kvantum): remove platform theme assertion (#741) `` |