### PR TITLE
chore(flake/sops-nix): `9fcfabe0` -> `6e5a38e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1317,11 +1317,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759188042,
-        "narHash": "sha256-f9QC2KKiNReZDG2yyKAtDZh0rSK2Xp1wkPzKbHeQVRU=",
+        "lastModified": 1759635238,
+        "narHash": "sha256-UvzKi02LMFP74csFfwLPAZ0mrE7k6EiYaKecplyX9Qk=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "9fcfabe085281dd793589bdc770a2e577a3caa5d",
+        "rev": "6e5a38e08a2c31ae687504196a230ae00ea95133",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                      |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`7f649eb3`](https://github.com/Mic92/sops-nix/commit/7f649eb3f38e16332a09eb66c015f115faaa204e) | `` [create-pull-request] automated change `` |