### PR TITLE
chore(flake/nur): `58e23a27` -> `7ad181b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1222,11 +1222,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1759755583,
-        "narHash": "sha256-ZY0EZTqlb3RwCEolM6d7S1ccVhay8GsXF9V2yLbdCmo=",
+        "lastModified": 1759778882,
+        "narHash": "sha256-xbEGU8C2VLYgPM5409JoZHkkZz2gqvIleTMDHXY8WjI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "58e23a2765d244dd4283f8f25c3a1b9a8f06417a",
+        "rev": "7ad181b4e9211682008feb5d06f86af865c90710",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7ad181b4`](https://github.com/nix-community/NUR/commit/7ad181b4e9211682008feb5d06f86af865c90710) | `` automatic update `` |
| [`3aa61738`](https://github.com/nix-community/NUR/commit/3aa6173861b1dab10b5c8bdcdb7ac6c127d115a0) | `` automatic update `` |