### PR TITLE
chore(flake/home-manager): `6f4021da` -> `929535c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -740,11 +740,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759711004,
-        "narHash": "sha256-B39NxeKCnK3DJlmJKIts6njcXcVVASLUChDNmRl4dxQ=",
+        "lastModified": 1759761710,
+        "narHash": "sha256-6ZG7VZZsbg39gtziGSvCJKurhIahIuiCn+W6TGB5kOU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6f4021da5d2bb5ea7cb782ff413ecb7062066820",
+        "rev": "929535c3082afdf0b18afec5ea1ef14d7689ff1c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`929535c3`](https://github.com/nix-community/home-manager/commit/929535c3082afdf0b18afec5ea1ef14d7689ff1c) | `` git: difftastic: use 'option' attrset ``             |
| [`ed100232`](https://github.com/nix-community/home-manager/commit/ed10023224107dc8479ead95a448d66f046785e0) | `` maintainers: update all-maintainers.nix ``           |
| [`7d3d323e`](https://github.com/nix-community/home-manager/commit/7d3d323e906a06247920c0a8fb2fa473a3770fb9) | `` git: add `extraArgs` option for difftastic ``        |
| [`1652349e`](https://github.com/nix-community/home-manager/commit/1652349e57daa25217f32656216e404948e512f3) | `` git: add option for difftastic context ``            |
| [`d328666d`](https://github.com/nix-community/home-manager/commit/d328666dbac08aefd639019516f22c61be14a326) | `` git: add tests for difftastic ``                     |
| [`e46b52ab`](https://github.com/nix-community/home-manager/commit/e46b52ab56ec5f981491a61e9aececa9e50f712c) | `` darwinScrublist: add difftastic ``                   |
| [`b72be79a`](https://github.com/nix-community/home-manager/commit/b72be79a42d470e4bafb5348dc62df484b6baab3) | `` smug: add new option introduced by v0.3.7 (#7930) `` |