### PR TITLE
chore(flake/nur): `12131b04` -> `84a5a792`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1222,11 +1222,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1759848772,
-        "narHash": "sha256-2pk6gW63zFHv2mwbpipdkfvsI2ISVJkVCKGoBza1tu0=",
+        "lastModified": 1759881814,
+        "narHash": "sha256-JzqQziv7mtD3IyxGOzcv2v3YqrzenQdAhzsDMQ9HYEY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "12131b048b753498a7c24b6b8a926635f4951f59",
+        "rev": "84a5a7921fc9c2246eb251e38b967dfd4db88dbc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`84a5a792`](https://github.com/nix-community/NUR/commit/84a5a7921fc9c2246eb251e38b967dfd4db88dbc) | `` automatic update `` |
| [`a9b46f89`](https://github.com/nix-community/NUR/commit/a9b46f898b7d0a6a2818bedbc0898a1ccccd2e85) | `` automatic update `` |
| [`c941a2f9`](https://github.com/nix-community/NUR/commit/c941a2f92788e7fa1530496d18087202e994bd43) | `` automatic update `` |
| [`eb7a5245`](https://github.com/nix-community/NUR/commit/eb7a5245ee418ba6a9f386fa3bab72ff5d87388e) | `` automatic update `` |
| [`5a4344ae`](https://github.com/nix-community/NUR/commit/5a4344ae57c97ec93c40aeb4adad31aebfc9b923) | `` automatic update `` |
| [`3d167c03`](https://github.com/nix-community/NUR/commit/3d167c0368882f02490e6c09f4cc2501c33d5fce) | `` automatic update `` |