### PR TITLE
chore(flake/home-manager): `929535c3` -> `1a09eb84`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -740,11 +740,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759761710,
-        "narHash": "sha256-6ZG7VZZsbg39gtziGSvCJKurhIahIuiCn+W6TGB5kOU=",
+        "lastModified": 1759853171,
+        "narHash": "sha256-uqbhyXtqMbYIiMqVqUhNdSuh9AEEkiasoK3mIPIVRhk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "929535c3082afdf0b18afec5ea1ef14d7689ff1c",
+        "rev": "1a09eb84fa9e33748432a5253102d01251f72d6d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`1a09eb84`](https://github.com/nix-community/home-manager/commit/1a09eb84fa9e33748432a5253102d01251f72d6d) | `` news: add amoco entry ``                          |
| [`c6f8669f`](https://github.com/nix-community/home-manager/commit/c6f8669f09a7d70abb0435614febbe03bb596a16) | `` amoco: add module ``                              |
| [`6c5025e2`](https://github.com/nix-community/home-manager/commit/6c5025e2bb117eb16c0aa55097ce69935f72e14c) | `` tests/dircolors: add nushell integration tests `` |
| [`38fbd890`](https://github.com/nix-community/home-manager/commit/38fbd8909e6d4a8a36fda318c5feb8704da178d1) | `` dircolors: add nushell integration ``             |
| [`462363e2`](https://github.com/nix-community/home-manager/commit/462363e248b0a2e8579a904a9991a86206ca98e8) | `` dircolors: remove no-op ``                        |
| [`5443ca20`](https://github.com/nix-community/home-manager/commit/5443ca20ed5c5da327de37a09910dc1c66fc3712) | `` news: add amfora entry ``                         |
| [`40ff7901`](https://github.com/nix-community/home-manager/commit/40ff79012e44c86b2f7c8260361b80c4794e504a) | `` amfora: add module ``                             |