### PR TITLE
chore(flake/nur): `dce08ba6` -> `af3cd643`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1222,11 +1222,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1759696599,
-        "narHash": "sha256-GkGJdNkR9gnVQt9OXwhGrD72EpK185jNVT7qoCh/3q4=",
+        "lastModified": 1759724112,
+        "narHash": "sha256-42DBBV0eLlIHwu+xNX0xNcoFCX7hqkKjAs5kgxZZi/w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dce08ba6904fcaad93c17ab65cf6b3e5dfc2d301",
+        "rev": "af3cd64344dd497054e393e288bdb32cc9621e7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`af3cd643`](https://github.com/nix-community/NUR/commit/af3cd64344dd497054e393e288bdb32cc9621e7f) | `` automatic update `` |
| [`77e071a3`](https://github.com/nix-community/NUR/commit/77e071a31cadf669cb74fd6663e063032505a79c) | `` automatic update `` |
| [`b5941e63`](https://github.com/nix-community/NUR/commit/b5941e63a9a4862236545c6da968239565f2ab7a) | `` automatic update `` |
| [`a8f8c41a`](https://github.com/nix-community/NUR/commit/a8f8c41a99f0ae26a0f10749d31188bd90466f2f) | `` automatic update `` |
| [`f5306839`](https://github.com/nix-community/NUR/commit/f53068397adcfa6497859e351ec12cd0b9e66bf8) | `` automatic update `` |
| [`0160b2a0`](https://github.com/nix-community/NUR/commit/0160b2a08d6c9af75a451a36f871f30253f68d84) | `` automatic update `` |
| [`a85ac1f5`](https://github.com/nix-community/NUR/commit/a85ac1f596a235e87b8161c29dca2a3884b26c73) | `` automatic update `` |
| [`7e31dbef`](https://github.com/nix-community/NUR/commit/7e31dbef1b48de02b08b43722dfd73b8b9168bc1) | `` automatic update `` |
| [`ff2dd3b1`](https://github.com/nix-community/NUR/commit/ff2dd3b1469d3c0de12ad0b30e7572a15a85de24) | `` automatic update `` |