### PR TITLE
chore(flake/emacs-overlay): `4eb2b6ba` -> `96f3adf9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,11 +552,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1759800013,
-        "narHash": "sha256-G1tH/Roh/VD2bTiW9kYowfGuGwuzl9mVbjaKZlfXBMo=",
+        "lastModified": 1759889117,
+        "narHash": "sha256-ml9BaclaS5boSrz3XFXsr3+llTJ81p3q+o041AgZ13g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4eb2b6bad5f03f002a584c8564a92b24060d1bd6",
+        "rev": "96f3adf9a34ed8828c004c4b11b8a14bab2e5eed",
         "type": "github"
       },
       "original": {
@@ -1069,11 +1069,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1759580034,
-        "narHash": "sha256-YWo57PL7mGZU7D4WeKFMiW4ex/O6ZolUS6UNBHTZfkI=",
+        "lastModified": 1759735786,
+        "narHash": "sha256-a0+h02lyP2KwSNrZz4wLJTu9ikujNsTWIC874Bv7IJ0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3bcc93c5f7a4b30335d31f21e2f1281cba68c318",
+        "rev": "20c4598c84a671783f741e02bf05cbfaf4907cff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`96f3adf9`](https://github.com/nix-community/emacs-overlay/commit/96f3adf9a34ed8828c004c4b11b8a14bab2e5eed) | `` Updated melpa ``        |
| [`fd205551`](https://github.com/nix-community/emacs-overlay/commit/fd20555128fd295f1f2a336faf84163d7833fe5f) | `` Updated emacs ``        |
| [`926b3a6c`](https://github.com/nix-community/emacs-overlay/commit/926b3a6c17e1e4823c795cc09f782d2ab8f39004) | `` Updated elpa ``         |
| [`734c3ccc`](https://github.com/nix-community/emacs-overlay/commit/734c3ccccb963d165d2c781c73ddf3b4272fbb93) | `` Updated nongnu ``       |
| [`b36275f6`](https://github.com/nix-community/emacs-overlay/commit/b36275f6174cbe6a7f74398540747ae3a485b62c) | `` Updated melpa ``        |
| [`4a0b0e3e`](https://github.com/nix-community/emacs-overlay/commit/4a0b0e3ee83f1f9225fbb1ff7f73537d1897425d) | `` Updated emacs ``        |
| [`a9b2099a`](https://github.com/nix-community/emacs-overlay/commit/a9b2099ad88b62c6a9b66ceb275bdf3ac4d0aa9f) | `` Updated elpa ``         |
| [`e1b387f5`](https://github.com/nix-community/emacs-overlay/commit/e1b387f54d334b7283077762fb0998c28e98edb2) | `` Updated nongnu ``       |
| [`6ff4ca5c`](https://github.com/nix-community/emacs-overlay/commit/6ff4ca5c01f5e504fcd8288fbda410dd261fab9b) | `` Updated emacs ``        |
| [`f42975f3`](https://github.com/nix-community/emacs-overlay/commit/f42975f36b13c0d8fe25e0a888bea246b57760e5) | `` Updated melpa ``        |
| [`d8b6bac9`](https://github.com/nix-community/emacs-overlay/commit/d8b6bac9cb819c05be9db3b42cb538246c160d61) | `` Updated elpa ``         |
| [`31669c9e`](https://github.com/nix-community/emacs-overlay/commit/31669c9efc54e3b99f4310c5728bd8b6f8b2ec67) | `` Updated flake inputs `` |