### PR TITLE
chore(flake/nur): `7ad181b4` -> `9a6d1363`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1222,11 +1222,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1759778882,
-        "narHash": "sha256-xbEGU8C2VLYgPM5409JoZHkkZz2gqvIleTMDHXY8WjI=",
+        "lastModified": 1759790712,
+        "narHash": "sha256-3KIfzcohPARwIc7nVtvioELW62+rXY7O3FhAIryqn4Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7ad181b4e9211682008feb5d06f86af865c90710",
+        "rev": "9a6d13630a078d81d0a2d3500f3c00aa4b681c89",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`9a6d1363`](https://github.com/nix-community/NUR/commit/9a6d13630a078d81d0a2d3500f3c00aa4b681c89) | `` automatic update `` |
| [`9d6e275d`](https://github.com/nix-community/NUR/commit/9d6e275d4f74ac272aef29fb9845ea7da6559de6) | `` automatic update `` |