### PR TITLE
chore(flake/nur): `84a5a792` -> `cd308601`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1222,11 +1222,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1759881814,
-        "narHash": "sha256-JzqQziv7mtD3IyxGOzcv2v3YqrzenQdAhzsDMQ9HYEY=",
+        "lastModified": 1759895616,
+        "narHash": "sha256-aTApu+hE5kDxP4Cnh5mF88T4BXlirP2Ctifynl/aXUc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "84a5a7921fc9c2246eb251e38b967dfd4db88dbc",
+        "rev": "cd308601119e1f833cf4ac319aa19972c15386e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cd308601`](https://github.com/nix-community/NUR/commit/cd308601119e1f833cf4ac319aa19972c15386e8) | `` automatic update `` |
| [`1c7dbdd3`](https://github.com/nix-community/NUR/commit/1c7dbdd3c897955e858f092008f300b5d7e2acc3) | `` automatic update `` |
| [`e61972f4`](https://github.com/nix-community/NUR/commit/e61972f490af1dd6b771ce4870e50c16a9eabe5b) | `` automatic update `` |
| [`2b6c093f`](https://github.com/nix-community/NUR/commit/2b6c093f1ce99e2bce40c1578dfd8e6e257b6b26) | `` automatic update `` |