### PR TITLE
chore(flake/emacs-overlay): `410b6407` -> `4eb2b6ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1759630368,
-        "narHash": "sha256-55Mu7ljx9nyUsy0SAlXos0bcfKvqWRJY+Oc33awB5dY=",
+        "lastModified": 1759800013,
+        "narHash": "sha256-G1tH/Roh/VD2bTiW9kYowfGuGwuzl9mVbjaKZlfXBMo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "410b6407637b28a825f5d6162e2514ea85fda08c",
+        "rev": "4eb2b6bad5f03f002a584c8564a92b24060d1bd6",
         "type": "github"
       },
       "original": {
@@ -1069,11 +1069,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1759439645,
-        "narHash": "sha256-oiAyQaRilPk525Z5aTtTNWNzSrcdJ7IXM0/PL3CGlbI=",
+        "lastModified": 1759580034,
+        "narHash": "sha256-YWo57PL7mGZU7D4WeKFMiW4ex/O6ZolUS6UNBHTZfkI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "879bd460b3d3e8571354ce172128fbcbac1ed633",
+        "rev": "3bcc93c5f7a4b30335d31f21e2f1281cba68c318",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`4eb2b6ba`](https://github.com/nix-community/emacs-overlay/commit/4eb2b6bad5f03f002a584c8564a92b24060d1bd6) | `` Updated nongnu ``       |
| [`4e4ed8f8`](https://github.com/nix-community/emacs-overlay/commit/4e4ed8f8beda9d47887cf4411720cb8a83a43e90) | `` Updated melpa ``        |
| [`184e12dc`](https://github.com/nix-community/emacs-overlay/commit/184e12dcb2ea42ef764f1c32b60f677dd2bbe26e) | `` Updated elpa ``         |
| [`fda1633d`](https://github.com/nix-community/emacs-overlay/commit/fda1633df4a14be1f5fb1037339759197bee0bd5) | `` Updated nongnu ``       |
| [`123abc69`](https://github.com/nix-community/emacs-overlay/commit/123abc6999170bfc259c81f9fc47881ca9b7f0cb) | `` Updated emacs ``        |
| [`722d8e6f`](https://github.com/nix-community/emacs-overlay/commit/722d8e6f96a0fd1dcf3d49a1f2dc38aec8c4039d) | `` Updated nongnu ``       |
| [`85a72536`](https://github.com/nix-community/emacs-overlay/commit/85a72536d0224341ffdfb9fbb724f5ef15476dd6) | `` Updated melpa ``        |
| [`f9b13507`](https://github.com/nix-community/emacs-overlay/commit/f9b135078c59e65804c7e5f037e0fec1024da802) | `` Updated emacs ``        |
| [`55e74940`](https://github.com/nix-community/emacs-overlay/commit/55e749403d52919e6f714da9247ea5547c74e758) | `` Updated flake inputs `` |