### PR TITLE
chore(flake/home-manager): `5f06ceaf` -> `6f4021da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -740,11 +740,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759573136,
-        "narHash": "sha256-ILSPD0Dm8p0w0fCVzOx98ZH8yFDrR75GmwmH3fS2VnE=",
+        "lastModified": 1759711004,
+        "narHash": "sha256-B39NxeKCnK3DJlmJKIts6njcXcVVASLUChDNmRl4dxQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5f06ceafc6c9b773a776b9195c3f47bbe1defa43",
+        "rev": "6f4021da5d2bb5ea7cb782ff413ecb7062066820",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                        |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`6f4021da`](https://github.com/nix-community/home-manager/commit/6f4021da5d2bb5ea7cb782ff413ecb7062066820) | `` deprecations: move just module deprecation to new module `` |
| [`3f07ce05`](https://github.com/nix-community/home-manager/commit/3f07ce05c3b6d59602bc380e42320483081fa38f) | `` deprecations: add deprecations/removal module ``            |
| [`5b45dcf4`](https://github.com/nix-community/home-manager/commit/5b45dcf4790bb94fec7e550d2915fc2540a3cdd6) | `` tests/hyprshot: add tests ``                                |
| [`9f2912e3`](https://github.com/nix-community/home-manager/commit/9f2912e3a6c4665bebe3d61ba967ddc65ecd18d4) | `` hyprshot: add platform assertion ``                         |
| [`3c3076b1`](https://github.com/nix-community/home-manager/commit/3c3076b1c1b941715302d731a4a978bca88fa16f) | `` tests/discoss: add tests ``                                 |
| [`6e8ab005`](https://github.com/nix-community/home-manager/commit/6e8ab005bc65649428cba369f2730f01955b3d6a) | `` tests/darwinscrublist: add discocss and discord ``          |
| [`f72f6609`](https://github.com/nix-community/home-manager/commit/f72f660976628775d8a5bb5ea6a3ba7ad2000cdb) | `` discocss: only generate css when provided ``                |
| [`aa10fe09`](https://github.com/nix-community/home-manager/commit/aa10fe094b444e173d5d51ee8bf5f07e7e72e473) | `` discocss: fix discordPackage override ``                    |
| [`994d854a`](https://github.com/nix-community/home-manager/commit/994d854a4a90df8d8f661b19d05eb1cb6a951419) | `` tests/grep: add tests ``                                    |
| [`c2e3f1ca`](https://github.com/nix-community/home-manager/commit/c2e3f1cacd0c6b2609552cb6eb1801afe1e6cc3c) | `` tests/gcc: add tests ``                                     |
| [`78fda50b`](https://github.com/nix-community/home-manager/commit/78fda50bd6e1f26ae914ae77d66e6d2381b64507) | `` gcc: fix sessionVariables mkIf evaluation error ``          |
| [`51870a37`](https://github.com/nix-community/home-manager/commit/51870a37a354a37dc3bd32f3a5a7c9054249492d) | `` grep: fix sessionVariables mkIf evaluation error ``         |
| [`06e268d6`](https://github.com/nix-community/home-manager/commit/06e268d66bbf6d606b349a4f0be3af66ab3ea2be) | `` services/barrier: drop module ``                            |
| [`b52ece2b`](https://github.com/nix-community/home-manager/commit/b52ece2bb670e888fa39ea7ef7cce523839a9452) | `` flake.lock: Update ``                                       |
| [`9070d7d3`](https://github.com/nix-community/home-manager/commit/9070d7d32b3d4317e95b6b92f98fee850c1f116d) | `` news: add am2rlauncher entry ``                             |
| [`87570dbc`](https://github.com/nix-community/home-manager/commit/87570dbc43fafb99081a24353a26763acdad6f76) | `` am2rlauncher: add module ``                                 |
| [`8b624044`](https://github.com/nix-community/home-manager/commit/8b62404497528386642f4368dc552a8f79d9febe) | `` news: add amber entry ``                                    |
| [`2b64e332`](https://github.com/nix-community/home-manager/commit/2b64e332a047ec8d3695946bfded39bc3f3583bb) | `` amber: add module ``                                        |