### PR TITLE
chore(flake/emacs-overlay): `94253087` -> `2eb98bc8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1759544172,
-        "narHash": "sha256-oSkKuK4qWhN9ccvRMcnYhSCO9TJOmBb67z9+LIRdtNg=",
+        "lastModified": 1759597627,
+        "narHash": "sha256-X/WpzfBNLiscm8bvZ4pSyBm8BTHA7C+OtJAceAyUmuc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "942530872529aad21e9ac205b630694ef6b755de",
+        "rev": "2eb98bc8bb9ceba2db02c70653c219ed17e90928",
         "type": "github"
       },
       "original": {
@@ -1069,11 +1069,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1759281824,
-        "narHash": "sha256-FIBE1qXv9TKvSNwst6FumyHwCRH3BlWDpfsnqRDCll0=",
+        "lastModified": 1759439645,
+        "narHash": "sha256-oiAyQaRilPk525Z5aTtTNWNzSrcdJ7IXM0/PL3CGlbI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5b5be50345d4113d04ba58c444348849f5585b4a",
+        "rev": "879bd460b3d3e8571354ce172128fbcbac1ed633",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`2eb98bc8`](https://github.com/nix-community/emacs-overlay/commit/2eb98bc8bb9ceba2db02c70653c219ed17e90928) | `` Updated melpa ``        |
| [`45b16eca`](https://github.com/nix-community/emacs-overlay/commit/45b16eca0c5e24adbfe78ae09e6bc37113bfd3b9) | `` Updated emacs ``        |
| [`55d85bd4`](https://github.com/nix-community/emacs-overlay/commit/55d85bd4b06fcd4ffc206fbd3d8deeb0a86577b0) | `` Updated elpa ``         |
| [`cc32b6ee`](https://github.com/nix-community/emacs-overlay/commit/cc32b6eecc0875cb855b671430bbac99d24b5a8a) | `` Updated nongnu ``       |
| [`deb747ec`](https://github.com/nix-community/emacs-overlay/commit/deb747ec83e2d6b1867d148a90e11903da4245d0) | `` Updated flake inputs `` |