### PR TITLE
chore(flake/nur): `fc4bde0d` -> `9ddd76bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1222,11 +1222,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1759562581,
-        "narHash": "sha256-Ws/2AeBPNO0rKZClWMZGHzpYYxvzipkQe0Uv0bRcYDM=",
+        "lastModified": 1759605953,
+        "narHash": "sha256-Mp7pvRYuFFW1SbARSesQQMYQ1Oc+oDqvYnd7bT1h/Cs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fc4bde0d1bbd11352fd7836af54e56573f6649e6",
+        "rev": "9ddd76bbee915f27a01f8eaea49d544ffc73f83f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9ddd76bb`](https://github.com/nix-community/NUR/commit/9ddd76bbee915f27a01f8eaea49d544ffc73f83f) | `` automatic update `` |
| [`7faf3839`](https://github.com/nix-community/NUR/commit/7faf3839d126d4aa40f85f8e64cfbdfb8d760089) | `` automatic update `` |
| [`86934671`](https://github.com/nix-community/NUR/commit/869346716f2f0cdebb5c3f9c365e3c104a534244) | `` automatic update `` |
| [`c95772f7`](https://github.com/nix-community/NUR/commit/c95772f7420e4710a497ec8d3f140d40d09d40e8) | `` automatic update `` |
| [`38a31b21`](https://github.com/nix-community/NUR/commit/38a31b2183210fe4aebf48c232ed89cc624456d5) | `` automatic update `` |
| [`fc81e15b`](https://github.com/nix-community/NUR/commit/fc81e15b9422a3457f8b0cb4d8c9a2fc2876fce6) | `` automatic update `` |
| [`8a83e7c7`](https://github.com/nix-community/NUR/commit/8a83e7c7dfbf5367a38a659b983cad26a0fb6a96) | `` automatic update `` |